### PR TITLE
Adding `self_attn_mask` to the Transformer Encoder Layer API.

### DIFF
--- a/src/fairseq2/models/conformer/block.py
+++ b/src/fairseq2/models/conformer/block.py
@@ -116,11 +116,14 @@ class ConformerBlock(TransformerEncoderLayer):
 
     @finaloverride
     def forward(
-        self, seqs: Tensor, padding_mask: Optional[Tensor]
+        self,
+        seqs: Tensor,
+        padding_mask: Optional[Tensor],
+        self_attn_mask: Optional[Tensor] = None,
     ) -> Tuple[Tensor, Optional[Tensor]]:
         seqs = self._forward_ffn1(seqs)
 
-        seqs = self._forward_self_attn(seqs, padding_mask)
+        seqs = self._forward_self_attn(seqs, padding_mask, self_attn_mask)
 
         seqs = self._forward_conv(seqs, padding_mask)
 
@@ -143,7 +146,10 @@ class ConformerBlock(TransformerEncoderLayer):
         return seqs + residual
 
     def _forward_self_attn(
-        self, seqs: Tensor, padding_mask: Optional[Tensor]
+        self,
+        seqs: Tensor,
+        padding_mask: Optional[Tensor],
+        self_attn_mask: Optional[Tensor],
     ) -> Tensor:
         residual = seqs
 
@@ -154,6 +160,7 @@ class ConformerBlock(TransformerEncoderLayer):
             padding_mask,
             keys=seqs,
             values=seqs,
+            attn_mask=self_attn_mask,
             key_padding_mask=padding_mask,
         )
 

--- a/src/fairseq2/models/conformer/convolution.py
+++ b/src/fairseq2/models/conformer/convolution.py
@@ -143,7 +143,13 @@ class ConformerConvolution(Module):
             seqs = self.batch_norm(seqs)
         else:
             assert self.layer_norm is not None
+            # (N, M, S) -> (N, S, M)
+            seqs = seqs.transpose(1, 2)
+
             seqs = self.layer_norm(seqs)
+
+            # (N, S, M) -> (N, M, S)
+            seqs = seqs.transpose(1, 2)
 
         seqs = self.depthwise_activation(seqs)
 

--- a/src/fairseq2/models/s2t_transformer/builder.py
+++ b/src/fairseq2/models/s2t_transformer/builder.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from dataclasses import dataclass
-from typing import Literal, Optional
+from typing import Optional
 
 from torch.nn import SiLU
 
@@ -90,9 +90,6 @@ class S2TTransformerConfig:
     depthwise_conv_kernel_size: int
     """The kernel size of depthwise convolutions in Conformer blocks."""
 
-    conv_norm_type: Literal["batch_norm", "layer_norm"]
-    """The type of norm layer in the Conformer convolution module."""
-
     def update_target_vocabulary(self, info: VocabularyInfo) -> None:
         """Update target vocabulary configuration from ``info``."""
         self.target_vocabulary_size, self.target_pad_idx = info.size, info.pad_idx
@@ -121,7 +118,6 @@ def _tiny() -> S2TTransformerConfig:
         ffn_inner_dim=256 * 4,
         dropout_p=0.3,
         depthwise_conv_kernel_size=0,
-        conv_norm_type="batch_norm",
     )
 
 
@@ -142,7 +138,6 @@ def _small() -> S2TTransformerConfig:
         ffn_inner_dim=256 * 8,
         dropout_p=0.1,
         depthwise_conv_kernel_size=0,
-        conv_norm_type="batch_norm",
     )
 
 
@@ -163,7 +158,6 @@ def _medium() -> S2TTransformerConfig:
         ffn_inner_dim=512 * 4,
         dropout_p=0.15,
         depthwise_conv_kernel_size=0,
-        conv_norm_type="batch_norm",
     )
 
 
@@ -184,7 +178,6 @@ def _large() -> S2TTransformerConfig:
         ffn_inner_dim=1024 * 4,
         dropout_p=0.2,
         depthwise_conv_kernel_size=0,
-        conv_norm_type="batch_norm",
     )
 
 
@@ -205,7 +198,6 @@ def _conformer_medium() -> S2TTransformerConfig:
         ffn_inner_dim=512 * 4,
         dropout_p=0.1,
         depthwise_conv_kernel_size=31,
-        conv_norm_type="batch_norm",
     )
 
 
@@ -388,7 +380,6 @@ class S2TTransformerBuilder:
         conv = ConformerConvolution(
             self.config.model_dim,
             self.config.depthwise_conv_kernel_size,
-            norm_type=self.config.conv_norm_type,
             device=self.device,
             dtype=self.dtype,
         )

--- a/src/fairseq2/models/s2t_transformer/builder.py
+++ b/src/fairseq2/models/s2t_transformer/builder.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Literal, Optional
 
 from torch.nn import SiLU
 
@@ -90,6 +90,9 @@ class S2TTransformerConfig:
     depthwise_conv_kernel_size: int
     """The kernel size of depthwise convolutions in Conformer blocks."""
 
