### PR TITLE
Introduce encoding as/decoding from tokens in SPM

### DIFF
--- a/fairseq2n/python/src/fairseq2n/bindings/data/text/sentencepiece.cc
+++ b/fairseq2n/python/src/fairseq2n/bindings/data/text/sentencepiece.cc
@@ -104,7 +104,16 @@ def_sentencepiece(py::module_ &text_module)
             py::arg("alpha")           = 0.1,
             py::arg("device")          = std::nullopt,
             py::arg("pin_memory")      = false)
-        .def("__call__", &sp_encoder::operator(), py::call_guard<py::gil_scoped_release>{})
+        .def(
+            "__call__",
+            &sp_encoder::operator(),
+            py::arg("text"),
+            py::call_guard<py::gil_scoped_release>{})
+        .def(
+            "encode_as_tokens",
+            &sp_encoder::encode_as_tokens,
+            py::arg("text"),
+            py::call_guard<py::gil_scoped_release>{})
 
         .def_property_readonly("prefix_indices", &sp_encoder::prefix_indices)
         .def_property_readonly("suffix_indices", &sp_encoder::suffix_indices);
@@ -114,7 +123,16 @@ def_sentencepiece(py::module_ &text_module)
             py::init<std::shared_ptr<const sp_model>, bool>(),
             py::arg("model"),
             py::arg("reverse") = false)
-        .def("__call__", &sp_decoder::operator(), py::call_guard<py::gil_scoped_release>{});
+        .def(
+            "__call__",
+            &sp_decoder::operator(),
+            py::arg("token_indices"),
+            py::call_guard<py::gil_scoped_release>{})
+        .def(
+            "decode_from_tokens",
+            &sp_decoder::decode_from_tokens,
+            py::arg("tokens"),
+            py::call_guard<py::gil_scoped_release>{});
 
     map_functors().register_<sp_encoder>();
     map_functors().register_<sp_decoder>();

--- a/fairseq2n/src/fairseq2n/data/text/sentencepiece/sp_decoder.cc
+++ b/fairseq2n/src/fairseq2n/data/text/sentencepiece/sp_decoder.cc
@@ -28,94 +28,6 @@
 using namespace fairseq2n::detail;
 
 namespace fairseq2n {
-namespace detail {
-
-class sp_decoder_op {
-public:
-    explicit
-    sp_decoder_op(const sp_decoder *decoder, const sp_processor *processor, at::Tensor &&tensor);
-
-    immutable_string &&
-    run() &&;
-
-private:
-    void
-    decode();
-
-    template <typename T>
-    void
-    decode();
-
-private:
-    const sp_decoder *decoder_;
-    const sp_processor *processor_;
-    at::Tensor tensor_;
-    immutable_string sentence_{};
-};
-
-sp_decoder_op::sp_decoder_op(
-    const sp_decoder *decoder, const sp_processor *processor, at::Tensor &&tensor)
-  : decoder_{decoder}, processor_{processor}, tensor_{std::move(tensor)}
-{}
-
-immutable_string &&
-sp_decoder_op::run() &&
-{
-    tensor_ = tensor_.to(at::kCPU);
-
-    decode();
-
-    return std::move(sentence_);
-}
-
-void
-sp_decoder_op::decode()
-{
-    switch (tensor_.scalar_type()) {
-    case at::ScalarType::Short:
-        decode<std::int16_t>();
-        break;
-
-    case at::ScalarType::Int:
-        decode<std::int32_t>();
-        break;
-
-    case at::ScalarType::Long:
-        decode<std::int64_t>();
-        break;
-
-    default:
-        throw_<not_supported_error>(
-            "`sp_decoder` supports only `torch.int16`, `torch.int32`, and `torch.int64` data types.");
-    }
-}
-
-template <typename T>
-void
-sp_decoder_op::decode()
-{
-    std::int64_t seq_len = tensor_.size(0);
-
-    std::vector<std::string_view> tokens{};
-
-    tokens.reserve(static_cast<std::size_t>(seq_len));
-
-    auto tensor_data = tensor_.accessor<T, 1>();
-
-    for (std::int64_t j = 0; j < seq_len; j++) {
-        T token_idx = tensor_data[decoder_->reverse_ ? seq_len - 1 - j : j];
-
-        auto token_idx_32bit = conditional_cast<std::int32_t>(token_idx);
-
-        std::string_view token = processor_->index_to_token(token_idx_32bit);
-
-        tokens.push_back(token);
-    }
-
-    sentence_ = processor_->decode(tokens);
-}
-
-}  // namespace detail
 
 sp_decoder::sp_decoder(std::shared_ptr<const sp_model> model, bool reverse) noexcept
   : model_{std::move(model)}, reverse_{reverse}
@@ -134,13 +46,47 @@ sp_decoder::operator()(data &&d) const
         throw_<std::invalid_argument>(
             "The input tensor must be one dimensional, but has {} dimension(s) instead.", tensor.dim());
 
-    return decode(std::move(tensor));
+    tensor = tensor.to(at::kCPU);
+
+    switch (tensor.scalar_type()) {
+    case at::ScalarType::Short:
+        return decode<std::int16_t>(tensor);
+
+    case at::ScalarType::Int:
+        return decode<std::int32_t>(tensor);
+
+    case at::ScalarType::Long:
+        return decode<std::int64_t>(tensor);
+
+    default:
+        throw_<not_supported_error>(
+            "`sp_decoder` supports only `torch.int16`, `torch.int32`, and `torch.int64` data types.");
+    }
 }
 
