### PR TITLE
Improvements to attention mask handling

### DIFF
--- a/src/fairseq2/models/nllb/builder.py
+++ b/src/fairseq2/models/nllb/builder.py
@@ -253,9 +253,7 @@ class NllbBuilder:
         """Build a Transformer decoder layer."""
         self_attn = self.build_attention(self.config.num_decoder_attn_heads)
 
-        encoder_decoder_attn = self.build_attention(
-            self.config.num_decoder_attn_heads, encoder_decoder=True
-        )
+        encoder_decoder_attn = self.build_attention(self.config.num_decoder_attn_heads)
 
         ffn = self.build_ffn()
 
@@ -269,16 +267,13 @@ class NllbBuilder:
             dtype=self.dtype,
         )
 
-    def build_attention(
-        self, num_heads: int, encoder_decoder: bool = False
-    ) -> MultiheadAttention:
+    def build_attention(self, num_heads: int) -> MultiheadAttention:
         """Build a Transformer multi-head attention layer."""
         sdpa = create_default_sdpa(attn_dropout_p=self.config.dropout_p)
 
         return StandardMultiheadAttention(
             self.config.model_dim,
             num_heads,
-            static_kv=encoder_decoder,
             sdpa=sdpa,
             device=self.device,
             dtype=self.dtype,

--- a/src/fairseq2/models/s2t_transformer/builder.py
+++ b/src/fairseq2/models/s2t_transformer/builder.py
@@ -404,7 +404,7 @@ class S2TTransformerBuilder:
         """Build a Transformer decoder layer."""
         self_attn = self.build_decoder_attention()
 
-        encoder_decoder_attn = self.build_decoder_attention(encoder_decoder=True)
+        encoder_decoder_attn = self.build_decoder_attention()
 
         ffn = self.build_ffn()
 
@@ -450,16 +450,13 @@ class S2TTransformerBuilder:
             dtype=self.dtype,
         )
 
