### PR TITLE
Remove check_model_dim

### DIFF
--- a/src/fairseq2/models/conformer/block.py
+++ b/src/fairseq2/models/conformer/block.py
@@ -20,7 +20,6 @@ from fairseq2.nn.transformer import (
     TransformerEncoderLayer,
     create_standard_layer_norm,
 )
-from fairseq2.nn.utils.module import check_model_dim
 from fairseq2.typing import DataType, Device, finaloverride
 
 
@@ -115,8 +114,6 @@ class ConformerBlock(TransformerEncoderLayer):
             self.register_module("ffn2_dropout", None)
 
         self.layer_norm = layer_norm_factory(model_dim, device=device, dtype=dtype)
-
-        check_model_dim(self)
 
     @finaloverride
     def forward(

--- a/src/fairseq2/models/transformer/decoder_model.py
+++ b/src/fairseq2/models/transformer/decoder_model.py
@@ -15,7 +15,6 @@ from fairseq2.nn.incremental_state import IncrementalStateBag
 from fairseq2.nn.padding import PaddingMask
 from fairseq2.nn.projection import Projection
 from fairseq2.nn.transformer import TransformerDecoder
-from fairseq2.nn.utils.module import check_model_dim
 from fairseq2.typing import finaloverride
 
 
@@ -55,8 +54,6 @@ class TransformerDecoderModel(DecoderModel):
         self.final_proj = final_proj
 
         self.target_pad_idx = target_pad_idx
-
-        check_model_dim(self)
 
     @finaloverride
     def decode(

--- a/src/fairseq2/models/transformer/model.py
+++ b/src/fairseq2/models/transformer/model.py
@@ -16,7 +16,6 @@ from fairseq2.nn.incremental_state import IncrementalStateBag
 from fairseq2.nn.padding import PaddingMask
 from fairseq2.nn.projection import Linear, Projection
 from fairseq2.nn.transformer import TransformerDecoder, TransformerEncoder
-from fairseq2.nn.utils.module import check_model_dim
 from fairseq2.typing import finaloverride
 
 
@@ -68,8 +67,6 @@ class TransformerModel(EncoderDecoderModel):
         self.final_proj = final_proj
 
         self.target_pad_idx = target_pad_idx
-
-        check_model_dim(self)
 
     @finaloverride
     def encode(

--- a/src/fairseq2/models/wav2vec2/model.py
+++ b/src/fairseq2/models/wav2vec2/model.py
@@ -23,7 +23,6 @@ from fairseq2.nn.ops import repeat_interleave
 from fairseq2.nn.padding import PaddingMask
 from fairseq2.nn.projection import Linear
 from fairseq2.nn.transformer import TransformerEncoder
-from fairseq2.nn.utils.module import check_model_dim
 from fairseq2.typing import DataType, Device
 
 
@@ -111,8 +110,6 @@ class Wav2Vec2Model(Module):
         self.num_distractors = num_distractors
         self.logit_temp = logit_temp
         self.diversity_loss_weight = diversity_loss_weight
-
-        check_model_dim(self)
 
     def forward(self, batch: SequenceBatch) -> "Wav2Vec2Output":
         """

--- a/src/fairseq2/nn/transformer/decoder.py
+++ b/src/fairseq2/nn/transformer/decoder.py
@@ -24,7 +24,6 @@ from fairseq2.nn.transformer.layer_norm import (
     create_standard_layer_norm,
 )
 from fairseq2.nn.transformer.norm_order import TransformerNormOrder
-from fairseq2.nn.utils.module import check_model_dim
 from fairseq2.typing import DataType, Device, finaloverride
 
 
@@ -179,8 +178,6 @@ class StandardTransformerDecoder(TransformerDecoder):
             self.register_module("layer_norm", None)
 
         self.norm_order = norm_order
-
-        check_model_dim(self)
 
     @finaloverride
     def forward(

--- a/src/fairseq2/nn/transformer/decoder_layer.py
+++ b/src/fairseq2/nn/transformer/decoder_layer.py
@@ -24,7 +24,6 @@ from fairseq2.nn.transformer.layer_norm import (
 )
 from fairseq2.nn.transformer.multihead_attention import MultiheadAttention
 from fairseq2.nn.transformer.norm_order import TransformerNormOrder
-from fairseq2.nn.utils.module import check_model_dim
 from fairseq2.typing import DataType, Device, finaloverride
 
 
@@ -211,8 +210,6 @@ class StandardTransformerDecoderLayer(TransformerDecoderLayer):
             self.ffn_layer_norm = ffn_layer_norm
 
         self.norm_order = norm_order
-
-        check_model_dim(self)
 
         self.reset_parameters()
 

--- a/src/fairseq2/nn/transformer/encoder.py
+++ b/src/fairseq2/nn/transformer/encoder.py
@@ -20,7 +20,6 @@ from fairseq2.nn.transformer.layer_norm import (
     create_standard_layer_norm,
 )
 from fairseq2.nn.transformer.norm_order import TransformerNormOrder
-from fairseq2.nn.utils.module import check_model_dim
 from fairseq2.typing import DataType, Device, finaloverride
 
 
@@ -151,8 +150,6 @@ class StandardTransformerEncoder(TransformerEncoder):
             self.register_module("layer_norm", None)
 
         self.norm_order = norm_order
-
-        check_model_dim(self)
 
     @finaloverride
     def forward(

--- a/src/fairseq2/nn/transformer/encoder_layer.py
+++ b/src/fairseq2/nn/transformer/encoder_layer.py
@@ -23,7 +23,6 @@ from fairseq2.nn.transformer.layer_norm import (
 )
 from fairseq2.nn.transformer.multihead_attention import MultiheadAttention
 from fairseq2.nn.transformer.norm_order import TransformerNormOrder
-from fairseq2.nn.utils.module import check_model_dim
 from fairseq2.typing import DataType, Device, finaloverride
 
 
@@ -169,8 +168,6 @@ class StandardTransformerEncoderLayer(TransformerEncoderLayer):
             self.ffn_layer_norm = ffn_layer_norm
 
         self.norm_order = norm_order
-
-        check_model_dim(self)
 
         self.reset_parameters()
 


### PR DESCRIPTION
This PR removes the `check_model_dim` utility function (which is sporadically used in seamless_communicaiton) and relies on the dimensionality check that happens during the forward pass. Less code to maintain.