### PR TITLE
fix module names in w2vbert loader

### DIFF
--- a/src/fairseq2/models/w2vbert/loader.py
+++ b/src/fairseq2/models/w2vbert/loader.py
@@ -31,10 +31,10 @@ class W2VBertLoader(ModelLoader[W2VBertModel, W2VBertConfig]):
         state_dict = checkpoint["model"]
 
         # Check if we have a fairseq2 checkpoint.
-        if "w2v2.final_target_proj.weight" in state_dict:
+        if "w2v2_model.final_target_proj.weight" in state_dict:
             return checkpoint
 
-        state_dict["w2v2.quantizer.num_updates"] = torch.zeros((), device="cpu")
+        state_dict["w2v2_model.quantizer.num_updates"] = torch.zeros((), device="cpu")
 
         key_map = self._fairseq_key_map()
 
@@ -44,32 +44,32 @@ class W2VBertLoader(ModelLoader[W2VBertModel, W2VBertConfig]):
     def _fairseq_key_map() -> Dict[str, str]:
         return {
             # fmt: off
-            r"^encoder\.pos_conv\.0\.":                                    r"w2v2.encoder_frontend.pos_encoder.conv.",
-            r"^layer_norm\.":                                              r"w2v2.encoder_frontend.post_extract_layer_norm.",
-            r"^mask_emb":                                                  r"w2v2.masker.temporal_mask_embed",
-            r"^post_extract_proj\.":                                       r"w2v2.encoder_frontend.model_dim_proj.",
-            r"^quantizer\.vars":                                           r"w2v2.quantizer.entries",
-            r"^quantizer\.weight_proj\.":                                  r"w2v2.quantizer.entry_proj.",
-            r"^final_proj\.":                                              r"w2v2.final_proj.",
-            r"^project_q\.":                                               r"w2v2.final_target_proj.",
-            r"^encoder\.layers\.([0-9]+)\.conv_module\.batch_norm\.":      r"w2v2.encoder.layers.\1.conv.batch_norm.",
-            r"^encoder\.layers\.([0-9]+)\.conv_module\.depthwise_conv\.":  r"w2v2.encoder.layers.\1.conv.depthwise_conv.",
-            r"^encoder\.layers\.([0-9]+)\.conv_module\.layer_norm\.":      r"w2v2.encoder.layers.\1.conv_layer_norm.",
-            r"^encoder\.layers\.([0-9]+)\.conv_module\.pointwise_conv1\.": r"w2v2.encoder.layers.\1.conv.pointwise_conv1.",
-            r"^encoder\.layers\.([0-9]+)\.conv_module\.pointwise_conv2\.": r"w2v2.encoder.layers.\1.conv.pointwise_conv2.",
-            r"^encoder\.layers\.([0-9]+)\.ffn(1|2)\.layer_norm\.":         r"w2v2.encoder.layers.\1.ffn\2_layer_norm.",
-            r"^encoder\.layers\.([0-9]+)\.ffn(1|2)\.w_1\.":                r"w2v2.encoder.layers.\1.ffn\2.inner_proj.",
-            r"^encoder\.layers\.([0-9]+)\.ffn(1|2)\.w_2\.":                r"w2v2.encoder.layers.\1.ffn\2.output_proj.",
-            r"^encoder\.layers\.([0-9]+)\.self_attn_layer_norm\.":         r"w2v2.encoder.layers.\1.self_attn_layer_norm.",
-            r"^encoder\.layers\.([0-9]+)\.self_attn\.linear_q\.":          r"w2v2.encoder.layers.\1.self_attn.q_proj.",
-            r"^encoder\.layers\.([0-9]+)\.self_attn\.linear_k\.":          r"w2v2.encoder.layers.\1.self_attn.k_proj.",
-            r"^encoder\.layers\.([0-9]+)\.self_attn\.linear_v\.":          r"w2v2.encoder.layers.\1.self_attn.v_proj.",
-            r"^encoder\.layers\.([0-9]+)\.self_attn\.linear_out\.":        r"w2v2.encoder.layers.\1.self_attn.output_proj.",
-            r"^encoder\.layers\.([0-9]+)\.self_attn\.linear_pos\.":        r"w2v2.encoder.layers.\1.self_attn.sdpa.r_proj.",
-            r"^encoder\.layers\.([0-9]+)\.self_attn\.pos_bias_u":          r"w2v2.encoder.layers.\1.self_attn.sdpa.u_bias",
-            r"^encoder\.layers\.([0-9]+)\.self_attn\.pos_bias_v":          r"w2v2.encoder.layers.\1.self_attn.sdpa.v_bias",
-            r"^encoder\.layers\.([0-9]+)\.final_layer_norm\.":             r"w2v2.encoder.layers.\1.layer_norm.",
-            r"^encoder\.layer_norm\.":                                     r"w2v2.encoder.layer_norm.",
+            r"^encoder\.pos_conv\.0\.":                                    r"w2v2_model.encoder_frontend.pos_encoder.conv.",
+            r"^layer_norm\.":                                              r"w2v2_model.encoder_frontend.post_extract_layer_norm.",
+            r"^mask_emb":                                                  r"w2v2_model.masker.temporal_mask_embed",
+            r"^post_extract_proj\.":                                       r"w2v2_model.encoder_frontend.model_dim_proj.",
+            r"^quantizer\.vars":                                           r"w2v2_model.quantizer.entries",
+            r"^quantizer\.weight_proj\.":                                  r"w2v2_model.quantizer.entry_proj.",
+            r"^final_proj\.":                                              r"w2v2_model.final_proj.",
+            r"^project_q\.":                                               r"w2v2_model.final_target_proj.",
+            r"^encoder\.layers\.([0-9]+)\.conv_module\.batch_norm\.":      r"w2v2_model.encoder.layers.\1.conv.batch_norm.",
+            r"^encoder\.layers\.([0-9]+)\.conv_module\.depthwise_conv\.":  r"w2v2_model.encoder.layers.\1.conv.depthwise_conv.",
+            r"^encoder\.layers\.([0-9]+)\.conv_module\.layer_norm\.":      r"w2v2_model.encoder.layers.\1.conv_layer_norm.",
+            r"^encoder\.layers\.([0-9]+)\.conv_module\.pointwise_conv1\.": r"w2v2_model.encoder.layers.\1.conv.pointwise_conv1.",
+            r"^encoder\.layers\.([0-9]+)\.conv_module\.pointwise_conv2\.": r"w2v2_model.encoder.layers.\1.conv.pointwise_conv2.",
+            r"^encoder\.layers\.([0-9]+)\.ffn(1|2)\.layer_norm\.":         r"w2v2_model.encoder.layers.\1.ffn\2_layer_norm.",
+            r"^encoder\.layers\.([0-9]+)\.ffn(1|2)\.w_1\.":                r"w2v2_model.encoder.layers.\1.ffn\2.inner_proj.",
+            r"^encoder\.layers\.([0-9]+)\.ffn(1|2)\.w_2\.":                r"w2v2_model.encoder.layers.\1.ffn\2.output_proj.",
+            r"^encoder\.layers\.([0-9]+)\.self_attn_layer_norm\.":         r"w2v2_model.encoder.layers.\1.self_attn_layer_norm.",
+            r"^encoder\.layers\.([0-9]+)\.self_attn\.linear_q\.":          r"w2v2_model.encoder.layers.\1.self_attn.q_proj.",
+            r"^encoder\.layers\.([0-9]+)\.self_attn\.linear_k\.":          r"w2v2_model.encoder.layers.\1.self_attn.k_proj.",
+            r"^encoder\.layers\.([0-9]+)\.self_attn\.linear_v\.":          r"w2v2_model.encoder.layers.\1.self_attn.v_proj.",
+            r"^encoder\.layers\.([0-9]+)\.self_attn\.linear_out\.":        r"w2v2_model.encoder.layers.\1.self_attn.output_proj.",
+            r"^encoder\.layers\.([0-9]+)\.self_attn\.linear_pos\.":        r"w2v2_model.encoder.layers.\1.self_attn.sdpa.r_proj.",
+            r"^encoder\.layers\.([0-9]+)\.self_attn\.pos_bias_u":          r"w2v2_model.encoder.layers.\1.self_attn.sdpa.u_bias",
+            r"^encoder\.layers\.([0-9]+)\.self_attn\.pos_bias_v":          r"w2v2_model.encoder.layers.\1.self_attn.sdpa.v_bias",
+            r"^encoder\.layers\.([0-9]+)\.final_layer_norm\.":             r"w2v2_model.encoder.layers.\1.layer_norm.",
+            r"^encoder\.layer_norm\.":                                     r"w2v2_model.encoder.layer_norm.",
             r"^mlm_proj\.":                                                r"final_bert_proj.",
             # fmt: on
         }


### PR DESCRIPTION
**What does this PR do? Please describe:**
The module name of the w2v2 encoder in w2vbert was changed from `w2v2` to `w2v2_model` in https://github.com/facebookresearch/fairseq2/pull/35. This PR fixes the module names in w2vbert loader so the pretrained models could be loaded successfully.

**Does your PR introduce any breaking changes? If yes, please list them:**
None

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
