### PR TITLE
Use __future__.annotations

### DIFF
--- a/src/fairseq2/assets/card.py
+++ b/src/fairseq2/assets/card.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 import os
 from typing import (
     AbstractSet,
@@ -35,10 +37,10 @@ class AssetCard:
 
     name: str
     data: Any
-    base: Optional["AssetCard"]
+    base: Optional[AssetCard]
 
     def __init__(
-        self, name: str, data: Mapping[str, Any], base: Optional["AssetCard"] = None
+        self, name: str, data: Mapping[str, Any], base: Optional[AssetCard] = None
     ) -> None:
         """
         :param name:

--- a/src/fairseq2/data/audio.py
+++ b/src/fairseq2/data/audio.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Optional, TypedDict, Union
 
 from torch import Tensor
@@ -24,7 +26,7 @@ if TYPE_CHECKING or _DOC_MODE:
         ) -> None:
             ...
 
-        def __call__(self, memory_block: MemoryBlock) -> "AudioDecoderOutput":
+        def __call__(self, memory_block: MemoryBlock) -> AudioDecoderOutput:
             ...
 
     class WaveformToFbankConverter:
@@ -41,7 +43,7 @@ if TYPE_CHECKING or _DOC_MODE:
         ) -> None:
             ...
 
-        def __call__(self, waveform: "WaveformToFbankInput") -> "WaveformToFbankOutput":
+        def __call__(self, waveform: WaveformToFbankInput) -> WaveformToFbankOutput:
             ...
 
 else:

--- a/src/fairseq2/data/data_pipeline.py
+++ b/src/fairseq2/data/data_pipeline.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -77,12 +79,12 @@ if TYPE_CHECKING or _DOC_MODE:
 
         @staticmethod
         def zip(
-            pipelines: Sequence["DataPipeline"],
+            pipelines: Sequence[DataPipeline],
             names: Optional[Sequence[str]] = None,
             zip_to_shortest: bool = False,
             flatten: bool = False,
             disable_parallelism: bool = False,
-        ) -> "DataPipelineBuilder":
+        ) -> DataPipelineBuilder:
             """Zip together examples read from ``pipelines``.
 
             :param pipelines:
@@ -96,9 +98,9 @@ if TYPE_CHECKING or _DOC_MODE:
 
         @staticmethod
         def round_robin(
-            pipelines: Sequence["DataPipeline"],
+            pipelines: Sequence[DataPipeline],
             stop_at_shortest: bool = False,
-        ) -> "DataPipelineBuilder":
+        ) -> DataPipelineBuilder:
             """Extract examples from ``pipelines`` in round robin.
 
             :param pipelines:
@@ -111,10 +113,10 @@ if TYPE_CHECKING or _DOC_MODE:
 
         @staticmethod
         def sample(
-            pipelines: Sequence["DataPipeline"],
+            pipelines: Sequence[DataPipeline],
             weights: Optional[Sequence[float]] = None,
             stop_at_shortest: bool = False,
-        ) -> "DataPipelineBuilder":
+        ) -> DataPipelineBuilder:
             """Extract examples from ``pipelines`` by sampling based on ``weights``.
 
             :param data_pipelines:
@@ -128,15 +130,15 @@ if TYPE_CHECKING or _DOC_MODE:
             """
 
         @staticmethod
-        def constant(example: Any, key: Optional[str] = None) -> "DataPipelineBuilder":
+        def constant(example: Any, key: Optional[str] = None) -> DataPipelineBuilder:
             ...
 
         @staticmethod
-        def count(start: int = 0, key: Optional[str] = None) -> "DataPipelineBuilder":
+        def count(start: int = 0, key: Optional[str] = None) -> DataPipelineBuilder:
             ...
 
         @staticmethod
-        def concat(pipelines: Sequence["DataPipeline"]) -> "DataPipelineBuilder":
+        def concat(pipelines: Sequence[DataPipeline]) -> DataPipelineBuilder:
             """Concatenate examples from ``pipelines``.
 
             :param pipelines:
@@ -169,7 +171,7 @@ if TYPE_CHECKING or _DOC_MODE:
             self,
             pad_value: Optional[int] = None,
             pad_to_multiple: int = 1,
