### PR TITLE
Remove tbb link when not used

### DIFF
--- a/fairseq2n/src/fairseq2n/CMakeLists.txt
+++ b/fairseq2n/src/fairseq2n/CMakeLists.txt
@@ -108,7 +108,6 @@ target_link_libraries(fairseq2n
         kaldi-native-fbank::core
         kuba-zip
         natsort
-        TBB::tbb
         Threads::Threads
         sentencepiece-static
         SndFile::sndfile


### PR DESCRIPTION
**What does this PR do? Please describe:**

Trying to build the library from source on ARM64 CPU, https://github.com/facebookresearch/fairseq2/pull/4 has added support for tbb being optional, but I had to remove one more line to get cmake to work.

I think this should still work without problems on Intel where TBB is supported because of this line https://github.com/facebookresearch/fairseq2/blob/main/fairseq2n/src/fairseq2n/CMakeLists.txt#L119 but worth double checking if my thinking is right.


Related to #1

**Does your PR introduce any breaking changes? If yes, please list them:**
List of all backwards-incompatible changes.

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**?
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
