### PR TITLE
Improve RelativePositionalEncoding

### DIFF
--- a/src/fairseq2/models/s2t_transformer/builder.py
+++ b/src/fairseq2/models/s2t_transformer/builder.py
@@ -421,7 +421,10 @@ class S2TTransformerBuilder:
         if self.config.use_relative_pos:
             if self.rel_pos_encoding is None:
                 self.rel_pos_encoding = RelativePositionalEncoding(
-                    self.config.model_dim, self.config.max_seq_len, device=self.device
+                    self.config.model_dim,
+                    self.config.max_seq_len,
+                    device=self.device,
+                    dtype=self.dtype,
                 )
 
             sdpa = RelativePositionSDPA(

--- a/src/fairseq2/models/s2t_transformer/feature_extractor.py
+++ b/src/fairseq2/models/s2t_transformer/feature_extractor.py
@@ -117,4 +117,4 @@ class Conv1dFbankSubsampler(SequenceFeatureExtractor):
         for _ in range(len(self.layers)):
             seq_lens = (((seq_lens - 1) / self.stride) + 1.0).floor()
 
-        return seq_lens.type(num_frames.dtype)
+        return seq_lens.type_as(num_frames)

--- a/src/fairseq2/models/wav2vec2/builder.py
+++ b/src/fairseq2/models/wav2vec2/builder.py
@@ -344,7 +344,10 @@ class Wav2Vec2EncoderBuilder:
         if self.config.pos_encoder_type == "relative":
             if self.rel_pos_encoding is None:
                 self.rel_pos_encoding = RelativePositionalEncoding(
-                    self.config.model_dim, self.config.max_seq_len, device=self.device
+                    self.config.model_dim,
+                    self.config.max_seq_len,
+                    device=self.device,
+                    dtype=self.dtype,
                 )
 
             sdpa = RelativePositionSDPA(

--- a/src/fairseq2/models/wav2vec2/feature_extractor.py
+++ b/src/fairseq2/models/wav2vec2/feature_extractor.py
@@ -154,7 +154,7 @@ class Wav2Vec2FeatureExtractor(SequenceFeatureExtractor):
 
             seq_lens = (((seq_lens - kernel_size) / stride) + 1.0).floor()
 
-        return seq_lens.type(num_frames.dtype)
+        return seq_lens.type_as(num_frames)
 
     def extra_repr(self) -> str:
         """:meta private:"""

--- a/src/fairseq2/nn/transformer/attention.py
+++ b/src/fairseq2/nn/transformer/attention.py
@@ -198,10 +198,10 @@ def _naive_scaled_dot_product_attention(
     needs_weights: bool,
     training: bool,
 ) -> Tuple[Tensor, Optional[Tensor]]:
-    queries = queries * (queries.size(-1) ** -0.5)
-
     # (*, S, K) @ (*, K, S_kv) = (*, S, S_kv)
     attn_weights = torch.matmul(queries, keys.transpose(-1, -2))
+
+    attn_weights = attn_weights * (queries.size(-1) ** -0.5)
 
     if mask is not None:
         attn_weights = attn_weights + mask

--- a/src/fairseq2/nn/transformer/decoder_layer.py
+++ b/src/fairseq2/nn/transformer/decoder_layer.py
@@ -331,7 +331,7 @@ class StandardTransformerDecoderLayer(TransformerDecoderLayer):
             seqs = self.ffn_dropout(seqs)
 
         if self.residual_scale is not None:
-            residual = torch.mul(self.residual_scale, residual)
+            residual = self.residual_scale * residual
 
         seqs = seqs + residual
 

--- a/src/fairseq2/nn/transformer/encoder_layer.py
+++ b/src/fairseq2/nn/transformer/encoder_layer.py
@@ -220,7 +220,7 @@ class StandardTransformerEncoderLayer(TransformerEncoderLayer):
             seqs = self.ffn_dropout(seqs)
 
         if self.residual_scale is not None:
-            residual = torch.mul(self.residual_scale, residual)
+            residual = self.residual_scale * residual
 
         seqs = seqs + residual
 


### PR DESCRIPTION
This PR improves the performance of `RelativePositionalEmbedding` by initializing its non-persistent buffer in model's native dtype instead of float32.