-            overrides: Optional[Sequence["CollateOptionsOverride"]] = None,
+            overrides: Optional[Sequence[CollateOptionsOverride]] = None,
         ) -> Self:
             """Concatenate a list of inputs into a single inputs.
 
@@ -281,7 +283,7 @@ if TYPE_CHECKING or _DOC_MODE:
 
     def list_files(
         pathname: PathLike, pattern: Optional[StringLike] = None
-    ) -> "DataPipelineBuilder":
+    ) -> DataPipelineBuilder:
         """List recursively all files under ``pathname`` that matches ``pattern``.
 
         :param pathname:
@@ -400,7 +402,7 @@ if TYPE_CHECKING or _DOC_MODE:
         ) -> None:
             ...
 
-        def __call__(self, filename: PathLike) -> "FileMapperOutput":
+        def __call__(self, filename: PathLike) -> FileMapperOutput:
             """Parses the file name and returns the file bytes.
 
             :returns:

--- a/src/fairseq2/generation/sequence_generator.py
+++ b/src/fairseq2/generation/sequence_generator.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 import math
 from dataclasses import dataclass
 from typing import List, Optional, Tuple, Union
@@ -146,7 +148,7 @@ class Seq2SeqGenerator:
         encoder_output: Tensor,
         encoder_padding_mask: Optional[PaddingMask],
         source_seq_len: Optional[int] = None,
-    ) -> "SequenceGeneratorOutput":
+    ) -> SequenceGeneratorOutput:
         opts = self.opts
 
         num_searches = encoder_output.size(0)
@@ -560,8 +562,8 @@ class Seq2SeqGenerator:
         eos_scores: Tensor,
         seqs: Tensor,
         scores: Tensor,
-        active_searches: List[Tuple[int, List["Hypothesis"]]],
-        finished_searches: List[List["Hypothesis"]],
+        active_searches: List[Tuple[int, List[Hypothesis]]],
+        finished_searches: List[List[Hypothesis]],
     ) -> List[int]:
         # fmt: off
         finalized_seqs   = seqs  .index_select(dim=0, index=eos_beam_indices)
@@ -623,7 +625,7 @@ class Seq2SeqGenerator:
 class SequenceGeneratorOutput:
     """Holds the output of a sequence generator."""
 
-    results: List[List["Hypothesis"]]
+    results: List[List[Hypothesis]]
     """The list of hypothesis generated per search, ordered by score."""
 
     device: Device

--- a/src/fairseq2/generation/text.py
+++ b/src/fairseq2/generation/text.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import List, Optional, Sequence
 
@@ -67,7 +69,7 @@ class SequenceToTextGeneratorBase:
     @torch.inference_mode()
     def _do_generate(
         self, source_seqs: Tensor, source_padding_mask: Optional[PaddingMask]
-    ) -> "SequenceToTextOutput":
+    ) -> SequenceToTextOutput:
         """A subclass should call this function for the actual text generation."""
         encoder_output, encoder_padding_mask = self.model.encode(
             source_seqs, source_padding_mask

--- a/src/fairseq2/models/seq2seq.py
+++ b/src/fairseq2/models/seq2seq.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Optional, Tuple
@@ -20,7 +22,7 @@ class Seq2SeqModel(Module, ABC):
     """Represents a sequence-to-sequence model."""
 
     @abstractmethod
-    def forward(self, batch: "Seq2SeqBatch") -> SequenceModelOutput:
+    def forward(self, batch: Seq2SeqBatch) -> SequenceModelOutput:
         """
         :param batch:
             The batch of sequences to process.
@@ -54,7 +56,7 @@ class Seq2SeqBatch:
     example: Any = None
     """The data example from which this batch was constructed."""
 
-    def as_training_input(self) -> Tuple["Seq2SeqBatch", Tensor]:
+    def as_training_input(self) -> Tuple[Seq2SeqBatch, Tensor]:
         """Return a copy of this batch for model training.
 
         :returns:

--- a/src/fairseq2/models/sequence.py
+++ b/src/fairseq2/models/sequence.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Optional
@@ -21,7 +23,7 @@ class SequenceModel(Module, ABC):
     """Represents a sequence model."""
 
     @abstractmethod
-    def forward(self, batch: "SequenceBatch") -> "SequenceModelOutput":
+    def forward(self, batch: SequenceBatch) -> SequenceModelOutput:
         """
         :param batch:
             The batch of sequences to process.

--- a/src/fairseq2/models/w2vbert/model.py
+++ b/src/fairseq2/models/w2vbert/model.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Optional
 
