### PR TITLE
Handle key padding mask reordering in beam search

### DIFF
--- a/src/fairseq2/nn/transformer/multihead_attention.py
+++ b/src/fairseq2/nn/transformer/multihead_attention.py
@@ -739,8 +739,7 @@ class MultiheadAttentionState(IncrementalState):
         self.k = self.k.index_select(0, new_order)
         self.v = self.v.index_select(0, new_order)
 
-        if self.has_mask:
-            self.key_padding_mask = self.key_padding_mask.index_select(0, new_order)
+        self.key_padding_mask = self.key_padding_mask.index_select(0, new_order)
 
 
 class StaticMultiheadAttentionState(IncrementalState):


### PR DESCRIPTION
This PR fixes the key padding mask reordering during beam search.