### PR TITLE
Dataloader Doc

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -10,6 +10,7 @@ other content generation tasks.
 
 .. toctree::
    :caption: fairseq2 Reference
+   :maxdepth: 1
 
    reference/data
    reference/all

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -9,17 +9,8 @@ to train custom models for translation, summarization, language modeling, and
 other content generation tasks.
 
 .. toctree::
-   :maxdepth: 1
-   :caption: Tutorials
-
-   tutorials/cli/training
-   tutorials/cli/authoring
-   tutorials/data
-
-.. toctree::
    :caption: fairseq2 Reference
 
-   reference/cli
    reference/dataloader
    reference/all
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -10,12 +10,17 @@ other content generation tasks.
 
 .. toctree::
    :maxdepth: 1
-   :caption: fairseq2.nn Reference
+   :caption: Tutorials
 
-   reference/abc
-   reference/classes
-   reference/enums
-   reference/functions
+   tutorials/cli/training
+   tutorials/cli/authoring
+   tutorials/data
+
+.. toctree::
+   :caption: fairseq2 Reference
+
+   reference/cli
+   reference/dataloader
    reference/all
 
 .. toctree::

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -11,7 +11,7 @@ other content generation tasks.
 .. toctree::
    :caption: fairseq2 Reference
 
-   reference/dataloader
+   reference/data
    reference/all
 
 .. toctree::

--- a/doc/reference/data.rst
+++ b/doc/reference/data.rst
@@ -7,7 +7,7 @@ fairseq2.data
 ``fairseq2.data`` provides a Python API to build a C++ :py:class:`DataPipeline`.
 
 The dataloader will be able to leverage several threads,
-working around Python GIL limitations,
+working around Python Global Interpreter Lock limitations,
 and also providing better performance
 than a pure Python dataloader.
 
@@ -37,7 +37,29 @@ Functions to build a :py:class:`DataPipeline`:
     Collater
     CollateOptionsOverride
 
+Column syntax
+~~~~~~~~~~~~~
+
+The data items going through the pipeline don't have to be flat tensors, but can be tuples, or python dictionaries.
+Several operators have a syntax to specify a specific column of the input data.
+Notably the :py:func:`DataPipelineBuilder.map` operator
+has a `selector` argument to choose the column to apply the function to.
+
+If the data item is a tuple,
+then the selector ``"[3]"`` selects the third column.
+If the data item is a dictionary, then ``"foo"`` will select the value corresponding to the key ``"foo"``.
+You can nest selectors using ``.`` to separate key selectors, following a python-like syntax.
+For a data item ``{"foo": [{"x": 1, "y": 2}, {"x": 3, "y": 4, "z": 5}], "bar": 6}``,
+the selector ``"foo[1].y"`` referes to  the value 4.
+
+Functions that accepts several selectors,
+accept them as a comma separated list of selectors.
+For example ``.map(lambda x: x * 10, selector="foo[1].y,bar")``
+will multiply the values 4 and 6 by 10, but leave others unmodified.
+
+
 Public classes used in fairseq2 API:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autosummary::
     :toctree: generated/data

--- a/doc/reference/data.rst
+++ b/doc/reference/data.rst
@@ -5,7 +5,7 @@ fairseq2.data
 .. currentmodule:: fairseq2.data
 
 .. autosummary::
-    :toctree: generated/dataloader
+    :toctree: generated/data
 
     DataPipeline
     DataPipelineBuilder
@@ -22,9 +22,7 @@ fairseq2.data
     ByteStreamError
     CollateOptionsOverride
     DataPipelineError
-    FileMapperOutput
     RecordError
-    SequenceData
     PathLike
     StringLike
     get_last_failed_example

--- a/doc/reference/data.rst
+++ b/doc/reference/data.rst
@@ -4,32 +4,64 @@ fairseq2.data
 
 .. currentmodule:: fairseq2.data
 
