### PR TITLE
Introduce LoRA layers and wrappers

### DIFF
--- a/src/fairseq2/models/llama/__init__.py
+++ b/src/fairseq2/models/llama/__init__.py
@@ -8,6 +8,7 @@ from fairseq2.models.llama.builder import LLaMABuilder as LLaMABuilder
 from fairseq2.models.llama.builder import LLaMAConfig as LLaMAConfig
 from fairseq2.models.llama.builder import create_llama_model as create_llama_model
 from fairseq2.models.llama.builder import llama_archs as llama_archs
+from fairseq2.models.llama.builder import get_llama_lora_config as get_llama_lora_config
 from fairseq2.models.llama.loader import LLaMALoader as LLaMALoader
 from fairseq2.models.llama.loader import LLaMATokenizerLoader as LLaMATokenizerLoader
 from fairseq2.models.llama.loader import load_llama_model as load_llama_model

--- a/src/fairseq2/models/llama/__init__.py
+++ b/src/fairseq2/models/llama/__init__.py
@@ -7,8 +7,8 @@
 from fairseq2.models.llama.builder import LLaMABuilder as LLaMABuilder
 from fairseq2.models.llama.builder import LLaMAConfig as LLaMAConfig
 from fairseq2.models.llama.builder import create_llama_model as create_llama_model
-from fairseq2.models.llama.builder import llama_archs as llama_archs
 from fairseq2.models.llama.builder import get_llama_lora_config as get_llama_lora_config
+from fairseq2.models.llama.builder import llama_archs as llama_archs
 from fairseq2.models.llama.loader import LLaMALoader as LLaMALoader
 from fairseq2.models.llama.loader import LLaMATokenizerLoader as LLaMATokenizerLoader
 from fairseq2.models.llama.loader import load_llama_config as load_llama_config

--- a/src/fairseq2/models/llama/builder.py
+++ b/src/fairseq2/models/llama/builder.py
@@ -365,5 +365,5 @@ def get_llama_lora_config() -> LoRAConfig:
         r=8,
         alpha=16.0,
         dropout_p=0.05,
-        keys=[".*decoder.layers.*.self_attn.*(q_proj|v_proj)$"]
+        keys=[".*decoder.layers.*.self_attn.*(q_proj|v_proj)$"],
     )

--- a/src/fairseq2/models/llama/builder.py
+++ b/src/fairseq2/models/llama/builder.py
@@ -15,6 +15,7 @@ from fairseq2.models.transformer import (
 )
 from fairseq2.models.utils.arch_registry import ArchitectureRegistry
 from fairseq2.nn.embedding import Embedding
