### PR TITLE
Call non-typed Storage.data instead of unsafe_data

### DIFF
--- a/fairseq2n/cmake/modules/FindTorch.cmake
+++ b/fairseq2n/cmake/modules/FindTorch.cmake
@@ -73,6 +73,15 @@ if(Python3_Interpreter_FOUND)
     cmake_path(REPLACE_FILENAME torch_init_file lib OUTPUT_VARIABLE torch_lib_dir)
     cmake_path(REPLACE_FILENAME torch_init_file include OUTPUT_VARIABLE torch_include_dir)
 
+    cmake_path(
+        APPEND
+            torch_include_dir
+        #INPUTS
+            torch csrc api include
+        OUTPUT_VARIABLE
+            torch_api_include_dir
+    )
+
     unset(torch_init_file)
 endif()
 
@@ -86,8 +95,15 @@ find_library(C10_CUDA_LIBRARY c10_cuda HINTS ${torch_lib_dir} NO_DEFAULT_PATH)
 find_library(TORCH_PYTHON_LIBRARY torch_python HINTS ${torch_lib_dir} NO_DEFAULT_PATH)
 
 find_path(TORCH_INCLUDE_DIR torch HINTS ${torch_include_dir} NO_DEFAULT_PATH)
+find_path(TORCH_API_INCLUDE_DIR torch HINTS ${torch_api_include_dir} NO_DEFAULT_PATH)
 
-set(torch_required_vars TORCH_LIBRARY TORCH_CPU_LIBRARY C10_LIBRARY TORCH_INCLUDE_DIR)
+set(torch_required_vars
+    TORCH_LIBRARY
+    TORCH_CPU_LIBRARY
+    C10_LIBRARY
+    TORCH_INCLUDE_DIR
+    TORCH_API_INCLUDE_DIR
+)
 
 mark_as_advanced(${torch_required_vars} TORCH_CUDA_LIBRARY C10_CUDA_LIBRARY TORCH_PYTHON_LIBRARY)
 
