### PR TITLE
Conver layer_norm_hook to a PyTorch hook

### DIFF
--- a/src/fairseq2/models/w2vbert/model.py
+++ b/src/fairseq2/models/w2vbert/model.py
@@ -92,10 +92,10 @@ class W2VBertModel(Module):
 
         w2v2_layer_output = None
 
-        def layer_output_hook(
+        def hook(
             layer_idx: int,
             layer_output: Tensor,
-            layer_padding_mask: PaddingMask,
+            layer_padding_mask: Optional[PaddingMask],
             num_layers: int,
         ) -> bool:
             nonlocal w2v2_layer_output
@@ -105,10 +105,8 @@ class W2VBertModel(Module):
 
             return True
 
-        # TODO: Should we pad for fp16?
-        encoder_output, _ = self.w2v2_model.encoder(
-            seqs, padding_mask, layer_output_hook=layer_output_hook
-        )
+        with self.w2v2_model.encoder.register_layer_output_hook(hook):
+            encoder_output, _ = self.w2v2_model.encoder(seqs, padding_mask)
 
         assert w2v2_layer_output is not None
 

--- a/src/fairseq2/nn/transformer/__init__.py
+++ b/src/fairseq2/nn/transformer/__init__.py
@@ -69,6 +69,9 @@ from fairseq2.nn.transformer.multihead_attention import (
     AttentionWeightHook as AttentionWeightHook,
 )
 from fairseq2.nn.transformer.multihead_attention import (
+    AttentionWeightStoreHook as AttentionWeightStoreHook,
+)
+from fairseq2.nn.transformer.multihead_attention import (
     FullAttentionState as FullAttentionState,
 )
 from fairseq2.nn.transformer.multihead_attention import (
@@ -85,9 +88,6 @@ from fairseq2.nn.transformer.multihead_attention import (
 )
 from fairseq2.nn.transformer.multihead_attention import (
     StaticAttentionState as StaticAttentionState,
-)
-from fairseq2.nn.transformer.multihead_attention import (
-    StoreAttentionWeights as StoreAttentionWeights,
 )
 from fairseq2.nn.transformer.norm_order import (
     TransformerNormOrder as TransformerNormOrder,

--- a/src/fairseq2/nn/transformer/encoder.py
+++ b/src/fairseq2/nn/transformer/encoder.py
@@ -4,11 +4,15 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
-from typing import Iterable, Optional, Protocol, Tuple, final
+from collections import OrderedDict
+from typing import Dict, Iterable, Optional, Protocol, Tuple, final
 
 from torch import Tensor
 from torch.nn import Module
+from torch.utils.hooks import RemovableHandle
 
 from fairseq2.nn.module_list import ModuleList
 from fairseq2.nn.normalization import LayerNorm
@@ -29,6 +33,8 @@ class TransformerEncoder(Module, ABC):
     model_dim: int
     layers: ModuleList
 
+    _layer_output_hooks: Dict[int, EncoderLayerOutputHook]
+
     def __init__(self, model_dim: int) -> None:
         """
         :param model_dim:
@@ -38,13 +44,11 @@ class TransformerEncoder(Module, ABC):
 
         self.model_dim = model_dim
 
+        self._layer_output_hooks = OrderedDict()
+
     @abstractmethod
     def forward(
-        self,
-        seqs: Tensor,
-        padding_mask: Optional[PaddingMask],
-        *,
-        layer_output_hook: Optional["EncoderLayerOutputHook"] = None,
+        self, seqs: Tensor, padding_mask: Optional[PaddingMask]
     ) -> Tuple[Tensor, Optional[PaddingMask]]:
         """
         :param seqs:
@@ -54,9 +58,6 @@ class TransformerEncoder(Module, ABC):
         :param padding_mask:
             The padding mask of ``seqs``. *Shape:* :math:`(N,S)`, where :math:`N`
             is the batch size and :math:`S` is the sequence length.
-        :param layer_output_hook:
-            If not ``None``, it will be called with the output of each layer in
-            the encoder stack.
 
         :returns:
             - The encoder output. *Shape:* Same as ``seqs``.
@@ -64,13 +65,35 @@ class TransformerEncoder(Module, ABC):
               ``padding_mask``.
         """
 
+    def register_layer_output_hook(
+        self, hook: EncoderLayerOutputHook
+    ) -> RemovableHandle:
+        """Register a layer output hook on the module.
+
+        The hook will be called every time after a layer in the encoder stack
+        has computed an output.
+
+        :param hook:
+            The hook to register.
+
+        :returns:
+            A handle that can be used to remove the added hook by calling
+            ``handle.remove()``.
+        """
+        handle = RemovableHandle(self._layer_output_hooks)
+
+        self._layer_output_hooks[handle.id] = hook
+
+        return handle
+
     def extra_repr(self) -> str:
         """:meta private:"""
         return f"model_dim={self.model_dim}"
 
 
 class EncoderLayerOutputHook(Protocol):
-    """Represents a hook to pass to :meth:`~TransformerEncoder.forward`."""
+    """Represents a hook to pass to
+    :meth:`~TransformerEncoder.register_layer_output_hook`."""
 
     def __call__(
         self,
@@ -153,14 +176,12 @@ class StandardTransformerEncoder(TransformerEncoder):
 
     @finaloverride
     def forward(
-        self,
-        seqs: Tensor,
-        padding_mask: Optional[PaddingMask],
-        *,
-        layer_output_hook: Optional[EncoderLayerOutputHook] = None,
+        self, seqs: Tensor, padding_mask: Optional[PaddingMask]
     ) -> Tuple[Tensor, Optional[PaddingMask]]:
-        if layer_output_hook is not None and self.layers.drop_p > 0.0:
-            raise ValueError("`layer_hook` must be `None` when LayerDrop is enabled.")
+        if self._layer_output_hooks and self.layers.drop_p > 0.0:
+            raise ValueError(
+                "The layer output hooks cannot be run when LayerDrop is enabled."
+            )
 
         num_layers = len(self.layers)
 
@@ -174,8 +195,8 @@ class StandardTransformerEncoder(TransformerEncoder):
         for layer_idx, layer in enumerate(self.layers.drop_iter()):
             seqs, padding_mask = layer(seqs, padding_mask, self_attn_mask)
 
-            if layer_output_hook is not None:
-                if not layer_output_hook(layer_idx, seqs, padding_mask, num_layers):
+            for hook in self._layer_output_hooks.values():
+                if not hook(layer_idx, seqs, padding_mask, num_layers):
                     break
 
         if self.layer_norm is not None:


### PR DESCRIPTION
This PR converts the parameter-based `layer_norm_hook` in `TransformerEncoder` and `TransformerDecoder` to a PyTorch hook (i.e. `RemovableHandle` for more flexibility (e.g. for early-exit fine-tuning work of SysML)