+from fairseq2.nn.lora import LoRAConfig
 from fairseq2.nn.normalization import LayerNorm, RMSNorm
 from fairseq2.nn.position_encoder import RotaryEncoder
 from fairseq2.nn.transformer import (
@@ -357,3 +358,12 @@ def create_llama_model(
         The data type of module parameters and buffers.
     """
     return LLaMABuilder(config, device=device, dtype=dtype).build_model()
+
+
+def get_llama_lora_config() -> LoRAConfig:
+    return LoRAConfig(
+        r=8,
+        alpha=16.0,
+        dropout_p=0.05,
+        keys=[".*decoder.layers.*.self_attn.*(q_proj|v_proj)$"]
+    )

--- a/src/fairseq2/nn/__init__.py
+++ b/src/fairseq2/nn/__init__.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from fairseq2.nn.embedding import Embedding as Embedding
+from fairseq2.nn.embedding import StandardEmbedding as StandardEmbedding
 from fairseq2.nn.incremental_state import IncrementalState as IncrementalState
 from fairseq2.nn.incremental_state import IncrementalStateBag as IncrementalStateBag
 from fairseq2.nn.module_list import ModuleList as ModuleList

--- a/src/fairseq2/nn/lora.py
+++ b/src/fairseq2/nn/lora.py
@@ -1,0 +1,139 @@
+from dataclasses import dataclass
+from typing import List, Optional, final
+
+import math
+import torch
+from torch import Tensor
+import torch.nn as nn
+
+from abc import ABC, abstractmethod
+from fairseq2.nn import Embedding, Projection
+from torch.nn import Dropout
+from torch.nn.functional import linear
+from torch.nn.parameter import Parameter
+
+from fairseq2.typing import DataType, Device
+
+
+@dataclass
+class LoRAConfig:
+    r: int
+    alpha: float
+    dropout_p: float
+    keys: List[str]
+
+
+class LoRALayer(ABC):
+    def __init__(self, config: LoRAConfig):
+        self.r = config.r
+        self.alpha = config.alpha
+        self.scaling = self.alpha / self.r
+        self.dropout_p = config.dropout_p
+
+    @property
+    @abstractmethod
+    def wrapped_module(self) -> nn.Module:
+        ...
+
+    @abstractmethod
+    def merge(self) -> None:
+        ...
+
+    @abstractmethod
+    def unmerge(self) -> None:
+        ...
+
+
+@final
+class LoRALinear(Projection, LoRALayer):
+
+    weight: Parameter
+    bias: Optional[Parameter]
+    lora_A: Parameter
+    lora_B: Parameter
+    dropout: Optional[Dropout]
+    skip_init: bool
+    merged: bool
+
+    def __init__(
+            self,
+            wrapped: Projection,
+            config: LoRAConfig,
+            skip_init: bool = False,
+            device: Device=None,
+            dtype: DataType=None
+        ) -> None:
+        Projection.__init__(self, wrapped.input_dim, wrapped.output_dim)
+
+        LoRALayer.__init__(self, config)
+
+        self.weight = Parameter(
+            wrapped.weight, requires_grad=False
+        )
+
+        if wrapped.bias is not None:
+            self.bias = Parameter(
+                wrapped.bias, requires_grad=False
+            )
+        else:
+            self.register_module("bias", None)
+
+        self.lora_A = Parameter(
+            torch.empty((self.r, self.input_dim), device=device, dtype=dtype)
+        )
+
+        self.lora_B = Parameter(
+            torch.empty((self.output_dim, self.r), device=device, dtype=dtype)
+        )
+
+        if self.dropout_p > 0.:
+            self.dropout = Dropout(self.dropout_p)
+
+        else:
+            self.register_module('dropout', None)
+
+        self.merged = False
+
+        self.skip_init = skip_init
+
+        self.reset_parameters()
+
+    def forward(self, x: Tensor) -> Tensor:
+        if self.merged:
+            return linear(x, self.weight, self.bias)
+
+        else:
+            h1 = linear(x, self.weight, self.bias)
+
+            if self.dropout is not None:
+                h2 = linear(self.dropout(x), self.lora_B @ self.lora_A * self.scaling)
+
+            else:
+                h2 = linear(x, self.lora_B @ self.lora_A * self.scaling)
+
+            return h1 + h2
+    
+    def reset_parameters(self) -> None:
+        """Reset the parameters and buffers of the module."""
+        if not self.skip_init:
+            nn.init.kaiming_uniform_(self.lora_A, a=math.sqrt(5))
+
+            nn.init.kaiming_uniform_(self.lora_B, a=math.sqrt(5))
+
+    def wrapped_module(self) -> nn.Module:
+        return self
+
+    def merge(self) -> None:
+        if self.merged:
+            return
+        self.weight.data += torch.matmul(self.lora_B.data, self.lora_A.data) * self.scaling
+
+        self.merged = True
+    
+    def unmerge(self) -> None:
+        if not self.merged:
+            return
+        else:
+            self.weight.data -= torch.matmul(self.lora_B.data, self.lora_A.data) * self.scaling
+
+            self.merged = False

--- a/src/fairseq2/nn/lora.py
+++ b/src/fairseq2/nn/lora.py
@@ -17,7 +17,7 @@ from torch.nn import Dropout
 from torch.nn.functional import embedding, linear
 from torch.nn.parameter import Parameter
 
-from fairseq2.nn import Embedding, Linear, Projection, StandardEmbedding
+from fairseq2.nn import Embedding, Projection
 from fairseq2.typing import DataType, Device
 
 
@@ -304,7 +304,6 @@ def unwrap_lora(module: nn.Module, merge: bool = True) -> nn.Module:
                 f"Cannot unwrap the module '{name}' as the module type '{type(submodule).__name__}' is not supported."
             )
 
-        unwrapped_layer.train(mode=submodule.training)
         setattr(parent, submodule_name, unwrapped_layer)
 
     return module

--- a/src/fairseq2/nn/lora.py
+++ b/src/fairseq2/nn/lora.py
@@ -176,7 +176,7 @@ class LoRALinear(Projection, LoRALayer):
             self.wrapped.bias.requires_grad_(False)
             self.bias = self.wrapped.bias  # type: ignore[assignment]
         else:
-            self.register_module("bias", None)
+            self.register_parameter("bias", None)
 
         self.lora_A = Parameter(
             torch.empty((self.r, self.input_dim), device=device, dtype=dtype)

--- a/src/fairseq2/nn/lora.py
+++ b/src/fairseq2/nn/lora.py
@@ -1,3 +1,9 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import re
 from dataclasses import dataclass
 from typing import Any, Dict, List, Literal, Optional, final

--- a/src/fairseq2/nn/lora.py
+++ b/src/fairseq2/nn/lora.py
@@ -1,6 +1,6 @@
 import re
 from dataclasses import dataclass
-from typing import List, Literal, Optional, final
+from typing import Any, Dict, List, Literal, Optional, final
 
 import math
 import torch
@@ -226,6 +226,16 @@ def unmerge_lora(module: nn.Module) -> None:
     for submodule in module.modules():
         if isinstance(submodule, LoRALayer):
             submodule.unmerge()
+
+
+def lora_state_dict(module: nn.Module) -> Dict[str, Any]:
+    state_dict = module.state_dict()
+    lora_states = {
+        name: state
+        for name, state in state_dict.items()
+        if "lora_" in name
+    }
+    return lora_states
 
 
 def freeze_non_lora(module: nn.Module, unfreeze_bias: Literal["none", "all", "lora_only"] = "none") -> None:

--- a/src/fairseq2/nn/lora.py
+++ b/src/fairseq2/nn/lora.py
@@ -118,8 +118,7 @@ class LoRALinear(Projection, LoRALayer):
         """Reset the parameters and buffers of the module."""
         if not self.skip_init:
             nn.init.kaiming_uniform_(self.lora_A, a=math.sqrt(5))
-
-            nn.init.kaiming_uniform_(self.lora_B, a=math.sqrt(5))
+            nn.init.zeros_(self.lora_B)
 
     def wrapped_module(self) -> nn.Module:
         return self

--- a/tests/integration/models/test_llama_lora.py
+++ b/tests/integration/models/test_llama_lora.py
@@ -1,0 +1,66 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+from fairseq2.models.llama import create_llama_model, get_llama_lora_config, llama_archs
+from fairseq2.nn.lora import (
+    wrap_lora,
+    unwrap_lora,
+    merge_lora,
+    unmerge_lora,
+    freeze_non_lora
+)
+
+
+def test_lora_wrappers_llama_works() -> None:
+    llama_config = llama_archs.get_config("7b")
+    model = create_llama_model(llama_config, device="cpu")
+
+    lora_config = get_llama_lora_config()
+
+    inputs = torch.LongTensor([[1, 2], [1, 3]], device="cpu")
+
+    model.eval()
+
+    with torch.inference_mode():
+        output_before_wrap, _ = model.decode(seqs=inputs, seq_lens=None)
+
+    model = wrap_lora(model, lora_config)
+
+    with torch.inference_mode():
+        output_after_wrap, _ = model.decode(seqs=inputs, seq_lens=None)
+
+    # Outputs should be the same as lora_B is initialized with zeros.
+    torch.testing.assert_close(output_before_wrap, output_after_wrap)
+
+    model = unwrap_lora(model, merge=False)
+
+    with torch.inference_mode():
+        output_after_unwrap, _ = model.decode(seqs=inputs, seq_lens=None)
+
+    torch.testing.assert_close(output_after_wrap, output_after_unwrap)
+
+    model = wrap_lora(model, lora_config)
+    merge_lora(model)
+
+    with torch.inference_mode():
+        output_after_merge, _ = model.decode(seqs=inputs, seq_lens=None)
+
+    torch.testing.assert_close(output_after_unwrap, output_after_merge)
+
+    unmerge_lora(model)
+
+    with torch.inference_mode():
+        output_after_unmerge, _ = model.decode(seqs=inputs, seq_lens=None)
+
+    torch.testing.assert_close(output_after_merge, output_after_unmerge)
+
+    model.train()
+    freeze_non_lora(model, unfreeze_bias="none")
+
+    for name, param in model.named_parameters():
+        if param.requires_grad:
+            assert "lora_" in name

--- a/tests/integration/models/test_llama_lora.py
+++ b/tests/integration/models/test_llama_lora.py
@@ -5,13 +5,14 @@
 # LICENSE file in the root directory of this source tree.
 
 import torch
+
 from fairseq2.models.llama import create_llama_model, get_llama_lora_config, llama_archs
 from fairseq2.nn.lora import (
-    wrap_lora,
-    unwrap_lora,
+    freeze_non_lora,
     merge_lora,
     unmerge_lora,
-    freeze_non_lora
+    unwrap_lora,
+    wrap_lora,
 )
 
 

--- a/tests/integration/models/test_llama_lora.py
+++ b/tests/integration/models/test_llama_lora.py
@@ -39,12 +39,12 @@ def test_lora_wrappers_llama_works() -> None:
     model.eval()
 
     with torch.inference_mode():
-        output_before_wrap, _ = model.decode(seqs=inputs, seq_lens=None)
+        output_before_wrap, _ = model.decode(seqs=inputs, padding_mask=None)
 
     model = wrap_lora(model, lora_config)  # type: ignore[assignment]
 
     with torch.inference_mode():
-        output_after_wrap, _ = model.decode(seqs=inputs, seq_lens=None)
+        output_after_wrap, _ = model.decode(seqs=inputs, padding_mask=None)
 
     # Outputs should be the same as lora_B is initialized with zeros.
     torch.testing.assert_close(output_before_wrap, output_after_wrap)
@@ -52,7 +52,7 @@ def test_lora_wrappers_llama_works() -> None:
     model = unwrap_lora(model, merge=False)  # type: ignore[assignment]
 
     with torch.inference_mode():
-        output_after_unwrap, _ = model.decode(seqs=inputs, seq_lens=None)
+        output_after_unwrap, _ = model.decode(seqs=inputs, padding_mask=None)
 
     torch.testing.assert_close(output_after_wrap, output_after_unwrap)
 
@@ -60,14 +60,14 @@ def test_lora_wrappers_llama_works() -> None:
     merge_lora(model)
 
     with torch.inference_mode():
-        output_after_merge, _ = model.decode(seqs=inputs, seq_lens=None)
+        output_after_merge, _ = model.decode(seqs=inputs, padding_mask=None)
 
     torch.testing.assert_close(output_after_unwrap, output_after_merge)
 
     unmerge_lora(model)
 
     with torch.inference_mode():
-        output_after_unmerge, _ = model.decode(seqs=inputs, seq_lens=None)
+        output_after_unmerge, _ = model.decode(seqs=inputs, padding_mask=None)
 
     torch.testing.assert_close(output_after_merge, output_after_unmerge)
 

--- a/tests/unit/nn/test_lora.py
+++ b/tests/unit/nn/test_lora.py
@@ -14,7 +14,7 @@ from fairseq2.nn.embedding import StandardEmbedding
 from fairseq2.nn.lora import LoRAConfig, LoRAEmbedding, LoRALinear
 
 
-def test_lora_liner_works() -> None:
+def test_lora_linear_works() -> None:
     lora_config = LoRAConfig(r=4, alpha=1.0, dropout_p=0.0, keys=[])
 
     linear_layer = Linear(8, 8, bias=True)

--- a/tests/unit/nn/test_lora.py
+++ b/tests/unit/nn/test_lora.py
@@ -1,0 +1,34 @@
+import pytest
+import torch
+
+from fairseq2.nn import Linear, Projection
+from src.fairseq2.nn.lora import LoRAConfig, LoRALinear
+
+from torch.nn.functional import linear
+
+
+def test_lora_liner_works() -> None:
+    lora_config = LoRAConfig(
+        r=4,
+        alpha=1.,
+        dropout_p=0.,
+        keys=None
+    )
+
+    linear_layer = Linear(8, 8, bias=True)
+
+    lora_linear = LoRALinear(linear_layer, lora_config, skip_init=False, device='cpu')
+
+    seqs = torch.randn([2, 8])
+
+    orig_out = linear_layer(seqs)
+
+    lora_out = lora_linear(seqs)
+
+    assert lora_linear.lora_A.shape == (4, 8)
+
+    assert lora_linear.lora_B.shape == (8, 4)
+
+    lora_partial_out = linear(seqs, lora_linear.lora_B @ lora_linear.lora_A) * lora_linear.scaling
+
+    torch.testing.assert_close(lora_out - orig_out, lora_partial_out)

--- a/tests/unit/nn/test_lora.py
+++ b/tests/unit/nn/test_lora.py
@@ -1,19 +1,18 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import math
-import pytest
 import torch
 
 from fairseq2.nn import Linear
 from fairseq2.nn.embedding import StandardEmbedding
-from fairseq2.models.llama import create_llama_model, get_llama_lora_config, llama_archs
 from fairseq2.nn.lora import (
     LoRAConfig,
     LoRAEmbedding,
-    LoRALinear,
-    wrap_lora,
-    unwrap_lora,
-    merge_lora,
-    unmerge_lora,
-    freeze_non_lora
+    LoRALinear
 )
 
 from torch.nn.functional import embedding, linear
@@ -167,54 +166,3 @@ def test_lora_embedding_merge_unmerge_work() -> None:
     lora_AB = (lora_embed.lora_B @ lora_embed.lora_A * lora_embed.scaling).data.T
 
     torch.testing.assert_close(merged_weight - un_merged_weight, lora_AB)
-
-
-def test_lora_wrappers_llama_works() -> None:
-    llama_config = llama_archs.get_config("7b")
-    model = create_llama_model(llama_config, device="cpu")
-
-    lora_config = get_llama_lora_config()
-
-    inputs = torch.LongTensor([[1, 2], [1, 3]], device="cpu")
-
-    model.eval()
-
-    with torch.inference_mode():
-        output_before_wrap, _ = model.decode(seqs=inputs, seq_lens=None)
-
-    model = wrap_lora(model, lora_config)
-
-    with torch.inference_mode():
-        output_after_wrap, _ = model.decode(seqs=inputs, seq_lens=None)
-
-    # Outputs should be the same as lora_B is initialized with zeros.
-    torch.testing.assert_close(output_before_wrap, output_after_wrap)
-
-    model = unwrap_lora(model, merge=False)
-
-    with torch.inference_mode():
-        output_after_unwrap, _ = model.decode(seqs=inputs, seq_lens=None)
-
-    torch.testing.assert_close(output_after_wrap, output_after_unwrap)
-
-    model = wrap_lora(model, lora_config)
-    merge_lora(model)
-
-    with torch.inference_mode():
-        output_after_merge, _ = model.decode(seqs=inputs, seq_lens=None)
-
-    torch.testing.assert_close(output_after_unwrap, output_after_merge)
-
-    unmerge_lora(model)
-
-    with torch.inference_mode():
-        output_after_unmerge, _ = model.decode(seqs=inputs, seq_lens=None)
-
-    torch.testing.assert_close(output_after_merge, output_after_unmerge)
-
-    model.train()
-    freeze_non_lora(model, unfreeze_bias="none")
-
-    for name, param in model.named_parameters():
-        if param.requires_grad:
-            assert "lora_" in name

--- a/tests/unit/nn/test_lora.py
+++ b/tests/unit/nn/test_lora.py
@@ -55,13 +55,21 @@ def test_lora_liner_merge_unmerge_work() -> None:
 
     seqs = torch.randn([2, 8])
 
-    orig_weight = lora_linear.weight.clone()
+    orig_weight = lora_linear.weight.data.clone()
+
+    wrapped_org_weight = lora_linear.wrapped.weight.data.clone()  # type: ignore[operator]
+
+    torch.testing.assert_close(orig_weight, wrapped_org_weight)
 
     lora_linear.merge()
 
     assert lora_linear.merged
 
-    merged_weight = lora_linear.weight.clone()
+    merged_weight = lora_linear.weight.data.clone()
+
+    wrapped_merged_weight = lora_linear.wrapped.weight.data.clone()  # type: ignore[operator]
+
+    torch.testing.assert_close(merged_weight, wrapped_merged_weight)
 
     merged_out = lora_linear(seqs)
 
@@ -69,7 +77,11 @@ def test_lora_liner_merge_unmerge_work() -> None:
 
     assert not lora_linear.merged
 
-    un_merged_weight = lora_linear.weight.clone()
+    un_merged_weight = lora_linear.weight.data.clone()
+
+    wrapped_un_merged_weight = lora_linear.wrapped.weight.data.clone()
+
+    torch.testing.assert_close(un_merged_weight, wrapped_un_merged_weight)
 
     un_merged_out = lora_linear(seqs)
 
@@ -123,13 +135,21 @@ def test_lora_embedding_merge_unmerge_work() -> None:
 
     seqs = torch.randint(0, 4, [2, 5])
 
-    orig_weight = lora_embed.weight.clone()
+    orig_weight = lora_embed.weight.data.clone()
+
+    wrapped_orig_weight = lora_embed.wrapped.weight.data.clone()  # type: ignore[operator]
+
+    torch.testing.assert_close(orig_weight, wrapped_orig_weight)
 
     lora_embed.merge()
 
     assert lora_embed.merged
 
-    merged_weight = lora_embed.weight.clone()
+    merged_weight = lora_embed.weight.data.clone()
+
+    wrapped_merged_weight = lora_embed.wrapped.weight.data.clone()  # type: ignore[operator]
+
+    torch.testing.assert_close(merged_weight, wrapped_merged_weight)
 
     merged_out = lora_embed(seqs)
 
@@ -137,7 +157,11 @@ def test_lora_embedding_merge_unmerge_work() -> None:
 
     assert not lora_embed.merged
 
-    un_merged_weight = lora_embed.weight.clone()
+    un_merged_weight = lora_embed.weight.data.clone()
+
+    wrapped_un_merged_weight = lora_embed.wrapped.weight.data.clone()
+
+    torch.testing.assert_close(un_merged_weight, wrapped_un_merged_weight)
 
     un_merged_out = lora_embed(seqs)
 

--- a/tests/unit/nn/test_lora.py
+++ b/tests/unit/nn/test_lora.py
@@ -1,10 +1,13 @@
+import math
 import pytest
 import torch
 
-from fairseq2.nn import Linear, Projection
+from fairseq2.nn import Linear
+from fairseq2.nn.embedding import StandardEmbedding
 from fairseq2.models.llama import create_llama_model, get_llama_lora_config, llama_archs
 from fairseq2.nn.lora import (
     LoRAConfig,
+    LoRAEmbedding,
     LoRALinear,
     wrap_lora,
     unwrap_lora,
@@ -13,7 +16,7 @@ from fairseq2.nn.lora import (
     freeze_non_lora
 )
 
-from torch.nn.functional import linear
+from torch.nn.functional import embedding, linear
 
 
 def test_lora_liner_works() -> None:
@@ -28,19 +31,142 @@ def test_lora_liner_works() -> None:
 
     lora_linear = LoRALinear(linear_layer, lora_config, skip_init=False, device='cpu')
 
+    torch.nn.init.kaiming_uniform_(lora_linear.lora_B, a=math.sqrt(5))
+
+    assert lora_linear.lora_A.shape == (4, 8)
+
+    assert lora_linear.lora_B.shape == (8, 4)
+
     seqs = torch.randn([2, 8])
 
     orig_out = linear_layer(seqs)
 
     lora_out = lora_linear(seqs)
 
-    assert lora_linear.lora_A.shape == (4, 8)
-
-    assert lora_linear.lora_B.shape == (8, 4)
-
     lora_partial_out = linear(seqs, lora_linear.lora_B @ lora_linear.lora_A) * lora_linear.scaling
 
     torch.testing.assert_close(lora_out - orig_out, lora_partial_out)
+
+
+def test_lora_liner_merge_unmerge_work() -> None:
+    lora_config = LoRAConfig(
+        r=4,
+        alpha=1.,
+        dropout_p=0.,
+        keys=None
+    )
+
+    linear_layer = Linear(8, 8, bias=True)
+
+    lora_linear = LoRALinear(linear_layer, lora_config, skip_init=False, device='cpu')
+
+    torch.nn.init.kaiming_uniform_(lora_linear.lora_B, a=math.sqrt(5))
+
+    seqs = torch.randn([2, 8])
+
+    orig_weight = lora_linear.weight.clone()
+
+    lora_linear.merge()
+
+    assert lora_linear.merged
+
+    merged_weight = lora_linear.weight.clone()
+
+    merged_out = lora_linear(seqs)
+
+    lora_linear.unmerge()
+
+    assert not lora_linear.merged
+
+    un_merged_weight = lora_linear.weight.clone()
+
+    un_merged_out = lora_linear(seqs)
+
+    torch.testing.assert_close(orig_weight, un_merged_weight)
+
+    torch.testing.assert_close(un_merged_out, merged_out)
+
+    lora_AB = (lora_linear.lora_B @ lora_linear.lora_A * lora_linear.scaling).data
+
+    torch.testing.assert_close(merged_weight - un_merged_weight, lora_AB)
+
+
+def test_lora_embedding_works() -> None:
+    lora_config = LoRAConfig(
+        r=4,
+        alpha=1.,
+        dropout_p=0.,
+        keys=None
+    )
+
+    pad_idx = 0
+
+    embed_layer = StandardEmbedding(4, 8, pad_idx)
+
+    lora_embed = LoRAEmbedding(embed_layer, lora_config, device='cpu')
+
+    torch.nn.init.normal_(lora_embed.lora_A)
+
+    assert lora_embed.lora_A.shape == (4, 4)
+
+    assert lora_embed.lora_B.shape == (8, 4)
+
+    seqs = torch.randint(0, 4, [2, 5])
+
+    orig_out = embed_layer(seqs)
+
+    lora_out = lora_embed(seqs)
+
+    lora_partial_out = embedding(
+        seqs, (lora_embed.lora_B @ lora_embed.lora_A).T * lora_embed.scaling,
+        pad_idx)
+
+    torch.testing.assert_close(lora_out - orig_out, lora_partial_out)
+
+
+def test_lora_embedding_merge_unmerge_work() -> None:
+    lora_config = LoRAConfig(
+        r=4,
+        alpha=1.,
+        dropout_p=0.,
+        keys=None
+    )
+
+    pad_idx = 0
+
+    embed_layer = StandardEmbedding(4, 8, pad_idx)
+
+    lora_embed = LoRAEmbedding(embed_layer, lora_config, device='cpu')
+
+    torch.nn.init.normal_(lora_embed.lora_A)
+
+    seqs = torch.randint(0, 4, [2, 5])
+
+    orig_weight = lora_embed.weight.clone()
+
+    lora_embed.merge()
+
+    assert lora_embed.merged
+
+    merged_weight = lora_embed.weight.clone()
+
+    merged_out = lora_embed(seqs)
+
+    lora_embed.unmerge()
+
+    assert not lora_embed.merged
+
+    un_merged_weight = lora_embed.weight.clone()
+
+    un_merged_out = lora_embed(seqs)
+
+    torch.testing.assert_close(orig_weight, un_merged_weight)
+
+    torch.testing.assert_close(un_merged_out, merged_out)
+
+    lora_AB = (lora_embed.lora_B @ lora_embed.lora_A * lora_embed.scaling).data.T
+
+    torch.testing.assert_close(merged_weight - un_merged_weight, lora_AB)
 
 
 def test_lora_wrappers_llama_works() -> None:

--- a/tests/unit/nn/test_lora.py
+++ b/tests/unit/nn/test_lora.py
@@ -5,30 +5,21 @@
 # LICENSE file in the root directory of this source tree.
 
 import math
+
 import torch
+from torch.nn.functional import embedding, linear
 
 from fairseq2.nn import Linear
 from fairseq2.nn.embedding import StandardEmbedding
-from fairseq2.nn.lora import (
-    LoRAConfig,
-    LoRAEmbedding,
-    LoRALinear
-)
-
-from torch.nn.functional import embedding, linear
+from fairseq2.nn.lora import LoRAConfig, LoRAEmbedding, LoRALinear
 
 
 def test_lora_liner_works() -> None:
-    lora_config = LoRAConfig(
-        r=4,
-        alpha=1.,
-        dropout_p=0.,
-        keys=None
-    )
+    lora_config = LoRAConfig(r=4, alpha=1.0, dropout_p=0.0, keys=[])
 
     linear_layer = Linear(8, 8, bias=True)
 
-    lora_linear = LoRALinear(linear_layer, lora_config, skip_init=False, device='cpu')
+    lora_linear = LoRALinear(linear_layer, lora_config, skip_init=False, device=torch.device("cpu"))
 
     torch.nn.init.kaiming_uniform_(lora_linear.lora_B, a=math.sqrt(5))
 
@@ -42,22 +33,19 @@ def test_lora_liner_works() -> None:
 
     lora_out = lora_linear(seqs)
 
-    lora_partial_out = linear(seqs, lora_linear.lora_B @ lora_linear.lora_A) * lora_linear.scaling
+    lora_partial_out = (
+        linear(seqs, lora_linear.lora_B @ lora_linear.lora_A) * lora_linear.scaling
+    )
 
     torch.testing.assert_close(lora_out - orig_out, lora_partial_out)
 
 
 def test_lora_liner_merge_unmerge_work() -> None:
-    lora_config = LoRAConfig(
-        r=4,
-        alpha=1.,
-        dropout_p=0.,
-        keys=None
-    )
+    lora_config = LoRAConfig(r=4, alpha=1.0, dropout_p=0.0, keys=[])
 
     linear_layer = Linear(8, 8, bias=True)
 
-    lora_linear = LoRALinear(linear_layer, lora_config, skip_init=False, device='cpu')
+    lora_linear = LoRALinear(linear_layer, lora_config, skip_init=False, device=torch.device("cpu"))
 
     torch.nn.init.kaiming_uniform_(lora_linear.lora_B, a=math.sqrt(5))
 
@@ -91,18 +79,13 @@ def test_lora_liner_merge_unmerge_work() -> None:
 
 
 def test_lora_embedding_works() -> None:
-    lora_config = LoRAConfig(
-        r=4,
-        alpha=1.,
-        dropout_p=0.,
-        keys=None
-    )
+    lora_config = LoRAConfig(r=4, alpha=1.0, dropout_p=0.0, keys=[])
 
     pad_idx = 0
 
     embed_layer = StandardEmbedding(4, 8, pad_idx)
 
-    lora_embed = LoRAEmbedding(embed_layer, lora_config, device='cpu')
+    lora_embed = LoRAEmbedding(embed_layer, lora_config, device=torch.device("cpu"))
 
     torch.nn.init.normal_(lora_embed.lora_A)
 
@@ -117,25 +100,20 @@ def test_lora_embedding_works() -> None:
     lora_out = lora_embed(seqs)
 
     lora_partial_out = embedding(
-        seqs, (lora_embed.lora_B @ lora_embed.lora_A).T * lora_embed.scaling,
-        pad_idx)
+        seqs, (lora_embed.lora_B @ lora_embed.lora_A).T * lora_embed.scaling, pad_idx
+    )
 
     torch.testing.assert_close(lora_out - orig_out, lora_partial_out)
 
 
 def test_lora_embedding_merge_unmerge_work() -> None:
-    lora_config = LoRAConfig(
-        r=4,
-        alpha=1.,
-        dropout_p=0.,
-        keys=None
-    )
+    lora_config = LoRAConfig(r=4, alpha=1.0, dropout_p=0.0, keys=[])
 
     pad_idx = 0
 
     embed_layer = StandardEmbedding(4, 8, pad_idx)
 
-    lora_embed = LoRAEmbedding(embed_layer, lora_config, device='cpu')
+    lora_embed = LoRAEmbedding(embed_layer, lora_config, device=torch.device("cpu"))
 
     torch.nn.init.normal_(lora_embed.lora_A)
 

--- a/tests/unit/nn/test_lora.py
+++ b/tests/unit/nn/test_lora.py
@@ -19,7 +19,9 @@ def test_lora_liner_works() -> None:
 
     linear_layer = Linear(8, 8, bias=True)
 
-    lora_linear = LoRALinear(linear_layer, lora_config, skip_init=False, device=torch.device("cpu"))
+    lora_linear = LoRALinear(
+        linear_layer, lora_config, skip_init=False, device=torch.device("cpu")
+    )
 
     torch.nn.init.kaiming_uniform_(lora_linear.lora_B, a=math.sqrt(5))
 
@@ -45,7 +47,9 @@ def test_lora_liner_merge_unmerge_work() -> None:
 
     linear_layer = Linear(8, 8, bias=True)
 
-    lora_linear = LoRALinear(linear_layer, lora_config, skip_init=False, device=torch.device("cpu"))
+    lora_linear = LoRALinear(
+        linear_layer, lora_config, skip_init=False, device=torch.device("cpu")
+    )
 
     torch.nn.init.kaiming_uniform_(lora_linear.lora_B, a=math.sqrt(5))
 

--- a/tests/unit/nn/test_lora.py
+++ b/tests/unit/nn/test_lora.py
@@ -2,7 +2,16 @@ import pytest
 import torch
 
 from fairseq2.nn import Linear, Projection
-from src.fairseq2.nn.lora import LoRAConfig, LoRALinear
+from fairseq2.models.llama import create_llama_model, get_llama_lora_config, llama_archs
+from fairseq2.nn.lora import (
+    LoRAConfig,
+    LoRALinear,
+    wrap_lora,
+    unwrap_lora,
+    merge_lora,
+    unmerge_lora,
+    freeze_non_lora
+)
 
 from torch.nn.functional import linear
 
@@ -32,3 +41,54 @@ def test_lora_liner_works() -> None:
     lora_partial_out = linear(seqs, lora_linear.lora_B @ lora_linear.lora_A) * lora_linear.scaling
 
     torch.testing.assert_close(lora_out - orig_out, lora_partial_out)
+
+
+def test_lora_wrappers_llama_works() -> None:
+    llama_config = llama_archs.get_config("7b")
+    model = create_llama_model(llama_config, device="cpu")
+
+    lora_config = get_llama_lora_config()
+
+    inputs = torch.LongTensor([[1, 2], [1, 3]], device="cpu")
+
+    model.eval()
+
+    with torch.inference_mode():
+        output_before_wrap, _ = model.decode(seqs=inputs, seq_lens=None)
+
+    model = wrap_lora(model, lora_config)
+
+    with torch.inference_mode():
+        output_after_wrap, _ = model.decode(seqs=inputs, seq_lens=None)
+
+    # Outputs should be the same as lora_B is initialized with zeros.
+    torch.testing.assert_close(output_before_wrap, output_after_wrap)
+
+    model = unwrap_lora(model, merge=False)
+
+    with torch.inference_mode():
+        output_after_unwrap, _ = model.decode(seqs=inputs, seq_lens=None)
+
+    torch.testing.assert_close(output_after_wrap, output_after_unwrap)
+
+    model = wrap_lora(model, lora_config)
+    merge_lora(model)
+
+    with torch.inference_mode():
+        output_after_merge, _ = model.decode(seqs=inputs, seq_lens=None)
+
+    torch.testing.assert_close(output_after_unwrap, output_after_merge)
+
+    unmerge_lora(model)
+
+    with torch.inference_mode():
+        output_after_unmerge, _ = model.decode(seqs=inputs, seq_lens=None)
+
+    torch.testing.assert_close(output_after_merge, output_after_unmerge)
+
+    model.train()
+    freeze_non_lora(model, unfreeze_bias="none")
+
+    for name, param in model.named_parameters():
+        if param.requires_grad:
+            assert "lora_" in name


### PR DESCRIPTION
**What does this PR do? Please describe:**
This PR introduces [Low-Rank Adaptation (LoRA)](https://arxiv.org/abs/2106.09685) modules as well as wrappers for enabling/disabling models with LoRA. This is a joint contribution with @light1726 .

**Notes**
- Currently only `Projection` and `Embedding` are supported. `Conv` layers are not supported yet.
- Currently `load_lora` is not implemented.
- For usage examples, please check `tests/unit/nn/test_lora.py` and `tests/integration/models/test_llama_lora.py`.

**Does your PR introduce any breaking changes? If yes, please list them:**
None

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**?
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
