### PR TITLE
Add a new "out" parameter to ModelLoader

### DIFF
--- a/src/fairseq2/models/llama/__init__.py
+++ b/src/fairseq2/models/llama/__init__.py
@@ -10,6 +10,7 @@ from fairseq2.models.llama.builder import create_llama_model as create_llama_mod
 from fairseq2.models.llama.builder import llama_archs as llama_archs
 from fairseq2.models.llama.loader import LLaMALoader as LLaMALoader
 from fairseq2.models.llama.loader import LLaMATokenizerLoader as LLaMATokenizerLoader
+from fairseq2.models.llama.loader import load_llama_config as load_llama_config
 from fairseq2.models.llama.loader import load_llama_model as load_llama_model
 from fairseq2.models.llama.loader import load_llama_tokenizer as load_llama_tokenizer
 from fairseq2.models.llama.tokenizer import LLaMATokenizer as LLaMATokenizer

--- a/src/fairseq2/models/nllb/__init__.py
+++ b/src/fairseq2/models/nllb/__init__.py
@@ -10,6 +10,7 @@ from fairseq2.models.nllb.builder import create_nllb_model as create_nllb_model
 from fairseq2.models.nllb.builder import nllb_arch as nllb_arch
 from fairseq2.models.nllb.builder import nllb_archs as nllb_archs
 from fairseq2.models.nllb.loader import NllbLoader as NllbLoader
+from fairseq2.models.nllb.loader import load_nllb_config as load_nllb_config
 from fairseq2.models.nllb.loader import load_nllb_model as load_nllb_model
 from fairseq2.models.nllb.loader import load_nllb_tokenizer as load_nllb_tokenizer
 from fairseq2.models.nllb.tokenizer import NllbTokenizer as NllbTokenizer

--- a/src/fairseq2/models/s2t_transformer/__init__.py
+++ b/src/fairseq2/models/s2t_transformer/__init__.py
@@ -26,6 +26,9 @@ from fairseq2.models.s2t_transformer.frontend import (
     S2TTransformerFrontend as S2TTransformerFrontend,
 )
 from fairseq2.models.s2t_transformer.loader import (
+    load_s2t_transformer_config as load_s2t_transformer_config,
+)
+from fairseq2.models.s2t_transformer.loader import (
     load_s2t_transformer_model as load_s2t_transformer_model,
 )
 from fairseq2.models.s2t_transformer.loader import (

--- a/src/fairseq2/models/w2vbert/__init__.py
+++ b/src/fairseq2/models/w2vbert/__init__.py
@@ -10,6 +10,7 @@ from fairseq2.models.w2vbert.builder import W2VBertConfig as W2VBertConfig
 from fairseq2.models.w2vbert.builder import create_w2vbert_model as create_w2vbert_model
 from fairseq2.models.w2vbert.builder import w2vbert_arch as w2vbert_arch
 from fairseq2.models.w2vbert.builder import w2vbert_archs as w2vbert_archs
+from fairseq2.models.w2vbert.loader import load_w2vbert_config as load_w2vbert_config
 from fairseq2.models.w2vbert.loader import load_w2vbert_model as load_w2vbert_model
 from fairseq2.models.w2vbert.model import W2VBertLoss as W2VBertLoss
 from fairseq2.models.w2vbert.model import W2VBertModel as W2VBertModel

--- a/src/fairseq2/models/wav2vec2/__init__.py
+++ b/src/fairseq2/models/wav2vec2/__init__.py
@@ -24,6 +24,7 @@ from fairseq2.models.wav2vec2.feature_extractor import (
     Wav2Vec2FeatureExtractor as Wav2Vec2FeatureExtractor,
 )
 from fairseq2.models.wav2vec2.frontend import Wav2Vec2Frontend as Wav2Vec2Frontend
+from fairseq2.models.wav2vec2.loader import load_wav2vec2_config as load_wav2vec2_config
 from fairseq2.models.wav2vec2.loader import load_wav2vec2_model as load_wav2vec2_model
 from fairseq2.models.wav2vec2.masker import Wav2Vec2Masker as Wav2Vec2Masker
 from fairseq2.models.wav2vec2.model import Wav2Vec2Loss as Wav2Vec2Loss

--- a/tests/integration/models/test_s2t_transformer.py
+++ b/tests/integration/models/test_s2t_transformer.py
@@ -12,10 +12,13 @@ import torch
 from fairseq2.generation import SequenceToTextGenerator
 from fairseq2.models.s2t_transformer import (
     S2TTransformerTokenizer,
+    create_s2t_transformer_model,
+    load_s2t_transformer_config,
     load_s2t_transformer_model,
     load_s2t_transformer_tokenizer,
 )
 from fairseq2.models.transformer import TransformerModel
+from fairseq2.typing import Device
 from tests.common import device
 
 TEST_FBANK_PATH: Final = Path(__file__).parent.joinpath("fbank.pt")
@@ -40,8 +43,12 @@ def test_load_s2t_transformer_mustc_st_jt_m() -> None:
 
 
 def test_load_s2t_conformer_covost_st_en_de() -> None:
-    model = load_s2t_transformer_model(
-        "s2t_conformer_covost_st_en_de", device=device, progress=False
+    config = load_s2t_transformer_config("s2t_conformer_covost_st_en_de")
+
+    model = create_s2t_transformer_model(config, device=Device("meta"))
+
+    load_s2t_transformer_model(
+        "s2t_conformer_covost_st_en_de", device=device, out=model, progress=False
     )
 
     tokenizer = load_s2t_transformer_tokenizer(
@@ -52,8 +59,12 @@ def test_load_s2t_conformer_covost_st_en_de() -> None:
 
 
 def test_load_s2t_conformer_rel_pos_covost_st_en_de() -> None:
-    model = load_s2t_transformer_model(
-        "s2t_conformer_covost_st_en_de_rel_pos", device=device, progress=False
+    config = load_s2t_transformer_config("s2t_conformer_covost_st_en_de_rel_pos")
+
+    model = create_s2t_transformer_model(config, device=device)
+
+    load_s2t_transformer_model(
+        "s2t_conformer_covost_st_en_de_rel_pos", out=model, progress=False
     )
 
     tokenizer = load_s2t_transformer_tokenizer(


### PR DESCRIPTION
This PR introduces a new `out` parameter in `ModelLoader` for complex use cases such as loading a model with its LoRA weights:

```
model = create_llama_model(config_7b, device="meta")

model = wrap_lora(model)

load_llama_model("finetuned_model", device="cuda:0", out=model)
```