### PR TITLE
Rename pad_idx to pad_value in pad_seqs and Collater

### DIFF
--- a/fairseq2n/python/src/fairseq2n/bindings/data/data_pipeline.cc
+++ b/fairseq2n/python/src/fairseq2n/bindings/data/data_pipeline.cc
@@ -423,13 +423,13 @@ def_data_pipeline(py::module_ &data_module)
             "collate",
             [](
                 data_pipeline_builder &self,
-                std::optional<std::int64_t> maybe_pad_idx,
+                std::optional<std::int64_t> maybe_pad_value,
                 std::int64_t pad_to_multiple,
                 std::optional<std::vector<collate_options_override>> maybe_opt_overrides,
                 std::size_t num_parallel_calls) -> data_pipeline_builder &
             {
                 auto opts = collate_options()
-                    .maybe_pad_idx(maybe_pad_idx).pad_to_multiple(pad_to_multiple);
+                    .maybe_pad_value(maybe_pad_value).pad_to_multiple(pad_to_multiple);
 
                 std::vector<collate_options_override> opt_overrides{};
                 if (maybe_opt_overrides)
@@ -441,7 +441,7 @@ def_data_pipeline(py::module_ &data_module)
 
                 return self;
             },
-            py::arg("pad_idx") = std::nullopt,
+            py::arg("pad_value") = std::nullopt,
             py::arg("pad_to_multiple") = 1,
             py::arg("overrides") = std::nullopt,
             py::arg("num_parallel_calls") = 1)