+    conv_norm_type: Literal["batch_norm", "layer_norm"]
+    """The type of norm layer in the Conformer convolution module."""
+
     def update_target_vocabulary(self, info: VocabularyInfo) -> None:
         """Update target vocabulary configuration from ``info``."""
         self.target_vocabulary_size, self.target_pad_idx = info.size, info.pad_idx
@@ -118,6 +121,7 @@ def _tiny() -> S2TTransformerConfig:
         ffn_inner_dim=256 * 4,
         dropout_p=0.3,
         depthwise_conv_kernel_size=0,
+        conv_norm_type="batch_norm",
     )
 
 
@@ -138,6 +142,7 @@ def _small() -> S2TTransformerConfig:
         ffn_inner_dim=256 * 8,
         dropout_p=0.1,
         depthwise_conv_kernel_size=0,
+        conv_norm_type="batch_norm",
     )
 
 
@@ -158,6 +163,7 @@ def _medium() -> S2TTransformerConfig:
         ffn_inner_dim=512 * 4,
         dropout_p=0.15,
         depthwise_conv_kernel_size=0,
+        conv_norm_type="batch_norm",
     )
 
 
@@ -178,6 +184,7 @@ def _large() -> S2TTransformerConfig:
         ffn_inner_dim=1024 * 4,
         dropout_p=0.2,
         depthwise_conv_kernel_size=0,
+        conv_norm_type="batch_norm",
     )
 
 
@@ -198,6 +205,7 @@ def _conformer_medium() -> S2TTransformerConfig:
         ffn_inner_dim=512 * 4,
         dropout_p=0.1,
         depthwise_conv_kernel_size=31,
+        conv_norm_type="batch_norm",
     )
 
 
@@ -380,6 +388,7 @@ class S2TTransformerBuilder:
         conv = ConformerConvolution(
             self.config.model_dim,
             self.config.depthwise_conv_kernel_size,
+            norm_type=self.config.conv_norm_type,
             device=self.device,
             dtype=self.dtype,
         )

--- a/src/fairseq2/models/w2vbert/builder.py
+++ b/src/fairseq2/models/w2vbert/builder.py
@@ -43,6 +43,7 @@ def _encoder_600m() -> Wav2Vec2EncoderConfig:
         layer_drop_p=0.0,
         norm_order=TransformerNormOrder.POST,
         depthwise_conv_kernel_size=31,
+        conv_norm_type="batch_norm",
     )
 
 
@@ -74,6 +75,7 @@ def _encoder_300m() -> Wav2Vec2EncoderConfig:
         layer_drop_p=0.0,
         norm_order=TransformerNormOrder.POST,
         depthwise_conv_kernel_size=31,
+        conv_norm_type="batch_norm",
     )
 
 

--- a/src/fairseq2/models/wav2vec2/builder.py
+++ b/src/fairseq2/models/wav2vec2/builder.py
@@ -139,6 +139,9 @@ class Wav2Vec2EncoderConfig:
     depthwise_conv_kernel_size: int
     """The kernel size of depthwise convolutions in Conformer blocks."""
 
+    conv_norm_type: Literal["batch_norm", "layer_norm"]
+    """The type of norm layer in the Conformer convolution module."""
+
 
 def _encoder_base() -> Wav2Vec2EncoderConfig:
     layer_descs = [(512, 10, 5)] + [(512, 3, 2)] * 4 + [(512, 2, 2)] * 2
@@ -170,6 +173,7 @@ def _encoder_base() -> Wav2Vec2EncoderConfig:
         layer_drop_p=0.05,
         norm_order=TransformerNormOrder.POST,
         depthwise_conv_kernel_size=0,
+        conv_norm_type="batch_norm",
     )
 
 
@@ -311,6 +315,7 @@ class Wav2Vec2EncoderBuilder:
         conv = ConformerConvolution(
             self.config.model_dim,
             self.config.depthwise_conv_kernel_size,
+            norm_type=self.config.conv_norm_type,
             device=self.device,
             dtype=self.dtype,
         )

--- a/src/fairseq2/models/wav2vec2/builder.py
+++ b/src/fairseq2/models/wav2vec2/builder.py
@@ -140,7 +140,7 @@ class Wav2Vec2EncoderConfig:
     """The kernel size of depthwise convolutions in Conformer blocks."""
 
     conv_norm_type: Literal["batch_norm", "layer_norm"]
-    """The type of norm layer in the Conformer convolution module."""
+    """The type of normalization to use in the Conformer convolution module."""
 
 
 def _encoder_base() -> Wav2Vec2EncoderConfig:


### PR DESCRIPTION
**What does this PR do? Please describe:**

- Adds `self_attn_mask `to the Transformer Encoder Layer API.
- Adds `conv_norm_type` as an explicit config parameter for the Conformer convolution module.

Tested with m4t_predict for S2ST and confirm that the behavior is as expected.

**Does your PR introduce any breaking changes? If yes, please list them:**
List of all backwards-incompatible changes.

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [ ] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
