### PR TITLE
Rename upgrade_checkpoint to convert_checkpoint

### DIFF
--- a/src/fairseq2/models/llama/loader.py
+++ b/src/fairseq2/models/llama/loader.py
@@ -27,7 +27,7 @@ class LLaMALoader(ModelLoader[TransformerDecoderModel, LLaMAConfig]):
     """Loads LLaMA models."""
 
     @finaloverride
-    def _upgrade_checkpoint(
+    def _convert_checkpoint(
         self, checkpoint: Mapping[str, Any], config: LLaMAConfig
     ) -> Mapping[str, Any]:
         key_map = self._key_map()

--- a/src/fairseq2/models/nllb/loader.py
+++ b/src/fairseq2/models/nllb/loader.py
@@ -28,7 +28,7 @@ class NllbLoader(ModelLoader[TransformerModel, NllbConfig]):
     """Loads NLLB models."""
 
     @finaloverride
-    def _upgrade_checkpoint(
+    def _convert_checkpoint(
         self, checkpoint: Mapping[str, Any], config: NllbConfig
     ) -> Mapping[str, Any]:
         state_dict = checkpoint["model"]

--- a/src/fairseq2/models/s2t_transformer/loader.py
+++ b/src/fairseq2/models/s2t_transformer/loader.py
@@ -31,7 +31,7 @@ class S2TTransformerLoader(ModelLoader[TransformerModel, S2TTransformerConfig]):
     """Loads S2T Transformer models."""
 
     @finaloverride
-    def _upgrade_checkpoint(
+    def _convert_checkpoint(
         self, checkpoint: Mapping[str, Any], config: S2TTransformerConfig
     ) -> Mapping[str, Any]:
         key_map = self._fairseq_key_map()

--- a/src/fairseq2/models/utils/model_loader.py
+++ b/src/fairseq2/models/utils/model_loader.py
@@ -197,7 +197,7 @@ class ModelLoader(Generic[ModelT, ModelConfigT]):
             card.name,
             map_location="cpu",
             restrict=self.restrict_checkpoints,
-            converter=partial(self._upgrade_checkpoint, config=config),
+            converter=partial(self._convert_checkpoint, config=config),
         )
 
         try:
@@ -233,7 +233,7 @@ class ModelLoader(Generic[ModelT, ModelConfigT]):
 
         return model
 
-    def _upgrade_checkpoint(
+    def _convert_checkpoint(
         self, checkpoint: Mapping[str, Any], config: ModelConfigT
     ) -> Mapping[str, Any]:
         """Upgrade ``checkpoint`` to be compatible with fairseq2.

--- a/src/fairseq2/models/w2vbert/loader.py
+++ b/src/fairseq2/models/w2vbert/loader.py
@@ -25,7 +25,7 @@ class W2VBertLoader(ModelLoader[W2VBertModel, W2VBertConfig]):
     """Loads w2v-BERT models."""
 
     @finaloverride
-    def _upgrade_checkpoint(
+    def _convert_checkpoint(
         self, checkpoint: Mapping[str, Any], config: W2VBertConfig
     ) -> Mapping[str, Any]:
         state_dict = checkpoint["model"]

--- a/src/fairseq2/models/wav2vec2/loader.py
+++ b/src/fairseq2/models/wav2vec2/loader.py
@@ -26,7 +26,7 @@ class Wav2Vec2Loader(ModelLoader[Wav2Vec2Model, Wav2Vec2Config]):
     """Loads wav2vec 2.0 models."""
 
     @finaloverride
-    def _upgrade_checkpoint(
+    def _convert_checkpoint(
         self, checkpoint: Mapping[str, Any], config: Wav2Vec2Config
     ) -> Mapping[str, Any]:
         state_dict = checkpoint["model"]


### PR DESCRIPTION
This small PR renames `_upgrade_checkpoint` to `_convert_checkpoint` in `ModelLoader` since we have started handling checkpoints beyond fairseq.