### PR TITLE
Introduce pad_sequence

### DIFF
--- a/src/fairseq2/data/vocabulary_info.py
+++ b/src/fairseq2/data/vocabulary_info.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 
-@dataclass(frozen=True)
+@dataclass
 class VocabularyInfo:
     size: int
     """The size of the vocabulary."""

--- a/src/fairseq2/generation/sequence_generator.py
+++ b/src/fairseq2/generation/sequence_generator.py
@@ -6,17 +6,18 @@
 
 import math
 from dataclasses import dataclass
-from typing import List, Optional, Tuple, Union, cast
+from typing import List, Optional, Tuple, Union
 
 import torch
 from torch import Tensor
 from torch.nn.functional import log_softmax
 
-from fairseq2.data import Collater, SequenceData, VocabularyInfo
+from fairseq2.data import VocabularyInfo
 from fairseq2.generation.beam_search import BeamSearch, StandardBeamSearch
 from fairseq2.generation.logits_processor import LogitsProcessor
 from fairseq2.models.encoder_decoder import Seq2SeqDecoder
 from fairseq2.nn.incremental_state import IncrementalStateBag
+from fairseq2.nn.utils.seq import pad_sequence
 from fairseq2.typing import Device
 
 
@@ -63,14 +64,13 @@ class Seq2SeqGenerator:
     decoder: Seq2SeqDecoder
     opts: SequenceGeneratorOptions
     beam_size: int
-    eos_idx: int
-    pad_idx: Optional[int]
     unk_idx: Optional[int]
+    eos_idx: int
+    pad_idx: int
     prefix_seq: Union[int, Tensor]
     prefix_seq_len: int
     search: BeamSearch
     logits_processor: Optional[LogitsProcessor]