+template <typename T>
 immutable_string
-sp_decoder::decode(at::Tensor &&tensor) const
+sp_decoder::decode(const at::Tensor &tensor) const
 {
-    return sp_decoder_op{this, model_->processor_.get(), std::move(tensor)}.run();
+    std::int64_t seq_len = tensor.size(0);
+
+    std::vector<std::string_view> tokens{};
+
+    tokens.reserve(static_cast<std::size_t>(seq_len));
+
+    auto tensor_data = tensor.accessor<T, 1>();
+
+    for (std::int64_t j = 0; j < seq_len; j++) {
+        T token_idx = tensor_data[reverse_ ? seq_len - 1 - j : j];
+
+        auto token_idx_32bit = conditional_cast<std::int32_t>(token_idx);
+
+        std::string_view token = model_->processor_->index_to_token(token_idx_32bit);
+
+        tokens.push_back(token);
+    }
+
+    return model_->processor_->decode(tokens);
 }
 
 data
@@ -150,7 +96,7 @@ sp_decoder::decode_from_tokens(data &&d) const
         throw_<std::invalid_argument>(
             "The input data must be of type `list`, but is of type `{}` instead.", d.type());
 
-    const std::vector<data> &tokens = d.as_list();
+    std::vector<data> &tokens = d.as_list();
 
     std::vector<std::string_view> pieces{};
 
@@ -167,6 +113,9 @@ sp_decoder::decode_from_tokens(data &&d) const
 
         idx++;
     }
+
+    if (reverse_)
+        std::reverse(pieces.begin(), pieces.end());
 
     return model_->processor_->decode(pieces);
 }

--- a/fairseq2n/src/fairseq2n/data/text/sentencepiece/sp_decoder.cc
+++ b/fairseq2n/src/fairseq2n/data/text/sentencepiece/sp_decoder.cc
@@ -143,4 +143,32 @@ sp_decoder::decode(at::Tensor &&tensor) const
     return sp_decoder_op{this, model_->processor_.get(), std::move(tensor)}.run();
 }
 
+data
+sp_decoder::decode_from_tokens(data &&d) const
+{
+    if (!d.is_list())
+        throw_<std::invalid_argument>(
+            "The input data must be of type `list`, but is of type `{}` instead.", d.type());
+
+    const std::vector<data> &tokens = d.as_list();
+
+    std::vector<std::string_view> pieces{};
+
+    pieces.reserve(tokens.size());
+
+    std::size_t idx = 0;
+
+    for (const data &token : tokens) {
+        if (!token.is_string())
+            throw_<std::invalid_argument>(
+                "The element at index {} in the input data must be of type `string`, but is of type `{}` instead.", idx, token.type());
+
+        pieces.emplace_back(token.as_string());
+
+        idx++;
+    }
+
+    return model_->processor_->decode(pieces);
+}
+
 }  // namespace fairseq2n

