### PR TITLE
Rename layer_norm_fn to layer_norm_factory

### DIFF
--- a/src/fairseq2/models/conformer/block.py
+++ b/src/fairseq2/models/conformer/block.py
@@ -48,7 +48,7 @@ class ConformerBlock(TransformerEncoderLayer):
         ffn2: FeedForwardNetwork,
         *,
         dropout_p: float = 0.1,
-        layer_norm_fn: Optional[LayerNormFactory] = None,
+        layer_norm_factory: Optional[LayerNormFactory] = None,
         device: Optional[Device] = None,
         dtype: Optional[DataType] = None,
     ) -> None:
@@ -64,17 +64,17 @@ class ConformerBlock(TransformerEncoderLayer):
         :param dropout_p:
             The dropout probability on outputs of the self attention layer, the
             feed-forward networks, and the Conformer convolution module.
-        :param layer_norm_fn:
+        :param layer_norm_factory:
             The factory to use to construct the Layer Normalization modules.
         """
         model_dim = self_attn.model_dim
 
         super().__init__(model_dim)
 
-        if layer_norm_fn is None:
-            layer_norm_fn = create_default_layer_norm
+        if layer_norm_factory is None:
+            layer_norm_factory = create_default_layer_norm
 
-        self.ffn1_layer_norm = layer_norm_fn(model_dim, device=device, dtype=dtype)
+        self.ffn1_layer_norm = layer_norm_factory(model_dim, device=device, dtype=dtype)
 
         self.ffn1 = ffn1
 
@@ -83,7 +83,9 @@ class ConformerBlock(TransformerEncoderLayer):
         else:
             self.register_module("ffn1_dropout", None)
 
-        self.self_attn_layer_norm = layer_norm_fn(model_dim, device=device, dtype=dtype)
+        self.self_attn_layer_norm = layer_norm_factory(
+            model_dim, device=device, dtype=dtype
+        )
 
         self.self_attn = self_attn
 
@@ -92,7 +94,7 @@ class ConformerBlock(TransformerEncoderLayer):
         else:
             self.register_module("self_attn_dropout", None)
 
-        self.conv_layer_norm = layer_norm_fn(model_dim, device=device, dtype=dtype)
+        self.conv_layer_norm = layer_norm_factory(model_dim, device=device, dtype=dtype)
 
         self.conv = conv
 
@@ -101,7 +103,7 @@ class ConformerBlock(TransformerEncoderLayer):
         else:
             self.register_module("conv_dropout", None)
 
-        self.ffn2_layer_norm = layer_norm_fn(model_dim, device=device, dtype=dtype)
+        self.ffn2_layer_norm = layer_norm_factory(model_dim, device=device, dtype=dtype)
 
         self.ffn2 = ffn2
 
@@ -110,7 +112,7 @@ class ConformerBlock(TransformerEncoderLayer):
         else:
             self.register_module("ffn2_dropout", None)
 
-        self.layer_norm = layer_norm_fn(model_dim, device=device, dtype=dtype)
+        self.layer_norm = layer_norm_factory(model_dim, device=device, dtype=dtype)
 
         check_model_dim(self)
 

--- a/src/fairseq2/models/llama/builder.py
+++ b/src/fairseq2/models/llama/builder.py
@@ -265,12 +265,10 @@ class LLaMABuilder:
 
         layers = [self.build_decoder_layer() for _ in range(num_layers)]
 
-        rms_norm_fn = self.build_layer_norm
-
         return StandardTransformerDecoder(
             layers,
             norm_order=TransformerNormOrder.PRE,
-            layer_norm_fn=rms_norm_fn,
+            layer_norm_factory=self.build_layer_norm,
             device=self.device,
             dtype=self.dtype,
         )
@@ -283,15 +281,13 @@ class LLaMABuilder:
 
         ffn = self.build_ffn()
 
-        rms_norm_fn = self.build_layer_norm
-
         return StandardTransformerDecoderLayer(
             self_attn,
             encoder_decoder_attn=None,
             ffn=ffn,
             dropout_p=self.config.dropout_p,
             norm_order=TransformerNormOrder.PRE,
-            layer_norm_fn=rms_norm_fn,
+            layer_norm_factory=self.build_layer_norm,
             device=self.device,
             dtype=self.dtype,
         )

--- a/src/fairseq2/models/transformer/frontend.py
+++ b/src/fairseq2/models/transformer/frontend.py
@@ -91,7 +91,7 @@ class TransformerEmbeddingFrontend(TransformerFrontend):
         no_scale: bool = False,
         layer_norm: bool = False,
         dropout_p: float = 0.1,
-        layer_norm_fn: Optional[LayerNormFactory] = None,
+        layer_norm_factory: Optional[LayerNormFactory] = None,
         device: Optional[Device] = None,
         dtype: Optional[DataType] = None,
     ) -> None:
@@ -108,15 +108,15 @@ class TransformerEmbeddingFrontend(TransformerFrontend):
             dropout.
         :param dropout_p:
             The dropout probability on embeddings.
-        :param layer_norm_fn:
+        :param layer_norm_factory:
             The factory to use to construct the Layer Normalization module.
         """
         model_dim = embed.embedding_dim
 
         super().__init__(model_dim)
 
