### PR TITLE
In Collater, handle empty bucket gracefully

### DIFF
--- a/fairseq2n/src/fairseq2n/data/collater.cc
+++ b/fairseq2n/src/fairseq2n/data/collater.cc
@@ -368,7 +368,13 @@ collater::operator()(data &&d) const
     if (!d.is_list())
         d = data_list{std::move(d)};
 
-    return collate_op{this, std::move(d).as_list()}.run();
+    data_list &bucket = d.as_list();
+
+    if (bucket.empty())
+        throw_<std::invalid_argument>(
+            "The bucket must contain at least one element, but is empty instead.");
+
+    return collate_op{this, std::move(bucket)}.run();
 }
 
 }  // namespace fairseq2n

--- a/tests/unit/data/test_collater.py
+++ b/tests/unit/data/test_collater.py
@@ -215,6 +215,15 @@ class TestCollater:
         assert output == {"foo1": [[0, 3, 6], [1, 4, 7], [2, 5, 8]], "foo2": {"subfoo1": [0, 1, 2]}, "foo3": [1, 2, 3]}
         # fmt: on
 
+    def test_call_raises_error_when_input_is_empty(self) -> None:
+        collater = Collater()
+
+        with pytest.raises(
+            ValueError,
+            match=r"^The bucket must contain at least one element, but is empty instead\.$",
+        ):
+            collater([])
+
     def test_call_works_when_input_is_not_a_bucket(self) -> None:
         bucket = {"foo1": 1}
 


### PR DESCRIPTION
This PR raises a descriptive error when an empty bucket is passed to `Collater`.