--- a/fairseq2n/src/fairseq2n/data/text/sentencepiece/sp_decoder.h
+++ b/fairseq2n/src/fairseq2n/data/text/sentencepiece/sp_decoder.h
@@ -34,6 +34,9 @@ public:
     data
     operator()(data &&d) const;
 
+    data
+    decode_from_tokens(data &&d) const;
+
 private:
     immutable_string
     decode(at::Tensor &&tensor) const;

--- a/fairseq2n/src/fairseq2n/data/text/sentencepiece/sp_decoder.h
+++ b/fairseq2n/src/fairseq2n/data/text/sentencepiece/sp_decoder.h
@@ -16,17 +16,10 @@
 #include "fairseq2n/data/immutable_string.h"
 
 namespace fairseq2n {
-namespace detail {
-
-class sp_decoder_op;
-
-}
 
 class sp_model;
 
 class FAIRSEQ2_API sp_decoder final {
-    friend class detail::sp_decoder_op;
-
 public:
     explicit
     sp_decoder(std::shared_ptr<const sp_model> model, bool reverse = false) noexcept;
@@ -38,8 +31,9 @@ public:
     decode_from_tokens(data &&d) const;
 
 private:
+    template <typename T>
     immutable_string
-    decode(at::Tensor &&tensor) const;
+    decode(const at::Tensor &tensor) const;
 
 private:
     std::shared_ptr<const sp_model> model_;

--- a/fairseq2n/src/fairseq2n/data/text/sentencepiece/sp_encoder.cc
+++ b/fairseq2n/src/fairseq2n/data/text/sentencepiece/sp_encoder.cc
@@ -184,4 +184,23 @@ sp_encoder::encode(immutable_string &&text) const
     return sp_encoder_op{this, model_->processor_.get(), std::move(text)}.run();
 }
 
+data
+sp_encoder::encode_as_tokens(data &&d) const
+{
+    if (!d.is_string())
+        throw_<std::invalid_argument>(
+            "The input data must be of type `string`, but is of type `{}` instead.", d.type());
+
+    ImmutableSentencePieceText spt = model_->processor_->encode(d.as_string());
+
+    std::vector<data> tokens{};
+
+    tokens.reserve(spt.pieces_size());
+
+    for (const auto &sp : spt.pieces())
+        tokens.emplace_back(sp.piece());
+
+    return tokens;
+}
+
 }  // namespace fairseq2n

--- a/fairseq2n/src/fairseq2n/data/text/sentencepiece/sp_encoder.cc
+++ b/fairseq2n/src/fairseq2n/data/text/sentencepiece/sp_encoder.cc
@@ -6,6 +6,7 @@
 
 #include "fairseq2n/data/text/sentencepiece/sp_encoder.h"
 
+#include <algorithm>
 #include <cstddef>
 #include <stdexcept>
 
