### PR TITLE
Compute positional encoding always in fp32

### DIFF
--- a/src/fairseq2/models/llama/builder.py
+++ b/src/fairseq2/models/llama/builder.py
@@ -304,7 +304,6 @@ class LLaMABuilder:
                 self.config.model_dim // num_heads,
                 self.config.max_seq_len,
                 device=self.device,
-                dtype=self.dtype,
             )
 
         return StandardMultiheadAttention(

--- a/src/fairseq2/models/nllb/builder.py
+++ b/src/fairseq2/models/nllb/builder.py
@@ -198,7 +198,6 @@ class NllbBuilder:
             self.config.max_seq_len,
             _legacy_pad_idx=self.config.pad_idx,
             device=self.device,
-            dtype=self.dtype,
         )
 
         return TransformerEmbeddingFrontend(

--- a/src/fairseq2/models/s2t_transformer/builder.py
+++ b/src/fairseq2/models/s2t_transformer/builder.py
@@ -308,10 +308,7 @@ class S2TTransformerBuilder:
             return None
 
         return SinusoidalPositionEncoder(
-            self.config.model_dim,
-            self.config.max_seq_len,
-            device=self.device,
-            dtype=self.dtype,
+            self.config.model_dim, self.config.max_seq_len, device=self.device
         )
 
     def build_target_position_encoder(self) -> PositionEncoder:
@@ -321,7 +318,6 @@ class S2TTransformerBuilder:
             self.config.max_seq_len,
             _legacy_pad_idx=self.config.target_pad_idx,
             device=self.device,
-            dtype=self.dtype,
         )
 
     def build_encoder(self) -> TransformerEncoder:
@@ -425,10 +421,7 @@ class S2TTransformerBuilder:
         if self.config.use_relative_pos:
             if self.rel_pos_encoding is None:
                 self.rel_pos_encoding = RelativePositionalEncoding(
-                    self.config.model_dim,
-                    self.config.max_seq_len,
-                    device=self.device,
-                    dtype=self.dtype,
+                    self.config.model_dim, self.config.max_seq_len, device=self.device
                 )
 
             sdpa = RelativePositionSDPA(

--- a/src/fairseq2/models/wav2vec2/builder.py
+++ b/src/fairseq2/models/wav2vec2/builder.py
@@ -344,10 +344,7 @@ class Wav2Vec2EncoderBuilder:
         if self.config.pos_encoder_type == "relative":
             if self.rel_pos_encoding is None:
                 self.rel_pos_encoding = RelativePositionalEncoding(
-                    self.config.model_dim,
-                    self.config.max_seq_len,
-                    device=self.device,
-                    dtype=self.dtype,
+                    self.config.model_dim, self.config.max_seq_len, device=self.device
                 )
 
             sdpa = RelativePositionSDPA(


### PR DESCRIPTION
This PR ensures that positional encoding types always use fp32 to have more numerical stability.