### PR TITLE
Revise Rotary encoder implementation

### DIFF
--- a/src/fairseq2/nn/position_encoder.py
+++ b/src/fairseq2/nn/position_encoder.py
@@ -16,7 +16,6 @@ from torch.nn.functional import embedding
 from torch.nn.parameter import Parameter
 
 from fairseq2.nn.incremental_state import IncrementalStateBag
-from fairseq2.nn.ops import repeat_interleave
 from fairseq2.typing import DataType, Device, finaloverride
 
 
@@ -151,7 +150,7 @@ class SinusoidalPositionEncoder(PositionEncoder):
             [ 1.0930e-02,  3.0000e-04, -5.1615e-01,  2.0000e+00]]) # pos 2
     """
 
-    weight: Tensor
+    freqs: Tensor
 
     def __init__(
         self,
@@ -175,11 +174,11 @@ class SinusoidalPositionEncoder(PositionEncoder):
         else:
             self._sin_offset = 1 + _legacy_pad_idx
 
-        weight = torch.empty(
+        freqs = torch.empty(
             (max_seq_len, encoding_dim), device=device, dtype=torch.float32
         )
 
-        self.register_buffer("weight", weight, persistent=False)
+        self.register_buffer("freqs", freqs, persistent=False)
 
         self.reset_parameters()
 
@@ -191,13 +190,10 @@ class SinusoidalPositionEncoder(PositionEncoder):
         """Reset the non-persistent buffers of the module."""
         num_sin = self.encoding_dim // 2
 
-        device, dtype = self.weight.device, self.weight.dtype
+        device, dtype = self.freqs.device, self.freqs.dtype
 
-        l_half = self.weight[:, :num_sin]
-        r_half = self.weight[:, num_sin:]
-
-        # (1, E)
-        indices = torch.arange(num_sin, device=device, dtype=dtype).unsqueeze(0)
+        l_half = self.freqs[:, :num_sin]
+        r_half = self.freqs[:, num_sin:]
 
         start = self._sin_offset
 
@@ -208,14 +204,14 @@ class SinusoidalPositionEncoder(PositionEncoder):
             start, start + self.max_seq_len, device=device, dtype=dtype
         )
 
-        # (S) -> (S, 1)
-        steps = steps.unsqueeze(1)
+        # (E)
+        indices = torch.arange(num_sin, device=device, dtype=dtype)
 
         # This is identical to tensor2tensor's implementation.
-        factors = torch.exp(indices * -math.log(10000) / (num_sin - 1))
+        freqs = torch.exp(indices * -math.log(10000) / (num_sin - 1))
 
-        # (S, 1) x (1, E) -> (S, E)
-        torch.matmul(steps, factors, out=l_half)
+        # (S) x (E) -> (S, E)
+        torch.outer(steps, freqs, out=l_half)
 
         r_half.copy_(l_half)
 
@@ -237,7 +233,7 @@ class SinusoidalPositionEncoder(PositionEncoder):
         else:
             start = 0
 
-        fp32_seqs = seqs.float() + self.weight[start : start + seq_len]
+        fp32_seqs = seqs.float() + self.freqs[start : start + seq_len]
 
         return fp32_seqs.type_as(seqs)
 
@@ -311,8 +307,7 @@ class RotaryEncoder(PositionEncoder):
     """Encodes sequences with relative positional information as described in
     :cite:t:`https://doi.org/10.48550/arxiv.2104.09864`."""
 
-    cos_weight: Tensor
-    sin_weight: Tensor
+    freqs: Tensor
 
     def __init__(
         self,
@@ -328,15 +323,11 @@ class RotaryEncoder(PositionEncoder):
                 f"`encoding_dim` must be even, but is {encoding_dim} instead."
             )
 
-        cos = torch.empty(
-            (max_seq_len, encoding_dim), device=device, dtype=torch.float32
-        )
-        sin = torch.empty(
-            (max_seq_len, encoding_dim), device=device, dtype=torch.float32
+        freqs = torch.empty(
+            (max_seq_len, encoding_dim // 2), device=device, dtype=torch.complex64
         )
 
-        self.register_buffer("cos_weight", cos, persistent=False)
-        self.register_buffer("sin_weight", sin, persistent=False)
+        self.register_buffer("freqs", freqs, persistent=False)
 
         self.reset_parameters()
 
@@ -346,30 +337,25 @@ class RotaryEncoder(PositionEncoder):
 
     def reset_non_persistent_buffers(self) -> None:
         """Reset the non-persistent buffers of the module."""
-        device, dtype = self.sin_weight.device, self.sin_weight.dtype
-
-        # (E)
-        indices = torch.arange(self.encoding_dim // 2, device=device, dtype=dtype)
-
-        # (E) -> (1, E)
-        indices = indices.unsqueeze(0)
+        device = self.freqs.device
 
         assert self.max_seq_len is not None
 
         # (S)
-        steps = torch.arange(self.max_seq_len, device=device, dtype=dtype)
+        steps = torch.arange(self.max_seq_len, device=device, dtype=torch.float32)
 
-        # (S, 1)
-        steps = steps.unsqueeze(1)
+        # (E / 2)
+        indices = torch.arange(
+            0, self.encoding_dim, step=2, device=device, dtype=torch.float32
+        )
 
-        # (S, 1) x (1, E) -> (S, E)
-        table = torch.matmul(steps, 10000 ** (-2.0 * indices / self.encoding_dim))
+        freqs = 1.0 / (10000.0 ** (indices / self.encoding_dim))
 
-        cos = torch.cos(table)
-        sin = torch.sin(table)
+        # (S) x (E / 2) -> (S, E / 2)
+        freqs = torch.outer(steps, freqs)
 
-        self.cos_weight[:] = repeat_interleave(cos, dim=-1, repeat=2)
-        self.sin_weight[:] = repeat_interleave(sin, dim=-1, repeat=2)
+        # (S, E / 2)
+        torch.polar(torch.ones_like(freqs), freqs, out=self.freqs)
 
     @finaloverride
     def _do_forward(
@@ -378,7 +364,6 @@ class RotaryEncoder(PositionEncoder):
         padding_mask: Optional[Tensor],
         state_bag: Optional[IncrementalStateBag],
     ) -> Tensor:
-        """:meta private:"""
         seq_len = seqs.size(-2)
 
         if not self.training and state_bag is not None:
@@ -386,16 +371,14 @@ class RotaryEncoder(PositionEncoder):
         else:
             start = 0
 
-        seqs_swapped = self._swap_pairs(seqs)
+        # (*, S, E) -> (*, S, E / 2, 2)
+        seqs = seqs.unflatten(-1, (-1, 2))
 
-        fp32_cos = self.cos_weight[start : start + seq_len] * seqs.float()
-        fp32_sin = self.sin_weight[start : start + seq_len] * seqs_swapped.float()
+        complex_seqs = torch.view_as_complex(seqs.float())
 
-        return (fp32_cos + fp32_sin).type_as(seqs)
+        complex_seqs = complex_seqs * self.freqs[start : start + seq_len]
 
-    @staticmethod
-    def _swap_pairs(seqs: Tensor) -> Tensor:
-        x1 = seqs[..., 0::2]
-        x2 = seqs[..., 1::2]
+        # (*, S, E / 2, 2) -> (*, S, E)
+        fp32_seqs = torch.view_as_real(complex_seqs).flatten(-2)
 
-        return torch.stack((-x2, x1), dim=-1).reshape(seqs.shape)
+        return fp32_seqs.type_as(seqs)

--- a/src/fairseq2/nn/transformer/attention.py
+++ b/src/fairseq2/nn/transformer/attention.py
@@ -198,10 +198,10 @@ def _naive_scaled_dot_product_attention(
     needs_weights: bool,
     training: bool,
 ) -> Tuple[Tensor, Optional[Tensor]]:
+    queries = queries * (queries.size(-1) ** -0.5)
+
     # (*, S, K) @ (*, K, S_kv) = (*, S, S_kv)
     attn_weights = torch.matmul(queries, keys.transpose(-1, -2))
-
-    attn_weights = attn_weights * (queries.size(-1) ** -0.5)
 
     if mask is not None:
         attn_weights = attn_weights + mask

--- a/src/fairseq2/nn/transformer/multihead_attention.py
+++ b/src/fairseq2/nn/transformer/multihead_attention.py
@@ -505,7 +505,7 @@ class StandardMultiheadAttention(MultiheadAttention):
             self._run_attn_weight_hooks(attn, attn_weights)
 
         # (N, H, S, V_h) -> (N, S, H, V_h)
-        attn = attn.permute(0, 2, 1, 3)
+        attn = attn.transpose(1, 2)
 
         if self.head_scale_weight is not None:
             attn = torch.einsum("nshv,h->nshv", attn, self.head_scale_weight)

--- a/src/fairseq2/nn/transformer/relative_attention.py
+++ b/src/fairseq2/nn/transformer/relative_attention.py
@@ -239,22 +239,16 @@ class RelativePositionalEncoding(Module):
         positive_w = self.weight[: self.max_seq_len]
         negative_w = self.weight[self.max_seq_len :]
 
-        # (E / 2)
-        indices = torch.arange(0, self.encoding_dim, step=2, device=device, dtype=dtype)
-
-        # (1, E / 2)
-        indices = indices.unsqueeze(0)
-
         # (S)
         steps = torch.arange(self.max_seq_len, device=device, dtype=dtype)
 
-        # (S, 1)
-        steps = steps.unsqueeze(1)
+        # (E / 2)
+        indices = torch.arange(0, self.encoding_dim, step=2, device=device, dtype=dtype)
 
         factors = torch.exp(indices * -math.log(10000) / self.encoding_dim)
 
-        # (S, 1) x (1, E / 2) -> (S, E / 2)
-        factors = torch.matmul(steps, factors)
+        # (S) x (E / 2) -> (S, E / 2)
+        factors = torch.outer(steps, factors)
 
         flipped_factors = factors.flip([0])
 

--- a/tests/unit/nn/test_position_encoder.py
+++ b/tests/unit/nn/test_position_encoder.py
@@ -19,7 +19,7 @@ from tests.common import assert_close, device, tmp_rng_seed
 
 class TestSinusoidalPositionEncoder:
     @staticmethod
-    def expected_weight() -> Tensor:
+    def expected_freqs() -> Tensor:
         # fmt: off
         return torch.tensor([
             [ 0.0000e+00,  0.0000e+00,  0.0000e+00,  0.0000e+00,  0.0000e+00,
@@ -97,7 +97,7 @@ class TestSinusoidalPositionEncoder:
     def test_init_works(self) -> None:
         m = SinusoidalPositionEncoder(encoding_dim=32, max_seq_len=10, device=device)
 
-        assert_close(m.weight, self.expected_weight())
+        assert_close(m.freqs, self.expected_freqs())
 
     def test_init_raises_error_when_encoding_dim_is_odd(self) -> None:
         with pytest.raises(
@@ -114,7 +114,7 @@ class TestSinusoidalPositionEncoder:
 
         assert y.shape == (3, 9, 4)
 
-        assert_close(y - x, m.weight[:9].expand_as(y))
+        assert_close(y - x, m.freqs[:9].expand_as(y))
 
         # Test with multiple batch dimensions.
         x = torch.randn((4, 3, 9, 4), device=device)
@@ -123,7 +123,7 @@ class TestSinusoidalPositionEncoder:
 
         assert y.shape == (4, 3, 9, 4)
 
-        assert_close(y - x, m.weight[:9].expand_as(y))
+        assert_close(y - x, m.freqs[:9].expand_as(y))
 
     @pytest.mark.parametrize("step", [0, 1, 2])
     def test_forward_works_in_incremental_eval(self, step: int) -> None:
@@ -142,7 +142,7 @@ class TestSinusoidalPositionEncoder:
 
         assert y.shape == (5, seq_len, 32)
 
-        assert_close(y - x, m.weight[step : step + seq_len].expand_as(y))
+        assert_close(y - x, m.freqs[step : step + seq_len].expand_as(y))
 
     def test_forward_raises_error_when_seq_len_is_out_of_range(self) -> None:
         m = SinusoidalPositionEncoder(encoding_dim=32, max_seq_len=3, device=device)


### PR DESCRIPTION
This PR revises the implementation of Rotary position encoder by using polar coordinates which reduces the number of matmuls by one. It typically speeds up the encoding by ~%30.