### PR TITLE
Remove norm eps from LLaMA

### DIFF
--- a/bibliography.bib
+++ b/bibliography.bib
@@ -176,15 +176,6 @@
   copyright = {arXiv.org perpetual, non-exclusive license}
 }
 
-@misc{https://doi.org/10.48550/arxiv.2207.00952,
-  title={M-Adapter: Modality Adaptation for End-to-End Speech-to-Text Translation},
-  author={Jinming Zhao and Hao Yang and Ehsan Shareghi and Gholamreza Haffari},
-  year={2022},
-  eprint={2207.00952},
-  archivePrefix={arXiv},
-  primaryClass={cs.CL}
-}
-
 @misc{https://doi.org/10.48550/arxiv.2207.04672,
   doi = {10.48550/arxiv.2207.04672},
   url = {https://arxiv.org/abs/2207.04672},

--- a/src/fairseq2/models/llama/builder.py
+++ b/src/fairseq2/models/llama/builder.py
@@ -67,9 +67,6 @@ class LLaMAConfig:
     dropout_p: float
     """The dropout probability in Transformer layers."""
 
-    norm_eps: float
-    """The epsilon used by Layer Normalization modules."""
-
 
 llama_archs = ArchitectureRegistry[LLaMAConfig]("llama")
 
@@ -89,7 +86,6 @@ def _7b() -> LLaMAConfig:
         ffn_inner_dim=4096 * 4,
         ffn_inner_dim_to_multiple=256,
         dropout_p=0.1,
-        norm_eps=1e-5,
     )
 
 
@@ -105,7 +101,6 @@ def _13b() -> LLaMAConfig:
         ffn_inner_dim=5120 * 4,
         ffn_inner_dim_to_multiple=256,
         dropout_p=0.1,
-        norm_eps=1e-5,
     )
 
 
@@ -121,7 +116,6 @@ def _33b() -> LLaMAConfig:
         ffn_inner_dim=6656 * 4,
         ffn_inner_dim_to_multiple=256,
         dropout_p=0.1,
-        norm_eps=1e-5,
     )
 
 
@@ -137,7 +131,6 @@ def _65b() -> LLaMAConfig:
         ffn_inner_dim=8192 * 4,
         ffn_inner_dim_to_multiple=256,
         dropout_p=0.1,
-        norm_eps=1e-5,
     )
 
 
@@ -153,7 +146,6 @@ def _llama2_7b() -> LLaMAConfig:
         ffn_inner_dim=4096 * 4,
         ffn_inner_dim_to_multiple=256,
         dropout_p=0.1,
-        norm_eps=1e-6,
     )
 
 
@@ -169,7 +161,6 @@ def _llama2_13b() -> LLaMAConfig:
         ffn_inner_dim=5120 * 4,
         ffn_inner_dim_to_multiple=256,
         dropout_p=0.1,
-        norm_eps=1e-5,
     )
 
 
@@ -185,7 +176,6 @@ def _llama2_70b() -> LLaMAConfig:
         ffn_inner_dim=int(8192 * 4 * 1.3),  # See A.2.1 in LLaMA 2
         ffn_inner_dim_to_multiple=4096,
         dropout_p=0.1,
-        norm_eps=1e-5,
     )
 
 
@@ -337,9 +327,7 @@ class LLaMABuilder:
         dtype: Optional[DataType] = None,
     ) -> LayerNorm:
         """Build a Layer Normalization module."""
