### PR TITLE
Skip fairseq2n tests in devel mode

### DIFF
--- a/.github/workflows/_test_py_devel.yaml
+++ b/.github/workflows/_test_py_devel.yaml
@@ -1,0 +1,65 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+on:
+  workflow_call:
+    inputs:
+      torch:
+        type: string
+        required: true
+      py:
+        type: string
+        required: true
+      arch:
+        type: string
+        default: 'x86_64'
+      run_on_device:
+        type: boolean
+        default: false
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/facebookresearch/fairseq2-ci-manylinux_${{ inputs.arch }}:1-cpu
+    steps:
+      - name: Check-out the repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Install libsndfile
+        run: |
+          yum --assumeyes install libsndfile-devel
+      - name: Create the Python virtual environment
+        run: |
+          python${{ inputs.py }} -m venv ~/venv
+
+          echo ~/venv/bin >> "$GITHUB_PATH"
+      - name: Install PyTorch
+        run: |
+          pip install torch==${{ inputs.torch }}
+      - name: Install fairseq2
+        run: |
+          pip install --editable .
+      - name: Install pytest
+        run: |
+          pip install --requirement requirements-devel.txt
+      - name: Run Python tests
+        env:
+          RUN_ON_DEVICE: ${{ inputs.run_on_device }}
+        run: |
+          if [[ $RUN_ON_DEVICE != true ]]; then
+            dev=cpu
+          else
+            dev=cuda:0
+          fi
+
+          pytest -rP --device $dev --verbose

--- a/.github/workflows/_test_py_devel.yaml
+++ b/.github/workflows/_test_py_devel.yaml
@@ -48,6 +48,8 @@ jobs:
           pip install torch==${{ inputs.torch }}
       - name: Install fairseq2
         run: |
+          unset CI
+
           pip install --editable .
       - name: Install pytest
         run: |

--- a/.github/workflows/ci_build_wheels.yaml
+++ b/.github/workflows/ci_build_wheels.yaml
@@ -14,6 +14,13 @@ on:
       - 'doc/**'
 
 jobs:
+  test_py_devel:
+    name: Test Python development
+    uses: ./.github/workflows/_test_py_devel.yaml
+    with:
+      torch: '2.0.1'
+      py: '3.11'
+
   build_wheel-linux:
     name: Build wheels (pt${{ matrix.torch }}, py${{ matrix.py }}, linux-x86_64, ${{ matrix.variant }}, ${{ matrix.sanitizers }})
     uses: ./.github/workflows/_build_wheel-linux.yaml

--- a/fairseq2n/src/fairseq2n/data/data_pipeline.cc
+++ b/fairseq2n/src/fairseq2n/data/data_pipeline.cc
@@ -241,7 +241,7 @@ data_pipeline::sample(
         });
     if (is_broken)
         throw_<std::invalid_argument>(
-            "At least one of the specified data pipelines is broken and cannot be used in sample.");
+            "At least one of the specified data pipelines is broken and cannot be sampled.");
 
     if (!weights)
         weights = std::vector<float32>(pipelines.size(), 1.0F / static_cast<float32>(pipelines.size()));

--- a/tests/common.py
+++ b/tests/common.py
@@ -60,3 +60,11 @@ def tmp_rng_seed(device: Device, seed: int = 0) -> Generator[None, None, None]:
         torch.manual_seed(seed)
 
         yield
+
+
+def python_devel_only() -> bool:
+    """Return ``True`` if fairseq2 is installed for Python development only."""
+    import fairseq2
+    import fairseq2n
+
+    return fairseq2.__version__ != fairseq2n.__version__


### PR DESCRIPTION
This PR introduces a new `python_devel_only` function to the test framework to filter out tests with native bindings in Python development mode (e.g. no `FAIRSEQ2N_DEVEL=1` env variable). It also adds a new workflow to CI to ensure that tests can run successfully in the typical Python-only user setup (i.e. `pip install -e .`). As a nit change, it also cleans up the syntax of the sample unit tests (mainly using `tmp_rng_seed` and aligning the test names with other op unit tests).

see #75 