@@ -27,30 +28,6 @@ using namespace fairseq2n::detail;
 
 namespace fairseq2n {
 namespace detail {
-
-class sp_encoder_op {
-public:
-    explicit
-    sp_encoder_op(
-        const sp_encoder *encoder, const sp_processor *processor, immutable_string &&text);
-
-    at::Tensor &&
-    run() &&;
-
-private:
-    void
-    encode_string();
-
-private:
-    const sp_encoder *encoder_;
-    const sp_processor *processor_;
-    immutable_string text_;
-    ImmutableSentencePieceText spt_{};
-    std::size_t extra_tokens_len_{};
-    std::size_t seq_len_{};
-    at::Tensor tensor_{};
-};
-
 namespace {
 
 std::int64_t
@@ -62,71 +39,6 @@ get_token_idx(const ImmutableSentencePieceText &spt, std::size_t idx) noexcept
 }
 
 }  // namespace
-
-sp_encoder_op::sp_encoder_op(
-    const sp_encoder *encoder, const sp_processor *processor, immutable_string &&text)
-  : encoder_{encoder}, processor_{processor}, text_{std::move(text)}
-{
-    extra_tokens_len_ += encoder_->prefix_token_indices_.size();
-    extra_tokens_len_ += encoder_->suffix_token_indices_.size();
-}
-
-at::Tensor &&
-sp_encoder_op::run() &&
-{
-    encode_string();
-
-    tensor_ = at::zeros({static_cast<std::int64_t>(seq_len_)},
-        at::dtype(at::kLong).device(at::kCPU).pinned_memory(encoder_->opts_.pin_memory()));
-
-    writable_memory_span tensor_bits = get_raw_mutable_storage(tensor_);
-
-    span tensor_data = cast<std::int64_t>(tensor_bits);
-
-    if (encoder_->opts_.reverse()) {
-        std::size_t i = seq_len_ - 1;
-
-        for (std::int64_t prefix_idx : encoder_->prefix_token_indices_)
-            tensor_data[i--] = prefix_idx;
-
-        for (std::size_t j = 0; j < spt_.pieces_size(); ++j)
-            tensor_data[i--] = get_token_idx(spt_, j);
-
-        for (std::int64_t suffix_idx : encoder_->suffix_token_indices_)
-            tensor_data[i--] = suffix_idx;
-    } else {
-        std::size_t i = 0;
-
-        for (std::int64_t prefix_idx : encoder_->prefix_token_indices_)
-            tensor_data[i++] = prefix_idx;
-
-        for (std::size_t j = 0; j < spt_.pieces_size(); ++j)
-            tensor_data[i++] = get_token_idx(spt_, j);
-
-        for (std::int64_t suffix_idx : encoder_->suffix_token_indices_)
-            tensor_data[i++] = suffix_idx;
-    }
-
-    at::Device device = encoder_->opts_.maybe_device().value_or(at::kCPU);
-    if (device != at::kCPU)
-        tensor_ = tensor_.to(device);
-
-    return std::move(tensor_);
-}
-
-void
-sp_encoder_op::encode_string()
-{
-    auto &opts = encoder_->opts_;
-
-    if (opts.enable_sampling())
-        spt_ = processor_->sample(text_, opts.nbest_size(), opts.alpha());
-    else
-        spt_ = processor_->encode(text_);
-
-    seq_len_ = spt_.pieces_size() + extra_tokens_len_;
-}
-
 }  // namespace detail
 
 sp_encoder::sp_encoder(std::shared_ptr<const sp_model> model, sp_encoder_options opts)
@@ -175,13 +87,54 @@ sp_encoder::operator()(data &&d) const
         throw_<std::invalid_argument>(
             "The input data must be of type `string`, but is of type `{}` instead.", d.type());
 
-    return encode(std::move(d).as_string());
-}
+    ImmutableSentencePieceText spt{};
 
-at::Tensor
-sp_encoder::encode(immutable_string &&text) const
-{
-    return sp_encoder_op{this, model_->processor_.get(), std::move(text)}.run();
+    if (opts_.enable_sampling())
+        spt = model_->processor_->sample(d.as_string(), opts_.nbest_size(), opts_.alpha());
+    else
+        spt = model_->processor_->encode(d.as_string());
+
+    const std::vector<std::string> &prefix_tokens = opts_.prefix_tokens();
+    const std::vector<std::string> &suffix_tokens = opts_.suffix_tokens();
+
+    std::size_t seq_len = spt.pieces_size() + prefix_tokens.size() + suffix_tokens.size();
+
+    at::Tensor tensor = at::zeros({static_cast<std::int64_t>(seq_len)},
+        at::dtype(at::kLong).device(at::kCPU).pinned_memory(opts_.pin_memory()));
+
+    writable_memory_span tensor_bits = get_raw_mutable_storage(tensor);
+
+    span tensor_data = cast<std::int64_t>(tensor_bits);
+
+    if (opts_.reverse()) {
+        std::size_t i = seq_len - 1;
+
+        for (std::int64_t prefix_idx : prefix_token_indices_)
+            tensor_data[i--] = prefix_idx;
+
+        for (std::size_t j = 0; j < spt.pieces_size(); ++j)
+            tensor_data[i--] = get_token_idx(spt, j);
+
+        for (std::int64_t suffix_idx : suffix_token_indices_)
+            tensor_data[i--] = suffix_idx;
+    } else {
+        std::size_t i = 0;
+
+        for (std::int64_t prefix_idx : prefix_token_indices_)
+            tensor_data[i++] = prefix_idx;
+
+        for (std::size_t j = 0; j < spt.pieces_size(); ++j)
+            tensor_data[i++] = get_token_idx(spt, j);
+
+        for (std::int64_t suffix_idx : suffix_token_indices_)
+            tensor_data[i++] = suffix_idx;
+    }
+
+    at::Device device = opts_.maybe_device().value_or(at::kCPU);
+    if (device != at::kCPU)
+        tensor = tensor.to(device);
+
+    return tensor;
 }
 
 data