@@ -104,6 +120,7 @@ find_package_handle_standard_args(Torch
 
 unset(torch_lib_dir)
 unset(torch_include_dir)
+unset(torch_api_include_dir)
 unset(torch_required_vars)
 
 if(NOT Torch_FOUND)
@@ -144,7 +161,7 @@ if(NOT TARGET torch)
 
     set_property(TARGET torch PROPERTY IMPORTED_LOCATION ${TORCH_LIBRARY})
 
-    target_include_directories(torch INTERFACE ${TORCH_INCLUDE_DIR})
+    target_include_directories(torch INTERFACE ${TORCH_INCLUDE_DIR} ${TORCH_API_INCLUDE_DIR})
 
     target_link_libraries(torch INTERFACE ${TORCH_CPU_LIBRARY} ${C10_LIBRARY} torch_cxx11_abi)
 

--- a/fairseq2n/src/fairseq2n/data/audio/audio_decoder.cc
+++ b/fairseq2n/src/fairseq2n/data/audio/audio_decoder.cc
@@ -11,7 +11,6 @@
 #include <stdexcept>
 
 #include <ATen/Functions.h>
-#include <ATen/Storage.h>
 #include <ATen/Tensor.h>
 
 #include "fairseq2n/exception.h"
@@ -20,6 +19,7 @@
 #include "fairseq2n/memory.h"
 #include "fairseq2n/span.h"
 #include "fairseq2n/data/audio/detail/sndfile.h"
+#include "fairseq2n/data/detail/tensor_storage.h"
 #include "fairseq2n/detail/exception.h"
 
 using namespace fairseq2n::detail;
@@ -63,9 +63,7 @@ audio_decoder::operator()(data &&d) const
     at::Tensor waveform = at::empty({file.num_frames(), file.num_channels()},
         at::dtype(dtype).device(at::kCPU).pinned_memory(opts_.pin_memory()));
 
-    const at::Storage &storage = waveform.storage();
-
-    writable_memory_span waveform_bits{storage.unsafe_data<std::byte>(), storage.nbytes()};
+    writable_memory_span waveform_bits = get_raw_mutable_storage(waveform);
 
     switch (dtype) {
     case at::kFloat: {

--- a/fairseq2n/src/fairseq2n/data/audio/detail/kaldi_fbank.cc
+++ b/fairseq2n/src/fairseq2n/data/audio/detail/kaldi_fbank.cc
@@ -11,10 +11,10 @@
 #include <utility>
 
 #include <ATen/Functions.h>
-#include <ATen/Storage.h>
 
 #include "fairseq2n/memory.h"
 #include "fairseq2n/span.h"
+#include "fairseq2n/data/detail/tensor_storage.h"
 #include "fairseq2n/detail/parallel.h"
 
 namespace fairseq2n::detail {
@@ -96,22 +96,18 @@ kaldi_fbank_compute_op::run() &&
     return std::move(fbank_);
 }
 
-span<float32>
+inline span<float32>
 kaldi_fbank_compute_op::get_fbank_storage() noexcept
 {
-    const at::Storage &storage = fbank_.storage();
-
-    writable_memory_span bits{storage.unsafe_data<std::byte>(), storage.nbytes()};
+    writable_memory_span bits = get_raw_mutable_storage(fbank_);
 
     return cast<float32>(bits);
 }
 
-span<const float32>
+inline span<const float32>
 kaldi_fbank_compute_op::get_waveform_storage() const noexcept
 {
-    const at::Storage &storage = waveform_->storage();
-
-    memory_span bits{storage.unsafe_data<std::byte>(), storage.nbytes()};
+    memory_span bits = get_raw_storage(*waveform_);
 
     return cast<const float32>(bits);
 }

--- a/fairseq2n/src/fairseq2n/data/detail/tensor_storage.h
+++ b/fairseq2n/src/fairseq2n/data/detail/tensor_storage.h
@@ -1,0 +1,40 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <cstddef>
+
+#include <ATen/Storage.h>
+#include <ATen/Tensor.h>
+#include <torch/version.h>
+
+#include "fairseq2n/memory.h"
+
+namespace fairseq2n::detail {
+
+inline memory_span
+get_raw_storage(const at::Tensor &tensor)
+{
+    const at::Storage &storage = tensor.storage();
+
+    return memory_span{static_cast<const std::byte *>(storage.data()), storage.nbytes()};
+}
+
+inline writable_memory_span
+get_raw_mutable_storage(const at::Tensor &tensor)
+{
+    const at::Storage &storage = tensor.storage();
+
+    return writable_memory_span{
+#if TORCH_VERSION_MAJOR < 2 || (TORCH_VERSION_MAJOR == 2 && TORCH_VERSION_MINOR < 1)
+        static_cast<std::byte *>(storage.data()), storage.nbytes()};
+#else
+        static_cast<std::byte *>(storage.mutable_data()), storage.nbytes()};
+#endif
+}
+
+}  // namespace fairseq2n::detail

--- a/fairseq2n/src/fairseq2n/data/text/sentencepiece/sp_encoder.cc
+++ b/fairseq2n/src/fairseq2n/data/text/sentencepiece/sp_encoder.cc
@@ -10,12 +10,12 @@
 #include <stdexcept>
 
 #include <ATen/Functions.h>
-#include <ATen/Storage.h>
 
 #include "fairseq2n/fmt.h"
 #include "fairseq2n/memory.h"
 #include "fairseq2n/span.h"
 #include "fairseq2n/data/immutable_string.h"
+#include "fairseq2n/data/detail/tensor_storage.h"
 #include "fairseq2n/data/text/sentencepiece/sp_model.h"
 #include "fairseq2n/data/text/sentencepiece/sp_processor.h"
 #include "fairseq2n/detail/exception.h"
@@ -79,9 +79,7 @@ sp_encoder_op::run() &&
     tensor_ = at::zeros({static_cast<std::int64_t>(seq_len_)},
         at::dtype(at::kLong).device(at::kCPU).pinned_memory(encoder_->opts_.pin_memory()));
 
-    const at::Storage &storage = tensor_.storage();
-
-    writable_memory_span tensor_bits{storage.unsafe_data<std::byte>(), storage.nbytes()};
+    writable_memory_span tensor_bits = get_raw_mutable_storage(tensor_);
 
     span tensor_data = cast<std::int64_t>(tensor_bits);
 


### PR DESCRIPTION
PyTorch 2.1 removes the `unsafe_data()` accessor for `Storage` type. This PR migrates such calls in fairseq2n to use the `data()` accessor.