### PR TITLE
Clean incremental decoding implementation in MHA

### DIFF
--- a/src/fairseq2/models/nllb/builder.py
+++ b/src/fairseq2/models/nllb/builder.py
@@ -253,7 +253,9 @@ class NllbBuilder:
         """Build a Transformer decoder layer."""
         self_attn = self.build_attention(self.config.num_decoder_attn_heads)
 
-        encoder_decoder_attn = self.build_attention(self.config.num_decoder_attn_heads)
+        encoder_decoder_attn = self.build_attention(
+            self.config.num_decoder_attn_heads, encoder_decoder=True
+        )
 
         ffn = self.build_ffn()
 
@@ -267,13 +269,16 @@ class NllbBuilder:
             dtype=self.dtype,
         )
 
-    def build_attention(self, num_heads: int) -> MultiheadAttention:
+    def build_attention(
+        self, num_heads: int, encoder_decoder: bool = False
+    ) -> MultiheadAttention:
         """Build a Transformer multi-head attention layer."""
         sdpa = create_default_sdpa(attn_dropout_p=self.config.dropout_p)
 
         return StandardMultiheadAttention(
             self.config.model_dim,
             num_heads,
+            static_kv=encoder_decoder,
             sdpa=sdpa,
             device=self.device,
             dtype=self.dtype,

--- a/src/fairseq2/models/s2t_transformer/builder.py
+++ b/src/fairseq2/models/s2t_transformer/builder.py
@@ -400,7 +400,7 @@ class S2TTransformerBuilder:
         """Build a Transformer decoder layer."""
         self_attn = self.build_decoder_attention()
 
-        encoder_decoder_attn = self.build_decoder_attention()
+        encoder_decoder_attn = self.build_decoder_attention(encoder_decoder=True)
 
         ffn = self.build_ffn()
 
@@ -446,13 +446,16 @@ class S2TTransformerBuilder:
             dtype=self.dtype,
         )
 
-    def build_decoder_attention(self) -> MultiheadAttention:
+    def build_decoder_attention(
+        self, encoder_decoder: bool = False
+    ) -> MultiheadAttention:
         """Build a Transformer decoder multi-head attention layer."""
         sdpa = create_default_sdpa(attn_dropout_p=self.config.dropout_p)
 
         return StandardMultiheadAttention(
             self.config.model_dim,
             self.config.num_decoder_attn_heads,
+            static_kv=encoder_decoder,
             sdpa=sdpa,
             device=self.device,
             dtype=self.dtype,

--- a/src/fairseq2/nn/transformer/__init__.py
+++ b/src/fairseq2/nn/transformer/__init__.py
@@ -55,26 +55,24 @@ from fairseq2.nn.transformer.layer_norm import LayerNormFactory as LayerNormFact
 from fairseq2.nn.transformer.layer_norm import (
     create_default_layer_norm as create_default_layer_norm,
 )
+from fairseq2.nn.transformer.multihead_attention import AttentionState as AttentionState
+from fairseq2.nn.transformer.multihead_attention import (
+    AttentionStateFactory as AttentionStateFactory,
+)
 from fairseq2.nn.transformer.multihead_attention import (
     AttentionWeightHook as AttentionWeightHook,
 )
 from fairseq2.nn.transformer.multihead_attention import (
-    EncoderDecoderAttentionState as EncoderDecoderAttentionState,
-)
-from fairseq2.nn.transformer.multihead_attention import (
-    GlobalSelfAttentionState as GlobalSelfAttentionState,
+    GlobalAttentionState as GlobalAttentionState,
 )
 from fairseq2.nn.transformer.multihead_attention import (
     MultiheadAttention as MultiheadAttention,
 )
 from fairseq2.nn.transformer.multihead_attention import (
-    SelfAttentionState as SelfAttentionState,
-)
-from fairseq2.nn.transformer.multihead_attention import (
-    SelfAttentionStateFactory as SelfAttentionStateFactory,
-)
-from fairseq2.nn.transformer.multihead_attention import (
     StandardMultiheadAttention as StandardMultiheadAttention,
+)
+from fairseq2.nn.transformer.multihead_attention import (
+    StaticAttentionState as StaticAttentionState,
 )
 from fairseq2.nn.transformer.multihead_attention import (
     StoreAttentionWeights as StoreAttentionWeights,


### PR DESCRIPTION
This PR cleans up and improves the incremental decoding implementation in MHA. The biggest change is that we now expect the user to pass a new `static_kv=True` to indicate whether the MHA module is meant for encoder-decoder type of attention. This simplifies the state construction logic.