### PR TITLE
Fix state_bag parameter in MHA pos encoder

### DIFF
--- a/src/fairseq2/nn/transformer/multihead_attention.py
+++ b/src/fairseq2/nn/transformer/multihead_attention.py
@@ -457,7 +457,7 @@ class StandardMultiheadAttention(MultiheadAttention):
         v = v.flatten(0, 1)
 
         if self.pos_encoder is not None:
-            q = self.pos_encoder(q, padding_mask, state_bag)
+            q = self.pos_encoder(q, padding_mask, state_bag=state_bag)
             k = self.pos_encoder(k, key_padding_mask)
 
         mask_pad = 0


### PR DESCRIPTION
This PR fixes the passing of the `state_bag` argument to `pos_encoder` in MHA after the recent keyword-only parameter update.