### PR TITLE
Rename LogitsProcessor to StepProcessor

### DIFF
--- a/src/fairseq2/generation/__init__.py
+++ b/src/fairseq2/generation/__init__.py
@@ -6,10 +6,6 @@
 
 from fairseq2.generation.beam_search import BeamSearch as BeamSearch
 from fairseq2.generation.beam_search import StandardBeamSearch as StandardBeamSearch
-from fairseq2.generation.logits_processor import (
-    BannedSequenceProcessor as BannedSequenceProcessor,
-)
-from fairseq2.generation.logits_processor import LogitsProcessor as LogitsProcessor
 from fairseq2.generation.sequence_generator import Hypothesis as Hypothesis
 from fairseq2.generation.sequence_generator import Seq2SeqGenerator as Seq2SeqGenerator
 from fairseq2.generation.sequence_generator import (
@@ -18,6 +14,10 @@ from fairseq2.generation.sequence_generator import (
 from fairseq2.generation.sequence_generator import (
     SequenceGeneratorOutput as SequenceGeneratorOutput,
 )
+from fairseq2.generation.step_processor import (
+    BannedSequenceProcessor as BannedSequenceProcessor,
+)
+from fairseq2.generation.step_processor import StepProcessor as StepProcessor
 from fairseq2.generation.text import SequenceToTextGenerator as SequenceToTextGenerator
 from fairseq2.generation.text import SequenceToTextOutput as SequenceToTextOutput
 from fairseq2.generation.text import TextTranslator as TextTranslator

--- a/src/fairseq2/generation/step_processor.py
+++ b/src/fairseq2/generation/step_processor.py
@@ -15,7 +15,7 @@ from torch.nn.functional import pad
 from fairseq2.typing import finaloverride
 
 
-class LogitsProcessor(ABC):
+class StepProcessor(ABC):
     """Processes next-step probabilities during sequence generation."""
 
     @abstractmethod
@@ -35,7 +35,7 @@ class LogitsProcessor(ABC):
 
 
 @final
-class BannedSequenceProcessor(LogitsProcessor):
+class BannedSequenceProcessor(StepProcessor):
     """Prevents a provided list of banned sequences from being generated."""
 
     _banned_seqs: Optional[Tensor]

--- a/tests/integration/generation/test_step_processor.py
+++ b/tests/integration/generation/test_step_processor.py
@@ -85,7 +85,7 @@ class TestBannedSequenceProcessor:
         banned_seqs = [text_encoder(b) for b in banned_words]
 
         opts = SequenceGeneratorOptions(
-            logits_processor=BannedSequenceProcessor(banned_seqs)
+            step_processor=BannedSequenceProcessor(banned_seqs)
         )
 
         translator = TextTranslator(


### PR DESCRIPTION
This PR renames `LogitsProcessor` to `StepProcessor` as a more accurate name based on the purpose of the type.