-        if layer_norm_fn is None:
-            layer_norm_fn = create_default_layer_norm
+        if layer_norm_factory is None:
+            layer_norm_factory = create_default_layer_norm
 
         self.embed = embed
 
@@ -133,7 +133,7 @@ class TransformerEmbeddingFrontend(TransformerFrontend):
             self.register_module("pos_encoder", None)
 
         if layer_norm:
-            self.layer_norm = layer_norm_fn(model_dim, device=device, dtype=dtype)
+            self.layer_norm = layer_norm_factory(model_dim, device=device, dtype=dtype)
         else:
             self.register_module("layer_norm", None)
 

--- a/src/fairseq2/nn/transformer/decoder.py
+++ b/src/fairseq2/nn/transformer/decoder.py
@@ -131,7 +131,7 @@ class StandardTransformerDecoder(TransformerDecoder):
         self_attn_mask_gen: Optional[AttentionMaskGenerator] = None,
         layer_drop_p: float = 0.0,
         norm_order: TransformerNormOrder = TransformerNormOrder.POST,
-        layer_norm_fn: Optional[LayerNormFactory] = None,
+        layer_norm_factory: Optional[LayerNormFactory] = None,
         device: Optional[Device] = None,
         dtype: Optional[DataType] = None,
     ) -> None:
@@ -146,7 +146,7 @@ class StandardTransformerDecoder(TransformerDecoder):
             described in :cite:t:`https://doi.org/10.48550/arxiv.1909.11556`.
         :param norm_order:
             The Layer Normalization order to use.
-        :param layer_norm_fn:
+        :param layer_norm_factory:
             The factory to use to construct the Layer Normalization module.
         """
         layer_list = ModuleList(layers, drop_p=layer_drop_p)
@@ -157,8 +157,8 @@ class StandardTransformerDecoder(TransformerDecoder):
 
         super().__init__(model_dim)
 
-        if layer_norm_fn is None:
-            layer_norm_fn = create_default_layer_norm
+        if layer_norm_factory is None:
+            layer_norm_factory = create_default_layer_norm
 
         if self_attn_mask_gen is None:
             self.self_attn_mask_gen = CausalAttentionMaskGenerator()
@@ -168,7 +168,7 @@ class StandardTransformerDecoder(TransformerDecoder):
         self.layers = layer_list
 
         if norm_order != TransformerNormOrder.POST:
-            self.layer_norm = layer_norm_fn(model_dim, device=device, dtype=dtype)
+            self.layer_norm = layer_norm_factory(model_dim, device=device, dtype=dtype)
         else:
             self.register_module("layer_norm", None)
 

--- a/src/fairseq2/nn/transformer/decoder_layer.py
+++ b/src/fairseq2/nn/transformer/decoder_layer.py
@@ -113,7 +113,7 @@ class StandardTransformerDecoderLayer(TransformerDecoderLayer):
         scale_residual: bool = False,
         dropout_p: float = 0.1,
         norm_order: TransformerNormOrder = TransformerNormOrder.POST,
-        layer_norm_fn: Optional[LayerNormFactory] = None,
+        layer_norm_factory: Optional[LayerNormFactory] = None,
         device: Optional[Device] = None,
         dtype: Optional[DataType] = None,
     ) -> None:
@@ -134,17 +134,17 @@ class StandardTransformerDecoderLayer(TransformerDecoderLayer):
             feed-forward network.
         :param norm_order:
             The Layer Normalization order to use.
-        :param layer_norm_fn:
+        :param layer_norm_factory:
             The factory to use to construct the Layer Normalization modules.
         """
         model_dim = self_attn.model_dim
 
         super().__init__(model_dim)
 
