### PR TITLE
Improve layer output hook API

### DIFF
--- a/src/fairseq2/models/w2vbert/model.py
+++ b/src/fairseq2/models/w2vbert/model.py
@@ -96,11 +96,13 @@ class W2VBertModel(Module):
             layer_output: Tensor,
             layer_padding_mask: Optional[Tensor],
             num_layers: int,
-        ) -> None:
+        ) -> bool:
             nonlocal w2v2_layer_output
 
             if layer_idx == num_layers - self.num_bert_encoder_layers - 1:
                 w2v2_layer_output = layer_output
+
+            return True
 
         # TODO: Should we pad for fp16?
         encoder_output, _ = self.w2v2_model.encoder(

--- a/src/fairseq2/nn/transformer/decoder.py
+++ b/src/fairseq2/nn/transformer/decoder.py
@@ -96,16 +96,22 @@ class DecoderLayerOutputHook(Protocol):
         layer_output: Tensor,
         layer_padding_mask: Optional[Tensor],
         num_layers: int,
-    ) -> None:
+    ) -> bool:
         """
         :param layer_idx:
             The index of the layer in the decoder stack.
         :param layer_output:
             The decoded output of the layer.
         :param layer_padding_mask:
-            The padding mask of `layer_output`.
+            The padding mask of ``layer_output``.
         :param num_layers:
             The number of layers in the decoder stack.
+
+        :returns:
+            ``True`` if the decoder should continue executing the remaining
+            layers in the stack; ``False`` if the decoder should stop executing
+            the remaining layers and treat this layer as the final layer in the
+            stack.
         """
 
 
@@ -202,7 +208,8 @@ class StandardTransformerDecoder(TransformerDecoder):
             )
 
             if layer_output_hook is not None:
-                layer_output_hook(layer_idx, seqs, padding_mask, num_layers)
+                if not layer_output_hook(layer_idx, seqs, padding_mask, num_layers):
+                    break
 
         if self.layer_norm is not None:
             seqs = self.layer_norm(seqs)


### PR DESCRIPTION
This PR introduces a small improvement to `layer_output_hook` parameter of `TransformerEncoder` and `TransformerDecoder` to skip remaining layers in a stack if requested by the hook. This is helpful to speed up models such as w2v-BERT unit extraction of SeamlessM4T.