### PR TITLE
RelativePositionSDPA Optimization

### DIFF
--- a/src/fairseq2/nn/transformer/relative_attention.py
+++ b/src/fairseq2/nn/transformer/relative_attention.py
@@ -18,7 +18,7 @@ from torch.nn.functional import dropout, pad, softmax
 from fairseq2.nn.padding import PaddingMask
 from fairseq2.nn.projection import Linear
 from fairseq2.nn.transformer.attention import SDPA
-from fairseq2.nn.transformer.attention_mask import AttentionMask
+from fairseq2.nn.transformer.attention_mask import AttentionMask, CausalAttentionMask
 from fairseq2.typing import DataType, Device, finaloverride
 
 


### PR DESCRIPTION
**What does this PR do? Please describe:**
Change RelativePositionSDPA to use torch scaled_dot_product_attention for optimized performance.

Torch's scaled_dot_production_attention basically performs `softmax((q@k)*scale_factor+bias)@value`
On the other hand, RelativePositionSDPA performs `softmax(((q+u_bias)@k+(q+v_bias)@r)*scale_factor+bias)@value`, which could be rewrote `softmax(((q+u_bias)@k)*scale_factor+bias+(q+v_bias)@r*scale_factor)@value`. 
With this equation, we can use Torch's scaled_dot_production_attention API by passing `q+u_bias` as query, `k` as key and `bias+(q+v_bias)@r*scale_factor` as attn_mask.


**Does your PR introduce any breaking changes? If yes, please list them:**
List of all backwards-incompatible changes.

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
