### PR TITLE
Accept only non-batched tensor in TextTokenDecoder

### DIFF
--- a/fairseq2n/python/src/fairseq2n/bindings/data/string.cc
+++ b/fairseq2n/python/src/fairseq2n/bindings/data/string.cc
@@ -76,6 +76,12 @@ def_string(py::module_ &data_module)
             })
 
         .def(
+            "strip",
+            [](const immutable_string &self)
+            {
+                return rtrim(ltrim(self));
+            })
+        .def(
             "lstrip",
             [](const immutable_string &self)
             {

--- a/fairseq2n/src/fairseq2n/data/audio/waveform_to_fbank_converter.cc
+++ b/fairseq2n/src/fairseq2n/data/audio/waveform_to_fbank_converter.cc
@@ -111,7 +111,7 @@ waveform_to_fbank_converter::find_waveform(data_dict &dict)
 
     if (waveform.dim() != 2)
         throw_<std::invalid_argument>(
-            "The input waveform must be two dimensional, but has {} dimensions instead.", waveform.dim());
+            "The input waveform must be two dimensional, but has {} dimension(s) instead.", waveform.dim());
 
     return waveform;
 }

--- a/fairseq2n/src/fairseq2n/data/text/sentencepiece/sp_decoder.h
+++ b/fairseq2n/src/fairseq2n/data/text/sentencepiece/sp_decoder.h
@@ -13,6 +13,7 @@
 
 #include "fairseq2n/api.h"
 #include "fairseq2n/data/data.h"
