### PR TITLE
Support for Homebrew on ARM64

### DIFF
--- a/.github/workflows/ci_build_wheels.yaml
+++ b/.github/workflows/ci_build_wheels.yaml
@@ -77,7 +77,7 @@ jobs:
       matrix:
         include:
           - torch: '2.0.1'
-            py: '3.10'
+            py: '3.11'
     with:
       torch: ${{ matrix.torch }}
       py: ${{ matrix.py }}

--- a/src/fairseq2/__init__.py
+++ b/src/fairseq2/__init__.py
@@ -4,6 +4,10 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+
+# We import fairseq2n to report any initialization error eagerly.
+import fairseq2n
+
 __version__ = "0.2.0+devel"
 
 


### PR DESCRIPTION
This PR extends fairseq2n's dynamic linker lookup logic with `/opt/homebrew` on ARM64 systems.