### PR TITLE
Use init_fn instead of skip_init

### DIFF
--- a/src/fairseq2/models/llama/builder.py
+++ b/src/fairseq2/models/llama/builder.py
@@ -8,15 +8,16 @@ from dataclasses import dataclass
 from typing import Optional
 
 from fairseq2.models.transformer import (
-    FinalProjection,
     TransformerDecoderModel,
     TransformerEmbeddingFrontend,
     TransformerFrontend,
+    init_final_projection,
 )
 from fairseq2.models.utils.arch_registry import ArchitectureRegistry
 from fairseq2.nn.embedding import StandardEmbedding
 from fairseq2.nn.normalization import LayerNorm, RMSNorm
 from fairseq2.nn.position_encoder import RotaryEncoder
+from fairseq2.nn.projection import Linear
 from fairseq2.nn.transformer import (
     FeedForwardNetwork,
     GLUFeedForwardNetwork,
@@ -227,9 +228,11 @@ class LLaMABuilder:
 
         decoder = self.build_decoder()
 
-        final_proj = FinalProjection(
+        final_proj = Linear(
             self.config.model_dim,
             self.config.vocabulary_size,
+            bias=False,
+            init_fn=init_final_projection,
             device=self.device,
             dtype=self.dtype,
         )

--- a/src/fairseq2/models/nllb/builder.py
+++ b/src/fairseq2/models/nllb/builder.py
@@ -14,7 +14,7 @@ from fairseq2.models.transformer import (
     TransformerModel,
 )
 from fairseq2.models.utils.arch_registry import ArchitectureRegistry
-from fairseq2.nn.embedding import Embedding, StandardEmbedding
+from fairseq2.nn.embedding import Embedding, StandardEmbedding, init_scaled_embedding
 from fairseq2.nn.position_encoder import SinusoidalPositionEncoder
 from fairseq2.nn.projection import TiedProjection
 from fairseq2.nn.transformer import (
@@ -180,13 +180,13 @@ class NllbBuilder:
             target_pad_idx=self.config.pad_idx,
         )
 
-    def build_embedding(self) -> Embedding:
+    def build_embedding(self) -> StandardEmbedding:
         """Build an embedding table."""
         return StandardEmbedding(
             num_embeddings=self.config.vocabulary_size,
             embedding_dim=self.config.model_dim,
             pad_idx=self.config.pad_idx,
-            scaled=True,
+            init_fn=init_scaled_embedding,
             device=self.device,
             dtype=self.dtype,
         )

--- a/src/fairseq2/models/s2t_transformer/builder.py
+++ b/src/fairseq2/models/s2t_transformer/builder.py
@@ -14,14 +14,15 @@ from fairseq2.models.conformer import ConformerBlock, ConformerConvolution
 from fairseq2.models.s2t_transformer.feature_extractor import Conv1dFbankSubsampler
 from fairseq2.models.s2t_transformer.frontend import S2TTransformerFrontend
 from fairseq2.models.transformer import (
-    FinalProjection,
     TransformerEmbeddingFrontend,
     TransformerFrontend,
     TransformerModel,
+    init_final_projection,
 )
 from fairseq2.models.utils.arch_registry import ArchitectureRegistry
-from fairseq2.nn.embedding import StandardEmbedding
+from fairseq2.nn.embedding import StandardEmbedding, init_scaled_embedding
 from fairseq2.nn.position_encoder import PositionEncoder, SinusoidalPositionEncoder
+from fairseq2.nn.projection import Linear
 from fairseq2.nn.transformer import (
     SDPA,
     FeedForwardNetwork,
@@ -242,9 +243,11 @@ class S2TTransformerBuilder:
         decoder_frontend = self.build_decoder_frontend()
         decoder = self.build_decoder()
 
-        final_proj = FinalProjection(
+        final_proj = Linear(
             self.config.model_dim,
             self.config.target_vocabulary_size,
+            bias=False,
+            init_fn=init_final_projection,
             device=self.device,
             dtype=self.dtype,
         )
@@ -287,7 +290,7 @@ class S2TTransformerBuilder:
             num_embeddings=self.config.target_vocabulary_size,
             embedding_dim=self.config.model_dim,
             pad_idx=self.config.target_pad_idx,
-            scaled=True,
+            init_fn=init_scaled_embedding,
             device=self.device,
             dtype=self.dtype,
         )

--- a/src/fairseq2/models/transformer/__init__.py
+++ b/src/fairseq2/models/transformer/__init__.py
@@ -13,5 +13,7 @@ from fairseq2.models.transformer.frontend import (
 from fairseq2.models.transformer.frontend import (
     TransformerFrontend as TransformerFrontend,
 )
-from fairseq2.models.transformer.model import FinalProjection as FinalProjection
 from fairseq2.models.transformer.model import TransformerModel as TransformerModel
+from fairseq2.models.transformer.model import (
+    init_final_projection as init_final_projection,
+)

--- a/src/fairseq2/models/transformer/model.py
+++ b/src/fairseq2/models/transformer/model.py
@@ -16,7 +16,7 @@ from fairseq2.nn.incremental_state import IncrementalStateBag
 from fairseq2.nn.projection import Linear, Projection
 from fairseq2.nn.transformer import TransformerDecoder, TransformerEncoder
 from fairseq2.nn.utils.module import check_model_dim
-from fairseq2.typing import DataType, Device, finaloverride
+from fairseq2.typing import finaloverride
 
 
 @final
@@ -107,32 +107,8 @@ class TransformerModel(EncoderDecoderModel):
         return SequenceModelOutput(logits, self.target_pad_idx)
 
 
-@final
-class FinalProjection(Linear):
-    """Produces logits from outputs of a Transformer decoder."""
+def init_final_projection(proj: Linear) -> None:
+    nn.init.normal_(proj.weight, std=proj.input_dim**-0.5)
 
-    def __init__(
-        self,
-        model_dim: int,
-        target_vocabulary_size: int,
-        *,
-        device: Optional[Device] = None,
-        dtype: Optional[DataType] = None,
-    ) -> None:
-        """
-        :param model_dim:
-            The dimensionality of the model.
-        :param target_vocabulary_size:
-            The size of the target vocabulary.
-        """
-        super().__init__(
-            model_dim, target_vocabulary_size, bias=False, device=device, dtype=dtype
-        )
-
-    @finaloverride
-    def _do_reset_parameters(self) -> None:
-        """Reset the parameters and buffers of the module."""
-        nn.init.normal_(self.weight, std=self.input_dim**-0.5)
-
-        if self.bias is not None:
-            nn.init.zeros_(self.bias)
+    if proj.bias is not None:
+        nn.init.zeros_(proj.bias)

--- a/src/fairseq2/models/wav2vec2/vector_quantizer.py
+++ b/src/fairseq2/models/wav2vec2/vector_quantizer.py
@@ -118,7 +118,7 @@ class GumbelVectorQuantizer(VectorQuantizer):
             self.input_dim,
             num_total_entries,
             bias=True,
-            skip_init=True,
+            init_fn=init_entry_projection,
             device=device,
             dtype=dtype,
         )
@@ -136,12 +136,6 @@ class GumbelVectorQuantizer(VectorQuantizer):
     def reset_parameters(self) -> None:
         """Reset the parameters and buffers of the module."""
         nn.init.uniform_(self.entries)
-
-        nn.init.normal_(self.entry_proj.weight, mean=0.0, std=1.0)
-
-        assert self.entry_proj.bias is not None
-
-        nn.init.zeros_(self.entry_proj.bias)
 
         self.num_updates.zero_()
 
@@ -213,6 +207,14 @@ class GumbelVectorQuantizer(VectorQuantizer):
             self.num_updates.add_(1)
 
         return max(temp, self.min_temp)
+
+
+def init_entry_projection(proj: Linear) -> None:
+    nn.init.normal_(proj.weight, mean=0.0, std=1.0)
+
+    assert proj.bias is not None
+
+    nn.init.zeros_(proj.bias)
 
 
 @final

--- a/src/fairseq2/nn/embedding.py
+++ b/src/fairseq2/nn/embedding.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from abc import ABC, abstractmethod
-from typing import Optional, final
+from typing import Callable, Optional, final
 
 import torch
 import torch.nn as nn
@@ -73,16 +73,16 @@ class Embedding(Module, ABC):
 class StandardEmbedding(Embedding):
     """Stores embeddings of a fixed dictionary and size in an in-memory table."""
 
-    scaled: bool
     weight: Parameter
+    init_fn: Optional[Callable[["StandardEmbedding"], None]]
 
     def __init__(
         self,
         num_embeddings: int,
         embedding_dim: int,
         pad_idx: Optional[int] = None,
-        scaled: bool = False,
         *,
+        init_fn: Optional[Callable[["StandardEmbedding"], None]] = None,
         device: Optional[Device] = None,
         dtype: Optional[DataType] = None,
     ) -> None:
@@ -95,27 +95,27 @@ class StandardEmbedding(Embedding):
             If not ``None``, entries at ``pad_idx`` do not contribute to the
             gradient; therefore, the embedding at ``pad_idx`` is not updated
             during training.
-        :param scaled:
-            If ``True``, initializes the embeddings from
-            :math:`\\mathcal{N}(0, \\frac{1}{\\text{embedding_dim}})`; otherwise,
-            from :math:`\\mathcal{N}(0, 1)`.
+        :param init_fn:
+            The callable to use for parameter initialization.
         """
         super().__init__(num_embeddings, embedding_dim, pad_idx)
-
-        self.scaled = scaled
 
         self.weight = Parameter(
             torch.empty((num_embeddings, embedding_dim), device=device, dtype=dtype)
         )
 
+        self.init_fn = init_fn
+
         self.reset_parameters()
 
     def reset_parameters(self) -> None:
         """Reset the parameters and buffers of the module."""
-        if self.scaled:
-            nn.init.normal_(self.weight, std=self.embedding_dim**-0.5)
-        else:
-            nn.init.normal_(self.weight)
+        if self.init_fn is not None:
+            self.init_fn(self)
+
+            return
+
+        nn.init.normal_(self.weight)
 
         if self.pad_idx is not None:
             with torch.no_grad():
@@ -129,7 +129,17 @@ class StandardEmbedding(Embedding):
         """:meta private:"""
         s = super().extra_repr()
 
-        if self.scaled:
-            s = f"{s}, scaled=True"
+        if self.init_fn is not None:
+            s = f"{s}, init_fn={getattr(self.init_fn, '__name__', self.init_fn)}"
 
         return s
+
+
+def init_scaled_embedding(embed: StandardEmbedding) -> None:
+    """Initialize ``embed`` from
+    :math:`\\mathcal{N}(0, \\frac{1}{\\text{embedding_dim}})`."""
+    nn.init.normal_(embed.weight, std=embed.embedding_dim**-0.5)
+
+    if embed.pad_idx is not None:
+        with torch.no_grad():
+            embed.weight[embed.pad_idx].fill_(0.0)

--- a/src/fairseq2/nn/projection.py
+++ b/src/fairseq2/nn/projection.py
@@ -6,7 +6,7 @@
 
 import math
 from abc import ABC, abstractmethod
-from typing import Optional, final
+from typing import Callable, Optional, final
 
 import torch
 import torch.nn as nn
@@ -15,7 +15,7 @@ from torch.nn import Module
 from torch.nn.functional import linear
 from torch.nn.parameter import Parameter
 
-from fairseq2.typing import DataType, Device, finaloverride, override
+from fairseq2.typing import DataType, Device, finaloverride
 
 
 class Projection(Module, ABC):
@@ -53,6 +53,7 @@ class Projection(Module, ABC):
         return f"input_dim={self.input_dim}, output_dim={self.output_dim}"
 
 
+@final
 class Linear(Projection):
     """Applies a linear transformation to incoming data using weights and bias.
 
@@ -66,7 +67,7 @@ class Linear(Projection):
 
     weight: Parameter
     bias: Optional[Parameter]
-    skip_init: bool
+    init_fn: Optional[Callable[["Linear"], None]]
 
     def __init__(
         self,
@@ -74,7 +75,7 @@ class Linear(Projection):
         output_dim: int,
         bias: bool,
         *,
-        skip_init: bool = False,
+        init_fn: Optional[Callable[["Linear"], None]] = None,
         device: Optional[Device] = None,
         dtype: Optional[DataType] = None,
     ) -> None:
@@ -85,12 +86,8 @@ class Linear(Projection):
             The dimensionality of projected outputs.
         :param bias:
             If ``True``, learns an additive bias.
-        :param skip_init:
-            If ``True``, the weights and bias will be left uninitialized, and
-            :meth:`reset_parameters` will become noop.
-
-            This parameter is intended to be used by module authors who want to
-            use a different weight initialization method in their modules.
+        :param init_fn:
+            The callable to use for parameter initialization.
         """
         super().__init__(input_dim, output_dim)
 
@@ -105,17 +102,17 @@ class Linear(Projection):
         else:
             self.register_parameter("bias", None)
 
-        self.skip_init = skip_init
+        self.init_fn = init_fn
 
         self.reset_parameters()
 
     def reset_parameters(self) -> None:
         """Reset the parameters and buffers of the module."""
-        if not self.skip_init:
-            self._do_reset_parameters()
+        if self.init_fn is not None:
+            self.init_fn(self)
 
-    def _do_reset_parameters(self) -> None:
-        """Reset the parameters and buffers of the module."""
+            return
+
         nn.init.kaiming_uniform_(self.weight, a=math.sqrt(5))
 
         if self.bias is not None:
@@ -126,7 +123,7 @@ class Linear(Projection):
 
             nn.init.uniform_(self.bias, -bound, bound)
 
-    @override
+    @finaloverride
     def forward(self, x: Tensor) -> Tensor:
         return linear(x, self.weight, self.bias)
 
@@ -134,7 +131,12 @@ class Linear(Projection):
         """:meta private:"""
         s = super().extra_repr()
 
-        return f"{s}, bias={self.bias is not None}"
+        s = f"{s}, bias={self.bias is not None}"
+
+        if self.init_fn is not None:
+            s = f"{s}, init_fn={getattr(self.init_fn, '__name__', self.init_fn)}"
+
+        return s
 
 
 @final

--- a/src/fairseq2/nn/transformer/multihead_attention.py
+++ b/src/fairseq2/nn/transformer/multihead_attention.py
@@ -21,7 +21,7 @@ from fairseq2.nn.ops import repeat_interleave
 from fairseq2.nn.position_encoder import PositionEncoder
 from fairseq2.nn.projection import Linear, Projection
 from fairseq2.nn.transformer.attention import SDPA, create_default_sdpa
-from fairseq2.typing import DataType, Device, finaloverride, override
+from fairseq2.typing import DataType, Device, finaloverride
 
 
 class MultiheadAttention(Module, ABC):
@@ -286,20 +286,27 @@ class StandardMultiheadAttention(MultiheadAttention):
         num_query_groups = num_heads // self.num_key_value_heads
 
         if q_proj is None and k_proj is None and v_proj is None:
-            q_proj = QKVProjection(
-                model_dim, model_dim, bias, device=device, dtype=dtype
-            )
-            k_proj = QKVProjection(
+            q_proj = Linear(
                 model_dim,
-                head_dim * self.num_key_value_heads,
+                model_dim,
                 bias,
+                init_fn=init_qkv_projection,
                 device=device,
                 dtype=dtype,
             )
-            v_proj = QKVProjection(
+            k_proj = Linear(
                 model_dim,
                 head_dim * self.num_key_value_heads,
                 bias,
+                init_fn=init_qkv_projection,
+                device=device,
+                dtype=dtype,
+            )
+            v_proj = Linear(
+                model_dim,
+                head_dim * self.num_key_value_heads,
+                bias,
+                init_fn=init_qkv_projection,
                 device=device,
                 dtype=dtype,
             )
@@ -372,8 +379,13 @@ class StandardMultiheadAttention(MultiheadAttention):
         v_dim = v_proj.output_dim * num_query_groups
 
         if output_proj is None:
-            self.output_proj = AttentionOutputProjection(
-                v_dim, model_dim, bias, device=device, dtype=dtype
+            self.output_proj = Linear(
+                v_dim,
+                model_dim,
+                bias,
+                init_fn=init_output_projection,
+                device=device,
+                dtype=dtype,
             )
         else:
             if v_dim != output_proj.input_dim:
@@ -594,50 +606,22 @@ class StandardMultiheadAttention(MultiheadAttention):
         return f"{s}, state_factory={self.state_factory}"
 
 
-class QKVProjection(Linear):
-    """Represents the default projection used for queries, keys, and values."""
+def init_qkv_projection(proj: Linear) -> None:
+    """Initialize ``proj`` as a multi-head attention input projection."""
+    # Empirically observed the convergence to be much better with the scaled
+    # initialization.
+    nn.init.xavier_uniform_(proj.weight, gain=2**-0.5)
 
-    def __init__(
-        self,
-        model_dim: int,
-        output_dim: int,
-        bias: bool,
-        *,
-        device: Optional[Device] = None,
-        dtype: Optional[DataType] = None,
-    ) -> None:
-        super().__init__(model_dim, output_dim, bias, device=device, dtype=dtype)
-
-    @override
-    def _do_reset_parameters(self) -> None:
-        # Empirically observed the convergence to be much better with the scaled
-        # initialization.
-        nn.init.xavier_uniform_(self.weight, gain=2**-0.5)
-
-        if self.bias is not None:
-            nn.init.zeros_(self.bias)
+    if proj.bias is not None:
+        nn.init.zeros_(proj.bias)
 
 
-class AttentionOutputProjection(Linear):
-    """Represents the default projection used for attention outputs."""
+def init_output_projection(proj: Linear) -> None:
+    """Initialize ``proj`` as a multi-head attention output projection."""
+    nn.init.xavier_uniform_(proj.weight)
 
-    def __init__(
-        self,
-        v_dim: int,
-        model_dim: int,
-        bias: bool,
-        *,
-        device: Optional[Device] = None,
-        dtype: Optional[DataType] = None,
-    ) -> None:
-        super().__init__(v_dim, model_dim, bias, device=device, dtype=dtype)
-
-    @override
-    def _do_reset_parameters(self) -> None:
-        nn.init.xavier_uniform_(self.weight)
-
-        if self.bias is not None:
-            nn.init.zeros_(self.bias)
+    if proj.bias is not None:
+        nn.init.zeros_(proj.bias)
 
 
 class AttentionState(IncrementalState):


### PR DESCRIPTION
This PR moves away from the `skip_init` approach for custom module initialization and instead uses a more flexible `init_fn` callable.