-        if layer_norm_fn is None:
-            layer_norm_fn = create_default_layer_norm
+        if layer_norm_factory is None:
+            layer_norm_factory = create_default_layer_norm
 
-        self_attn_layer_norm = layer_norm_fn(model_dim, device=device, dtype=dtype)
+        self_attn_layer_norm = layer_norm_factory(model_dim, device=device, dtype=dtype)
 
         if norm_order != TransformerNormOrder.POST:
             self.self_attn_layer_norm = self_attn_layer_norm
@@ -152,7 +152,9 @@ class StandardTransformerDecoderLayer(TransformerDecoderLayer):
         self.self_attn = self_attn
 
         if norm_order == TransformerNormOrder.PRE_WITH_NORMFORMER:
-            self.self_attn_norm = layer_norm_fn(model_dim, device=device, dtype=dtype)
+            self.self_attn_norm = layer_norm_factory(
+                model_dim, device=device, dtype=dtype
+            )
         else:
             self.register_module("self_attn_norm", None)
 
@@ -168,7 +170,7 @@ class StandardTransformerDecoderLayer(TransformerDecoderLayer):
             self.register_module("encoder_decoder_attn", None)
             self.register_module("encoder_decoder_attn_layer_norm", None)
         else:
-            encoder_decoder_attn_layer_norm = layer_norm_fn(
+            encoder_decoder_attn_layer_norm = layer_norm_factory(
                 model_dim, device=device, dtype=dtype
             )
 
@@ -185,7 +187,7 @@ class StandardTransformerDecoderLayer(TransformerDecoderLayer):
             if norm_order == TransformerNormOrder.POST:
                 self.encoder_decoder_attn_layer_norm = encoder_decoder_attn_layer_norm
 
-        ffn_layer_norm = layer_norm_fn(model_dim, device=device, dtype=dtype)
+        ffn_layer_norm = layer_norm_factory(model_dim, device=device, dtype=dtype)
 
         if norm_order != TransformerNormOrder.POST:
             self.ffn_layer_norm = ffn_layer_norm

--- a/src/fairseq2/nn/transformer/encoder.py
+++ b/src/fairseq2/nn/transformer/encoder.py
@@ -110,7 +110,7 @@ class StandardTransformerEncoder(TransformerEncoder):
         *,
         layer_drop_p: float = 0.0,
         norm_order: TransformerNormOrder = TransformerNormOrder.POST,
-        layer_norm_fn: Optional[LayerNormFactory] = None,
+        layer_norm_factory: Optional[LayerNormFactory] = None,
         device: Optional[Device] = None,
         dtype: Optional[DataType] = None,
     ) -> None:
@@ -122,7 +122,7 @@ class StandardTransformerEncoder(TransformerEncoder):
             described in :cite:t:`https://doi.org/10.48550/arxiv.1909.11556`.
         :param norm_order:
             The Layer Normalization order to use.
-        :param layer_norm_fn:
+        :param layer_norm_factory:
             The factory to use to construct the Layer Normalization module.
         """
         layer_list = ModuleList(layers, drop_p=layer_drop_p)
@@ -133,13 +133,13 @@ class StandardTransformerEncoder(TransformerEncoder):
 
         super().__init__(model_dim)
 
-        if layer_norm_fn is None:
-            layer_norm_fn = create_default_layer_norm
+        if layer_norm_factory is None:
+            layer_norm_factory = create_default_layer_norm
 
         self.layers = layer_list
 
         if norm_order != TransformerNormOrder.POST:
-            self.layer_norm = layer_norm_fn(model_dim, device=device, dtype=dtype)
+            self.layer_norm = layer_norm_factory(model_dim, device=device, dtype=dtype)
         else:
             self.register_module("layer_norm", None)
 

--- a/src/fairseq2/nn/transformer/encoder_layer.py
+++ b/src/fairseq2/nn/transformer/encoder_layer.py
@@ -94,7 +94,7 @@ class StandardTransformerEncoderLayer(TransformerEncoderLayer):
         scale_residual: bool = False,
         dropout_p: float = 0.1,
         norm_order: TransformerNormOrder = TransformerNormOrder.POST,
-        layer_norm_fn: Optional[LayerNormFactory] = None,
+        layer_norm_factory: Optional[LayerNormFactory] = None,
         device: Optional[Device] = None,
         dtype: Optional[DataType] = None,
     ) -> None:
@@ -113,17 +113,17 @@ class StandardTransformerEncoderLayer(TransformerEncoderLayer):
             the feed-forward network.
         :param norm_order:
             The Layer Normalization order to use.
-        :param layer_norm_fn:
+        :param layer_norm_factory:
             The factory to use to construct the Layer Normalization modules.
         """
         model_dim = self_attn.model_dim
 
         super().__init__(model_dim)
 
