### PR TITLE
Introduce set_default_sdpa

### DIFF
--- a/src/fairseq2/nn/transformer/__init__.py
+++ b/src/fairseq2/nn/transformer/__init__.py
@@ -6,8 +6,11 @@
 
 from fairseq2.nn.transformer.attention import SDPA as SDPA
 from fairseq2.nn.transformer.attention import NaiveSDPA as NaiveSDPA
+from fairseq2.nn.transformer.attention import SDPAFactory as SDPAFactory
 from fairseq2.nn.transformer.attention import TorchSDPA as TorchSDPA
 from fairseq2.nn.transformer.attention import create_default_sdpa as create_default_sdpa
+from fairseq2.nn.transformer.attention import sdpa as sdpa
+from fairseq2.nn.transformer.attention import set_default_sdpa as set_default_sdpa
 from fairseq2.nn.transformer.attention_mask import (
     ALiBiAttentionMaskGenerator as ALiBiAttentionMaskGenerator,
 )

--- a/tests/common.py
+++ b/tests/common.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import contextlib
+from contextlib import contextmanager
 from typing import Any, Generator, List, Union
 
 import torch
@@ -43,7 +43,7 @@ def has_no_nan(a: Tensor) -> bool:
     return not torch.any(torch.isnan(a))
 
 
-@contextlib.contextmanager
+@contextmanager
 def tmp_rng_seed(device: Device, seed: int = 0) -> Generator[None, None, None]:
     """Set a temporary manual RNG seed.
 


### PR DESCRIPTION
This PR introduces `set_default_sdpa` function and `sdpa` context manager to switch between different attention implementations during runtime.

```python
from fairseq2.nn.transformer import TorchSDPA, NaiveSDPA, set_default_sdpa, sdpa

set_default_sdpa(TorchSDPA)  # or None to use the library default

# Use naive SDPA for debugging (e.g. pdb)
with sdpa(NaiveSDPA)
    model = load_llama_model("llama_7b")
```