### PR TITLE
Refactor MultiheadAttentionState

### DIFF
--- a/doc/reference/classes.rst
+++ b/doc/reference/classes.rst
@@ -19,7 +19,6 @@ Classes
     nn.TiedProjection
     nn.transformer.ALiBiAttentionMaskGenerator
     nn.transformer.CausalAttentionMaskGenerator
-    nn.transformer.MultiheadAttentionState
     nn.transformer.RelativePositionSDPA
     nn.transformer.StandardFeedForwardNetwork
     nn.transformer.StandardMultiheadAttention

--- a/src/fairseq2/models/decoder.py
+++ b/src/fairseq2/models/decoder.py
@@ -36,7 +36,7 @@ class SequenceDecoder(ABC):
             the same index in ``seqs``. *Shape:* :math:`(N)`, where :math:`N` is
             the batch size.
         :param state_bag:
-            The state bag to use for incremental evaluation.
+            The state bag to use for incremental decoding.
 
         :returns:
             - The decoder output. *Shape:* :math:`(N,S,M)`, where :math:`N` is

--- a/src/fairseq2/models/encoder_decoder.py
+++ b/src/fairseq2/models/encoder_decoder.py
@@ -50,7 +50,7 @@ class Seq2SeqDecoder(ABC):
             :math:`(N,S_{enc})`, where :math:`N` is the batch size and
             :math:`S_{enc}` is the encoder output sequence length.
         :param state_bag:
-            The state bag to use for incremental evaluation.
+            The state bag to use for incremental decoding.
 
         :returns:
             - The decoder output. *Shape:* :math:`(N,S_{tgt},M)`, where

--- a/src/fairseq2/models/s2t_transformer/frontend.py
+++ b/src/fairseq2/models/s2t_transformer/frontend.py
@@ -102,7 +102,7 @@ class S2TTransformerFrontend(TransformerFrontend):
     ) -> Tuple[Tensor, Optional[Tensor]]:
         if state_bag is not None:
             raise ValueError(
-                "`S2TTransformerFrontend` does not support incremental evaluation."
+                "`S2TTransformerFrontend` does not support incremental decoding."
             )
 
         if self.feature_extractor is not None:

--- a/src/fairseq2/models/transformer/frontend.py
+++ b/src/fairseq2/models/transformer/frontend.py
@@ -55,7 +55,7 @@ class TransformerFrontend(Module, ABC):
             the same index in ``seqs``. *Shape:* :math:`(N)`, where :math:`N` is
             the batch size.
         :param state_bag:
-            The state bag to use for incremental evaluation.
+            The state bag to use for incremental decoding.
 
         :returns:
             - The processed sequences to pass to a Transformer encoder/decoder.

--- a/src/fairseq2/models/utils/model_loader.py
+++ b/src/fairseq2/models/utils/model_loader.py
@@ -143,7 +143,7 @@ class ModelLoader(Generic[ModelT, ModelConfigT]):
         :param download_manager:
             The download manager to use to download model checkpoints.
         :param model_factory:
-            The callable responsible for constructing models.
+            The factory to use to construct models.
         :param archs:
             The registry containing all supported model architectures.
         :param restrict_checkpoints:

--- a/src/fairseq2/models/wav2vec2/frontend.py
+++ b/src/fairseq2/models/wav2vec2/frontend.py
@@ -128,7 +128,7 @@ class Wav2Vec2Frontend(TransformerFrontend):
     ) -> Tuple[Tensor, Optional[Tensor]]:
         if state_bag is not None:
             raise ValueError(
-                "`Wav2Vec2Frontend` does not support incremental evaluation."
+                "`Wav2Vec2Frontend` does not support incremental decoding."
             )
 
         seqs, seq_lens = self.extract_features(seqs, seq_lens)

--- a/src/fairseq2/models/wav2vec2/position_encoder.py
+++ b/src/fairseq2/models/wav2vec2/position_encoder.py
@@ -70,7 +70,7 @@ class Wav2Vec2PositionEncoder(PositionEncoder):
         """:meta private:"""
         if state_bag is not None:
             raise ValueError(
-                "`Wav2Vec2PositionEncoder` does not support incremental evaluation."
+                "`Wav2Vec2PositionEncoder` does not support incremental decoding."
             )
 
         # We have to ensure that the padded elements are correctly set to