@@ -81,7 +83,7 @@ class W2VBertModel(Module):
         self.bert_loss_weight = bert_loss_weight
         self.bert_label_smoothing = bert_label_smoothing
 
-    def forward(self, batch: SequenceBatch) -> "W2VBertOutput":
+    def forward(self, batch: SequenceBatch) -> W2VBertOutput:
         """
         :param batch:
             The batch of sequences to process.
@@ -176,7 +178,7 @@ class W2VBertOutput:
     bert_label_smoothing: float = 0.0
     """The amount of label smoothing when computing masked prediction loss."""
 
-    def compute_loss(self) -> "W2VBertLoss":
+    def compute_loss(self) -> W2VBertLoss:
         """Compute the loss."""
         bert_loss = self.compute_bert_loss()
 

--- a/src/fairseq2/models/wav2vec2/model.py
+++ b/src/fairseq2/models/wav2vec2/model.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Optional, Tuple
 
@@ -111,7 +113,7 @@ class Wav2Vec2Model(Module):
         self.logit_temp = logit_temp
         self.diversity_loss_weight = diversity_loss_weight
 
-    def forward(self, batch: SequenceBatch) -> "Wav2Vec2Output":
+    def forward(self, batch: SequenceBatch) -> Wav2Vec2Output:
         """
         :param batch:
             The batch of sequences to process.
@@ -321,7 +323,7 @@ class Wav2Vec2Output:
     diversity_loss_weight: float
     """The weight of diversity in loss computation."""
 
-    def compute_loss(self) -> "Wav2Vec2Loss":
+    def compute_loss(self) -> Wav2Vec2Loss:
         """Compute the loss."""
         contrastive_loss = self.compute_contrastive_loss()
 

--- a/src/fairseq2/nn/embedding.py
+++ b/src/fairseq2/nn/embedding.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from typing import Callable, Optional, final
 
@@ -74,7 +76,7 @@ class StandardEmbedding(Embedding):
     """Stores embeddings of a fixed dictionary and size in an in-memory table."""
 
     weight: Parameter
-    init_fn: Optional[Callable[["StandardEmbedding"], None]]
+    init_fn: Optional[Callable[[StandardEmbedding], None]]
 
     def __init__(
         self,
@@ -82,7 +84,7 @@ class StandardEmbedding(Embedding):
         embedding_dim: int,
         pad_idx: Optional[int] = None,
         *,
-        init_fn: Optional[Callable[["StandardEmbedding"], None]] = None,
+        init_fn: Optional[Callable[[StandardEmbedding], None]] = None,
         device: Optional[Device] = None,
         dtype: Optional[DataType] = None,
     ) -> None:

--- a/src/fairseq2/nn/projection.py
+++ b/src/fairseq2/nn/projection.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 import math
 from abc import ABC, abstractmethod
 from typing import Callable, Optional, final
@@ -67,7 +69,7 @@ class Linear(Projection):
 
     weight: Parameter
     bias: Optional[Parameter]
-    init_fn: Optional[Callable[["Linear"], None]]
+    init_fn: Optional[Callable[[Linear], None]]
 
     def __init__(
         self,
@@ -75,7 +77,7 @@ class Linear(Projection):
         output_dim: int,
         bias: bool,
         *,
-        init_fn: Optional[Callable[["Linear"], None]] = None,
+        init_fn: Optional[Callable[[Linear], None]] = None,
         device: Optional[Device] = None,
         dtype: Optional[DataType] = None,
     ) -> None:

--- a/src/fairseq2/nn/transformer/relative_attention.py
+++ b/src/fairseq2/nn/transformer/relative_attention.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 import math
 from typing import Optional, Tuple, final
 
@@ -27,7 +29,7 @@ class RelativePositionSDPA(SDPA):
 
     model_dim: int
     num_heads: int
-    pos_encoding: "RelativePositionalEncoding"
+    pos_encoding: RelativePositionalEncoding
     u_bias: Parameter
     v_bias: Parameter
     r_proj: Linear
@@ -36,7 +38,7 @@ class RelativePositionSDPA(SDPA):
         self,
         model_dim: int,
         num_heads: int,
-        pos_encoding: "RelativePositionalEncoding",
+        pos_encoding: RelativePositionalEncoding,
         *,
         attn_dropout_p: float = 0.0,
         device: Optional[Device] = None,


### PR DESCRIPTION
This PR starts using `from __future__ import annotations` for cleaner annotation syntax (i.e. postponed annotation evaluation) 