### PR TITLE
add `.collate` for `.map(Collater)`

### DIFF
--- a/fairseq2n/python/src/fairseq2n/bindings/data/data_pipeline.cc
+++ b/fairseq2n/python/src/fairseq2n/bindings/data/data_pipeline.cc
@@ -420,9 +420,8 @@ def_data_pipeline(py::module_ &data_module)
                     opt_overrides = *std::move(maybe_opt_overrides);
 
                 map_fn f = collater(opts, std::move(opt_overrides));
-                element_mapper mapper{f, std::nullopt};
 
-                self = std::move(self).map(std::move(mapper), num_parallel_calls);
+                self = std::move(self).map(std::move(f), num_parallel_calls);
 
                 return self;
             },

--- a/src/fairseq2/data/data_pipeline.py
+++ b/src/fairseq2/data/data_pipeline.py
@@ -33,8 +33,9 @@ if TYPE_CHECKING or _DOC_MODE:
 
         The pipeline state can be persisted to the disk, allowing it to be resumed later.
         It is a Python Iterable, but it also contains the iterator states.
-        Calling `iter` a second time while the first iterator is still being used
-        will segfault or worse.
+
+        Calling `iter` twice will create two iterators reading from the same dataloader,
+        and sharing the same state, so it will behave inconcistently.
         """
 
         def __iter__(self) -> Iterator[Any]:

--- a/src/fairseq2/data/data_pipeline.py
+++ b/src/fairseq2/data/data_pipeline.py
@@ -163,6 +163,7 @@ if TYPE_CHECKING or _DOC_MODE:
         ) -> Self:
             """Concatenate a list of inputs into a single inputs.
 
+            This is equivalent to calling `.map(Collater())`.
             See :py:class:`fairseq2.data.Collater` for details.
             """
 

--- a/src/fairseq2/data/data_pipeline.py
+++ b/src/fairseq2/data/data_pipeline.py
@@ -155,6 +155,17 @@ if TYPE_CHECKING or _DOC_MODE:
         ) -> Self:
             """Combine examples of similar shape into batches."""
 
+        def collate(
+            self,
+            pad_idx: Optional[int] = None,
+            pad_to_multiple: int = 1,
+            overrides: Optional[Sequence["CollateOptionsOverride"]] = None,
+        ) -> Self:
+            """Concatenate a list of inputs into a single inputs.
+
+            See :py:class:`fairseq2.data.Collater` for details.
+            """
+
         def filter(self, predicate: Callable[[Any], Any]) -> Self:
             """Filter examples from data pipeline and keep only those who match
             ``predicate``.

--- a/tests/unit/data/test_collater.py
+++ b/tests/unit/data/test_collater.py
@@ -9,7 +9,7 @@ import torch
 from torch.nn.functional import pad
 
 from fairseq2.data import CollateOptionsOverride, Collater, read_sequence
-from tests.common import assert_close, assert_equal, device
+from tests.common import assert_close, assert_equal, device, python_devel_only
 
 
 class TestCollater:
@@ -380,6 +380,7 @@ class TestCollater:
             Collater(overrides=[CollateOptionsOverride("foo", pad_to_multiple=2)])
 
 
+@pytest.mark.skipif(python_devel_only(), reason="fairseq2n 0.2.0")
 @pytest.mark.parametrize("pad_to_multiple,pad_size", [(1, 0), (2, 0), (3, 2), (8, 4)])
 def test_collate_works_when_input_has_sequence_tensors(
     pad_to_multiple: int, pad_size: int


### PR DESCRIPTION
As disscussed in #64 I propose to add a shortcut `.collate` to replace `.map(Collater)`.
This simplifies the API for the user, because they don't have to learn about the `Collater` class, and it's more discoverable because the `.collate` function will be documented next to the other data pipeline ops.