@@ -590,16 +590,16 @@ def_data_pipeline(py::module_ &data_module)
         .def(
             py::init([](
                 std::string selector,
-                std::optional<std::int64_t> maybe_pad_idx,
+                std::optional<std::int64_t> maybe_pad_value,
                 std::int64_t pad_to_multiple)
             {
                 return collate_options_override{std::move(selector),
                     collate_options()
-                        .maybe_pad_idx(maybe_pad_idx)
+                        .maybe_pad_value(maybe_pad_value)
                         .pad_to_multiple(pad_to_multiple)};
             }),
             py::arg("selector"),
-            py::arg("pad_idx") = std::nullopt,
+            py::arg("pad_value") = std::nullopt,
             py::arg("pad_to_multiple") = 1)
         .def_property_readonly(
             "selector",
@@ -608,10 +608,10 @@ def_data_pipeline(py::module_ &data_module)
                 return self.selector().string_();
             })
         .def_property_readonly(
-            "pad_idx",
+            "pad_value",
             [](const collate_options_override &self)
             {
-                return self.options().maybe_pad_idx();
+                return self.options().maybe_pad_value();
             })
         .def_property_readonly(
             "pad_to_multiple",
@@ -623,12 +623,12 @@ def_data_pipeline(py::module_ &data_module)
     py::class_<collater, std::shared_ptr<collater>>(m, "Collater")
         .def(
             py::init([](
-                std::optional<std::int64_t> maybe_pad_idx,
+                std::optional<std::int64_t> maybe_pad_value,
                 std::int64_t pad_to_multiple,
                 std::optional<std::vector<collate_options_override>> maybe_opt_overrides)
             {
                 auto opts = collate_options()
-                    .maybe_pad_idx(maybe_pad_idx).pad_to_multiple(pad_to_multiple);
+                    .maybe_pad_value(maybe_pad_value).pad_to_multiple(pad_to_multiple);
 
                 std::vector<collate_options_override> opt_overrides{};
                 if (maybe_opt_overrides)
@@ -636,7 +636,7 @@ def_data_pipeline(py::module_ &data_module)
 
                 return std::make_shared<collater>(opts, std::move(opt_overrides));
             }),
-            py::arg("pad_idx") = std::nullopt,
+            py::arg("pad_value") = std::nullopt,
             py::arg("pad_to_multiple") = 1,
             py::arg("overrides") = std::nullopt)
         .def("__call__", &collater::operator(), py::call_guard<py::gil_scoped_release>{});

--- a/fairseq2n/src/fairseq2n/data/collater.h
+++ b/fairseq2n/src/fairseq2n/data/collater.h
@@ -20,19 +20,19 @@ namespace fairseq2n {
 class collate_options {
 public:
     collate_options
-    maybe_pad_idx(std::optional<std::int64_t> value) noexcept
+    maybe_pad_value(std::optional<std::int64_t> value) noexcept
     {
         auto tmp = *this;
 
-        tmp.maybe_pad_idx_ = value;
+        tmp.maybe_pad_value_ = value;
 
         return tmp;
     }
 
     std::optional<std::int64_t>
-    maybe_pad_idx() const noexcept
+    maybe_pad_value() const noexcept
     {
-        return maybe_pad_idx_;
+        return maybe_pad_value_;
     }
 
     collate_options
@@ -52,7 +52,7 @@ public:
     }
 
 private:
-    std::optional<std::int64_t> maybe_pad_idx_;
+    std::optional<std::int64_t> maybe_pad_value_;
     std::int64_t pad_to_multiple_ = 1;
 };
 

--- a/src/fairseq2/data/data_pipeline.py
+++ b/src/fairseq2/data/data_pipeline.py
@@ -167,7 +167,7 @@ if TYPE_CHECKING or _DOC_MODE:
 
         def collate(
             self,
-            pad_idx: Optional[int] = None,
+            pad_value: Optional[int] = None,
             pad_to_multiple: int = 1,
             overrides: Optional[Sequence["CollateOptionsOverride"]] = None,
         ) -> Self:
@@ -315,7 +315,7 @@ if TYPE_CHECKING or _DOC_MODE:
         def __init__(
             self,
             selector: str,
-            pad_idx: Optional[int] = None,
+            pad_value: Optional[int] = None,
             pad_to_multiple: int = 1,
         ) -> None:
             ...
@@ -325,7 +325,7 @@ if TYPE_CHECKING or _DOC_MODE:
             ...
 
         @property
-        def pad_idx(self) -> Optional[int]:
+        def pad_value(self) -> Optional[int]:
             ...
 
         @property
@@ -339,7 +339,7 @@ if TYPE_CHECKING or _DOC_MODE:
         If all tensors in the input example have the same last dimension,
         ``Collater`` returns the concatenated tensors.
 
-        Otherwise ``pad_idx`` is required, and the last dimension of the batch will
+        Otherwise ``pad_value`` is required, and the last dimension of the batch will
         be made long enough to fit the longest tensor, rounded up to ``pad_to_multiple``.
         The returned batch is then a dictionary with the following keys::
 
@@ -353,7 +353,7 @@ if TYPE_CHECKING or _DOC_MODE:
         For a tuple of lists, it returns a tuple of batches.
         For a dict of lists, it returns a dict of lists.
 
-        :param pad_idx:
+        :param pad_value:
             When concatenating tensors of different lengths,
             the value used to pad the shortest tensor
 
@@ -362,12 +362,12 @@ if TYPE_CHECKING or _DOC_MODE:
 
         :param overrides:
             List of overrides :py:class:`CollateOptionsOverride`.
-            Allows to override ``pad_idx`` and ``pad_to_multiple`` for specific columns.
+            Allows to override ``pad_value`` and ``pad_to_multiple`` for specific columns.
         """
 
         def __init__(
             self,
-            pad_idx: Optional[int] = None,
+            pad_value: Optional[int] = None,
             pad_to_multiple: int = 1,
             overrides: Optional[Sequence[CollateOptionsOverride]] = None,
         ) -> None:

--- a/src/fairseq2/generation/text.py
+++ b/src/fairseq2/generation/text.py
@@ -210,7 +210,7 @@ class TextTranslator(SequenceToTextGeneratorBase):
             The sentences in the source language.
         """
         seqs, padding_mask = pad_seqs(
-            [self.source_encoder(s) for s in source_sentences], pad_idx=self.pad_idx
+            [self.source_encoder(s) for s in source_sentences], self.pad_idx
         )
 
         return self._do_generate(seqs, padding_mask)

--- a/src/fairseq2/nn/padding.py
+++ b/src/fairseq2/nn/padding.py
@@ -76,7 +76,7 @@ def to_padding_mask(seq_lens: Tensor, batch_seq_len: int) -> Tensor:
 
 
 def apply_padding_mask(
-    seqs: Tensor, padding_mask: Optional[PaddingMask], fill_value: Any = 0
+    seqs: Tensor, padding_mask: Optional[PaddingMask], pad_value: Any = 0
 ) -> Tensor:
     """Apply the specified padding mask to ``seqs``.
 
@@ -87,8 +87,8 @@ def apply_padding_mask(
     :param padding_mask:
         The padding mask to apply. *Shape:* :math:`(N,S)`, where :math:`N` is
         the batch size and :math:`S` is the sequence length.
-    :param fill_value:
-        The value for padded elements.
+    :param pad_value:
+        The value for padded positions.
 
     :returns:
         The input sequences with mask applied. *Shape:* Same as ``seqs``.
@@ -101,7 +101,7 @@ def apply_padding_mask(
     for _ in range(seqs.ndim - m.ndim):
         m = m.unsqueeze(-1)
 
-    return seqs.where(m, fill_value)
+    return seqs.where(m, pad_value)
 
 
 def get_seqs_and_padding_mask(
@@ -122,14 +122,14 @@ def get_seqs_and_padding_mask(
 
 
 def pad_seqs(
-    seqs: Sequence[Tensor], pad_idx: int = 0, pad_to_multiple: int = 1
+    seqs: Sequence[Tensor], pad_value: int = 0, pad_to_multiple: int = 1
 ) -> Tuple[Tensor, Optional[PaddingMask]]:
     """Stack ``seqs`` along a new batch dimension and pad them to equal length.
 
     :param seqs:
         The list of variable length sequences. All elements in ``seqs`` are
         expected to have the same shape except the first dimension.
-    :param pad_idx:
+    :param pad_value:
         The value for padded positions.
     :param pad_to_multiple:
         The sequence dimension is rounded up to the nearest multiple of the
@@ -142,7 +142,7 @@ def pad_seqs(
         - The padding mask of the sequence stack. *Shape:* :math:`(N,S)`, where
           :math:`N` is the batch size and :math:`S` is the sequence length.
     """
-    collater = Collater(pad_idx=pad_idx, pad_to_multiple=pad_to_multiple)
+    collater = Collater(pad_value=pad_value, pad_to_multiple=pad_to_multiple)
 
     seq_data = cast(SequenceData, collater(seqs))
 

--- a/tests/unit/data/data_pipeline/test_collate.py
+++ b/tests/unit/data/data_pipeline/test_collate.py
@@ -15,7 +15,7 @@ class TestCollateOp:
     @pytest.mark.skipif(python_devel_only(), reason="fairseq2n 0.2.0")
     @pytest.mark.parametrize("pad_to_multiple", [1, 2, 3, 8])
     def test_op_works(self, pad_to_multiple: int) -> None:
-        pad_idx = 3
+        pad_value = 3
 
         bucket1 = [
             torch.full((4, 2), 0, device=device, dtype=torch.int64),
@@ -31,11 +31,11 @@ class TestCollateOp:
 
         seq = [bucket1, bucket2]
 
-        pipeline = read_sequence(seq).collate(pad_idx, pad_to_multiple).and_return()
+        pipeline = read_sequence(seq).collate(pad_value, pad_to_multiple).and_return()
 
         output1, output2 = list(pipeline)
 
-        collater = Collater(pad_idx, pad_to_multiple)
+        collater = Collater(pad_value, pad_to_multiple)
 
         expected_output1 = collater(bucket1)
         expected_output2 = collater(bucket2)

--- a/tests/unit/data/test_collater.py
+++ b/tests/unit/data/test_collater.py
@@ -90,7 +90,7 @@ class TestCollater:
             torch.full((4, 2), 2, device=device, dtype=torch.int64),
         ]
 
-        collater = Collater(pad_idx=3, pad_to_multiple=pad_to_multiple)
+        collater = Collater(pad_value=3, pad_to_multiple=pad_to_multiple)
 
         output = collater(bucket)
 
@@ -120,7 +120,7 @@ class TestCollater:
             {"foo1": torch.full((3, 2), 2, device=device, dtype=torch.int64)},
         ]
 
-        collater = Collater(pad_idx=3, pad_to_multiple=3)
+        collater = Collater(pad_value=3, pad_to_multiple=3)
 
         output = collater(bucket)
 
@@ -151,8 +151,8 @@ class TestCollater:
         # fmt: on
 
         collater = Collater(
-            pad_idx=1,
-            overrides=[CollateOptionsOverride("foo1", pad_idx=3, pad_to_multiple=3)],
+            pad_value=1,
+            overrides=[CollateOptionsOverride("foo1", pad_value=3, pad_to_multiple=3)],
         )
 
         output = collater(bucket)
@@ -368,17 +368,17 @@ class TestCollater:
         ):
             collater(bucket2)
 
-    def test_init_raises_error_when_pad_idx_is_none_and_pad_to_multiple_is_greater_than_1(
+    def test_init_raises_error_when_pad_value_is_none_and_pad_to_multiple_is_greater_than_1(
         self,
     ) -> None:
         with pytest.raises(
             ValueError,
-            match=r"^`pad_idx` must be set when `pad_to_multiple` is greater than 1\.$",
+            match=r"^`pad_value` must be set when `pad_to_multiple` is greater than 1\.$",
         ):
             Collater(pad_to_multiple=4)
 
         with pytest.raises(
             ValueError,
-            match=r"^`pad_idx` of the selector 'foo' must be set when `pad_to_multiple` is greater than 1\.$",
+            match=r"^`pad_value` of the selector 'foo' must be set when `pad_to_multiple` is greater than 1\.$",
         ):
             Collater(overrides=[CollateOptionsOverride("foo", pad_to_multiple=2)])


### PR DESCRIPTION
A nit PR that renames `pad_idx` to `pad_value` in `pad_seqs` and `Collater to better reflect the purpose of the parameter.