### PR TITLE
Make tbb optional

### DIFF
--- a/fairseq2n/CMakeLists.txt
+++ b/fairseq2n/CMakeLists.txt
@@ -101,6 +101,31 @@ option(FAIRSEQ2N_USE_CUDA
         OFF
 )
 
+if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+    set(default_thread_lib tbb)
+else()
+    set(default_thread_lib)
+endif()
+
+set(FAIRSEQ2N_THREAD_LIB
+    #VALUE
+        ${default_thread_lib}
+    #TYPE
+        CACHE STRING
+    #DESCRIPTION
+        "Thread library to use."
+)
+set_property(CACHE FAIRSEQ2N_THREAD_LIB PROPERTY
+    STRINGS
+        "" "tbb"
+)
+
+if(FAIRSEQ2N_THREAD_LIB STREQUAL "tbb")
+    if(NOT CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+        message(FATAL_ERROR "Intel oneTBB is only supported on x86-64 systems.")
+    endif()
+endif()
+
 option(FAIRSEQ2N_BUILD_PYTHON_BINDINGS
     #DESCRIPTION
         "Builds the Python bindings."
@@ -135,7 +160,9 @@ find_package(SndFile 1.0.25 REQUIRED)
 
 find_package(Threads REQUIRED)
 
-find_package(TBB 2021.8 REQUIRED)
+if(FAIRSEQ2N_THREAD_LIB STREQUAL "tbb")
+    find_package(TBB 2021.8 REQUIRED)
+endif()
 
 find_package(Torch 1.12 REQUIRED)
 

--- a/fairseq2n/cmake/base.cmake
+++ b/fairseq2n/cmake/base.cmake
@@ -89,6 +89,7 @@ function(fairseq2n_set_compile_options target)
                 -Wno-missing-variable-declarations
                 -Wno-old-style-cast
                 -Wno-padded
+                -Wno-poison-system-directories
                 -Wno-reserved-id-macro
                 -Wno-shadow-uncaptured-local
                 -Wno-switch-enum

--- a/fairseq2n/cmake/modules/FindTBB.cmake
+++ b/fairseq2n/cmake/modules/FindTBB.cmake
@@ -38,7 +38,7 @@ find_path(TBB_INCLUDE_DIR tbb HINTS ${tbb_include_dir} NO_DEFAULT_PATH)
 mark_as_advanced(TBB_LIBRARY TBBMALLOC_LIBRARY TBB_INCLUDE_DIR)
 
 if(TBB_INCLUDE_DIR)
-    set(TBB_VERSION 2021.9.0)  # TODO(balioglu): Infer this!
+    set(TBB_VERSION 2021.8.0)  # TODO(balioglu): Infer this!
 endif()
 
 find_package_handle_standard_args(TBB

--- a/fairseq2n/python/requirements-build.txt
+++ b/fairseq2n/python/requirements-build.txt
@@ -3,5 +3,5 @@ ninja~=1.11
 packaging~=23.1
 pip~=23.2
 setuptools~=67.8
-tbb-devel==2021.8
+tbb-devel==2021.8;platform_machine=='x86_64'
 wheel~=0.40

--- a/fairseq2n/python/setup.py
+++ b/fairseq2n/python/setup.py
@@ -163,7 +163,7 @@ setup(
     install_requires=[
         # We use the tbb package as a fallback in case the system does not
         # provide Intel oneTBB.
-        "tbb>=2021.8;platform_machine=='x86_64'",
+        "tbb>=2021.8,<2021.10;platform_machine=='x86_64'",
         # PyTorch has no ABI compatibility between releases; this means we have
         # to ensure that we depend on the exact same version that we used to
         # build our extension module.

--- a/fairseq2n/python/setup.py
+++ b/fairseq2n/python/setup.py
@@ -163,7 +163,7 @@ setup(
     install_requires=[
         # We use the tbb package as a fallback in case the system does not
         # provide Intel oneTBB.
-        "tbb==2021.8",
+        "tbb>=2021.8;platform_machine=='x86_64'",
         # PyTorch has no ABI compatibility between releases; this means we have
         # to ensure that we depend on the exact same version that we used to
         # build our extension module.

--- a/fairseq2n/python/src/fairseq2n/__init__.py
+++ b/fairseq2n/python/src/fairseq2n/__init__.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import platform
 import site
 import sys
 from ctypes import CDLL, RTLD_GLOBAL
@@ -86,7 +87,9 @@ def _load_sndfile() -> None:
 
 # We load the shared libraries we depend on using our own extended lookup logic
 # since they might be located in a virtual environment.
-_load_tbb()
+if (uname := platform.uname()).machine == "x86_64":
+    _load_tbb()
+
 _load_sndfile()
 
 

--- a/fairseq2n/src/fairseq2n/CMakeLists.txt
+++ b/fairseq2n/src/fairseq2n/CMakeLists.txt
@@ -77,6 +77,10 @@ fairseq2n_set_compile_options(fairseq2n)
 
 target_compile_features(fairseq2n PUBLIC cxx_std_17)
 
+if(FAIRSEQ2N_THREAD_LIB STREQUAL "tbb")
+    target_compile_definitions(fairseq2n PRIVATE FAIRSEQ2N_USE_TBB)
+endif()
+
 if(FAIRSEQ2N_USE_CUDA)
     target_compile_features(fairseq2n PRIVATE cuda_std_17)
 
@@ -111,6 +115,10 @@ target_link_libraries(fairseq2n
     PUBLIC
         torch
 )
+
+if(FAIRSEQ2N_THREAD_LIB STREQUAL "tbb")
+    target_link_libraries(fairseq2n PRIVATE TBB::tbb)
+endif()
 
 if(FAIRSEQ2N_USE_CUDA)
     target_link_libraries(fairseq2n PRIVATE CUDA::cudart)

--- a/fairseq2n/src/fairseq2n/detail/exception.h
+++ b/fairseq2n/src/fairseq2n/detail/exception.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <exception>
+#include <system_error>
 #include <utility>
 
 #include <fmt/core.h>

--- a/fairseq2n/src/fairseq2n/detail/parallel.h
+++ b/fairseq2n/src/fairseq2n/detail/parallel.h
@@ -1,0 +1,42 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <functional>
+
+#ifdef FAIRSEQ2N_USE_TBB
+#include <oneapi/tbb.h>
+#endif
+
+namespace fairseq2n::detail {
+
+template<typename T>
+void
+parallel_for(const std::function<void(T begin, T end)> &fn, T begin, T end)
+{
+#ifdef FAIRSEQ2N_USE_TBB
+    tbb::blocked_range<T> range{begin, end};
+
+    tbb::parallel_for(
+        range, [&fn](const tbb::blocked_range<T> &r)
+        {
+            fn(r.begin(), r.end());
+        });
+#else
+    // TODO: Use OpenMP!
+    fn(begin, end);
+#endif
+}
+
+template<typename T>
+inline void
+parallel_for(const std::function<void(T begin, T end)> &fn, T size)
+{
+    parallel_for(fn, T{}, size);
+}
+
+}  // namespace fairseq2n::detail


### PR DESCRIPTION
In preparation of ARM builds, this PR makes Intel oneTBB an optional dependency. 