-    collater: Collater
 
     def __init__(
         self,
@@ -96,21 +96,22 @@ class Seq2SeqGenerator:
 
         self.opts = opts or SequenceGeneratorOptions()
 
-        # Set beam size.
-        if vocab_info.pad_idx is None:
-            self.beam_size = min(self.opts.beam_size, vocab_info.size)
-        else:
-            # -1 since we never select PAD.
-            self.beam_size = min(self.opts.beam_size, vocab_info.size - 1)
+        # Set beam size. -1 since we never select PAD.
+        self.beam_size = min(self.opts.beam_size, vocab_info.size - 1)
 
         if vocab_info.eos_idx is None:
             raise ValueError(
                 "`vocab_info` must have `eos_idx` set for sequence generation."
             )
 
+        if vocab_info.pad_idx is None:
+            raise ValueError(
+                "`vocab_info` must have `pad_idx` set for sequence generation."
+            )
+
         # Set vocab info.
-        self.eos_idx = vocab_info.eos_idx
         self.unk_idx = vocab_info.unk_idx
+        self.eos_idx = vocab_info.eos_idx
         self.pad_idx = vocab_info.pad_idx
 
         # Set prefix sequence.
@@ -135,12 +136,8 @@ class Seq2SeqGenerator:
 
         # Set beam search.
         self.search = self.opts.search or StandardBeamSearch()
-        self.logits_processor = self.opts.logits_processor
 
-        if vocab_info.pad_idx is None:
-            self.collater = Collater()
-        else:
-            self.collater = Collater(self.pad_idx, pad_to_multiple=2)
+        self.logits_processor = self.opts.logits_processor
 
     @torch.inference_mode()
     def __call__(
@@ -267,8 +264,7 @@ class Seq2SeqGenerator:
             # fmt: on
 
             # Never allow PAD.
-            if self.pad_idx is not None:
-                lprobs[:, :, self.pad_idx] = -torch.inf
+            lprobs[:, :, self.pad_idx] = -torch.inf
 
             # Apply UNK penalty.
             if self.unk_idx is not None:
@@ -449,7 +445,7 @@ class Seq2SeqGenerator:
             batch.sort(key=lambda b: b.score, reverse=True)  # type: ignore[arg-type, return-value]
 
         return SequenceGeneratorOutput(
-            results=finished_searches, device=device, collater=self.collater
+            results=finished_searches, device=device, pad_idx=self.pad_idx
         )
 
     def _determine_max_seq_len(self, source_seq_len: Optional[int]) -> int:
@@ -626,8 +622,8 @@ class SequenceGeneratorOutput:
     device: Device
     """The device on which generated sequences reside."""
 
-    collater: Optional[Collater] = None
-    """The collater to use in :meth:`collate`."""
+    pad_idx: int
+    """The index of the PAD symbol."""
 
     def collate(
         self, *, hypo_idx: int = 0, skip_batch: bool = False
@@ -648,9 +644,6 @@ class SequenceGeneratorOutput:
             the same index in the first returned value. *Shape:* :math:`(N)`,
             where :math:`N` is the number of search results.
         """
-        if self.collater is None:
-            raise RuntimeError("The output has no associated `Collater` instance.")
-
         if not self.results and not skip_batch:
             raise ValueError("The output must contain at least one search result.")
 
@@ -671,9 +664,7 @@ class SequenceGeneratorOutput:
             # Return a zero-dimensional (not scalar!) tensor.
             return torch.empty((0,), device=self.device, dtype=torch.int64), None
 
-        output = cast(SequenceData, self.collater(seqs))
-
-        return output["seqs"], output["seq_lens"] if output["is_ragged"] else None
+        return pad_sequence(seqs, self.pad_idx, pad_to_multiple=2)
 
 
 @dataclass

--- a/src/fairseq2/generation/text.py
+++ b/src/fairseq2/generation/text.py
@@ -5,12 +5,12 @@
 # LICENSE file in the root directory of this source tree.
 
 from dataclasses import dataclass
-from typing import List, Optional, Sequence, cast
+from typing import List, Optional, Sequence
 
 import torch
 from torch import Tensor
 
-from fairseq2.data import Collater, SequenceData, StringLike
+from fairseq2.data import StringLike
 from fairseq2.data.text import TextTokenDecoder, TextTokenEncoder, TextTokenizer
 from fairseq2.generation.sequence_generator import (
     Seq2SeqGenerator,
@@ -19,6 +19,7 @@ from fairseq2.generation.sequence_generator import (
 )
 from fairseq2.models.encoder_decoder import EncoderDecoderModel
 from fairseq2.nn.utils.module import infer_device
+from fairseq2.nn.utils.seq import pad_sequence
 
 
 class SequenceToTextGeneratorBase:
@@ -76,7 +77,6 @@ class SequenceToTextGeneratorBase:
             encoder_output, encoder_padding_mask, source_seq_len=source_seqs.size(1)
         )
 
-        # TODO: use parallel_invoke
         sentences = [self.token_decoder(b[0].seq)[0] for b in gen_output.results]
 
         return SequenceToTextOutput(
@@ -114,9 +114,7 @@ class SequenceToTextGenerator(SequenceToTextGeneratorBase):
     """
 
     def __call__(
-        self,
-        source_seqs: Tensor,
-        source_seq_lens: Optional[Tensor],
+        self, source_seqs: Tensor, source_seq_lens: Optional[Tensor]
     ) -> List[StringLike]:
         """
         :param source_seqs:
@@ -137,9 +135,7 @@ class SequenceToTextGenerator(SequenceToTextGeneratorBase):
         return output.sentences
 
     def generate_ex(
-        self,
-        source_seqs: Tensor,
-        source_seq_lens: Optional[Tensor],
+        self, source_seqs: Tensor, source_seq_lens: Optional[Tensor]
     ) -> SequenceToTextOutput:
         """
         :param source_seqs:
@@ -159,7 +155,7 @@ class TextTranslator(SequenceToTextGeneratorBase):
     """Translates text from one language to another."""
 
     source_encoder: TextTokenEncoder
-    collater: Collater
+    pad_idx: int
 
     def __init__(
         self,
@@ -189,7 +185,12 @@ class TextTranslator(SequenceToTextGeneratorBase):
             task="translation", lang=source_lang, mode="source", device=device
         )
 
-        self.collater = Collater(pad_idx=tokenizer.vocab_info.pad_idx)
+        if tokenizer.vocab_info.pad_idx is None:
+            raise ValueError(
+                "`tokenizer.vocab_info` must have `pad_idx` set for sequence generation."
+            )
+
+        self.pad_idx = tokenizer.vocab_info.pad_idx
 
     def __call__(self, source_sentences: Sequence[StringLike]) -> List[StringLike]:
         """
@@ -210,14 +211,8 @@ class TextTranslator(SequenceToTextGeneratorBase):
         :param source_sentences:
             The sentences in the source language.
         """
-        indices: List[Tensor] = []
-
-        # TODO: use parallel_invoke
-        for source_sentence in source_sentences:
-            indices.append(self.source_encoder(source_sentence))
-
-        batch = cast(SequenceData, self.collater(indices))
-
-        return self._do_generate(
-            batch["seqs"], batch["seq_lens"] if batch["is_ragged"] else None
+        seqs, seq_lens = pad_sequence(
+            [self.source_encoder(s) for s in source_sentences], pad_idx=self.pad_idx
         )
+
+        return self._do_generate(seqs, seq_lens)

--- a/src/fairseq2/nn/utils/seq.py
+++ b/src/fairseq2/nn/utils/seq.py
@@ -1,0 +1,49 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Optional, Sequence, Tuple, cast
+
+from torch import Tensor
+
+from fairseq2.data.data_pipeline import Collater, SequenceData
+
+
+def pad_sequence(
+    seqs: Sequence[Tensor], pad_idx: int = 0, pad_to_multiple: int = 1
+) -> Tuple[Tensor, Optional[Tensor]]:
+    """Stack ``seqs`` along the first dimension and pad them to equal length.
+
+    :param seqs:
+        The list of variable length sequences. All elements in ``seqs`` are
+        expected to have the same shape except the first dimension.
+    :param pad_idx:
+        The value for padded positions.
+    :param pad_to_multiple:
+        The sequence dimension is rounded up to the nearest multiple of the
+        specified value.
+
+    :returns:
+        - The padded sequence stack. *Shape:* :math:`(N,S,*)`, where :math:`N`
+          is the batch size, :math:`S` is the sequence length, and :math:`*` is
+          any number of sequence-specific dimensions including none.
+        - An array where each element represents the length of the sequence at
+          the same index in the first returned value. *Shape:* :math:`(N)`,
+          where :math:`N` is the batch size. ``None`` if all input sequences
+          have the same length and it is a multiple of ``pad_to_multiple``.
+    """
+    collater = Collater(pad_idx=pad_idx, pad_to_multiple=pad_to_multiple)
+
+    output = cast(SequenceData, collater(seqs))
+
+    padded_seqs, seq_lens = output["seqs"], output["seq_lens"]
+
+    if not output["is_ragged"]:
+        # If `pad_to_multiple` is greater than 1, we might still need to return
+        # the sequence lengths even if all sequences have the same length.
+        if padded_seqs.size(1) == seq_lens[0]:
+            return padded_seqs, None
+
+    return padded_seqs, seq_lens


### PR DESCRIPTION
This PR introduces a new `pad_sequence` utility function and updates sequence generator to use it. As an additional change we now require PAD symbol to be defined in sequence generator to simplify its implementation.