### PR TITLE
Fix casual mask flag

### DIFF
--- a/src/fairseq2/nn/transformer/attention_mask.py
+++ b/src/fairseq2/nn/transformer/attention_mask.py
@@ -77,11 +77,13 @@ class CausalAttentionMaskGenerator:
 
             self._cached_attn_mask = mask
 
+        mask = mask[:seq_len, :seq_len]
+
         # The `is_causal` tag is checked by efficient SDPA implementations to
         # optimize attention masking.
         setattr(mask, "is_causal", True)
 
-        return mask[:seq_len, :seq_len]
+        return mask
 
     def __repr__(self) -> str:
         return "CausalAttentionMaskGenerator"


### PR DESCRIPTION
This PR fixes the bug where we discard the `causal_mask` flag after slicing the self attention mask.