@@ -191,14 +144,31 @@ sp_encoder::encode_as_tokens(data &&d) const
         throw_<std::invalid_argument>(
             "The input data must be of type `string`, but is of type `{}` instead.", d.type());
 
-    ImmutableSentencePieceText spt = model_->processor_->encode(d.as_string());
+    ImmutableSentencePieceText spt{};
+
+    if (opts_.enable_sampling())
+        spt = model_->processor_->sample(d.as_string(), opts_.nbest_size(), opts_.alpha());
+    else
+        spt = model_->processor_->encode(d.as_string());
 
     std::vector<data> tokens{};
 
-    tokens.reserve(spt.pieces_size());
+    const std::vector<std::string> &prefix_tokens = opts_.prefix_tokens();
+    const std::vector<std::string> &suffix_tokens = opts_.suffix_tokens();
+
+    tokens.reserve(spt.pieces_size() + prefix_tokens.size() + suffix_tokens.size());
+
+    for (const std::string &token : prefix_tokens)
+        tokens.emplace_back(token);
 
     for (const auto &sp : spt.pieces())
         tokens.emplace_back(sp.piece());
+
+    for (const std::string &token : suffix_tokens)
+        tokens.emplace_back(token);
+
+    if (opts_.reverse())
+        std::reverse(tokens.begin(), tokens.end());
 
     return tokens;
 }

--- a/fairseq2n/src/fairseq2n/data/text/sentencepiece/sp_encoder.h
+++ b/fairseq2n/src/fairseq2n/data/text/sentencepiece/sp_encoder.h
@@ -159,19 +159,11 @@ private:
     bool pin_memory_ = false;
 };
 