-        if layer_norm_fn is None:
-            layer_norm_fn = create_default_layer_norm
+        if layer_norm_factory is None:
+            layer_norm_factory = create_default_layer_norm
 
-        self_attn_layer_norm = layer_norm_fn(model_dim, device=device, dtype=dtype)
+        self_attn_layer_norm = layer_norm_factory(model_dim, device=device, dtype=dtype)
 
         if norm_order != TransformerNormOrder.POST:
             self.self_attn_layer_norm = self_attn_layer_norm
@@ -131,7 +131,9 @@ class StandardTransformerEncoderLayer(TransformerEncoderLayer):
         self.self_attn = self_attn
 
         if norm_order == TransformerNormOrder.PRE_WITH_NORMFORMER:
-            self.self_attn_norm = layer_norm_fn(model_dim, device=device, dtype=dtype)
+            self.self_attn_norm = layer_norm_factory(
+                model_dim, device=device, dtype=dtype
+            )
         else:
             self.register_module("self_attn_norm", None)
 
@@ -143,7 +145,7 @@ class StandardTransformerEncoderLayer(TransformerEncoderLayer):
         if norm_order == TransformerNormOrder.POST:
             self.self_attn_layer_norm = self_attn_layer_norm
 
-        ffn_layer_norm = layer_norm_fn(model_dim, device=device, dtype=dtype)
+        ffn_layer_norm = layer_norm_factory(model_dim, device=device, dtype=dtype)
 
         if norm_order != TransformerNormOrder.POST:
             self.ffn_layer_norm = ffn_layer_norm

--- a/src/fairseq2/nn/transformer/ffn.py
+++ b/src/fairseq2/nn/transformer/ffn.py
@@ -71,7 +71,7 @@ class StandardFeedForwardNetwork(FeedForwardNetwork):
         inner_activation: Optional[Module] = None,
         inner_dropout_p: float = 0.0,
         norm_order: TransformerNormOrder = TransformerNormOrder.POST,
-        layer_norm_fn: Optional[LayerNormFactory] = None,
+        layer_norm_factory: Optional[LayerNormFactory] = None,
         device: Optional[Device] = None,
         dtype: Optional[DataType] = None,
     ) -> None:
@@ -90,13 +90,13 @@ class StandardFeedForwardNetwork(FeedForwardNetwork):
             The dropout probability on outputs of the inner projection layer.
         :param norm_order:
             The Layer Normalization order to use.
-        :param layer_norm_fn:
+        :param layer_norm_factory:
             The factory to use to construct the Layer Normalization module.
         """
         super().__init__(model_dim)
 
-        if layer_norm_fn is None:
-            layer_norm_fn = create_default_layer_norm
+        if layer_norm_factory is None:
+            layer_norm_factory = create_default_layer_norm
 
         self.inner_proj = Linear(model_dim, inner_dim, bias, device=device, dtype=dtype)
 
@@ -111,7 +111,9 @@ class StandardFeedForwardNetwork(FeedForwardNetwork):
             self.register_module("inner_dropout", None)
 
         if norm_order == TransformerNormOrder.PRE_WITH_NORMFORMER:
-            self.inner_layer_norm = layer_norm_fn(inner_dim, device=device, dtype=dtype)
+            self.inner_layer_norm = layer_norm_factory(
+                inner_dim, device=device, dtype=dtype
+            )
         else:
             self.register_module("inner_layer_norm", None)
 


### PR DESCRIPTION
A nit PR that renamed `layer_norm_fn` to `layer_norm_factory` to follow the "factory" convention in the rest of the API.