### PR TITLE
Improve relative SDPA implementations

### DIFF
--- a/src/fairseq2/models/s2t_transformer/builder.py
+++ b/src/fairseq2/models/s2t_transformer/builder.py
@@ -24,7 +24,6 @@ from fairseq2.nn.embedding import StandardEmbedding, init_scaled_embedding
 from fairseq2.nn.position_encoder import PositionEncoder, SinusoidalPositionEncoder
 from fairseq2.nn.projection import Linear
 from fairseq2.nn.transformer import (
-    SDPA,
     FeedForwardNetwork,
     MultiheadAttention,
     RelativePositionalEncoding,
@@ -418,7 +417,7 @@ class S2TTransformerBuilder:
 
     def build_encoder_attention(self) -> MultiheadAttention:
         """Build a Transformer encoder multi-head attention layer."""
-        sdpa: SDPA
+        sdpa = create_default_sdpa(attn_dropout_p=self.config.dropout_p)
 
         if self.config.use_relative_pos:
             if self.rel_pos_encoding is None:
@@ -433,12 +432,10 @@ class S2TTransformerBuilder:
                 self.config.model_dim,
                 self.config.num_encoder_attn_heads,
                 self.rel_pos_encoding,
-                attn_dropout_p=self.config.dropout_p,
+                inner_sdpa=sdpa,
                 device=self.device,
                 dtype=self.dtype,
             )
-        else:
-            sdpa = create_default_sdpa(attn_dropout_p=self.config.dropout_p)
 
         return StandardMultiheadAttention(
             self.config.model_dim,

--- a/src/fairseq2/models/wav2vec2/builder.py
+++ b/src/fairseq2/models/wav2vec2/builder.py
@@ -347,6 +347,8 @@ class Wav2Vec2EncoderBuilder:
         )
 
     def build_sdpa(self) -> SDPA:
+        sdpa = create_default_sdpa(attn_dropout_p=self.config.attn_dropout_p)
+
         if self.config.pos_encoder_type == "relative":
             if self.rel_pos_encoding is None:
                 self.rel_pos_encoding = RelativePositionalEncoding(
@@ -356,16 +358,16 @@ class Wav2Vec2EncoderBuilder:
                     dtype=self.dtype,
                 )
 
-            return RelativePositionSDPA(
+            sdpa = RelativePositionSDPA(
                 self.config.model_dim,
                 self.config.num_encoder_attn_heads,
                 self.rel_pos_encoding,
-                attn_dropout_p=self.config.attn_dropout_p,
+                inner_sdpa=sdpa,
                 device=self.device,
                 dtype=self.dtype,
             )
 
-        return create_default_sdpa(attn_dropout_p=self.config.attn_dropout_p)
+        return sdpa
 
     def build_conformer_conv(self) -> ConformerConvolution:
         return ConformerConvolution(

--- a/src/fairseq2/nn/transformer/__init__.py
+++ b/src/fairseq2/nn/transformer/__init__.py
@@ -9,8 +9,12 @@ from fairseq2.nn.transformer.attention import NaiveSDPA as NaiveSDPA
 from fairseq2.nn.transformer.attention import SDPAFactory as SDPAFactory
 from fairseq2.nn.transformer.attention import TorchSDPA as TorchSDPA
 from fairseq2.nn.transformer.attention import create_default_sdpa as create_default_sdpa
-from fairseq2.nn.transformer.attention import sdpa as sdpa
-from fairseq2.nn.transformer.attention import set_default_sdpa as set_default_sdpa
+from fairseq2.nn.transformer.attention import (
+    default_sdpa_factory as default_sdpa_factory,
+)
+from fairseq2.nn.transformer.attention import (
+    set_default_sdpa_factory as set_default_sdpa_factory,
+)
 from fairseq2.nn.transformer.attention_mask import ALiBiMask as ALiBiMask
 from fairseq2.nn.transformer.attention_mask import ALiBiMaskFactory as ALiBiMaskFactory
 from fairseq2.nn.transformer.attention_mask import AttentionMask as AttentionMask

--- a/src/fairseq2/nn/transformer/layer_norm.py
+++ b/src/fairseq2/nn/transformer/layer_norm.py
@@ -33,5 +33,5 @@ class LayerNormFactory(Protocol):
 def create_standard_layer_norm(
     model_dim: int, *, device: Optional[Device] = None, dtype: Optional[DataType] = None
 ) -> LayerNorm:
-    """Construct instances of :class:`StandardLayerNorm`."""
+    """Constructs an instance of :class:`StandardLayerNorm`."""
     return StandardLayerNorm(model_dim, bias=True, device=device, dtype=dtype)

--- a/src/fairseq2/nn/transformer/multihead_attention.py
+++ b/src/fairseq2/nn/transformer/multihead_attention.py
@@ -226,8 +226,8 @@ class StandardMultiheadAttention(MultiheadAttention):
         :param pos_encoder:
             The position encoder to apply to sequences and keys after projection.
         :param sdpa:
-            The scaled dot-product attention module to compute head attentions.
-            If ``None``, a default implementation will be used.
+            The :class:`SDPA` module to compute head attentions. If ``None``, a
+            default implementation will be used.
         :param scale_heads:
             If ``True``, applies head scaling as described in
             :cite:t:`https://doi.org/10.48550/arxiv.2110.09456`


### PR DESCRIPTION
This PR uses a clever trick proposed by @YJYJLee to leverage optimized SDPA implementations within `RelativePositionSDPA` and `ShawRelativePositionSDPA`. We treat the secondary attention terms as attention masks and this enables us to use efficient SDPAs (e.g. PyTorch SDPA). The credit goes to @YJYJLee's #142; due to urgency of the remaining fairseq2 tasks before the upcoming release, this PR "expedites" her work.