+``fairseq2.data`` provides a Python API to build a C++ :py:class:`DataPipeline`.
+
+The dataloader will be able to leverage several threads,
+working around Python GIL limitations,
+and also providing better performance
+than a pure Python dataloader.
+
+Building a :py:class:`DataPipeline` looks like this::
+
+    data = (
+        text.read_text("file.tsv")
+        .map(lambda x: str(x.split("\t")[1]).lower())
+        .filter(lambda x: len(x) < 10)
+    )
+
+Functions to build a :py:class:`DataPipeline`:
+
+
 .. autosummary::
     :toctree: generated/data
 
     DataPipeline
     DataPipelineBuilder
-    CString
 
     list_files
     read_sequence
     read_zipped_records
-
-    Collater
+    text.read_text
     FileMapper
 
-    VocabularyInfo
-    ByteStreamError
+    Collater
     CollateOptionsOverride
-    DataPipelineError
-    RecordError
+
+Public classes used in fairseq2 API:
+
+.. autosummary::
+    :toctree: generated/data
+
+    CString
     PathLike
     StringLike
+    ByteStreamError
+    DataPipelineError
+    RecordError
+    VocabularyInfo
+
+Helper methods:
+
+.. autosummary::
+    :toctree: generated/data
+
     get_last_failed_example
     is_string_like
 
 fairseq2.data.text
 ~~~~~~~~~~~~~~~~~~
+
+Tools to tokenize text, converting it from bytes to tensors.
 
 .. currentmodule:: fairseq2.data.text
 
@@ -50,4 +82,3 @@ fairseq2.data.text
     SentencePieceDecoder
     vocabulary_from_sentencepiece
     LineEnding
-    read_text

--- a/doc/reference/dataloader.rst
+++ b/doc/reference/dataloader.rst
@@ -1,0 +1,55 @@
+fairseq2.data
+=============
+.. body
+
+.. currentmodule:: fairseq2.data
+
+.. autosummary::
+    :toctree: generated/dataloader
+
+    DataPipeline
+    DataPipelineBuilder
+    CString
+
+    list_files
+    read_sequence
+    read_zipped_records
+
+    Collater
+    FileMapper
+
+    VocabularyInfo
+    ByteStreamError
+    CollateOptionsOverride
+    DataPipelineError
+    FileMapperOutput
+    RecordError
+    SequenceData
+    PathLike
+    StringLike
+    get_last_failed_example
+    is_string_like
+
+fairseq2.data.text
+~~~~~~~~~~~~~~~~~~
+
+.. currentmodule:: fairseq2.data.text
+
+.. autosummary::
+    :toctree: generated/data_text
+
+    TextTokenizer
+    MultilingualTextTokenizer
+    TextTokenDecoder
+    TextTokenEncoder
+
+    StrSplitter
+    StrToIntConverter
+    StrToTensorConverter
+
+    SentencePieceModel
+    SentencePieceEncoder
+    SentencePieceDecoder
+    vocabulary_from_sentencepiece
+    LineEnding
+    read_text

--- a/src/fairseq2/data/data_pipeline.py
+++ b/src/fairseq2/data/data_pipeline.py
@@ -288,13 +288,14 @@ if TYPE_CHECKING or _DOC_MODE:
         The batch is returned as a dictionary with the following keys::
 
             {
-                "is_ragged": True/False # TODO what does this mean ???
+                "is_ragged": True/False # True if padding was needed
                 "seqs": [[1, 4, 5, 0], [1, 2, 3, 4]]  # "(Tensor) concatenated and padded tensors from the input
                 "seq_lens": [3, 4]  # A tensor describing the original length of each input tensor
             }
 
