### PR TITLE
Revise the implementation of AssetCard

### DIFF
--- a/src/fairseq2/assets/card.py
+++ b/src/fairseq2/assets/card.py
@@ -137,7 +137,7 @@ class AssetCard:
 class AssetCardField:
     """Represents a field of an asset card."""
 
-    cast: AssetCard
+    card: AssetCard
     path: List[str]
 
     def __init__(self, card: AssetCard, path: List[str]) -> None:

--- a/src/fairseq2/assets/card.py
+++ b/src/fairseq2/assets/card.py
@@ -10,16 +10,18 @@ import os
 from typing import (
     AbstractSet,
     Any,
+    Dict,
     List,
     Mapping,
-    NoReturn,
+    MutableMapping,
     Optional,
     Type,
     TypeVar,
     cast,
-    get_origin,
 )
 from urllib.parse import urlparse
+
+from typing_extensions import Self
 
 from fairseq2.assets.error import AssetError
 
@@ -27,27 +29,24 @@ T = TypeVar("T")
 
 
 class AssetCard:
-    """Provides information about an asset.
-
-    Since asset cards have no formal schema, they can describe any type of asset
-    including pretrained models and datasets. They typically contain information
-    such as the configuration, location, intended use, and evaluation results of
-    an asset.
-    """
+    """Holds information about an asset."""
 
     name: str
-    data: Any
+    data: MutableMapping[str, Any]
     base: Optional[AssetCard]
 
     def __init__(
-        self, name: str, data: Mapping[str, Any], base: Optional[AssetCard] = None
+        self,
+        name: str,
+        data: MutableMapping[str, Any],
+        base: Optional[AssetCard] = None,
     ) -> None:
         """
         :param name:
             The name of the asset.
         :param data:
-            The data of the asset card. Each key-value entry (i.e. field) should
-            hold a specific piece of information about the asset.
+            The data to be held in the card. Each key-value entry (i.e. field)
+            should contain a specific piece of information about the asset.
         :param base:
             The card that this card derives from.
         """
@@ -55,86 +54,150 @@ class AssetCard:
         self.data = data
         self.base = base
 
-    def field(self, name: str) -> "AssetCardField":
-        """Return a field of the card.
+    def field(self, name: str) -> AssetCardField:
+        """Return a field of this card.
 
-        If this card does not contain the specified field, its base card will be
-        recursively checked.
+        If the card does not contain the specified field, its base card will be
+        checked recursively.
 
         :param name:
             The name of the field.
-
-        :returns:
-            An :class:`AssetCardField` representing the field.
         """
-        data = None
+        return AssetCardField(self, [name])
 
-        card: Optional[AssetCard] = self
+    def _get_field_value(self, name: str, path: List[str]) -> Any:
+        assert len(path) > 0
 
-        while card and data is None:
+        data = self.data
+
+        contains = True
+
+        for field in path:
+            if data is None:
+                contains = False
+
+                break
+
+            if not isinstance(data, Mapping):
+                pathname = ".".join(path)
+
+                raise AssetCardFieldNotFoundError(
+                    f"The asset card '{name}' must have a field named '{pathname}'."
+                )
+
             try:
-                data = card.data[name]
+                data = data[field]
             except KeyError:
-                pass
+                contains = False
 
-            card = card.base
+                break
 
-        return AssetCardField(self, [name], data)
+        if not contains:
+            if self.base is not None:
+                return self.base._get_field_value(name, path)
+
+            pathname = ".".join(path)
+
+            raise AssetCardFieldNotFoundError(
+                f"The asset card '{name}' must have a field named '{pathname}'."
+            )
+
+        return data
+
+    def _set_field_value(self, path: List[str], value: Any) -> None:
+        assert len(path) > 0
+
+        data = self.data
+
+        for depth, field in enumerate(path[:-1]):
+            try:
+                data = data[field]
+            except KeyError:
+                tmp: Dict[str, Any] = {}
+
+                data[field] = tmp
+
+                data = tmp
+
+            if not isinstance(data, Mapping):
+                conflict_pathname = ".".join(path[: depth + 1])
+
+                pathname = ".".join(path)
+
+                raise AssetCardError(
+                    f"The asset card '{self.name}' cannot have a field named '{pathname}' due to path conflict at '{conflict_pathname}'."
+                )
+
+        data[path[-1]] = value
 
     def __str__(self) -> str:
         return str(self.data)
 
 
 class AssetCardField:
-    """Represents a field in an asset card."""
+    """Represents a field of an asset card."""
 
-    card: AssetCard
+    cast: AssetCard
     path: List[str]
-    data: Any
 
-    def __init__(self, card: AssetCard, path: List[str], data: Any) -> None:
+    def __init__(self, card: AssetCard, path: List[str]) -> None:
         """
         :param card:
