### PR TITLE
Allow assignment of config objects to model_config

### DIFF
--- a/src/fairseq2/models/utils/model_loader.py
+++ b/src/fairseq2/models/utils/model_loader.py
@@ -13,6 +13,7 @@ from torch.nn import Module
 
 from fairseq2.assets import (
     AssetCard,
+    AssetCardError,
     AssetCardFieldNotFoundError,
     AssetDownloadManager,
     AssetError,
@@ -75,6 +76,16 @@ class ModelConfigLoader(Generic[ModelConfigT]):
         # Load the model configuration.
         config = self.archs.get_config(arch_name)
 
+        # If the card holds a configuration object, it takes precedence.
+        try:
+            config = card.field("model_config").as_(type(config))
+
+            return deepcopy(config)
+        except AssetCardError:
+            pass
+
+        # Otherwise, check if we should override anything in the default model
+        # configuration.
         try:
             config_overrides = card.field("model_config").as_(dict)
         except AssetCardFieldNotFoundError:


### PR DESCRIPTION
This PR allows assigning a model configuration data class to an asset card's model_config field.

```python
config = load_llama_config("llama2_7b")
config.foo = "xyz"

card = asset_store.retrieve_card("llama2_7b_chat")
card.field("model_config").set(config)
```