### PR TITLE
Introduce restict_checkpoints parameter in ModelLoader

### DIFF
--- a/src/fairseq2/models/nllb/loader.py
+++ b/src/fairseq2/models/nllb/loader.py
@@ -89,7 +89,11 @@ class NllbLoader(ModelLoader[TransformerModel, NllbConfig]):
 
 
 load_nllb_model = NllbLoader(
-    asset_store, download_manager, create_nllb_model, nllb_archs
+    asset_store,
+    download_manager,
+    create_nllb_model,
+    nllb_archs,
+    restrict_checkpoints=False,
 )
 
 

--- a/src/fairseq2/models/s2t_transformer/loader.py
+++ b/src/fairseq2/models/s2t_transformer/loader.py
@@ -86,7 +86,11 @@ class S2TTransformerLoader(ModelLoader[TransformerModel, S2TTransformerConfig]):
 
 
 load_s2t_transformer_model = S2TTransformerLoader(
-    asset_store, download_manager, create_s2t_transformer_model, s2t_transformer_archs
+    asset_store,
+    download_manager,
+    create_s2t_transformer_model,
+    s2t_transformer_archs,
+    restrict_checkpoints=False,
 )
 
 

--- a/src/fairseq2/models/utils/model_loader.py
+++ b/src/fairseq2/models/utils/model_loader.py
@@ -123,6 +123,7 @@ class ModelLoader(Generic[ModelT, ModelConfigT]):
     download_manager: AssetDownloadManager
     model_factory: ModelFactory[ModelConfigT, ModelT]
     config_loader: ModelConfigLoader[ModelConfigT]
+    restrict_checkpoints: bool
 
     def __init__(
         self,
@@ -130,6 +131,7 @@ class ModelLoader(Generic[ModelT, ModelConfigT]):
         download_manager: AssetDownloadManager,
         model_factory: ModelFactory[ModelConfigT, ModelT],
         archs: ArchitectureRegistry[ModelConfigT],
+        restrict_checkpoints: bool = True,
     ) -> None:
         """
         :param asset_store:
@@ -140,12 +142,17 @@ class ModelLoader(Generic[ModelT, ModelConfigT]):
             The callable responsible for constructing models.
         :param archs:
             The registry containing all supported model architectures.
+        :param restrict_checkpoints:
+            If ``True``, restricts the Python unpickler to load only tensors,
+            primitive types, and dictionaries.
         """
         self.asset_store = asset_store
         self.download_manager = download_manager
         self.model_factory = model_factory
 
         self.config_loader = ModelConfigLoader(asset_store, archs)
+
+        self.restrict_checkpoints = restrict_checkpoints
 
     def __call__(
         self,
@@ -189,6 +196,7 @@ class ModelLoader(Generic[ModelT, ModelConfigT]):
             pathname,
             card.name,
             map_location="cpu",
+            restrict=self.restrict_checkpoints,
             converter=partial(self._upgrade_checkpoint, config=config),
         )
 


### PR DESCRIPTION
This PR introduces a new `restrict_checkpoints` parameter in `ModelLoader` as a safety measure. Unfortunately fairseq checkpoints hold several pickled Python objects and therefore cannot be loaded in restricted setting.