-            The asset card owning this field.
+            The card owning this field.
         :param path:
-            The list containing the names of this field and all its parent
-            fields in top-down order.
-        :param data:
-            The data held by this field.
+            The path to this field in the card.
         """
         self.card = card
         self.path = path
-        self.data = data
+
+    def field(self, name: str) -> AssetCardField:
+        """Return a sub-field of this field.
+
+        :param name:
+            The name of the sub-field.
+        """
+        return AssetCardField(self.card, self.path + [name])
+
+    def is_none(self) -> bool:
+        """Return ``True`` if the field is ``None``."""
+        value = self.card._get_field_value(self.card.name, self.path)
+
+        return value is None
 
     def as_(self, kls: Type[T], allow_empty: bool = False) -> T:
-        """Return the value of this field if it exists and is of type ``kls``;
-        otherwise, raise an :class:`AssertCardError`.
+        """Return the value of this field.
 
         :param kls:
-            The type to check against.
+            The type of the field.
         :param allow_empty:
-            If ``True``, allows the value to be empty.
+            If ``True``, allows the field to be empty.
         """
-        if self.data is None:
+        value = self.card._get_field_value(self.card.name, self.path)
+        if value is None:
             pathname = ".".join(self.path)
 
-            raise AssetCardFieldNotFoundError(
-                f"The asset card '{self.card.name}' must have a field named '{pathname}'."
+            raise AssetCardError(
+                f"The value of the field '{pathname}' of the asset card '{self.card.name}' must not be `None`."
             )
 
-        if not isinstance(self.data, get_origin(kls) or kls):
-            self._raise_card_error(
-                f"The type of the {{display_name}} must be {kls}, but is {type(self.data)} instead."
+        if not isinstance(value, kls):
+            pathname = ".".join(self.path)
+
+            raise AssetCardError(
+                f"The value of the field '{pathname}' of the asset card '{self.card.name}' must be of type `{kls}`, but is of type `{type(value)}` instead."
             )
 
-        if not allow_empty and not self.data:
-            self._raise_card_error("The value of the {display_name} must be non-empty.")
+        if not allow_empty and not value:
+            pathname = ".".join(self.path)
 
-        return cast(T, self.data)
+            raise AssetCardError(
+                f"The value of the field '{pathname}' of the asset card '{self.card.name}' must not be empty."
+            )
+
+        return value
 
     def as_uri(self) -> str:
-        """Return the value of this field if it represents a valid URI;
-        otherwise, raise an :class:`AssertCardError`."""
+        """Return the value of this field as a URI."""
         value = self.as_(str)
 
         try:
@@ -145,96 +208,80 @@ class AssetCardField:
         if uri and uri.scheme and uri.netloc:
             return value
 
-        self._raise_card_error(
-            f"The value of the {{display_name}} must be a valid URI, but is '{value}' instead."
+        pathname = ".".join(self.path)
+
+        raise AssetCardError(
+            f"The value of the field '{pathname}' of the asset card '{self.card.name}' must be a URI, but is '{value}' instead."
         )
 
     def as_filename(self) -> str:
-        """Return the value of this field if it represents a valid filename;
-        otherwise, raise an :class:`AssertCardError`."""
+        """Return the value of this field as a filename."""
         value = self.as_(str)
 
         if os.sep in value or (os.altsep and os.altsep in value):
-            self._raise_card_error(
-                f"The value of the {{display_name}} must be a valid filename, but is '{value}' instead."
+            pathname = ".".join(self.path)
+
+            raise AssetCardError(
+                f"The value of the field '{pathname}' of the asset card '{self.card.name}' must be a filename, but is '{value}' instead."
             )
 
         return value
 
     def as_list(self, kls: Type[T], allow_empty: bool = False) -> List[T]:
-        """Return the value of this field as a :class:`list` if all its elements
-        are of type ``kls``; otherwise, raise an :class:`AssertCardError`.
+        """Return the value of this field as a :class:`list` of type ``kls``.
 
         :param kls:
-            The type to check against.
+            The type of the field elements.
         :param allow_empty:
             If ``True``, allows the list to be empty.
         """
         value = self.as_(list, allow_empty)
 
-        for elem in value:
-            if not isinstance(elem, kls):
-                self._raise_card_error(
-                    f"The value of the {{display_name}} must be a list of type of {kls}, but has at least one element of type {type(elem)}."
+        for element in value:
+            if not isinstance(element, kls):
+                pathname = ".".join(self.path)
+
+                raise AssetCardError(
+                    f"The elements of the field '{pathname}' of the asset card '{self.card.name}' must be of type `{kls}`, but at least one element is of type `{type(element)}` instead."
                 )
 
         return value
 
     def as_one_of(self, valid_values: AbstractSet[T]) -> T:
-        """Return the value of this field if it is included in ``valid_values``;
-        otherwise, raise an :class:`AssertCardError`.
+        """Return the value of this field as one of the values in ``valid_values``
 
         :param values:
             The values to check against.
         """
-        if self.data in valid_values:
-            return cast(T, self.data)
+        value = self.as_(object)
 
-        values = ", ".join(sorted([repr(v) for v in valid_values]))
+        if value in valid_values:
+            return cast(T, value)
 
-        self._raise_card_error(
-            f"The value of the {{display_name}} must be one of [{values}], but is {repr(self.data)} instead."
-        )
-
-    def check_equals(self, value: Any) -> "AssetCardField":
-        """Check if the value of this field equals ``value``; if not, raise an
-        :class:`AssertCardError`.
-
-        :param value:
-            The value to check against.
-        """
-        if self.data == value:
-            return self
-
-        self._raise_card_error(
-            f"The value of the {{display_name}} must be {repr(value)}, but is {repr(self.data)} instead."
-        )
-
-    def field(self, name: str) -> "AssetCardField":
-        """Return a sub-field of this field.
-
-        :param name:
-            The name of the sub-field.
-
-        :returns:
-            An :class:`AssetCardField` representing the sub-field.
-        """
-        data = None
-
-        if self.data is not None and isinstance(self.data, Mapping):
-            try:
-                data = self.data[name]
-            except KeyError:
-                pass
-
-        return AssetCardField(self.card, self.path + [name], data)
-
-    def _raise_card_error(self, msg: str) -> NoReturn:
         pathname = ".".join(self.path)
 
-        display_name = f"field '{pathname}' of the asset card '{self.card.name}'"
+        values = list(valid_values)
 
-        raise AssetCardError(msg.format(display_name=display_name))
+        values.sort()
+
+        raise AssetCardError(
+            f"The value of the field '{pathname}' of the asset card '{self.card.name}' must be one of {values}, but is {repr(value)} instead."
+        )
+
+    def set(self, value: Any) -> None:
+        """Set the value of this field."""
+        self.card._set_field_value(self.path, value)
+
+    def check_equals(self, value: Any) -> Self:
+        """Check if the value of this field equals to ``value``."""
+        if (v := self.as_(object)) != value:
+            pathname = ".".join(self.path)
+
+            raise AssetCardError(
+                f"The value of the field '{pathname}' of the asset card '{self.card.name}' must be '{value}', but is {repr(v)} instead."
+            )
+
+        return self
 
 
 class AssetCardError(AssetError):

--- a/src/fairseq2/models/utils/model_loader.py
+++ b/src/fairseq2/models/utils/model_loader.py
@@ -85,7 +85,7 @@ class ModelConfigLoader(Generic[ModelConfigT]):
         config = self.archs.get_config(arch_name)
 
         try:
-            config_overrides = card.field("model_config").as_(MutableMapping[str, Any])
+            config_overrides = card.field("model_config").as_(dict)
         except AssetCardFieldNotFoundError:
             config_overrides = None
 

--- a/src/fairseq2/models/utils/model_loader.py
+++ b/src/fairseq2/models/utils/model_loader.py
@@ -7,16 +7,7 @@
 import logging
 from copy import deepcopy
 from functools import partial
-from typing import (
-    Any,
-    Generic,
-    Mapping,
-    MutableMapping,
-    Optional,
-    Protocol,
-    TypeVar,
-    Union,
-)
+from typing import Any, Generic, Mapping, Optional, Protocol, TypeVar, Union
 
 from torch.nn import Module
 

--- a/tests/unit/assets/test_card.py
+++ b/tests/unit/assets/test_card.py
@@ -19,6 +19,7 @@ class TestAssetCard:
 
         base_data = {
             "field1": "base-foo1",
+            "field2": {"sub-field1": "sub-foo1"},
             "field8": [1, "b", 3],
         }
 
@@ -27,7 +28,7 @@ class TestAssetCard:
         data = {
             "field1": "foo1",
             "field2": {
-                "sub-field": "sub-foo",
+                "sub-field2": "sub-foo2",
             },
             "field4": "",
             "field5": [],
@@ -38,63 +39,81 @@ class TestAssetCard:
 
         self.card = AssetCard("test-card", data, base_card)
 
-    def test_returns_correct_field_value(self) -> None:
+    def test_field_works(self) -> None:
         value = self.card.field("field1").as_(str)
 
         assert value == "foo1"
 
-    def test_returns_correct_base_field_value(self) -> None:
-        value = self.card.field("field3").as_(int)
+        value = self.card.field("field2").field("sub-field1").as_(str)
 
-        assert value == 3
+        assert value == "sub-foo1"
 
-    def test_returns_correct_sub_field_value(self) -> None:
-        value = self.card.field("field2").field("sub-field").as_(str)
+        value = self.card.field("field2").field("sub-field2").as_(str)
 
-        assert value == "sub-foo"
+        assert value == "sub-foo2"
 
-    def test_raises_error_if_field_type_is_incorrect(self) -> None:
+        int_value = self.card.field("field3").as_(int)
+
+        assert int_value == 3
+
+    def test_is_none_works(self) -> None:
+        self.card.field("field7").set(None)
+
+        assert self.card.field("field7").is_none()
+
+        self.card.field("field2").field("sub_field1").set(None)
+
+        assert self.card.field("field2").field("sub_field1").is_none()
+
+    def test_is_none_raises_error_when_field_does_not_exist(self) -> None:
+        self.card.field("field2").set(None)
+
+        with pytest.raises(
+            AssetCardFieldNotFoundError,
+            match=r"^The asset card 'test-card' must have a field named 'field2.sub_field2'\.$",
+        ):
+            self.card.field("field2").field("sub_field2").is_none()
+
+    def test_as_raises_error_when_field_type_is_incorrect(self) -> None:
         with pytest.raises(
             AssetCardError,
-            match=r"^The type of the field 'field1' of the asset card 'test-card' must be <class 'int'>, but is <class 'str'> instead\.$",
+            match=r"^The value of the field 'field1' of the asset card 'test-card' must be of type `<class 'int'>`, but is of type `<class 'str'>` instead\.$",
         ):
             self.card.field("field1").as_(int)
 
-    def test_raises_error_if_sub_field_type_is_incorrect(self) -> None:
         with pytest.raises(
             AssetCardError,
-            match=r"^The type of the field 'field2\.sub-field' of the asset card 'test-card' must be <class 'int'>, but is <class 'str'> instead\.$",
+            match=r"^The value of the field 'field2\.sub-field1' of the asset card 'test-card' must be of type `<class 'int'>`, but is of type `<class 'str'>` instead\.$",
         ):
-            self.card.field("field2").field("sub-field").as_(int)
+            self.card.field("field2").field("sub-field1").as_(int)
 
-    def test_raises_error_if_field_does_not_exist(self) -> None:
+    def test_as_raises_error_when_field_does_not_exist(self) -> None:
         with pytest.raises(
             AssetCardFieldNotFoundError,
             match=r"^The asset card 'test-card' must have a field named 'field10'\.$",
         ):
             self.card.field("field10").as_(str)
 
-    def test_raises_error_if_sub_field_does_not_exist(self) -> None:
         with pytest.raises(
             AssetCardError,
             match=r"^The asset card 'test-card' must have a field named 'field10\.sub-field'\.$",
         ):
             self.card.field("field10").field("sub-field").as_(str)
 
-    def test_raises_error_if_field_value_is_empty(self) -> None:
+    def test_as_raises_error_when_field_is_empty(self) -> None:
         with pytest.raises(
             AssetCardError,
-            match=r"^The value of the field 'field4' of the asset card 'test-card' must be non-empty\.$",
+            match=r"^The value of the field 'field4' of the asset card 'test-card' must not be empty\.$",
         ):
             self.card.field("field4").as_(str)
 
         with pytest.raises(
             AssetCardError,
-            match=r"^The value of the field 'field5' of the asset card 'test-card' must be non-empty\.$",
+            match=r"^The value of the field 'field5' of the asset card 'test-card' must not be empty\.$",
         ):
             self.card.field("field5").as_list(str)
 
-    def test_returns_empty_if_empty_field_value_is_allowed(self) -> None:
+    def test_as_works_when_allow_empty_is_specified(self) -> None:
         value1 = self.card.field("field4").as_(str, allow_empty=True)
 
         assert value1 == ""
@@ -103,58 +122,78 @@ class TestAssetCard:
 
         assert value2 == []
 
-    def test_returns_field_value_if_it_is_valid_url(self) -> None:
+    def test_as_uri_works(self) -> None:
         value = self.card.field("field9").as_uri()
 
         assert value == "http://foo.com"
 
-    def test_raises_error_if_field_value_is_not_a_valid_uri(self) -> None:
+    def test_as_uri_raises_error_when_field_is_not_uri(self) -> None:
         with pytest.raises(
             AssetCardError,
-            match=r"The value of the field 'field1' of the asset card 'test-card' must be a valid URI, but is 'foo1' instead\.$",
+            match=r"The value of the field 'field1' of the asset card 'test-card' must be a URI, but is 'foo1' instead\.$",
         ):
             self.card.field("field1").as_uri()
 
-    def test_returns_field_value_if_it_is_valid_filename(self) -> None:
+    def test_as_filename_works(self) -> None:
         value = self.card.field("field1").as_filename()
 
         assert value == "foo1"
 
-    def test_raises_error_if_field_value_is_not_a_valid_filename(self) -> None:
+    def test_as_filename_raises_error_when_field_is_not_filename(self) -> None:
         with pytest.raises(
             AssetCardError,
-            match=r"^The value of the field 'field6' of the asset card 'test-card' must be a valid filename, but is 'invalid/filename' instead\.$",
+            match=r"^The value of the field 'field6' of the asset card 'test-card' must be a filename, but is 'invalid/filename' instead\.$",
         ):
             self.card.field("field6").as_filename()
 
-    def test_returns_field_value_if_it_is_valid_list(self) -> None:
+    def test_as_list_works(self) -> None:
         value = self.card.field("field7").as_list(int)
 
         assert value == [1, 2, 3]
 
-    def test_raises_error_if_field_value_is_not_a_valid_list(self) -> None:
+    def test_as_list_raises_error_when_field_is_not_valid_list(self) -> None:
         with pytest.raises(
             AssetCardError,
-            match=r"The value of the field 'field8' of the asset card 'test-card' must be a list of type of <class 'int'>, but has at least one element of type <class 'str'>\.$",
+            match=r"The elements of the field 'field8' of the asset card 'test-card' must be of type `<class 'int'>`, but at least one element is of type `<class 'str'>` instead\.$",
         ):
             self.card.field("field8").as_list(int)
 
-    def test_returns_field_value_if_it_is_one_of_valid_values(self) -> None:
+    def test_as_one_of_works(self) -> None:
         value = self.card.field("field1").as_one_of({"foo2", "foo1"})
 
         assert value == "foo1"
 
-    def test_raises_error_if_field_value_is_not_one_of_valid_values(self) -> None:
+    def test_as_one_of_raises_error_when_field_is_not_one_of_valid_values(self) -> None:
         with pytest.raises(
             AssetCardError,
             match=r"The value of the field 'field1' of the asset card 'test-card' must be one of \['foo2', 'foo3'\], but is 'foo1' instead\.$",
         ):
-            self.card.field("field1").as_one_of({"foo2", "foo3"})
+            self.card.field("field1").as_one_of({"foo3", "foo2"})
 
-    def test_check_equals_raises_no_error_if_equal(self) -> None:
+    def test_set_works(self) -> None:
+        self.card.field("field1").set("xyz")
+
+        value = self.card.field("field1").as_(str)
+
+        assert value == "xyz"
+
+        self.card.field("field2").field("sub-field3").field("field").set("foo3")
+
+        value = self.card.field("field2").field("sub-field3").field("field").as_(str)
+
+        assert value == "foo3"
+
+    def test_set_raises_error_when_path_conflicts(self) -> None:
+        with pytest.raises(
+            AssetCardError,
+            match=r"^The asset card 'test-card' cannot have a field named 'field1.field2' due to path conflict at 'field1'\.$",
+        ):
+            self.card.field("field1").field("field2").set("foo")
+
+    def test_check_equals_works(self) -> None:
         self.card.field("field1").check_equals("foo1")
 
-    def test_check_equals_raises_error_if_not_equal(self) -> None:
+    def test_check_equals_raises_error_when_field_is_not_equal(self) -> None:
         with pytest.raises(
             AssetCardError,
             match=r"The value of the field 'field1' of the asset card 'test-card' must be 'foo2', but is 'foo1' instead\.$",

--- a/tests/unit/utils/test_dataclass.py
+++ b/tests/unit/utils/test_dataclass.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from dataclasses import dataclass
+from typing import Optional
 
 import pytest
 
@@ -13,7 +14,7 @@ from fairseq2.utils.dataclass import update_dataclass
 
 @dataclass
 class Foo2:
-    x: int
+    x: Optional[int]
     y: str
 
 
@@ -22,46 +23,39 @@ class Foo1:
     a: int
     b: str
     c: Foo2
+    d: Optional[Foo2]
 
 
 class TestUpdateClassFunction:
     def test_call_works(self) -> None:
-        obj = Foo1(a=1, b="b", c=Foo2(x=2, y="foo3"))
+        obj = Foo1(a=1, b="b", c=Foo2(x=2, y="foo3"), d=Foo2(x=3, y="foo3"))
 
-        overrides = {"b": "a", "c": {"y": "foo4"}}
+        overrides = {"b": "a", "c": {"x": None, "y": "foo4"}, "d": None}
 
         update_dataclass(obj, overrides)
 
-        assert obj == Foo1(a=1, b="a", c=Foo2(x=2, y="foo4"))
+        assert obj == Foo1(a=1, b="a", c=Foo2(x=None, y="foo4"), d=None)
 
     def test_call_works_when_overrides_is_empty(self) -> None:
-        obj = Foo1(a=1, b="b", c=Foo2(x=2, y="foo3"))
+        obj = Foo1(a=1, b="b", c=Foo2(x=2, y="foo3"), d=Foo2(x=3, y="foo3"))
 
         update_dataclass(obj, {})
 
-        assert obj == Foo1(a=1, b="b", c=Foo2(x=2, y="foo3"))
+        assert obj == Foo1(a=1, b="b", c=Foo2(x=2, y="foo3"), d=Foo2(x=3, y="foo3"))
 
         update_dataclass(obj, {"c": {}})
 
-        assert obj == Foo1(a=1, b="b", c=Foo2(x=2, y="foo3"))
+        assert obj == Foo1(a=1, b="b", c=Foo2(x=2, y="foo3"), d=Foo2(x=3, y="foo3"))
 
     def test_call_raises_error_when_obj_is_not_dataclass(self) -> None:
         with pytest.raises(
             TypeError,
-            match=r"^`obj` must be a dataclass, but is of type `<class 'int'>` instead\.$",
+            match=r"^`obj` must be a `dataclass`, but is of type `<class 'int'>` instead\.$",
         ):
             update_dataclass(4, {})
 
     def test_call_raises_error_when_override_has_invalid_type(self) -> None:
-        obj = Foo1(a=1, b="b", c=Foo2(x=2, y=3))  # type: ignore[arg-type]
-
-        overrides = {"c": {"x": "a"}}
-
-        with pytest.raises(
-            TypeError,
-            match=r"^The key 'c\.x' must be of type `<class 'int'>`, but is of type `<class 'str'>` instead\.$",
-        ):
-            update_dataclass(obj, overrides)
+        obj = Foo1(a=1, b="b", c=Foo2(x=2, y=3), d=Foo2(x=3, y="foo3"))  # type: ignore[arg-type]
 
         overrides = {"c": 4}  # type: ignore[dict-item]
 
@@ -72,14 +66,14 @@ class TestUpdateClassFunction:
             update_dataclass(obj, overrides)
 
     def test_call_raises_error_when_there_are_leftover_overrides(self) -> None:
-        obj = Foo1(a=1, b="b", c=Foo2(x=2, y="foo3"))
+        obj = Foo1(a=1, b="b", c=Foo2(x=2, y="foo3"), d=Foo2(x=3, y="foo3"))
 
-        overrides = {"b": "a", "c": {"y": "foo4", "z": 2}, "d": 4}
+        overrides = {"b": "a", "c": {"y": "foo4", "z": 2}, "e": 4}
 
         with pytest.raises(
             ValueError,
-            match=r"^The following keys contained in `overrides` do not exist in `obj`: \['c\.z', 'd'\]$",
+            match=r"^The following keys contained in `overrides` do not exist in `obj`: \['c\.z', 'e'\]$",
         ):
             update_dataclass(obj, overrides)
 
-        assert obj == Foo1(a=1, b="a", c=Foo2(x=2, y="foo4"))
+        assert obj == Foo1(a=1, b="a", c=Foo2(x=2, y="foo4"), d=Foo2(x=3, y="foo3"))


### PR DESCRIPTION
This PR overhauls the implementation of `AssetCard` with the introduction of two new features: (1) "Fused" `field()` method that checks the base asset card for sub-fields as well (the original implementation only checked base card for the root fields) (2) a new `set()` method to modify an existing card:

```python
card = ...
card.field("foo").set("xyz")
```

Along with `AssetCard` re-implementation, this PR also includes some bug fixes for the related `update_dataclass` utility function.