-        return RMSNorm(
-            model_dim, bias=False, eps=self.config.norm_eps, device=device, dtype=dtype
-        )
+        return RMSNorm(model_dim, bias=False, device=device, dtype=dtype)
 
 
 def create_llama_model(

--- a/src/fairseq2/models/llama/tokenizer.py
+++ b/src/fairseq2/models/llama/tokenizer.py
@@ -36,10 +36,6 @@ class LLaMATokenizer(TextTokenizer):
 
         vocabulary_info = vocabulary_from_sentencepiece(self.model)
 
-        # LLaMA tokenizer has no PAD symbol defined in its SentencePiece model
-        # and uses EOS instead.
-        vocabulary_info.pad_idx = vocabulary_info.eos_idx
-
         super().__init__(vocabulary_info)
 
     @finaloverride

--- a/src/fairseq2/models/mistral/tokenizer.py
+++ b/src/fairseq2/models/mistral/tokenizer.py
@@ -36,10 +36,6 @@ class MistralTokenizer(TextTokenizer):
 
         vocabulary_info = vocabulary_from_sentencepiece(self.model)
 
-        # Mistral tokenizer has no PAD symbol defined in its SentencePiece model
-        # and uses EOS instead.
-        vocabulary_info.pad_idx = vocabulary_info.eos_idx
-
         super().__init__(vocabulary_info)
 
     @finaloverride

--- a/src/fairseq2/models/nllb/builder.py
+++ b/src/fairseq2/models/nllb/builder.py
@@ -50,7 +50,7 @@ class NllbConfig:
     """The size of the vocabulary."""
 
     pad_idx: Optional[int]
-    """The index of the pad symbol in the vocabulary."""
+    """The index of the PAD symbol in the vocabulary."""
 
     num_encoder_layers: int
     """The number of Transformer encoder layers."""

--- a/src/fairseq2/models/nllb/tokenizer.py
+++ b/src/fairseq2/models/nllb/tokenizer.py
@@ -45,8 +45,8 @@ class NllbTokenizer(TextTokenizer):
         control_symbols.extend(["<MINED_DATA>", "<MMT_BT_DATA>", "<SMT_BT_DATA>"])
 
         # The SentencePiece model of NLLB is peculiar as it does not define a
-        # pad symbol. We use an undocumented feature of our C++ API to insert
-        # a pad symbol to the model at index 0.
+        # PAD symbol. We use an undocumented feature of our C++ API to insert
+        # it to the model at index 0.
         control_symbols.append("<pad>@0")
 
         self.model = SentencePieceModel(pathname, control_symbols)

--- a/src/fairseq2/models/s2t_transformer/builder.py
+++ b/src/fairseq2/models/s2t_transformer/builder.py
@@ -62,7 +62,7 @@ class S2TTransformerConfig:
     """The size of the target vocabulary."""
 
     target_pad_idx: Optional[int]
-    """The index of the pad symbol in the target vocabulary."""
+    """The index of the PAD symbol in the target vocabulary."""
 
     use_relative_pos: bool
     """If ``True``, uses relative positional encodings for source sequences."""

--- a/src/fairseq2/models/sequence.py
+++ b/src/fairseq2/models/sequence.py
@@ -67,7 +67,7 @@ class SequenceModelOutput:
     is the size of the target vocabulary."""
 
     pad_idx: Optional[int] = None
-    """The index of the pad symbol in the target vocabulary."""
+    """The index of the PAD symbol in the target vocabulary."""
 
     def compute_loss(
         self,

--- a/src/fairseq2/models/transformer/decoder_model.py
+++ b/src/fairseq2/models/transformer/decoder_model.py
@@ -42,7 +42,7 @@ class TransformerDecoderModel(DecoderModel):
         :param final_proj:
             The projection to apply to decoder outputs to produce logits.
         :param target_pad_idx:
-            The index of the pad symbol in the target vocabulary.
+            The index of the PAD symbol in the target vocabulary.
         """
         model_dim = decoder.model_dim
 

--- a/src/fairseq2/models/transformer/model.py
+++ b/src/fairseq2/models/transformer/model.py
@@ -52,7 +52,7 @@ class TransformerModel(EncoderDecoderModel):
         :param final_proj:
             The projection to apply to decoder outputs to produce logits.
         :param target_pad_idx:
-            The index of the pad symbol in the target vocabulary.
+            The index of the PAD symbol in the target vocabulary.
         """
         model_dim = encoder.model_dim
 

--- a/src/fairseq2/nn/functional.py
+++ b/src/fairseq2/nn/functional.py
@@ -32,7 +32,7 @@ def nll_loss(
         The target indices. *Shape:* :math:`(N,S)`, where :math:`N` is the batch
         size and :math:`S` is the sequence length.
     :param pad_idx:
-        The index of the pad symbol in the target vocabulary.
+        The index of the PAD symbol in the target vocabulary.
     :param label_smoothing:
         The amount of label smoothing to apply while computing the loss.
     :param reduction:

--- a/tests/integration/models/test_llama_lora.py
+++ b/tests/integration/models/test_llama_lora.py
@@ -28,7 +28,6 @@ def test_lora_wrappers_llama_works() -> None:
         ffn_inner_dim=1024 * 4,
         ffn_inner_dim_to_multiple=1,
         dropout_p=0.1,
-        norm_eps=1e-5,
     )
     model = create_llama_model(llama_config, device=torch.device("cpu"))
 


### PR DESCRIPTION
This PR removes the `norm_eps` config from LLaMA that was apparently introduced by accident in the reference implementation. See https://github.com/facebookresearch/llama/issues/771. It also includes a few nit docstr updates.