-namespace detail {
-
-class sp_encoder_op;
-
-}
-
 class immutable_string;
 
 class sp_model;
 
 class FAIRSEQ2_API sp_encoder final {
-    friend class detail::sp_encoder_op;
-
 public:
     explicit
     sp_encoder(std::shared_ptr<const sp_model> model, sp_encoder_options opts = {});

--- a/fairseq2n/src/fairseq2n/data/text/sentencepiece/sp_encoder.h
+++ b/fairseq2n/src/fairseq2n/data/text/sentencepiece/sp_encoder.h
@@ -179,6 +179,9 @@ public:
     data
     operator()(data &&d) const;
 
+    data
+    encode_as_tokens(data &&d) const;
+
     const std::optional<at::Tensor> &
     prefix_indices() const
     {

--- a/src/fairseq2/data/text/sentencepiece.py
+++ b/src/fairseq2/data/text/sentencepiece.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import TYPE_CHECKING, Optional, Sequence, final
+from typing import TYPE_CHECKING, List, Optional, Sequence, final
 
 from torch import Tensor
 
@@ -71,6 +71,10 @@ if TYPE_CHECKING or _DOC_MODE:
         def __call__(self, text: StringLike) -> Tensor:
             ...
 
+        @finaloverride
+        def encode_as_tokens(self, text: StringLike) -> List[StringLike]:
+            ...
+
         @property
         @finaloverride
         def prefix_indices(self) -> Optional[Tensor]:
@@ -88,6 +92,10 @@ if TYPE_CHECKING or _DOC_MODE:
 
         @finaloverride
         def __call__(self, token_indices: Tensor) -> StringLike:
+            ...
+
+        @finaloverride
+        def decode_from_tokens(self, tokens: Sequence[StringLike]) -> StringLike:
             ...
 
 else:

--- a/src/fairseq2/data/text/text_tokenizer.py
+++ b/src/fairseq2/data/text/text_tokenizer.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import List, Optional, Sequence
 
 from torch import Tensor
 
@@ -80,10 +80,17 @@ class TextTokenizer(ABC):
 
 
 class TextTokenEncoder(ABC):
-    """Encodes texts into token indices."""
+    """Encodes texts into tokens or token indices."""
 
     @abstractmethod
     def __call__(self, text: StringLike) -> Tensor:
+        """
+        :param text:
+            The text to encode.
+        """
+
+    @abstractmethod
+    def encode_as_tokens(self, text: StringLike) -> List[StringLike]:
         """
         :param text:
             The text to encode.
@@ -103,11 +110,18 @@ class TextTokenEncoder(ABC):
 
 
 class TextTokenDecoder(ABC):
-    """Decodes texts from token indices."""
+    """Decodes texts from tokens or token indices."""
 
     @abstractmethod
     def __call__(self, token_indices: Tensor) -> StringLike:
         """
         :param token_indices:
             The token indices to decode from.
+        """
+
+    @abstractmethod
+    def decode_from_tokens(self, tokens: Sequence[StringLike]) -> StringLike:
+        """
+        :param tokens:
+            The tokens to decode from.
         """

--- a/src/fairseq2/nn/transformer/decoder_layer.py
+++ b/src/fairseq2/nn/transformer/decoder_layer.py
@@ -97,7 +97,7 @@ class StandardTransformerDecoderLayer(TransformerDecoderLayer):
     self_attn_dropout: Optional[Dropout]
     self_attn_layer_norm: LayerNorm
     encoder_decoder_attn: Optional[MultiheadAttention]
-    encoder_decoder_dropout: Optional[Dropout]
+    encoder_decoder_attn_dropout: Optional[Dropout]
     encoder_decoder_attn_layer_norm: Optional[LayerNorm]
     ffn: FeedForwardNetwork
     ffn_dropout: Optional[Dropout]

--- a/tests/unit/data/text/test_sentencepiece.py
+++ b/tests/unit/data/text/test_sentencepiece.py
@@ -24,12 +24,12 @@ TEST_SPM_PATH: Final = Path(__file__).parent.joinpath("test.spm")
 
 
 class TestSentencePieceModel:
-    sentence: ClassVar[str]
+    text: ClassVar[str]
     token_indices: ClassVar[List[int]]
 
     @classmethod
     def setup_class(cls) -> None:
-        cls.sentence = "What's up? Hope you are doing well today."
+        cls.text = "What's up? Hope you are doing well today."
 
         # fmt: off
         cls.token_indices = [
@@ -75,17 +75,17 @@ class TestSentencePieceModel:
         encoder = SentencePieceEncoder(model, device=device)
         decoder = SentencePieceDecoder(model)
 
-        indices = encoder(self.sentence)
+        indices = encoder(self.text)
 
         # Assert encoder.
         assert_equal(indices, self.token_indices)
 
-        sentence = decoder(indices)
+        text = decoder(indices)
 
         # Assert decoder
-        assert isinstance(sentence, CString)
+        assert isinstance(text, CString)
 
-        assert sentence == self.sentence
+        assert text == self.text
 
     def test_encode_decode_work_when_reverse_is_true(self) -> None:
         model = self.build_model()
@@ -93,17 +93,17 @@ class TestSentencePieceModel:
         encoder = SentencePieceEncoder(model, device=device, reverse=True)
         decoder = SentencePieceDecoder(model, reverse=True)
 
-        indices = encoder(self.sentence)
+        indices = encoder(self.text)
 
         # Assert encoder.
         assert_equal(indices, self.token_indices[::-1])
 
-        sentence = decoder(indices)
+        text = decoder(indices)
 
         # Assert decoder.
-        assert isinstance(sentence, CString)
+        assert isinstance(text, CString)
 
-        assert sentence == self.sentence
+        assert text == self.text
 
     def test_decode_works_when_control_symbols_are_specified(self) -> None:
         model = self.build_model(control_symbols=["<foo>"])
@@ -111,7 +111,7 @@ class TestSentencePieceModel:
         encoder = SentencePieceEncoder(model, device=device)
         decoder = SentencePieceDecoder(model)
 
-        indices = encoder(self.sentence)
+        indices = encoder(self.text)
 
         # Assert encoder.
         assert_equal(indices, self.token_indices)
@@ -124,12 +124,12 @@ class TestSentencePieceModel:
         indices = torch.cat([indices[:2], foo, indices[2:]])
 
         # We expect the decoder to ignore the <foo> tokens.
-        sentence = decoder(indices)
+        text = decoder(indices)
 
         # Assert decoder.
-        assert isinstance(sentence, CString)
+        assert isinstance(text, CString)
 
-        assert sentence == self.sentence
+        assert text == self.text
 
     def test_encode_works_when_prefix_and_suffix_tokens_are_specified(self) -> None:
         model = self.build_model(control_symbols=["<foo1>", "<foo2>", "<foo3>"])
@@ -142,7 +142,7 @@ class TestSentencePieceModel:
         )
         decoder = SentencePieceDecoder(model)
 
-        indices = encoder(self.sentence)
+        indices = encoder(self.text)
 
         # Assert encoder.
         foo1_idx = model.token_to_index("<foo1>")
@@ -157,26 +157,80 @@ class TestSentencePieceModel:
         assert_equal(indices, e)
 
         # We expect the decoder to ignore the prefix and suffix tokens.
-        sentence = decoder(indices)
+        text = decoder(indices)
 
         # Assert decoder.
-        assert sentence == self.sentence
+        assert text == self.text
 
-    @pytest.mark.parametrize("dtype", [torch.float32, torch.int8])
-    def test_decode_raises_error_when_data_type_is_not_supported(
-        self, dtype: DataType
+    def test_encode_as_tokens_works(self) -> None:
+        model = self.build_model()
+
+        encoder = SentencePieceEncoder(model)
+
+        tokens = encoder.encode_as_tokens("Hello world!")
+
+        assert [str(t) for t in tokens] == ["▁He", "l", "lo", "▁w", "or", "ld", "!"]
+
+    def test_decode_from_tokens_works(self) -> None:
+        model = self.build_model()
+
+        encoder = SentencePieceDecoder(model)
+
+        text = encoder.decode_from_tokens(["▁He", "l", "lo", "▁w", "or", "ld", "!"])
+
+        assert text == "Hello world!"
+
+    def test_encode_raises_error_when_input_is_not_string(self) -> None:
+        model = self.build_model()
+
+        encoder = SentencePieceEncoder(model)
+
+        with pytest.raises(
+            ValueError,
+            match=r"^The input data must be of type `string`, but is of type `int` instead\.$",
+        ):
+            encoder(123)  # type: ignore[arg-type]
+
+    def test_encode_as_tokens_raises_error_when_input_is_not_string(self) -> None:
+        model = self.build_model()
+
+        encoder = SentencePieceEncoder(model)
+
+        with pytest.raises(
+            ValueError,
+            match=r"^The input data must be of type `string`, but is of type `int` instead\.$",
+        ):
+            encoder.encode_as_tokens(123)  # type: ignore[arg-type]
+
+    def test_decode_raises_error_when_input_is_not_tensor(self) -> None:
+        model = self.build_model()
+
+        decoder = SentencePieceDecoder(model)
+
+        with pytest.raises(
+            ValueError,
+            match=r"^The input data must be of type `torch.Tensor`, but is of type `int` instead\.$",
+        ):
+            decoder(123)  # type: ignore[arg-type]
+
+    def test_decode_from_tokens_raises_error_when_input_is_not_list_of_strings(
+        self,
     ) -> None:
         model = self.build_model()
 
         decoder = SentencePieceDecoder(model)
 
-        indices = torch.zeros((10,), device=device, dtype=dtype)
+        with pytest.raises(
+            ValueError,
+            match=r"^The input data must be of type `list`, but is of type `int` instead\.$",
+        ):
+            decoder.decode_from_tokens(123)  # type: ignore[arg-type]
 
         with pytest.raises(
             ValueError,
-            match=r"^`sp_decoder` supports only `torch.int16`, `torch.int32`, and `torch.int64` data types\.$",
+            match=r"^The element at index 1 in the input data must be of type `string`, but is of type `int` instead\.$",
         ):
-            decoder(indices)
+            decoder.decode_from_tokens(["a", 3])  # type: ignore[list-item]
 
     @pytest.mark.parametrize("shape", [(), (4, 4, 4)])
     def test_decode_raises_error_when_input_has_more_than_1_dimension(
@@ -191,6 +245,22 @@ class TestSentencePieceModel:
         with pytest.raises(
             ValueError,
             match=rf"^The input tensor must be one dimensional, but has {len(shape)} dimension\(s\) instead\.$",
+        ):
+            decoder(indices)
+
+    @pytest.mark.parametrize("dtype", [torch.float32, torch.int8])
+    def test_decode_raises_error_when_data_type_is_not_supported(
+        self, dtype: DataType
+    ) -> None:
+        model = self.build_model()
+
+        decoder = SentencePieceDecoder(model)
+
+        indices = torch.zeros((10,), device=device, dtype=dtype)
+
+        with pytest.raises(
+            ValueError,
+            match=r"^`sp_decoder` supports only `torch.int16`, `torch.int32`, and `torch.int64` data types\.$",
         ):
             decoder(indices)
 

--- a/tests/unit/data/text/test_sentencepiece.py
+++ b/tests/unit/data/text/test_sentencepiece.py
@@ -165,18 +165,48 @@ class TestSentencePieceModel:
     def test_encode_as_tokens_works(self) -> None:
         model = self.build_model()
 
-        encoder = SentencePieceEncoder(model)
+        encoder = SentencePieceEncoder(
+            model, prefix_tokens=["<s>"], suffix_tokens=["</s>"]
+        )
 
         tokens = encoder.encode_as_tokens("Hello world!")
 
-        assert [str(t) for t in tokens] == ["▁He", "l", "lo", "▁w", "or", "ld", "!"]
+        t = [str(t) for t in tokens]
+
+        assert t == ["<s>", "▁He", "l", "lo", "▁w", "or", "ld", "!", "</s>"]
+
+    def test_encode_as_tokens_works_when_reverse_is_true(self) -> None:
+        model = self.build_model()
+
+        encoder = SentencePieceEncoder(
+            model, prefix_tokens=["<s>"], suffix_tokens=["</s>"], reverse=True
+        )
+
+        tokens = encoder.encode_as_tokens("Hello world!")
+
+        t = [str(t) for t in tokens]
+
+        assert t == ["</s>", "!", "ld", "or", "▁w", "lo", "l", "▁He", "<s>"]
 
     def test_decode_from_tokens_works(self) -> None:
         model = self.build_model()
 
         encoder = SentencePieceDecoder(model)
 
-        text = encoder.decode_from_tokens(["▁He", "l", "lo", "▁w", "or", "ld", "!"])
+        text = encoder.decode_from_tokens(
+            ["▁He", "l", "lo", "▁w", "or", "ld", "!", "</s>"]
+        )
+
+        assert text == "Hello world!"
+
+    def test_decode_from_tokens_works_when_reverse_is_true(self) -> None:
+        model = self.build_model()
+
+        encoder = SentencePieceDecoder(model, reverse=True)
+
+        text = encoder.decode_from_tokens(
+            ["</s>", "!", "ld", "or", "▁w", "lo", "l", "▁He"]
+        )
 
         assert text == "Hello world!"
 


### PR DESCRIPTION
This PR introduces a new `encode_as_tokens` in `TextEncoder`, and a new `decode_from_tokens` in `TextDecoder` along with their SentencePiece implementations. 