### PR TITLE
Fix CacheControl in S3 publish

### DIFF
--- a/ci/scripts/update_pep503_index.py
+++ b/ci/scripts/update_pep503_index.py
@@ -81,7 +81,7 @@ def create_or_update_package_index(
 
 
 def upload_index(bucket: "Bucket", prefix: str, index: str) -> None:
-    metadata = {"ContentType": "text/html", "Cache-Control": "max-age=300"}
+    metadata = {"ContentType": "text/html", "CacheControl": "max-age=300"}
 
     with BytesIO(index.encode("utf-8")) as fp:
         bucket.upload_fileobj(  # type: ignore[attr-defined]


### PR DESCRIPTION
This PR fixes the Cache-Control key in boto3 call for S3 package publish.