### PR TITLE
Introduce create_raw_encoder

### DIFF
--- a/src/fairseq2/data/text/multilingual_text_tokenizer.py
+++ b/src/fairseq2/data/text/multilingual_text_tokenizer.py
@@ -107,7 +107,7 @@ class MultilingualTextTokenizer(TextTokenizer):
 
             if lang not in self.source_langs:
                 raise ValueError(
-                    f"`lang` ({lang}) is not a supported source language. It must be one of: {self.source_langs}"
+                    f"`lang` must be a supported source language, but is '{lang}' instead. Supported source languages: {self.source_langs}"
                 )
         elif mode == "target":
             if lang is None:
@@ -115,7 +115,7 @@ class MultilingualTextTokenizer(TextTokenizer):
 
             if lang not in self.target_langs:
                 raise ValueError(
-                    f"`lang` ({lang}) is not a supported target language. It must be one of: {self.target_langs}"
+                    f"`lang` must be a supported target language, but is '{lang}' instead. Supported target languages: {self.source_langs}"
                 )
         else:
             raise ValueError(
@@ -129,6 +129,12 @@ class MultilingualTextTokenizer(TextTokenizer):
             device=device,
             pin_memory=pin_memory,
         )
+
+    @finaloverride
+    def create_raw_encoder(
+        self, *, device: Optional[Device] = None, pin_memory: bool = False
+    ) -> TextTokenEncoder:
+        return SentencePieceEncoder(self.model, device=device, pin_memory=pin_memory)
 
     @finaloverride
     def create_decoder(self) -> TextTokenDecoder:

--- a/src/fairseq2/data/text/text_tokenizer.py
+++ b/src/fairseq2/data/text/text_tokenizer.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from typing import Optional
 
@@ -35,7 +37,7 @@ class TextTokenizer(ABC):
         mode: Optional[str] = None,
         device: Optional[Device] = None,
         pin_memory: bool = False,
-    ) -> "TextTokenEncoder":
+    ) -> TextTokenEncoder:
         """Create a token encoder.
 
         The valid arguments for the ``task``, ``lang``, and ``mode`` parameters
@@ -61,7 +63,19 @@ class TextTokenizer(ABC):
         """
 
     @abstractmethod
-    def create_decoder(self) -> "TextTokenDecoder":
+    def create_raw_encoder(
+        self, *, device: Optional[Device] = None, pin_memory: bool = False
+    ) -> TextTokenEncoder:
+        """Create a raw token encoder with no control symbols.
+
+        :param device:
+            The device on which to construct tensors.
+        :param pin_memory:
+            If ``True``, uses pinned memory while constructing tensors.
+        """
+
+    @abstractmethod
+    def create_decoder(self) -> TextTokenDecoder:
         """Create a token decoder."""
 
 

--- a/src/fairseq2/models/llama/tokenizer.py
+++ b/src/fairseq2/models/llama/tokenizer.py
@@ -88,5 +88,11 @@ class LLaMATokenizer(TextTokenizer):
         )
 
     @finaloverride
+    def create_raw_encoder(
+        self, *, device: Optional[Device] = None, pin_memory: bool = False
+    ) -> TextTokenEncoder:
+        return SentencePieceEncoder(self.model, device=device, pin_memory=pin_memory)
+
+    @finaloverride
     def create_decoder(self) -> TextTokenDecoder:
         return SentencePieceDecoder(self.model)

--- a/src/fairseq2/models/mistral/builder.py
+++ b/src/fairseq2/models/mistral/builder.py
@@ -80,7 +80,7 @@ def _7b() -> MistralConfig:
         model_dim=4096,
         max_seq_len=8192,
         vocabulary_size=32000,
-        attn_window_len=4,
+        attn_window_len=4096,
         num_layers=32,
         num_attn_heads=32,
         num_key_value_heads=8,

--- a/src/fairseq2/models/mistral/tokenizer.py
+++ b/src/fairseq2/models/mistral/tokenizer.py
@@ -55,7 +55,7 @@ class MistralTokenizer(TextTokenizer):
         :param lang:
             Not used.
         :param mode:
-            Must be 'prompt'. If ``None``, defaults to 'prompt'.
+            Must be 'default' or 'prompt'. If ``None``, defaults to 'default'.
         :param device:
             The device on which to construct tensors.
         :param pin_memory:
@@ -67,12 +67,17 @@ class MistralTokenizer(TextTokenizer):
         if lang is not None:
             raise ValueError(f"`lang` must be `None`, but is '{lang}' instead.")
 
-        if mode is None or mode == "prompt":
+        if mode is None or mode == "default":
+            prefix_tokens = ["<s>"]
+            suffix_tokens = ["</s>"]
+        elif mode == "prompt":
             prefix_tokens = ["<s>"]
             # In prompt mode, we expect the generator to finish the sequence.
             suffix_tokens = None
         else:
-            raise ValueError(f"`mode` must be 'prompt', but is '{mode}' instead.")
+            raise ValueError(
+                f"`mode` must be 'default' or 'prompt', but is '{mode}' instead."
+            )
 
         return SentencePieceEncoder(
             self.model,
@@ -81,6 +86,12 @@ class MistralTokenizer(TextTokenizer):
             device=device,
             pin_memory=pin_memory,
         )
+
+    @finaloverride
+    def create_raw_encoder(
+        self, *, device: Optional[Device] = None, pin_memory: bool = False
+    ) -> TextTokenEncoder:
+        return SentencePieceEncoder(self.model, device=device, pin_memory=pin_memory)
 
     @finaloverride
     def create_decoder(self) -> TextTokenDecoder:

--- a/src/fairseq2/models/nllb/tokenizer.py
+++ b/src/fairseq2/models/nllb/tokenizer.py
@@ -129,5 +129,11 @@ class NllbTokenizer(TextTokenizer):
         )
 
     @finaloverride
+    def create_raw_encoder(
+        self, *, device: Optional[Device] = None, pin_memory: bool = False
+    ) -> TextTokenEncoder:
+        return SentencePieceEncoder(self.model, device=device, pin_memory=pin_memory)
+
+    @finaloverride
     def create_decoder(self) -> TextTokenDecoder:
         return SentencePieceDecoder(self.model)

--- a/src/fairseq2/models/s2t_transformer/tokenizer.py
+++ b/src/fairseq2/models/s2t_transformer/tokenizer.py
@@ -113,5 +113,11 @@ class S2TTransformerTokenizer(TextTokenizer):
         )
 
     @finaloverride
+    def create_raw_encoder(
+        self, *, device: Optional[Device] = None, pin_memory: bool = False
+    ) -> TextTokenEncoder:
+        return SentencePieceEncoder(self.model, device=device, pin_memory=pin_memory)
+
+    @finaloverride
     def create_decoder(self) -> TextTokenDecoder:
         return SentencePieceDecoder(self.model)


### PR DESCRIPTION
This PR introduces a new `create_raw_encoder` method in `TextTokenizer` that uses no control symbols. This is beneficial for use cases such as toxicity filtering, and other low-level sequence handling functions.