-        Collater will try to preserve the columns in the original data.
-        Applied to a tuple of lists, it will return a tuple of batches.
+        Collater preserves the shape of the original data.
+        For a tuple of lists, it returns a tuple of batches.
+        For a dict of lists, it returns a dict of lists.
         """
 
         def __init__(
@@ -305,7 +306,7 @@ if TYPE_CHECKING or _DOC_MODE:
         ) -> None:
             ...
 
-        def __call__(self, data: Sequence[Any]) -> Any:
+        def __call__(self, data: Any) -> Any:
             """Concatenates the input tensors"""
             ...
 

--- a/src/fairseq2/data/data_pipeline.py
+++ b/src/fairseq2/data/data_pipeline.py
@@ -161,6 +161,7 @@ if TYPE_CHECKING or _DOC_MODE:
 
             :param selector:
                 The column to apply the function to. Several colums can be specified by separating them with a ",".
+                See :ref:`reference/data:column syntax` for more details.
             :param num_parallel_calls:
                 The number of examples to process in parallel.
             """
@@ -251,10 +252,12 @@ if TYPE_CHECKING or _DOC_MODE:
     class CollateOptionsOverride:
         """Overrides how the collater should create batch for a particular column.
 
-        Useful if not all columns should use the same padding idx.
+        Useful if not all columns should use the same padding idx, or padding multiple.
         See :py:class:`Collater` for details.
 
-        :param selector: the column this overrides applies to.
+        :param selector:
+            The columns this overrides applies to.
+            See :ref:`reference/data:column syntax` for details on how the columns can be specified.
         """
 
         def __init__(
@@ -296,6 +299,17 @@ if TYPE_CHECKING or _DOC_MODE:
         Collater preserves the shape of the original data.
         For a tuple of lists, it returns a tuple of batches.
         For a dict of lists, it returns a dict of lists.
+
+        :param pad_idx:
+            When concatenating tensors of different lenght,
+            the value used to pad the shortest tensor
+
+        :param pad_to_multiple:
+            Always pad to a lenght of that multiple.
+
+        :param overrides:
+            List of overrides :py:class:`CollateOptionsOverride`.
+            Allows to override ``pad_idx`` and ``pad_to_multiple`` for specific columns.
         """
 
         def __init__(
@@ -307,7 +321,7 @@ if TYPE_CHECKING or _DOC_MODE:
             ...
 
         def __call__(self, data: Any) -> Any:
-            """Concatenates the input tensors"""
+            """Concatenate the input tensors"""
             ...
 
     class FileMapper:

--- a/src/fairseq2/data/data_pipeline.py
+++ b/src/fairseq2/data/data_pipeline.py
@@ -32,12 +32,17 @@ if TYPE_CHECKING or _DOC_MODE:
         """fairseq2 native data pipeline.
 
         The pipeline state can be persisted to the disk, allowing it to be resumed later.
-        It is a Python Iterable, but the returned iterator isn't standalone.
-        Calling `iter` a seconde time while the first iterator is still being used will segfault or worse.
+        It is a Python Iterable, but it also contains the iterator states.
+        Calling `iter` a second time while the first iterator is still being used
+        will segfault or worse.
         """
 
         def __iter__(self) -> Iterator[Any]:
-            """Return an iterator over the examples in the data pipeline."""
+            """Return an iterator over the examples in the data pipeline.
+
+            The iterator will modify the internal state of the this DataPipeline,
+            so it's not safe to have several iterators over the same DataPipeline.
+            """
 
         def reset(self) -> None:
             """Move back to the first example in the data pipeline."""
@@ -257,7 +262,7 @@ if TYPE_CHECKING or _DOC_MODE:
 
         :param selector:
             The columns this overrides applies to.
-            See :ref:`reference/data:column syntax` for details on how the columns can be specified.
+            See :ref:`reference/data:column syntax` for details on how to specify columns.
         """
 
         def __init__(
@@ -281,14 +286,15 @@ if TYPE_CHECKING or _DOC_MODE:
             ...
 
     class Collater:
-        """Concatenate a list of tensors into a single contiguous tensor.
+        """Concatenate a list of inputs into a single inputs.
 
-        Used to create batches. If all tensors in the input list have the same last dimension,
+        Used to create batches.
+        If all tensors in the input example have the same last dimension,
         ``Collater`` returns the concatenated tensors.
 
         Otherwise ``pad_idx`` is required, and the last dimension of the batch will
-        be the enough to fit the longest tensor, rounded up to ``pad_to_multiple``.
-        The batch is returned as a dictionary with the following keys::
+        be made long enough to fit the longest tensor, rounded up to ``pad_to_multiple``.
+        The returned batch is then a dictionary with the following keys::
 
             {
                 "is_ragged": True/False # True if padding was needed
@@ -301,11 +307,11 @@ if TYPE_CHECKING or _DOC_MODE:
         For a dict of lists, it returns a dict of lists.
 
         :param pad_idx:
-            When concatenating tensors of different lenght,
+            When concatenating tensors of different lengths,
             the value used to pad the shortest tensor
 
         :param pad_to_multiple:
-            Always pad to a lenght of that multiple.
+            Always pad to a length of that multiple.
 
         :param overrides:
             List of overrides :py:class:`CollateOptionsOverride`.
@@ -329,7 +335,6 @@ if TYPE_CHECKING or _DOC_MODE:
 
         The file name can also specify a slice of the file in bytes:
         ``FileMapper("big_file.txt:1024:48")`` will read 48 bytes at offset 1024.
-
 
         :param root_dir:
             Root directory for looking up relative file names.
@@ -362,7 +367,7 @@ if TYPE_CHECKING or _DOC_MODE:
             ...
 
     class ByteStreamError(RuntimeError):
-        """Raised when a dataset cannot be read."""
+        """Raised when a dataset file can't be read."""
 
     class RecordError(RuntimeError):
         """Raised when a corrupt record is encountered while reading a dataset."""

--- a/src/fairseq2/data/data_pipeline.py
+++ b/src/fairseq2/data/data_pipeline.py
@@ -254,14 +254,15 @@ if TYPE_CHECKING or _DOC_MODE:
 
     class Collater:
         """Concatenate a list of tensors into a single tensor.
-        Used to create batches.
-        Batches are represented by a dictionary with the following keys:
 
-        {
-            "is_ragged": True/False # TODO what does this mean ???
-            "seqs": Tensor the concatenated tensors from the input
-            "seq_lens": A tensor describing the original length of each input tensor
-        }
+        Used to create batches.
+        Batches are represented by a dictionary with the following keys::
+
+            {
+                "is_ragged": True/False # TODO what does this mean ???
+                "seqs": [[1, 4, 5, 0], [1, 2, 3, 4]]  # "(Tensor) the concatenated tensors from the input
+                "seq_lens": [3, 4]  # A tensor describing the original length of each input tensor
+            }
 
         Collater will try to preserve the columns in the original data.
         Applied to a tuple of lists, it will return a tuple of batches.

--- a/src/fairseq2/data/text/converters.py
+++ b/src/fairseq2/data/text/converters.py
@@ -15,6 +15,29 @@ from fairseq2.typing import DataType
 if TYPE_CHECKING or _DOC_MODE:
 
     class StrSplitter:
+        """Split string on a given character.
+
+        :param sep:
+            The character to split on (default to tab)
+
+        :param names:
+            names of the corresponding columns of the input tsv file
+            Will create dictionaries object with one entry per column
+
+        :param indices:
+            The indices of the column to keep.
+
+        Example usage::
+
+            # read all columns: ["Go.", "Va !", "CC-BY 2.0 (France)"]
+            dataloader = read_text("tatoeba.tsv").map(StrSplitter()).and_return()
+            # keep only the second column and convert to string: "Va !"
+            dataloader = read_text("tatoeba.tsv").map(StrSplitter(indices=[1])).map(lambda x: x[0]).and_return()
+            # keep only the first and second column and convert to dict: {"en": "Go.", "fr": "Va !"}
+            dataloader = read_text("tatoeba.tsv").map(StrSplitter(names=["en", "fr"], indices=[0, 1])).and_return()
+
+        """
+
         def __init__(
             self,
             sep: str = "\t",
@@ -30,6 +53,8 @@ if TYPE_CHECKING or _DOC_MODE:
             ...
 
     class StrToIntConverter:
+        """Parses integers in a given base"""
+
         def __init__(self, base: int = 10) -> None:
             ...
 

--- a/src/fairseq2/data/text/text_reader.py
+++ b/src/fairseq2/data/text/text_reader.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING or _DOC_MODE:
         memory_map: bool = False,
         block_size: Optional[int] = None,
     ) -> DataPipelineBuilder:
-        """Opens a text files and returns a data pipeline reading lines one by one."""
+        """Open a text files and return a data pipeline reading lines one by one."""
         ...
 
 else:

--- a/src/fairseq2/data/text/text_reader.py
+++ b/src/fairseq2/data/text/text_reader.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING or _DOC_MODE:
         memory_map: bool = False,
         block_size: Optional[int] = None,
     ) -> DataPipelineBuilder:
-        """Open a text files and return a data pipeline reading lines one by one."""
+        """Open a text file and return a data pipeline reading lines one by one."""
         ...
 
 else:

--- a/src/fairseq2/data/text/text_reader.py
+++ b/src/fairseq2/data/text/text_reader.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING or _DOC_MODE:
         memory_map: bool = False,
         block_size: Optional[int] = None,
     ) -> DataPipelineBuilder:
+        """Opens a text files and returns a data pipeline reading lines one by one."""
         ...
 
 else:

--- a/src/fairseq2/data/vocabulary_info.py
+++ b/src/fairseq2/data/vocabulary_info.py
@@ -10,6 +10,8 @@ from typing import Optional
 
 @dataclass
 class VocabularyInfo:
+    """Describes the vocabulary used by a :py:class:`fairseq2.data.text.TextTokenizer`"""
+
     size: int
     """The size of the vocabulary."""
 

--- a/src/fairseq2/data/vocabulary_info.py
+++ b/src/fairseq2/data/vocabulary_info.py
@@ -10,7 +10,7 @@ from typing import Optional
 
 @dataclass
 class VocabularyInfo:
-    """Describes the vocabulary used by a :py:class:`fairseq2.data.text.TextTokenizer`"""
+    """Describes the vocabulary used by a tokenizer"""
 
     size: int
     """The size of the vocabulary."""

--- a/src/fairseq2/memory.py
+++ b/src/fairseq2/memory.py
@@ -37,6 +37,9 @@ if TYPE_CHECKING or _DOC_MODE:
         def __len__(self) -> int:
             ...
 
+        def __bytes__(self) -> bytes:
+            ...
+
 else:
     from fairseq2n.bindings.memory import MemoryBlock as MemoryBlock
 

--- a/tests/unit/data/test_collater.py
+++ b/tests/unit/data/test_collater.py
@@ -217,6 +217,7 @@ class TestCollater:
         collater = Collater()
 
         assert collater(bucket) == {"foo1": [1]}
+        assert collater(1) == [1]
 
     def test_call_raises_error_when_items_have_different_types(self) -> None:
         bucket = [1, "foo", 2]


### PR DESCRIPTION
Exposes docstring documentation of the datapipeline APIs.
I've added a few docstring for uncommented operations.

While working on this, I came to the following questions:

* why aren't `zip` and `round_robin` in the same namespace than `map` (`DataPipeline` vs `DataPipelineBuilder`) or in `fairseq2.data` ?
* could we add an alias `.collate(pad_idx=PAD)` instead of `.map(Collater(pad_idx=PAD))` this would make it easier to document and explain
* if you want only one column `StrSplitter` is a bit awkward: `read_text("tatoeba.tsv").map(StrSplitter(indices=[1])).map(lambda x: x[0])` could we simplify that to `read_text("tatoeba.tsv").map(StrSplitter(indices=1))` ?
* `MemoryBlock` should be moved to `data.MemoryBlock`
* `read_text` could be promoted to `data` instead of `data.text`

Preview: 

![image](https://github.com/facebookresearch/fairseq2/assets/5920036/fa0250e7-7bc6-4184-bfcb-246753446d0b)