### PR TITLE
Introduce `build_conformer_conv()` and `build_sdpa()` in wav2vec2 builder.

### DIFF
--- a/src/fairseq2/models/w2vbert/builder.py
+++ b/src/fairseq2/models/w2vbert/builder.py
@@ -43,9 +43,6 @@ def _encoder_600m() -> Wav2Vec2EncoderConfig:
         layer_drop_p=0.0,
         norm_order=TransformerNormOrder.POST,
         depthwise_conv_kernel_size=31,
-        causal_depthwise_conv=False,
-        conv_norm_type="batch_norm",
-        shaw_rel_pos_sdpa_config=None,
     )
 
 
@@ -77,9 +74,6 @@ def _encoder_300m() -> Wav2Vec2EncoderConfig:
         layer_drop_p=0.0,
         norm_order=TransformerNormOrder.POST,
         depthwise_conv_kernel_size=31,
-        causal_depthwise_conv=False,
-        conv_norm_type="batch_norm",
-        shaw_rel_pos_sdpa_config=None,
     )
 
 

--- a/src/fairseq2/models/wav2vec2/builder.py
+++ b/src/fairseq2/models/wav2vec2/builder.py
@@ -98,7 +98,7 @@ class Wav2Vec2EncoderConfig:
 
     # Position Encoder
     pos_encoder_type: str
-    """The type of position encoder."""
+    """The type of position encoder ('conv', 'relative', 'rotary')."""
 
     # Convolutional Position Encoder
     pos_encoder_depth: int
@@ -355,7 +355,7 @@ class Wav2Vec2EncoderBuilder:
                     dtype=self.dtype,
                 )
 
-            sdpa = RelativePositionSDPA(
+            return RelativePositionSDPA(
                 self.config.model_dim,
                 self.config.num_encoder_attn_heads,
                 self.rel_pos_encoding,
@@ -363,10 +363,8 @@ class Wav2Vec2EncoderBuilder:
                 device=self.device,
                 dtype=self.dtype,
             )
-        else:
-            sdpa = create_default_sdpa(self.config.attn_dropout_p)
 
-        return sdpa
+        return create_default_sdpa(self.config.attn_dropout_p)
 
     def build_conformer_conv(self) -> ConformerConvolution:
         return ConformerConvolution(


### PR DESCRIPTION
**What does this PR do? Please describe:**

Refactor wav2vec2 builder to have build_conformer_conv() and build_sdpa() methods which can be overriden in the subclasses.

Hence we can remove causal_depthwise_conv, conv_norm_type, shaw_rel_pos_sdpa_config attributes out of the wav2vec2 config into the subclass' config.

**Does your PR introduce any breaking changes? If yes, please list them:**
List of all backwards-incompatible changes.

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [ ] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
