### PR TITLE
Require max_num_steps in IncrementalStateBag

### DIFF
--- a/src/fairseq2/generation/sequence_generator.py
+++ b/src/fairseq2/generation/sequence_generator.py
@@ -198,7 +198,7 @@ class Seq2SeqGenerator:
 
         cand_offsets = torch.arange(2 * beam_size, device=device)
 
-        state_bag = IncrementalStateBag()
+        state_bag = IncrementalStateBag(max_seq_len)
 
         # At this point, the state is fully initialized, kick off the search.
         self._bootstrap_seqs_and_scores(

--- a/src/fairseq2/nn/incremental_state.py
+++ b/src/fairseq2/nn/incremental_state.py
@@ -41,18 +41,20 @@ T = TypeVar("T", bound=IncrementalState)
 class IncrementalStateBag:
     """Holds the module states during an incremental evaluation."""
 
-    _step: int
+    step: int
+    max_num_steps: int
+
     _module_states: Dict[Module, IncrementalState]
 
-    def __init__(self) -> None:
-        self._step = 0
+    def __init__(self, max_num_steps: int) -> None:
+        """
+        :param max_num_steps:
+            The expected maximum number of steps to take.
+        """
+        self.step = 0
+        self.max_num_steps = max_num_steps
 
         self._module_states = {}
-
-    @property
-    def step(self) -> int:
-        """Return the current step in the sequence."""
-        return self._step
 
     def increment_step(self, delta: int = 1) -> None:
         """Increment the step.
@@ -64,7 +66,14 @@ class IncrementalStateBag:
         :param delta:
             The value by which to increment the step.
         """
-        self._step += delta
+        step = self.step + delta
+
+        if step >= self.max_num_steps:
+            raise ValueError(
+                f"The `delta` increment ({delta}) to the current step ({self.step}) exceeds the maximum number of steps ({self.max_num_steps})."
+            )
+
+        self.step = step
 
     def get_state(self, m: Module, kls: Type[T]) -> Optional[T]:
         """Get the incremental state of ``m``, or ``None`` if ``m`` is not

--- a/tests/integration/models/test_incremental_decode.py
+++ b/tests/integration/models/test_incremental_decode.py
@@ -83,7 +83,7 @@ def test_incremental_decoding_works() -> None:
     assert decoder_padding_mask is not None
 
     # Now try to match the decoder output with incremental decoding.
-    state_bag = IncrementalStateBag()
+    state_bag = IncrementalStateBag(max_num_steps=256)
 
     incremental_output       = torch.empty((3, 0, model.model_dim), device=device, dtype=torch.float32)
     incremental_padding_mask = torch.empty((3, 0),                  device=device, dtype=torch.float32)

--- a/tests/unit/nn/test_position_encoder.py
+++ b/tests/unit/nn/test_position_encoder.py
@@ -129,7 +129,7 @@ class TestSinusoidalPositionEncoder:
     def test_forward_works_in_incremental_eval(self, step: int) -> None:
         m = SinusoidalPositionEncoder(encoding_dim=32, max_seq_len=4, device=device)
 
-        state_bag = IncrementalStateBag()
+        state_bag = IncrementalStateBag(max_num_steps=3)
         state_bag.increment_step(delta=step)
 
         seq_len = 2
@@ -160,7 +160,7 @@ class TestSinusoidalPositionEncoder:
 
         x = torch.randn((5, 2, 32), device=device)
 
-        state_bag = IncrementalStateBag()
+        state_bag = IncrementalStateBag(max_num_steps=30)
         state_bag.increment_step(delta=20)  # out of range
 
         y = m(x, padding_mask=None, state_bag=state_bag)
@@ -204,7 +204,7 @@ class TestLearnedPositionEncoder:
     def test_forward_works_in_incremental_eval(self, step: int) -> None:
         m = LearnedPositionEncoder(encoding_dim=32, max_seq_len=4, device=device)
 
-        state_bag = IncrementalStateBag()
+        state_bag = IncrementalStateBag(max_num_steps=3)
         state_bag.increment_step(delta=step)
 
         seq_len = 2
@@ -235,7 +235,7 @@ class TestLearnedPositionEncoder:
 
         x = torch.randn((5, 2, 32), device=device)
 
-        state_bag = IncrementalStateBag()
+        state_bag = IncrementalStateBag(max_num_steps=30)
         state_bag.increment_step(delta=20)  # out of range
 
         y = m(x, padding_mask=None, state_bag=state_bag)
@@ -287,7 +287,7 @@ class TestRotaryEncoder:
     def test_forward_works_in_incremental_eval(self, step: int) -> None:
         m = RotaryEncoder(encoding_dim=32, max_seq_len=4, device=device)
 
-        state_bag = IncrementalStateBag()
+        state_bag = IncrementalStateBag(max_num_steps=3)
         state_bag.increment_step(delta=step)
 
         seq_len = 2
@@ -322,7 +322,7 @@ class TestRotaryEncoder:
 
         x = torch.randn((5, 2, 32), device=device)
 
-        state_bag = IncrementalStateBag()
+        state_bag = IncrementalStateBag(max_num_steps=30)
         state_bag.increment_step(delta=20)  # out of range
 
         y = m(x, padding_mask=None, state_bag=state_bag)


### PR DESCRIPTION
This PR adds a new `max_num_steps` parameter to `IncrementalStateBag` for better memory handling during incremental evaluation. It simplifies the cache logic within `MultiheadAttentionState` and ensures that we never allocate more than the expected maximum sequence length.