### PR TITLE
Rename bytes to __bytes__ in CString

### DIFF
--- a/fairseq2n/python/src/fairseq2n/bindings/data/string.cc
+++ b/fairseq2n/python/src/fairseq2n/bindings/data/string.cc
@@ -69,7 +69,7 @@ def_string(py::module_ &data_module)
             })
 
         .def(
-            "bytes",
+            "__bytes__",
             [](const immutable_string &self)
             {
                 return py::bytes(static_cast<std::string_view>(self));

--- a/src/fairseq2/data/cstring.py
+++ b/src/fairseq2/data/cstring.py
@@ -42,8 +42,8 @@ if TYPE_CHECKING or _DOC_MODE:
         def __hash__(self) -> int:
             ...
 
-        def bytes(self) -> bytes:
-            """Return a copy of this string as :class:`bytes`."""
+        def __bytes__(self) -> bytes:
+            ...
 
         def strip(self) -> "CString":
             """Return a copy of this string with no whitespace at the beginning and end."""


### PR DESCRIPTION
A nit PR that renames `CString`'s `bytes` to the dunder `__bytes__`.