-    def build_decoder_attention(
-        self, encoder_decoder: bool = False
-    ) -> MultiheadAttention:
+    def build_decoder_attention(self) -> MultiheadAttention:
         """Build a Transformer decoder multi-head attention layer."""
         sdpa = create_default_sdpa(attn_dropout_p=self.config.dropout_p)
 
         return StandardMultiheadAttention(
             self.config.model_dim,
             self.config.num_decoder_attn_heads,
-            static_kv=encoder_decoder,
             sdpa=sdpa,
             device=self.device,
             dtype=self.dtype,

--- a/src/fairseq2/nn/padding.py
+++ b/src/fairseq2/nn/padding.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Optional, Sequence, Tuple, cast
+from typing import Any, Optional, Sequence, Tuple, cast
 
 import torch
 from torch import Tensor
@@ -76,7 +76,7 @@ def to_padding_mask(seq_lens: Tensor, batch_seq_len: int) -> Tensor:
 
 
 def apply_padding_mask(
-    seqs: Tensor, padding_mask: Optional[PaddingMask], fill_value: float = 0.0
+    seqs: Tensor, padding_mask: Optional[PaddingMask], fill_value: Any = 0
 ) -> Tensor:
     """Apply the specified padding mask to ``seqs``.
 

--- a/src/fairseq2/nn/transformer/__init__.py
+++ b/src/fairseq2/nn/transformer/__init__.py
@@ -18,13 +18,13 @@ from fairseq2.nn.transformer.attention_mask import (
     AttentionMaskFactory as AttentionMaskFactory,
 )
 from fairseq2.nn.transformer.attention_mask import (
+    CausalAttentionMask as CausalAttentionMask,
+)
+from fairseq2.nn.transformer.attention_mask import (
+    CausalAttentionMaskFactory as CausalAttentionMaskFactory,
+)
+from fairseq2.nn.transformer.attention_mask import (
     CustomAttentionMask as CustomAttentionMask,
-)
-from fairseq2.nn.transformer.attention_mask import (
-    GlobalCausalAttentionMask as GlobalCausalAttentionMask,
-)
-from fairseq2.nn.transformer.attention_mask import (
-    GlobalCausalAttentionMaskFactory as GlobalCausalAttentionMaskFactory,
 )
 from fairseq2.nn.transformer.decoder import (
     DecoderLayerOutputHook as DecoderLayerOutputHook,
@@ -69,7 +69,7 @@ from fairseq2.nn.transformer.multihead_attention import (
     AttentionWeightHook as AttentionWeightHook,
 )
 from fairseq2.nn.transformer.multihead_attention import (
-    GlobalAttentionState as GlobalAttentionState,
+    FullAttentionState as FullAttentionState,
 )
 from fairseq2.nn.transformer.multihead_attention import (
     LocalAttentionState as LocalAttentionState,

--- a/src/fairseq2/nn/transformer/decoder.py
+++ b/src/fairseq2/nn/transformer/decoder.py
@@ -16,7 +16,7 @@ from fairseq2.nn.normalization import LayerNorm
 from fairseq2.nn.padding import PaddingMask
 from fairseq2.nn.transformer.attention_mask import (
     AttentionMaskFactory,
-    GlobalCausalAttentionMaskFactory,
+    CausalAttentionMaskFactory,
 )
 from fairseq2.nn.transformer.decoder_layer import TransformerDecoderLayer
 from fairseq2.nn.transformer.layer_norm import (
@@ -120,7 +120,7 @@ class StandardTransformerDecoder(TransformerDecoder):
     """Represents a Transformer decoder as described in
     :cite:t:`https://doi.org/10.48550/arxiv.1706.03762`."""
 
-    self_attn_mask_factory: AttentionMaskFactory
+    self_attn_mask_factory: Optional[AttentionMaskFactory]
     layer_norm: Optional[LayerNorm]
     norm_order: TransformerNormOrder
 
@@ -129,6 +129,7 @@ class StandardTransformerDecoder(TransformerDecoder):
         layers: Iterable[TransformerDecoderLayer],
         *,
         self_attn_mask_factory: Optional[AttentionMaskFactory] = None,
+        use_causal_attn_mask: bool = True,
         layer_drop_p: float = 0.0,
         norm_order: TransformerNormOrder = TransformerNormOrder.POST,
         layer_norm_factory: Optional[LayerNormFactory] = None,
@@ -139,8 +140,11 @@ class StandardTransformerDecoder(TransformerDecoder):
         :param layers:
             The decoder layers.
         :param self_attn_mask_factory:
-            The self attention mask factory. If ``None``,
-            :class:`GlobalCausalAttentionMask` will be used.
+            The self attention mask factory.
+        :param use_causal_attn_mask:
+            If ``True``, passes a full :class:`CausalAttentionMask` to the
+            decoder layers; otherwise, passes ``None``. Ignored if
+            ``self_attn_mask_factory`` is specified.
         :param layer_drop_p:
             If greater than zero, applies LayerDrop to the decoder layers as
             described in :cite:t:`https://doi.org/10.48550/arxiv.1909.11556`.
@@ -162,8 +166,10 @@ class StandardTransformerDecoder(TransformerDecoder):
 
         if self_attn_mask_factory is not None:
             self.self_attn_mask_factory = self_attn_mask_factory
+        elif use_causal_attn_mask:
+            self.self_attn_mask_factory = CausalAttentionMaskFactory()
         else:
-            self.self_attn_mask_factory = GlobalCausalAttentionMaskFactory()
+            self.self_attn_mask_factory = None
 
         self.layers = layer_list
 
@@ -192,9 +198,12 @@ class StandardTransformerDecoder(TransformerDecoder):
 
         num_layers = len(self.layers)
 
-        self_attn_mask = self.self_attn_mask_factory(
-            seqs, padding_mask, self.training, state_bag
-        )
+        if self.self_attn_mask_factory is None:
+            self_attn_mask = None
+        else:
+            self_attn_mask = self.self_attn_mask_factory(
+                seqs, keys=seqs, training=self.training, state_bag=state_bag
+            )
 
         for layer_idx, layer in enumerate(self.layers.drop_iter()):
             seqs, padding_mask = layer(
@@ -219,12 +228,11 @@ class StandardTransformerDecoder(TransformerDecoder):
         """:meta private:"""
         s = super().extra_repr()
 
-        self_attn_mask_factory = getattr(
-            self.self_attn_mask_factory, "__name__", self.self_attn_mask_factory
-        )
+        if self.self_attn_mask_factory is not None:
+            self_attn_mask_factory = getattr(
+                self.self_attn_mask_factory, "__name__", self.self_attn_mask_factory
+            )
 
-        return (
-            f"{s}, "
-            f"norm_order={self.norm_order}, "
-            f"self_attn_mask_factory={self_attn_mask_factory}"
-        )
+            s = f"{s}, self_attn_mask_factory={self_attn_mask_factory}"
+
+        return f"{s}, norm_order={self.norm_order}"

--- a/src/fairseq2/nn/transformer/multihead_attention.py
+++ b/src/fairseq2/nn/transformer/multihead_attention.py
@@ -21,7 +21,7 @@ from fairseq2.nn.padding import PaddingMask
 from fairseq2.nn.position_encoder import PositionEncoder
 from fairseq2.nn.projection import Linear, Projection
 from fairseq2.nn.transformer.attention import SDPA, create_default_sdpa
-from fairseq2.nn.transformer.attention_mask import AttentionMask
+from fairseq2.nn.transformer.attention_mask import AttentionMask, AttentionMaskFactory
 from fairseq2.typing import DataType, Device, finaloverride
 
 
@@ -50,7 +50,7 @@ class MultiheadAttention(Module, ABC):
     @abstractmethod
     def forward(
         self,
-        queries: Tensor,
+        seqs: Tensor,
         padding_mask: Optional[PaddingMask],
         keys: Tensor,
         key_padding_mask: Optional[PaddingMask],
@@ -60,13 +60,13 @@ class MultiheadAttention(Module, ABC):
         state_bag: Optional[IncrementalStateBag] = None,
     ) -> Tensor:
         """
-        :param queries:
-            The queries. *Shape:* :math:`(N,S,M)`, where :math:`N` is the batch
-            size, :math:`S` is the sequence length, and :math:`M` is the
-            dimensionality of the model.
+        :param seqs:
+            The sequences to query. *Shape:* :math:`(N,S,M)`, where :math:`N` is
+            the batch size, :math:`S` is the sequence length, and :math:`M` is
+            the dimensionality of the model.
         :param padding_mask:
-            The padding mask of ``queries``. *Shape:* :math:`(N,S)`, where
-            :math:`N` is the batch size and :math:`S` is the sequence length.
+            The padding mask of ``seqs``. *Shape:* :math:`(N,S)`, where :math:`N`
+            is the batch size and :math:`S` is the sequence length.
         :param keys:
             The keys. *Shape:* :math:`(N,S_{kv},K)`, where :math:`N` is the
             batch size, :math:`S_{kv}` is the key/value sequence length, and
@@ -89,9 +89,9 @@ class MultiheadAttention(Module, ABC):
             The state bag to use for incremental decoding.
 
         :returns:
-            The attention values for ``queries``. *Shape:* :math:`(N,S,M)`,
-            where :math:`N` is the batch size, :math:`S` is the sequence length,
-            and :math:`M` is the dimensionality of the model.
+            The attention values for ``seqs``. *Shape:* :math:`(N,S,M)`, where
+            :math:`N` is the batch size, :math:`S` is the sequence length, and
+            :math:`M` is the dimensionality of the model.
         """
 
     def register_attn_weight_hook(self, hook: "AttentionWeightHook") -> RemovableHandle:
@@ -183,11 +183,11 @@ class StandardMultiheadAttention(MultiheadAttention):
     """Represents a Transformer multi-head attention as described in
     :cite:t:`https://doi.org/10.48550/arxiv.1706.03762`."""
 
-    static_kv: bool
     num_key_value_heads: int
     q_proj: Projection
     k_proj: Projection
     v_proj: Projection
+    attn_mask_factory: Optional[AttentionMaskFactory]
     pos_encoder: Optional[PositionEncoder]
     bias_k: Optional[Parameter]
     bias_v: Optional[Parameter]
@@ -195,18 +195,18 @@ class StandardMultiheadAttention(MultiheadAttention):
     sdpa: SDPA
     head_scale_weight: Optional[Parameter]
     output_proj: Projection
-    state_factory: "AttentionStateFactory"
+    state_factory: Optional["AttentionStateFactory"]
 
     def __init__(
         self,
         model_dim: int,
         num_heads: int,
         *,
-        static_kv: bool = False,
         num_key_value_heads: Optional[int] = None,
         q_proj: Optional[Projection] = None,
         k_proj: Optional[Projection] = None,
         v_proj: Optional[Projection] = None,
+        attn_mask_factory: Optional[AttentionMaskFactory] = None,
         pos_encoder: Optional[PositionEncoder] = None,
         sdpa: Optional[SDPA] = None,
         scale_heads: bool = False,
@@ -221,9 +221,6 @@ class StandardMultiheadAttention(MultiheadAttention):
             The dimensionality of the model.
         :param num_heads:
             The number of attention heads.
-        :param static_kv:
-            If ``True``, assumes that keys and values are static during
-            incremental decoding (e.g. encoder-decoder attention).
         :param num_key_value_heads:
             The number of key/value heads for Grouped Query Attention as
             described in :cite:t:`https://doi.org/10.48550/arXiv.2305.13245`.
@@ -231,7 +228,7 @@ class StandardMultiheadAttention(MultiheadAttention):
             Multi Head Attention (MHA); if set to 1, it is equivalent to Multi
             Query Attention (MQA).
         :param q_proj:
-            The projection to apply to queries before computing attention. If
+            The projection to apply to sequences before computing attention. If
             ``None``, a default projection will be used.
         :param k_proj:
             The projection to apply to keys before computing attention. If
@@ -239,8 +236,10 @@ class StandardMultiheadAttention(MultiheadAttention):
         :param v_proj:
             The projection to apply to values before computing attention. If
             ``None``, a default projection will be used.
+        :param attn_mask_factory:
+            The attention mask factory.
         :param pos_encoder:
-            The position encoder to apply to queries and keys after projection.
+            The position encoder to apply to sequences and keys after projection.
         :param sdpa:
             The scaled dot-product attention module to compute head attentions.
             If ``None``, a default implementation will be used.
@@ -258,8 +257,6 @@ class StandardMultiheadAttention(MultiheadAttention):
             for incremental decoding.
         """
         super().__init__(model_dim, num_heads)
-
-        self.static_kv = static_kv
 
         if num_key_value_heads is None:
             self.num_key_value_heads = num_heads
@@ -335,6 +332,8 @@ class StandardMultiheadAttention(MultiheadAttention):
         self.k_proj = k_proj
         self.v_proj = v_proj
 
+        self.attn_mask_factory = attn_mask_factory
+
         if pos_encoder is not None:
             if head_dim != pos_encoder.encoding_dim:
                 raise ValueError(
@@ -381,13 +380,7 @@ class StandardMultiheadAttention(MultiheadAttention):
 
             self.output_proj = output_proj
 
-        if state_factory is not None:
-            self.state_factory = state_factory
-        else:
-            if static_kv:
-                self.state_factory = StaticAttentionState
-            else:
-                self.state_factory = GlobalAttentionState
+        self.state_factory = state_factory
 
         self.reset_parameters()
 
@@ -399,7 +392,7 @@ class StandardMultiheadAttention(MultiheadAttention):
     @finaloverride
     def forward(
         self,
-        queries: Tensor,
+        seqs: Tensor,
         padding_mask: Optional[PaddingMask],
         keys: Tensor,
         key_padding_mask: Optional[PaddingMask],
@@ -409,28 +402,14 @@ class StandardMultiheadAttention(MultiheadAttention):
         state_bag: Optional[IncrementalStateBag] = None,
     ) -> Tensor:
         # (N, S, M) -> (N, H, S, K_h)
-        q = self._project_q(queries, padding_mask, state_bag)
+        q = self._project_q(seqs, padding_mask, state_bag)
 
         if self.training or state_bag is None:
             # k: (N, S_kv, M) -> (N, H_kv, S_kv, K_h)
             # v: (N, S_kv, M) -> (N, H_kv, S_kv, V_h)
             k, v = self._project_kv(keys, key_padding_mask, values)
         else:
-            if self.static_kv:
-                state = state_bag.get_state(self, AttentionState)
-                if state is None:
-                    # k: (N, S_kv, M) -> (N, H_kv, S_kv, K_h)
-                    # v: (N, S_kv, M) -> (N, H_kv, S_kv, V_h)
-                    k, v = self._project_kv(keys, key_padding_mask, values)
-
-                    state = self.state_factory(k, v, max_seq_len=k.size(2))
-
-                    state_bag.set_state(self, state)
-                else:
-                    # k: (N, H_kv, S_kv, K_h)
-                    # v: (N, H_kv, S_kv, V_h)
-                    k, v = state.get()
-            else:
+            if seqs is keys:  # Self attention
                 if key_padding_mask is not None:
                     raise ValueError(
                         "`key_padding_mask` must be `None` during incremental decoding."
@@ -442,12 +421,30 @@ class StandardMultiheadAttention(MultiheadAttention):
 
                 state = state_bag.get_state(self, AttentionState)
                 if state is None:
-                    state = self.state_factory(k, v, state_bag.max_num_steps)
+                    state_factory = self.state_factory or FullAttentionState
+
+                    state = state_factory(k, v, state_bag.max_num_steps)
 
                     state_bag.set_state(self, state)
                 else:
                     state.append(k, v)
 
+                    # k: (N, H_kv, S_kv, K_h)
+                    # v: (N, H_kv, S_kv, V_h)
+                    k, v = state.get()
+            else:
+                state = state_bag.get_state(self, AttentionState)
+                if state is None:
+                    # k: (N, S_kv, M) -> (N, H_kv, S_kv, K_h)
+                    # v: (N, S_kv, M) -> (N, H_kv, S_kv, V_h)
+                    k, v = self._project_kv(keys, key_padding_mask, values)
+
+                    state_factory = self.state_factory or StaticAttentionState
+
+                    state = state_factory(k, v, max_seq_len=k.size(2))
+
+                    state_bag.set_state(self, state)
+                else:
                     # k: (N, H_kv, S_kv, K_h)
                     # v: (N, H_kv, S_kv, V_h)
                     k, v = state.get()
@@ -458,6 +455,11 @@ class StandardMultiheadAttention(MultiheadAttention):
             k = repeat_interleave(k, dim=1, repeat=num_query_groups)
             # (N, H_kv, S_kv, K_h) -> (N, H, S_kv, V_h)
             v = repeat_interleave(v, dim=1, repeat=num_query_groups)
+
+        if self.attn_mask_factory is not None:
+            attn_mask = self.attn_mask_factory(
+                seqs, keys=keys, training=self.training, state_bag=state_bag
+            )
 
         needs_weights = len(self._attn_weight_hooks) > 0
 
@@ -491,12 +493,12 @@ class StandardMultiheadAttention(MultiheadAttention):
 
     def _project_q(
         self,
-        queries: Tensor,
+        seqs: Tensor,
         padding_mask: Optional[PaddingMask],
         state_bag: Optional[IncrementalStateBag] = None,
     ) -> Tensor:
         # (N, S, M) -> (N, S, K_proj)
-        q = self.q_proj(queries)
+        q = self.q_proj(seqs)
 
         # (N, S, K_proj) -> (N, H, S, K_h)
         q = q.unflatten(-1, (self.num_heads, -1)).transpose(1, 2)
@@ -532,15 +534,15 @@ class StandardMultiheadAttention(MultiheadAttention):
         """:meta private:"""
         s = super().extra_repr()
 
-        if self.static_kv:
-            s = f"{s}, static_kv=True"
-
         if self.num_key_value_heads != self.num_heads:
             s = f"{s}, num_key_value_heads={self.num_key_value_heads}"
 
-        state_factory = getattr(self.state_factory, "__name__", self.state_factory)
+        if self.state_factory is not None:
+            state_factory = getattr(self.state_factory, "__name__", self.state_factory)
 
-        return f"{s}, state_factory={state_factory}"
+            s = f"{s}, state_factory={state_factory}"
+
+        return s
 
 
 def init_qkv_projection(proj: Linear) -> None:
@@ -606,7 +608,7 @@ class AttentionStateFactory(Protocol):
 
 
 @final
-class GlobalAttentionState(AttentionState):
+class FullAttentionState(AttentionState):
     """Holds the past projected keys and values of a :class:`MultiheadAttention`
     module during incremental decoding."""
 

--- a/src/fairseq2/nn/transformer/relative_attention.py
+++ b/src/fairseq2/nn/transformer/relative_attention.py
@@ -92,7 +92,7 @@ class RelativePositionSDPA(SDPA):
     @finaloverride
     def forward(
         self,
-        queries: Tensor,
+        seqs: Tensor,
         keys: Tensor,
         key_padding_mask: Optional[PaddingMask],
         values: Tensor,
@@ -100,7 +100,7 @@ class RelativePositionSDPA(SDPA):
         attn_mask: Optional[AttentionMask] = None,
         needs_weights: bool = False,
     ) -> Tuple[Tensor, Optional[Tensor]]:
-        q = queries
+        q = seqs
         k = keys
 
         # (H, K_h) -> (H, 1, K_h)
@@ -144,7 +144,7 @@ class RelativePositionSDPA(SDPA):
 
         attn_weights = softmax(attn_weights, dim=-1, dtype=torch.float32)
 
-        attn_weights = attn_weights.type_as(queries)
+        attn_weights = attn_weights.type_as(seqs)
 
         if self.training and self.attn_dropout_p > 0.0:
             attn_weights = dropout(attn_weights, self.attn_dropout_p)

--- a/tests/unit/nn/test_position_encoder.py
+++ b/tests/unit/nn/test_position_encoder.py
@@ -126,7 +126,7 @@ class TestSinusoidalPositionEncoder:
         assert_close(y - x, m.freqs[:9].expand_as(y))
 
     @pytest.mark.parametrize("step", [0, 1, 2])
-    def test_forward_works_in_incremental_eval(self, step: int) -> None:
+    def test_forward_works_in_incremental_decode(self, step: int) -> None:
         m = SinusoidalPositionEncoder(encoding_dim=32, max_seq_len=4, device=device)
 
         state_bag = IncrementalStateBag(max_num_steps=3)
@@ -201,7 +201,7 @@ class TestLearnedPositionEncoder:
         assert_close(y - x, m.weight[:9].expand_as(y))
 
     @pytest.mark.parametrize("step", [0, 1, 2])
-    def test_forward_works_in_incremental_eval(self, step: int) -> None:
+    def test_forward_works_in_incremental_decode(self, step: int) -> None:
         m = LearnedPositionEncoder(encoding_dim=32, max_seq_len=4, device=device)
 
         state_bag = IncrementalStateBag(max_num_steps=3)
@@ -284,7 +284,7 @@ class TestRotaryEncoder:
         assert_close(dot1, dot2)
 
     @pytest.mark.parametrize("step", [0, 1, 2])
-    def test_forward_works_in_incremental_eval(self, step: int) -> None:
+    def test_forward_works_in_incremental_decode(self, step: int) -> None:
         m = RotaryEncoder(encoding_dim=32, max_seq_len=4, device=device)
 
         state_bag = IncrementalStateBag(max_num_steps=3)

--- a/tests/unit/nn/transformer/test_attention.py
+++ b/tests/unit/nn/transformer/test_attention.py
@@ -92,7 +92,7 @@ class TestScaledDotProductAttention:
             attn_mask = None
 
         return {
-            "queries": q,
+            "seqs": q,
             "keys": k,
             "key_padding_mask": key_padding_mask,
             "values": v,


### PR DESCRIPTION
This PR (1) improves the implementation of both `CausalAttentionMask` and `ALiBiMask` (2) accepts `self_attn_mask_factory` in `MultiheadAttention` and `StandardTransformerEncoder` for Longformer-based architectures.