@@ -178,7 +178,7 @@ class Wav2Vec2StackedPositionEncoder(PositionEncoder):
         """:meta private:"""
         if state_bag is not None:
             raise ValueError(
-                "`Wav2Vec2StackedPositionEncoder` does not support incremental evaluation."
+                "`Wav2Vec2StackedPositionEncoder` does not support incremental decoding."
             )
 
         # We have to ensure that the padded elements are correctly set to

--- a/src/fairseq2/nn/incremental_state.py
+++ b/src/fairseq2/nn/incremental_state.py
@@ -12,12 +12,12 @@ from torch.nn import Module
 
 
 class IncrementalState(ABC):
-    """Holds the state of a module during an incremental evaluation.
+    """Holds the state of a module during incremental decoding.
 
-    Incremental evaluation is a special mode where the module only receives an
-    input corresponding to the previous output and must produce the next output
-    incrementally. Thus the module must cache any long-term state that is needed
-    about the sequence.
+    Incremental decoding is a special mode at inference time where the module
+    only receives an input corresponding to the previous output and must produce
+    the next output incrementally. Thus the module must cache any long-term
+    state that is needed about the sequence.
     """
 
     @abstractmethod
@@ -39,7 +39,7 @@ T = TypeVar("T", bound=IncrementalState)
 
 
 class IncrementalStateBag:
-    """Holds the module states during an incremental evaluation."""
+    """Holds the module states during incremental decoding."""
 
     step: int
     max_num_steps: int
@@ -59,9 +59,8 @@ class IncrementalStateBag:
     def increment_step(self, delta: int = 1) -> None:
         """Increment the step.
 
-        This method should be called after every incremental evaluation (e.g.
-        beam search) step. It is used by modules to keep track of the position
-        in the sequence.
+        This method should be called after every decoding step. It is used by
+        modules to keep track of the position in the sequence.
 
         :param delta:
             The value by which to increment the step.

--- a/src/fairseq2/nn/position_encoder.py
+++ b/src/fairseq2/nn/position_encoder.py
@@ -55,7 +55,7 @@ class PositionEncoder(Module, ABC):
             :math:`*` is any number of batch dimensions including none and
             :math:`S` is the sequence length.
         :param state_bag:
-            The state bag to use for incremental evaluation.
+            The state bag to use for incremental decoding.
 
         :returns:
             The input sequences with positional information encoded. *Shape:*
@@ -92,7 +92,7 @@ class PositionEncoder(Module, ABC):
             :math:`*` is any number of batch dimensions including none and
             :math:`S` is the sequence length.
         :param state_bag:
-            The state bag to use for incremental evaluation.
+            The state bag to use for incremental decoding.
 
         :returns:
             The input sequences with positional information encoded. *Shape:*