+#include "fairseq2n/data/immutable_string.h"
 
 namespace fairseq2n {
 namespace detail {
@@ -34,7 +35,7 @@ public:
     operator()(data &&d) const;
 
 private:
-    data_list
+    immutable_string
     decode(at::Tensor &&tensor) const;
 
 private:

--- a/src/fairseq2/data/cstring.py
+++ b/src/fairseq2/data/cstring.py
@@ -45,6 +45,9 @@ if TYPE_CHECKING or _DOC_MODE:
         def bytes(self) -> bytes:
             """Return a copy of this string as :class:`bytes`."""
 
+        def strip(self) -> "CString":
+            """Return a copy of this string with no whitespace at the beginning and end."""
+
         def lstrip(self) -> "CString":
             """Return a copy of this string with no whitespace at the beginning."""
 

--- a/src/fairseq2/data/text/sentencepiece.py
+++ b/src/fairseq2/data/text/sentencepiece.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import TYPE_CHECKING, List, Optional, Sequence, final
+from typing import TYPE_CHECKING, Optional, Sequence, final
 
 from torch import Tensor
 
@@ -87,7 +87,7 @@ if TYPE_CHECKING or _DOC_MODE:
             ...
 
         @finaloverride
-        def __call__(self, token_indices: Tensor) -> List[StringLike]:
+        def __call__(self, token_indices: Tensor) -> StringLike:
             ...
 
 else:

--- a/src/fairseq2/data/text/text_tokenizer.py
+++ b/src/fairseq2/data/text/text_tokenizer.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from abc import ABC, abstractmethod
-from typing import List, Optional
+from typing import Optional
 
 from torch import Tensor
 
@@ -92,7 +92,7 @@ class TextTokenDecoder(ABC):
     """Decodes sentences from token indices."""
 
     @abstractmethod
-    def __call__(self, token_indices: Tensor) -> List[StringLike]:
+    def __call__(self, token_indices: Tensor) -> StringLike:
         """
         :param token_indices:
             The token indices to decode from.

--- a/src/fairseq2/generation/text.py
+++ b/src/fairseq2/generation/text.py
@@ -77,7 +77,7 @@ class SequenceToTextGeneratorBase:
             encoder_output, encoder_padding_mask, source_seq_len=source_seqs.size(1)
         )
 
-        sentences = [self.token_decoder(b[0].seq)[0] for b in gen_output.results]
+        sentences = [self.token_decoder(b[0].seq) for b in gen_output.results]
 
         return SequenceToTextOutput(
             sentences, gen_output, encoder_output, encoder_padding_mask

--- a/tests/unit/data/audio/test_waveform_to_fbank_converter.py
+++ b/tests/unit/data/audio/test_waveform_to_fbank_converter.py
@@ -185,7 +185,7 @@ class TestWaveformToFbankConverter:
 
         with pytest.raises(
             ValueError,
-            match=rf"^The input waveform must be two dimensional, but has {len(shape)} dimensions instead\.$",
+            match=rf"^The input waveform must be two dimensional, but has {len(shape)} dimension\(s\) instead\.$",
         ):
             converter({"waveform": waveform, "sample_rate": 16000.0})
 

--- a/tests/unit/data/text/test_sentencepiece.py
+++ b/tests/unit/data/text/test_sentencepiece.py
@@ -11,6 +11,7 @@ from typing import ClassVar, Final, List, Optional, Sequence
 import pytest
 import torch
 
+from fairseq2.data import CString
 from fairseq2.data.text import (
     SentencePieceDecoder,
     SentencePieceEncoder,
@@ -23,20 +24,16 @@ TEST_SPM_PATH: Final = Path(__file__).parent.joinpath("test.spm")
 
 
 class TestSentencePieceModel:
-    sentences: ClassVar[List[str]]
-    token_indices: ClassVar[List[List[int]]]
+    sentence: ClassVar[str]
+    token_indices: ClassVar[List[int]]
 
     @classmethod
     def setup_class(cls) -> None:
-        cls.sentences = [
-            "Hello world! How are you?",
-            "What's up? Hope you are doing well today.",
-        ]
+        cls.sentence = "What's up? Hope you are doing well today."
 
         # fmt: off
         cls.token_indices = [
-            [132, 30, 131, 114, 52, 418, 68, 166, 106, 40, 11],
-            [169, 87, 5, 227, 11, 424, 294, 40, 106, 120, 26, 597, 19, 303, 4]
+            169, 87, 5, 227, 11, 424, 294, 40, 106, 120, 26, 597, 19, 303, 4
         ]
         # fmt: on
 
@@ -78,19 +75,17 @@ class TestSentencePieceModel:
         encoder = SentencePieceEncoder(model, device=device)
         decoder = SentencePieceDecoder(model)
 
-        indices = encoder(self.sentences[0])
+        indices = encoder(self.sentence)
 
         # Assert encoder.
-        assert_equal(indices, self.token_indices[0])
+        assert_equal(indices, self.token_indices)
 
-        sentences = decoder(indices)
+        sentence = decoder(indices)
 
         # Assert decoder
-        assert isinstance(sentences, list)
+        assert isinstance(sentence, CString)
 
-        assert len(sentences) == 1
-
-        assert sentences[0] == self.sentences[0]
+        assert sentence == self.sentence
 
     def test_encode_decode_work_when_reverse_is_true(self) -> None:
         model = self.build_model()
@@ -98,19 +93,17 @@ class TestSentencePieceModel:
         encoder = SentencePieceEncoder(model, device=device, reverse=True)
         decoder = SentencePieceDecoder(model, reverse=True)
 
-        indices = encoder(self.sentences[0])
+        indices = encoder(self.sentence)
 
         # Assert encoder.
-        assert_equal(indices, self.token_indices[0][::-1])
+        assert_equal(indices, self.token_indices[::-1])
 
-        sentences = decoder(indices)
+        sentence = decoder(indices)
 
         # Assert decoder.
-        assert isinstance(sentences, list)
+        assert isinstance(sentence, CString)
 
-        assert len(sentences) == 1
-
-        assert sentences[0] == self.sentences[0]
+        assert sentence == self.sentence
 
     def test_decode_works_when_control_symbols_are_specified(self) -> None:
         model = self.build_model(control_symbols=["<foo>"])
@@ -118,10 +111,10 @@ class TestSentencePieceModel:
         encoder = SentencePieceEncoder(model, device=device)
         decoder = SentencePieceDecoder(model)
 
-        indices = encoder(self.sentences[0])
+        indices = encoder(self.sentence)
 
         # Assert encoder.
-        assert_equal(indices, self.token_indices[0])
+        assert_equal(indices, self.token_indices)
 
         # We inject a dummy <foo> token to the returned tokens.
         foo_idx = model.token_to_index("<foo>")
@@ -131,14 +124,12 @@ class TestSentencePieceModel:
         indices = torch.cat([indices[:2], foo, indices[2:]])
 
         # We expect the decoder to ignore the <foo> tokens.
-        sentences = decoder(indices)
+        sentence = decoder(indices)
 
         # Assert decoder.
-        assert isinstance(sentences, list)
+        assert isinstance(sentence, CString)
 
-        assert len(sentences) == 1
-
-        assert sentences[0] == self.sentences[0]
+        assert sentence == self.sentence
 
     def test_encode_works_when_prefix_and_suffix_tokens_are_specified(self) -> None:
         model = self.build_model(control_symbols=["<foo1>", "<foo2>", "<foo3>"])
@@ -151,45 +142,25 @@ class TestSentencePieceModel:
         )
         decoder = SentencePieceDecoder(model)
 
-        indices = encoder(self.sentences[0])
+        indices = encoder(self.sentence)
 
         # Assert encoder.
         foo1_idx = model.token_to_index("<foo1>")
         foo2_idx = model.token_to_index("<foo2>")
         foo3_idx = model.token_to_index("<foo3>")
 
-        e = (
-            [foo1_idx, model.bos_idx]
-            + self.token_indices[0]
-            + [foo2_idx, model.eos_idx, foo3_idx]
-        )
+        bos_idx = model.bos_idx
+        eos_idx = model.eos_idx
+
+        e = [foo1_idx, bos_idx] + self.token_indices + [foo2_idx, eos_idx, foo3_idx]
 
         assert_equal(indices, e)
 
         # We expect the decoder to ignore the prefix and suffix tokens.
-        sentences = decoder(indices)
+        sentence = decoder(indices)
 
         # Assert decoder.
-        assert sentences[0] == self.sentences[0]
-
-    @pytest.mark.parametrize("dtype", [torch.int16, torch.int32, torch.int64])
-    def test_decode_works_when_input_is_batched(self, dtype: DataType) -> None:
-        model = self.build_model()
-
-        decoder = SentencePieceDecoder(model)
-
-        indices1 = torch.tensor(self.token_indices[0], device=device, dtype=dtype)
-        indices2 = torch.tensor(self.token_indices[1], device=device, dtype=dtype)
-
-        batch = torch.nn.utils.rnn.pad_sequence([indices1, indices2], batch_first=True)
-
-        sentences = decoder(batch)
-
-        assert isinstance(sentences, list)
-
-        assert len(sentences) == 2
-
-        assert sentences == self.sentences
+        assert sentence == self.sentence
 
     @pytest.mark.parametrize("dtype", [torch.float32, torch.int8])
     def test_decode_raises_error_when_data_type_is_not_supported(
@@ -208,7 +179,7 @@ class TestSentencePieceModel:
             decoder(indices)
 
     @pytest.mark.parametrize("shape", [(), (4, 4, 4)])
-    def test_decode_raises_error_when_input_has_more_than_2_dimensions(
+    def test_decode_raises_error_when_input_has_more_than_1_dimension(
         self, shape: Sequence[int]
     ) -> None:
         model = self.build_model()
@@ -219,7 +190,7 @@ class TestSentencePieceModel:
 
         with pytest.raises(
             ValueError,
-            match=rf"^The input tensor must be one or two dimensional, but has {len(shape)} dimensions instead\.$",
+            match=rf"^The input tensor must be one dimensional, but has {len(shape)} dimension\(s\) instead\.$",
         ):
             decoder(indices)
 


### PR DESCRIPTION
This PR fixes the inconsistency between `TextTokenEncoder` and `TextTokenDecoder`, where the former accepts only a single string, while the latter accepts only a batched tensor. `TextTokenDecoder` now accepts only a one-dimensional tensor holding the token indices of a single sentence and returns a string instead of a list of strings (another issue with batching in the decoder was the lack of pad handling). Batching is typically handled by the code that performs decoding (e.g. `SequenceToTextGenerator`). Also included is a nit convenience `CString` method `strip`, which internally calls `ltrim` and `rtrim`.