### PR TITLE
Apply Bessel correction in fbank conversion

### DIFF
--- a/fairseq2n/src/fairseq2n/data/audio/waveform_to_fbank_converter.cc
+++ b/fairseq2n/src/fairseq2n/data/audio/waveform_to_fbank_converter.cc
@@ -70,7 +70,7 @@ waveform_to_fbank_converter::operator()(data &&d) const
     if (opts_.standardize()) {
         at::Tensor stdev{}, mean{};
 
-        std::tie(stdev, mean) = at::std_mean(fbank, /*dim=*/0, /*unbiased=*/true);
+        std::tie(stdev, mean) = at::std_mean(fbank, /*dim=*/0);
 
         fbank = at::divide(at::subtract(fbank, mean), stdev);
     }


### PR DESCRIPTION
Applying Bessel correction (default behavior) makes standardization numerically more stable (i.e. fp16) in fbank computation. 