--- a/src/fairseq2/nn/transformer/__init__.py
+++ b/src/fairseq2/nn/transformer/__init__.py
@@ -59,10 +59,19 @@ from fairseq2.nn.transformer.multihead_attention import (
     AttentionWeightHook as AttentionWeightHook,
 )
 from fairseq2.nn.transformer.multihead_attention import (
+    EncoderDecoderAttentionState as EncoderDecoderAttentionState,
+)
+from fairseq2.nn.transformer.multihead_attention import (
+    GlobalSelfAttentionState as GlobalSelfAttentionState,
+)
+from fairseq2.nn.transformer.multihead_attention import (
     MultiheadAttention as MultiheadAttention,
 )
 from fairseq2.nn.transformer.multihead_attention import (
-    MultiheadAttentionState as MultiheadAttentionState,
+    SelfAttentionState as SelfAttentionState,
+)
+from fairseq2.nn.transformer.multihead_attention import (
+    SelfAttentionStateFactory as SelfAttentionStateFactory,
 )
 from fairseq2.nn.transformer.multihead_attention import (
     StandardMultiheadAttention as StandardMultiheadAttention,

--- a/src/fairseq2/nn/transformer/attention.py
+++ b/src/fairseq2/nn/transformer/attention.py
@@ -210,7 +210,7 @@ def _naive_scaled_dot_product_attention(
 
 
 class SDPAFactory(Protocol):
-    """Creates instances of :class:`SDPA`."""
+    """Constructs instances of :class:`SDPA`."""
 
     def __call__(self, *, attn_dropout_p: float) -> SDPA:
         """

--- a/src/fairseq2/nn/transformer/decoder.py
+++ b/src/fairseq2/nn/transformer/decoder.py
@@ -74,7 +74,7 @@ class TransformerDecoder(Module, ABC):
             If not ``None``, it will be called with the output of each layer in
             the decoder stack.
         :param state_bag:
-            The state bag to use for incremental evaluation.
+            The state bag to use for incremental decoding.
 
         :returns:
             - The decoder output. *Shape:* Same as ``seqs``.

--- a/src/fairseq2/nn/transformer/decoder_layer.py
+++ b/src/fairseq2/nn/transformer/decoder_layer.py
@@ -73,7 +73,7 @@ class TransformerDecoderLayer(Module, ABC):
             :math:`(N,S_{enc})`, where :math:`N` is the batch size and
             :math:`S_{enc}` is the encoder output sequence length.
         :param state_bag:
-            The state bag to use for incremental evaluation.
+            The state bag to use for incremental decoding.
 
         :returns:
             - The decoder layer output. *Shape:* Same as ``seqs``.

--- a/src/fairseq2/nn/transformer/ffn.py
+++ b/src/fairseq2/nn/transformer/ffn.py
@@ -157,7 +157,7 @@ class GLUFeedForwardNetwork(FeedForwardNetwork):
         *,
         gate_activation: Optional[Module] = None,
         inner_dim_scale: float = 2 / 3,
-        inner_dim_to_multiple: int = 2,
+        inner_dim_to_multiple: int = 1,
         inner_dropout_p: float = 0.0,
         device: Optional[Device] = None,
         dtype: Optional[DataType] = None,
@@ -190,7 +190,7 @@ class GLUFeedForwardNetwork(FeedForwardNetwork):
 
         self.inner_dim_to_multiple = inner_dim_to_multiple
 
-        if inner_dim_to_multiple != 1.0:
+        if inner_dim_to_multiple != 1:
             inner_dim = inner_dim_to_multiple * (
                 (inner_dim + inner_dim_to_multiple - 1) // inner_dim_to_multiple
             )

--- a/src/fairseq2/nn/transformer/layer_norm.py
+++ b/src/fairseq2/nn/transformer/layer_norm.py
@@ -11,7 +11,7 @@ from fairseq2.typing import DataType, Device
 
 
 class LayerNormFactory(Protocol):
-    """Creates instances of :class:`LayerNorm`."""
+    """Constructs instances of :class:`LayerNorm`."""
 
     def __call__(
         self,

--- a/src/fairseq2/nn/transformer/multihead_attention.py
+++ b/src/fairseq2/nn/transformer/multihead_attention.py
@@ -746,7 +746,7 @@ class GlobalSelfAttentionState(SelfAttentionState):
 
         return k, v, key_padding_mask
 
-    @override
+    @finaloverride
     def reorder(self, new_order: Tensor) -> None:
         self.k = self.k.index_select(0, new_order)
         self.v = self.v.index_select(0, new_order)

--- a/src/fairseq2/nn/transformer/multihead_attention.py
+++ b/src/fairseq2/nn/transformer/multihead_attention.py
@@ -85,7 +85,7 @@ class MultiheadAttention(Module, ABC):
             :math:`N` is the batch size and :math:`S_{kv}` is the key/value
             sequence length.
         :param state_bag:
-            The state bag to use for incremental evaluation.
+            The state bag to use for incremental decoding.
 
         :returns:
             The attention values for ``queries``. *Shape:* :math:`(N,S,M)`,
@@ -193,6 +193,7 @@ class StandardMultiheadAttention(MultiheadAttention):
     sdpa: SDPA
     head_scale_weight: Optional[Parameter]
     output_proj: Projection
+    state_factory: "SelfAttentionStateFactory"
 
     def __init__(
         self,
@@ -210,6 +211,7 @@ class StandardMultiheadAttention(MultiheadAttention):
         scale_heads: bool = False,
         output_proj: Optional[Projection] = None,
         bias: bool = True,
+        self_attn_state_factory: Optional["SelfAttentionStateFactory"] = None,
         device: Optional[Device] = None,
         dtype: Optional[DataType] = None,
     ) -> None:
@@ -251,6 +253,9 @@ class StandardMultiheadAttention(MultiheadAttention):
         :param bias:
             If ``True``, query, key, value, and output projections learn an
             additive bias. Ignored for explicitly specified projections.
+        :param self_attn_state_factory:
+            The factory to use to construct self attention state for incremental
+            decoding.
         """
         super().__init__(model_dim, num_heads)
 
@@ -376,6 +381,11 @@ class StandardMultiheadAttention(MultiheadAttention):
 
             self.output_proj = output_proj
 
+        if self_attn_state_factory is not None:
+            self.self_attn_state_factory = self_attn_state_factory
+        else:
+            self.self_attn_state_factory = GlobalSelfAttentionState
+
         self.reset_parameters()
 
     def reset_parameters(self) -> None:
@@ -410,10 +420,10 @@ class StandardMultiheadAttention(MultiheadAttention):
         else:
             encoder_decoder_attn = keys is values and keys is not queries
             if encoder_decoder_attn:
-                static_state = state_bag.get_state(self, StaticMultiheadAttentionState)
+                static_state = state_bag.get_state(self, EncoderDecoderAttentionState)
 
                 # The K and V tensors of an encoder-decoder attention (i.e. the
-                # projected encoder outputs) remain static during evaluation.
+                # projected encoder outputs) remain static during decoding.
                 if static_state is not None:
                     k = static_state.k
                     v = static_state.v
@@ -422,15 +432,15 @@ class StandardMultiheadAttention(MultiheadAttention):
                     # v: (N, S_kv, M) -> (N, H_kv, S_kv, V_h)
                     k, v = self._project_kv(keys, key_padding_mask, values)
 
-                    state_bag.set_state(self, StaticMultiheadAttentionState(k, v))
+                    state_bag.set_state(self, EncoderDecoderAttentionState(k, v))
             else:
                 # k: (N, S_step, M) -> (N, H_kv, S_step, K_h)
                 # v: (N, S_step, M) -> (N, H_kv, S_step, V_h)
                 k, v = self._project_kv(keys, key_padding_mask, values, state_bag)
 
-                state = state_bag.get_state(self, MultiheadAttentionState)
+                state = state_bag.get_state(self, SelfAttentionState)
                 if state is None:
-                    state = MultiheadAttentionState(k, v, state_bag.max_num_steps)
+                    state = self.self_attn_state_factory(k, v, state_bag.max_num_steps)
 
                     state_bag.set_state(self, state)
 
@@ -616,29 +626,80 @@ class AttentionOutputProjection(Linear):
             nn.init.zeros_(self.bias)
 
 
-class MultiheadAttentionState(IncrementalState):
-    """Holds the state of a :class:`MultiheadAttention` module during an
-    incremental evaluation."""
+class SelfAttentionState(IncrementalState):
+    """Holds the self attention state of a :class:`MultiheadAttention` module
+    during incremental decoding."""
+
+    @abstractmethod
+    def append(
+        self, k: Tensor, v: Tensor, key_padding_mask: Optional[Tensor]
+    ) -> Tuple[Tensor, Tensor, Optional[Tensor]]:
+        """Append the projected keys, projected values, and float key padding
+        mask to the current incremental state.
+
+        :param k:
+            The projected keys. *Shape:* :math:`(N,H,S_{stp},K_{proj})`, where
+            :math:`N` is the batch size, :math:`H` is the number of heads,
+            :math:`S_{stp}` is the number of steps (e.g. 1), and :math:`K_{proj}`
+            is the projected key size.
+        :param v:
+            The projected values. *Shape:* :math:`(N,H,S_{stp},V_{proj})`, where
+            :math:`N` is the batch size, :math:`H` is the number of heads,
+            :math:`S_{stp}` is the number of steps (e.g. 1), and :math:`V_{proj}`
+            is the projected value size.
+        :param key_padding_mask:
+            The float key padding mask. *Shape:* :math:`(N,S_{stp})`, where
+            :math:`N` is the batch size and :math:`S_{stp}` is the number of
+            steps (e.g. 1).
+
+        :returns:
+            The projected keys, projected values, and float key padding mask
+            that should be used to compute the attention.
+        """
+
+
+class SelfAttentionStateFactory(Protocol):
+    """Constructs instances of :class:`SelfAttentionState`."""
+
+    def __call__(self, k: Tensor, v: Tensor, max_seq_len: int) -> SelfAttentionState:
+        """
+        :param k:
+            The initial projected keys.
+        :param v:
+            The initial projected values.
+        :param max_seq_len:
+            The expected maximum sequence length.
+        """
+
+
+@final
+class GlobalSelfAttentionState(SelfAttentionState):
+    """Holds the self attention state of a :class:`MultiheadAttention` module
+    during incremental decoding.
+
+    This (default) implementation caches the entirety of the projected keys and
+    values seen so far in the sequence.
+    """
 
     seq_len: int
     """The current sequence length of :attr:`k` and :attr:`v`."""
 
     k: Tensor
-    """The projected keys accumulated from the past incremental evaluation
-    steps. *Shape:* :math:`(N,H,S,K_{proj})`, where :math:`N` is the batch
-    size, :math:`H` is the number of heads, :math:`S` is the reserved sequence
-    length capacity, and :math:`K_{proj}` is the projected key size."""
+    """The projected keys accumulated from the past decoding steps. *Shape:*
+    :math:`(N,H,S,K_{proj})`, where :math:`N` is the batch size, :math:`H` is
+    the number of heads, :math:`S` is the reserved sequence length capacity, and
+    :math:`K_{proj}` is the projected key size."""
 
     v: Tensor
-    """The projected values accumulated from the past incremental evaluation
-    steps. *Shape:* :math:`(N,H,S,V_{proj})`, where :math:`N` is the batch
-    size, :math:`H` is the number of heads, :math:`S` is the reserved sequence
-    length capacity, and :math:`V_{proj}` is the projected value size."""
+    """The projected values accumulated from the past decoding steps. *Shape:*
+    :math:`(N,H,S,V_{proj})`, where :math:`N` is the batch size, :math:`H` is
+    the number of heads, :math:`S` is the reserved sequence length capacity, and
+    :math:`V_{proj}` is the projected value size."""
 
     key_padding_mask: Tensor
-    """The float key padding mask accumulated from the past incremental
-    evaluation steps. *Shape:* :math:`(N,S)`, where :math:`N` is the batch
-    size and :math:`S` is the reserved sequence length capacity."""
+    """The float key padding mask accumulated from the past decoding steps.
+    *Shape:* :math:`(N,S)`, where :math:`N` is the batch size and :math:`S` is
+    the reserved sequence length capacity."""
 
     has_mask: bool
 
@@ -662,34 +723,10 @@ class MultiheadAttentionState(IncrementalState):
 
         self.has_mask = False
 
+    @finaloverride
     def append(
         self, k: Tensor, v: Tensor, key_padding_mask: Optional[Tensor]
     ) -> Tuple[Tensor, Tensor, Optional[Tensor]]:
-        """Append the projected key, projected value, and float key padding mask
-        of the current incremental evaluation step to :attr:`k`,
-        :attr:`v`, and :attr:`key_padding_mask`.
-
-        :param k:
-            The projected key of the current incremental evaluation step.
-            *Shape:* :math:`(N,H,S_{stp},K_{proj})`, where :math:`N` is the
-            batch size, :math:`H` is the number of heads, :math:`S_{stp}` is the
-            step length (e.g. 1), and :math:`K_{proj}` is the projected key
-            size.
-        :param v:
-            The projected value of the current incremental evaluation step.
-            *Shape:* :math:`(N,H,S_{stp},V_{proj})`, where :math:`N` is the
-            batch size, :math:`H` is the number of heads, :math:`S_{stp}` is the
-            step length (e.g. 1), and :math:`V_{proj}` is the projected value
-            size.
-        :param key_padding_mask:
-            The float key padding mask of the current incremental evaluation
-            step. *Shape:* :math:`(N,S_{stp})`, where :math:`N` is the batch
-            size and :math:`S_{stp}` is the step length (e.g. 1).
-
-        :returns:
-            The projected keys, projected values, and float key padding mask
-            that should be used to compute the attention.
-        """
         start, end = self.seq_len, self.seq_len + k.size(2)
 
         self.k[:, :, start:end] = k
@@ -717,9 +754,10 @@ class MultiheadAttentionState(IncrementalState):
         self.key_padding_mask = self.key_padding_mask.index_select(0, new_order)
 
 
-class StaticMultiheadAttentionState(IncrementalState):
-    """Holds the state of an encoder-decoder :class:`MultiheadAttention` module
-    during an incremental evaluation."""
+@final
+class EncoderDecoderAttentionState(IncrementalState):
+    """Holds the encoder-decoder state of a :class:`MultiheadAttention` module
+    during incremental decoding."""
 
     k: Tensor
     v: Tensor
@@ -734,7 +772,7 @@ class StaticMultiheadAttentionState(IncrementalState):
         self.k = k
         self.v = v
 
-    @override
+    @finaloverride
     def reorder(self, new_order: Tensor) -> None:
         self.k = self.k.index_select(0, new_order)
         self.v = self.v.index_select(0, new_order)


### PR DESCRIPTION
This PR refactors the `MultiheadAttentionState` into a base `SelfAttentionState` and a `GlobalSelfAttentionState` in prep of `LocalSelfAttentionState` used in mistral 7b. It also makes some nit updates to docstrs.