### PR TITLE
Parquet dataloader with fairseq2 primitives 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,8 @@ setup(
         "fairseq2n" + fairseq2n_version_spec,
         "jiwer~=3.0",
         "numpy~=1.23",
+        "pyarrow>=13.0.0",
+        "pandas>=2.0.0",
         "overrides~=7.3",
         "packaging~=23.1",
         "pyyaml~=6.0",

--- a/src/fairseq2/utils/asr_parquet_dataloader.py
+++ b/src/fairseq2/utils/asr_parquet_dataloader.py
@@ -1,0 +1,280 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import typing as tp
+from dataclasses import dataclass
+
+import pyarrow as pa
+import torch
+from torch import Tensor
+
+from fairseq2.data.audio import WaveformToFbankConverter
+from fairseq2.data.data_pipeline import DataPipelineBuilder
+from fairseq2.data.text import SentencePieceEncoder
+from fairseq2.models.nllb.tokenizer import NllbTokenizer
+from fairseq2.typing import Device
+from fairseq2.utils.parquet_dataloader import (
+    ParquetBasicDataloaderConfig,
+    NestedDictTensor,
+    ParquetBasicDataLoader,
+    ParquetBatchFormat,
+    pyarrow_cpu,
+)
+
+
+@dataclass
+class SeqsBatch:
+    # XXX: using TensorDict would be more practical here
+    # for batch level operations like to(device), slicing, del and so on
+    src_tokens: tp.Optional[Tensor]
+    src_lengths: tp.Optional[Tensor]
+    target_tokens: Tensor
+    prev_output_tokens: Tensor
+    target_lengths: Tensor
+    prefix_tokens: tp.Optional[Tensor]
+
+    def __del__(self) -> None:
+        """Explicitly delete tensors
+        to force GPU memory cleanup"""
+        for tensor in [
+            self.src_tokens,
+            self.src_lengths,
+            self.target_tokens,
+            self.prev_output_tokens,
+            self.target_lengths,
+            self.prefix_tokens,
+        ]:
+            if tensor is not None:
+                tensor = tensor.cpu()
+                del tensor
+
+
+def batch_collater(inp: tp.List[Tensor], padding: int) -> tp.Dict[str, Tensor]:
+    # TODO: replace it with fairseq2 Collater
+    seq_lens = torch.IntTensor([x.shape[0] for x in inp])
+    return {
+        "seqs": torch.nested.to_padded_tensor(
+            torch.nested.as_nested_tensor(inp), padding=padding
+        ),
+        "seq_lens": seq_lens,
+        "is_ragged": False
+        if len(seq_lens) == 0
+        else (seq_lens != seq_lens[0]).any().item(),
+    }
+
+
+_not_init = object()  # deal with class inheritance
+
+
+@dataclass
+class ASRDataLoadingConfig(ParquetBasicDataloaderConfig):
+    text_tokenizer: NllbTokenizer = _not_init  # type: ignore
+
+    audio_column: str = "audio_wav"
+    text_column: str = "src_text"
+    lang_column: str = "src_lang"
+
+    audio_sample_rate: int = 16_000
+    """Audio sample rate of the decoded wavs"""
+
+    fbank_feats_pad_idx: int = 0
+    """The pad index to use in fbanks batching."""
+
+    max_audio_frames_per_sample: int = 1500
+    """Accept only samples with less than max_audio_frames_per_sample frames in fbanks"""
+
+    device: Device = Device("cpu")
+    """The device on which to allocate batches."""
+
+    dtype: torch.dtype = torch.float16
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        self.output_format = ParquetBatchFormat.torch
+
+        assert isinstance(self.text_tokenizer, NllbTokenizer)
+        assert self.drop_null
+        assert self.max_audio_frames_per_sample >= 1
+
+        minimal_columns_set = [self.audio_column, self.text_column, self.lang_column]
+        if self.columns is not None:  # extend
+            self.columns += [
+                col for col in minimal_columns_set if col not in self.columns
+            ]
+        else:
+            self.columns = minimal_columns_set
+
+        max_frame_filter = pa.compute.less_equal(
+            pa.compute.list_value_length(pa.dataset.field(self.audio_column)),
+            self.audio_sample_rate * self.max_audio_frames_per_sample / 99.6,
+        )
+        if self.filters is None:
+            self.filters = max_frame_filter
+        else:  # extend the exsiting filters
+            self.filters = pa.compute.and_(self.filters, max_frame_filter)
+
+
+class ASRBatchIterator:
+    """Convenience wrapper for data loading"""
+
+    config: ASRDataLoadingConfig
+    raw_parquet_dataloader: ParquetBasicDataLoader
+
+    def __init__(self, config: ASRDataLoadingConfig):
+        self.config = config
+        self.raw_parquet_dataloader = ParquetBasicDataLoader(self.config)
+
+        self.audio_column, self.text_column, self.lang_column = (
+            self.config.audio_column,
+            self.config.text_column,
+            self.config.lang_column,
+        )
+        self.vec_audio_column, self.vec_text_column, self.vec_lang_column = (
+            f"fbank_{aself.udio_column}",
+            f"tokenized_{self.text_column}",
+            f"prefixed_{self.lang_column}",
+        )
+
+    def __iter__(self) -> tp.Iterable[SeqsBatch]:
+        with pyarrow_cpu(self.config.num_parallel_calls):
+            yield from iter(
+                self.build_asr_datapipeline()
+                .prefetch(self.config.num_parallel_calls)
+                .and_return(max_num_warnings=4)
+            )
+
+    def build_asr_datapipeline(self) -> DataPipelineBuilder:
+        converter_to_fbank = self.get_to_fbank_converter()
+        tokenizer = SentencePieceEncoder(
+            model=self.config.text_tokenizer.model, suffix_tokens=["</s>"]
+        )
+        prefix_fn = self.get_prefix_lambda()
+
+        def vectorize_batch(batch):
+            batch[self.vec_audio_column] = list(
+                map(converter_to_fbank, batch.pop(self.audio_column))
+            )
+            batch[self.vec_text_column] = list(
+                map(tokenizer, batch.pop(self.text_column))
+            )
+            batch[self.vec_lang_column] = list(
+                map(prefix_fn, batch.pop(self.lang_column))
+            )
+            return batch
+
+        def manual_collater(batch):
+            batch[self.vec_audio_column] = batch_collater(
+                batch[self.vec_audio_column], padding=self.config.fbank_feats_pad_idx
+            )
+            batch[self.vec_lang_column] = torch.stack(batch[self.vec_lang_column])
+            batch[self.vec_text_column] = batch_collater(
+                batch[self.vec_text_column],
+                padding=self.config.text_tokenizer.vocab_info.pad_idx,
+            )
+            return batch
+
+        builder = (
+            self.raw_parquet_dataloader.build_epoch_iterator_pipeline()
+            .map(vectorize_batch, num_parallel_calls=self.config.num_parallel_calls)
+            .map(manual_collater, num_parallel_calls=self.config.num_parallel_calls)
+            .map(
+                self.filter_audio_fbank_nulls,
+                num_parallel_calls=self.config.num_parallel_calls,
+            )
+            .map(
+                self.map_to_seqs_batch,
+                num_parallel_calls=self.config.num_parallel_calls,
+            )
+            .filter(
+                lambda batch: bool(
+                    batch.src_lengths.shape[0] >= self.config.min_batch_size
+                )
+            )
+        )
+
+        return builder
+
+    def filter_audio_fbank_nulls(self, batch: NestedDictTensor) -> NestedDictTensor:
+        null_count_per_row = torch.sum(
+            torch.isnan(batch[self.vec_audio_column]), dim=[-2, -1]
+        )
+        if torch.any(null_count_per_row > 0):
+            rows_to_keep = null_count_per_row == 0
+            batch = {k: v[rows_to_keep] for k, v in batch.items()}
+
+        return batch
+
+    def map_to_seqs_batch(self, batch: NestedDictTensor) -> SeqsBatch:
+        """Convert batch tree into a convenient representation"""
+
+        # text tokens
+        target_letter_output_tokens = torch.cat(
+            (
+                batch[self.vec_lang_column][:, 0, :],
+                batch[self.vec_text_column]["seqs"],
+            ),
+            dim=1,
+        )
+        target_letter_target = target_letter_output_tokens[:, 1:]
+        target_letter_prev_output_tokens = torch.clone(target_letter_output_tokens)[
+            :, :-1
+        ]
+        target_letter_prev_output_tokens[
+            target_letter_prev_output_tokens
+            == self.config.text_tokenizer.vocab_info.eos_idx
+        ] = self.config.text_tokenizer.vocab_info.pad_idx  # type:ignore
+        target_letter_prev_output_tokens[
+            :, 0
+        ] = self.config.text_tokenizer.vocab_info.eos_idx  # type:ignore
+
+        target_letter_target_lengths = (
+            batch[self.vec_text_column]["seq_lens"] + 1
+        )  # count EOS
+        target_letter_prefix_tokens = batch[self.vec_lang_column][:, 0, 1:]
+
+        device = self.config.device
+        seqs_batch = SeqsBatch(
+            src_tokens=batch[self.vec_audio_column]["seqs"].to(device),
+            src_lengths=batch[self.vec_audio_column]["seq_lens"].to(device),
+            target_tokens=target_letter_target.to(device),
+            prev_output_tokens=target_letter_prev_output_tokens.to(device),
+            target_lengths=target_letter_target_lengths.to(device),
+            prefix_tokens=target_letter_prefix_tokens.to(device),
+        )
+        return seqs_batch
+
+    def get_to_fbank_converter(self):
+        _convert_to_fbank = WaveformToFbankConverter(
+            num_mel_bins=80,
+            waveform_scale=2**15,
+            channel_last=True,
+            standardize=True,
+            device=torch.device("cpu"),
+            dtype=self.config.dtype,
+        )
+
+        def convert_to_fbank(wav: Tensor) -> Tensor:
+            return _convert_to_fbank(
+                {
+                    "waveform": torch.unsqueeze(wav, 1),
+                    "sample_rate": self.config.audio_sample_rate,
+                }
+            )["fbank"]
+
+        return convert_to_fbank
+
+    def get_prefix_lambda(self):
+        def prefix_fn(lang_tok):
+            return torch.LongTensor(
+                [
+                    self.config.text_tokenizer.create_encoder(
+                        lang=lang_tok.bytes().decode("utf8"), mode="target"
+                    ).prefix_indices.tolist(),  # type:ignore
+                ]
+            )
+
+        return prefix_fn

--- a/src/fairseq2/utils/asr_parquet_dataloader.py
+++ b/src/fairseq2/utils/asr_parquet_dataloader.py
@@ -17,9 +17,9 @@ from fairseq2.data.text import SentencePieceEncoder
 from fairseq2.models.nllb.tokenizer import NllbTokenizer
 from fairseq2.typing import Device
 from fairseq2.utils.parquet_dataloader import (
-    ParquetBasicDataloaderConfig,
     NestedDictTensor,
     ParquetBasicDataLoader,
+    ParquetBasicDataloaderConfig,
     ParquetBatchFormat,
     pyarrow_cpu,
 )

--- a/src/fairseq2/utils/parquet_dataloader.py
+++ b/src/fairseq2/utils/parquet_dataloader.py
@@ -1,0 +1,507 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import typing as tp
+from contextlib import contextmanager
+from dataclasses import dataclass
+from enum import Enum
+from functools import partial
+
+import numpy as np
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+import torch
+from pyarrow.dataset import get_partition_keys  # requires pyarrow >= 13
+
+from fairseq2.data import CString
+from fairseq2.data.data_pipeline import DataPipelineBuilder, read_sequence
+
+
+class ParquetBatchFormat(Enum):
+    pyarrow = 0
+    pandas = 1
+    torch = 2
+
+
+@dataclass  # TODO: (kw_only=True) with python3.10
+class ParquetBasicDataloaderConfig:
+    parquet_path: str
+    """Path to parquet dataset file
+    TODO: show s3 reading example.
+    """
+
+    columns: tp.Optional[tp.List[str]] = None
+    """List of columns to load"""
+
+    filters: tp.Optional[tp.Union[tp.List[tp.Any], pa.dataset.Expression]] = None
+    """
+    See https://arrow.apache.org/docs/python/generated/pyarrow.dataset.Expression.html#pyarrow.dataset.Expression
+    Some examples :
+
+    >>> import pyarrow.compute as pc
+    >>> import pyarrow as pa
+
+    >>> filters = [("data_split", "=", "train"), ("lang1", "in", ["eng","spa"]), ("lang2", "=", "eng")])
+    >>> filters = (pc.field("data_split") == pc.scalar("train")) & (pc.field("duration") > 7)
+    >>> filters = pa.compute.greater(pa.compute.utf8_length(ds.field("lang1_text")), 4)
+    >>> filters = pa.compute.less_equal(pa.compute.list_value_length(pa.dataset.field("audio_wav")), 16_000 * 30)
+
+    Note that all fields used here should be among existing columns in the dataset schema
+    """
+
+    split_to_row_groups: bool = True
+    """Use parquet row groups instead of simple partitions which are generally smaller.
+    Highly recommended for non-partitioned parquet file.
+    """
+
+    shuffle: bool = True
+    """
+    Whether to shuffle dataset samples during the iteration.
+    If False and `order_by` is None, the batch samples will be produced in natural parquet dataset reading order.
+    """
+
+    drop_null: bool = True
+    """Dropping rows containing any null value"""
+
+    output_format: ParquetBatchFormat = ParquetBatchFormat.pyarrow
+    """
+    Format to use for output batches
+    """
+
+    batch_size: tp.Optional[int] = None
+    """
+    Fixed output batch size
+    """
+
+    order_by: tp.Optional[str] = None
+    """Column in dataset whose value length `L` will be used for batches ordering.
+       This results in batches with relatively homogeneous values of `L`,
+       typically to support optimal padding.
+    """
+
+    max_tokens: tp.Optional[int] = None
+    """
+    Used with `order_by` option to control the total number of padded tokens in a each batch.
+    Typically, this option is preferred to `batch_size` for reducing the memory footprint. 
+    """
+
+    seed: tp.Optional[int] = None
+    """
+    seed making iteration deterministic
+    """
+
+    min_batch_size: int = 1
+    """Drops batches whose length < `min_batch_size`"""
+
+    nb_producers: int = 5
+    """Number of parquet partitions read allowed to be read symonymously.
+       Higher values will result in higher speed, better randomization and higher memory footprint.
+       If partitions size is rather small compared to batch size, we recommend to increase nb_producers.
+    """
+
+    nb_prefetch: int = 2
+    """
+    Nb of producers groups (of size `nb_producers`) to prefetch
+    """
+
+    rank: int = 0
+    """The rank of this worker in the process group."""
+
+    world_size: int = 1
+    """The world size of the process group."""
+
+    num_parallel_calls: int = 8
+    """The number of parallel calls in map operations."""
+
+    use_threads: bool = False
+    """
+    Whether pyarrow should use its internal // threads to read the parquet part.
+    Since we rely on the external //, this param is tuned off.
+    """
+
+    def __post_init__(self):
+        assert self.parquet_path, "requires path"
+        assert self.num_parallel_calls >= 1
+        assert self.world_size >= 1
+        assert self.world_size - 1 >= self.rank >= 0
+        assert self.nb_prefetch >= 1
+        assert self.nb_producers >= 1
+
+        assert self.min_batch_size >= 0
+        assert self.batch_size is None or self.batch_size > 0
+        assert self.max_tokens is None or self.max_tokens > 0
+
+        if not ((self.batch_size is None) ^ (self.max_tokens is None)):
+            raise ValueError("need to provide either `batch_size` either `max_tokens`")
+        if self.max_tokens is not None and self.order_by is None:
+            raise ValueError("`order_by` should be given to deal with `max_tokens`")
+
+        if self.filters is not None and not isinstance(
+            self.filters, pa.dataset.Expression
+        ):
+            self.filters = pq.filters_to_expression(self.filters)
+
+
+@contextmanager
+def pyarrow_cpu(nb_cpu: int):
+    nb_cpu_old = pa.cpu_count()
+    nb_io_cpu_old = pa.io_thread_count()
+    pa.set_cpu_count(nb_cpu)
+    pa.set_io_thread_count(nb_cpu)
+    try:
+        yield
+    finally:
+        pa.set_cpu_count(nb_cpu_old)
+        pa.set_io_thread_count(nb_io_cpu_old)
+
+
+NestedDictTensor = tp.Dict[str, "NestedDictTensorValue"]
+NestedDictTensorValue = tp.Union[
+    torch.Tensor, tp.List[CString], pd.Series, NestedDictTensor
+]
+
+
+def from_pyarrow_to_torch_tensor(
+    arr: tp.Union[pa.Array, pa.ChunkedArray], strict: bool = True
+) -> NestedDictTensorValue:
+    """
+    struct_array = pa.Array.from_pandas([{"x": 4, "y": "RR"}] * 10)
+    nest_array = pa.Array.from_pandas([[{'a': 1}, {'a': 2}]])
+    """
+    # for future ideas https://arrow.apache.org/docs/python/generated/pyarrow.Tensor.html
+    # for sparse matrix support https://github.com/apache/arrow/blob/main/python/pyarrow/tests/test_sparse_tensor.py
+
+    assert arr.null_count == 0, "does not support null values yet"
+
+    if isinstance(arr, pa.ChunkedArray):
+        arr = arr.chunks[0] if arr.num_chunks == 1 else arr.combine_chunks()
+
+    arr_type = arr.type
+    if pa.types.is_primitive(arr_type):
+        return torch.from_numpy(arr.to_numpy(zero_copy_only=True))
+
+    try:
+        return torch.from_numpy(arr.to_numpy(zero_copy_only=True))
+    except pa.ArrowInvalid:
+        pass
+
+    if pa.types.is_dictionary(arr_type):
+        return from_pyarrow_to_torch_tensor(arr.dictionary_decode())
+
+    if pa.types.is_string(arr_type):
+        return list(map(CString, arr.to_pandas()))
+
+    if (
+        pa.types.is_list(arr_type) or pa.types.is_large_list(arr_type)
+    ) and pa.types.is_primitive(arr_type.value_type):
+        return torch.nested.as_nested_tensor(
+            list(map(torch.from_numpy, arr.to_pandas()))
+        )
+
+    if pa.types.is_fixed_size_list(arr_type) and pa.types.is_primitive(
+        arr_type.value_type
+    ):
+        return torch.from_numpy(np.reshape(arr.values, (-1, arr_type.list_size)))
+
+    if pa.types.is_struct(arr_type):
+        return {
+            arr_type.field(i).name: from_pyarrow_to_torch_tensor(arr.field(i))
+            for i in range(arr_type.num_fields)
+        }
+
+    if pa.types.is_nested(arr_type):
+        # TODO: deal with arr = [[{'a': 1}, {'a': 2}]]
+        pass
+
+    if strict:
+        raise NotImplementedError(f"{arr_type} cannot be converted to torch.Tensor")
+    else:
+        return arr.to_pandas()
+
+
+def pyarrow_table_to_torch_dict(tt: pa.Table, strict: bool = True) -> NestedDictTensor:
+    return {
+        col: from_pyarrow_to_torch_tensor(tt[col], strict) for col in tt.column_names
+    }
+
+
+class _TableWrapper:
+    """
+    class to avoid fairseq2 casting pa.Table to iterable objects
+    which currently fails
+    """
+
+    def __init__(self, table: pa.Table) -> None:
+        self.table: pa.Table = table
+
+
+class ParquetBasicDataLoader:
+    """
+    Example of usage :
+
+       >>> from fairseq2.utils.parquet_dataloader import ParquetBasicDataLoader
+       >>> from tqdm.auto import tqdm
+       >>> bpd_config = BasicParquetDataloaderConfig(parquet_path="...", batch_size=20,
+       ...                                           columns=["src_text", "src_lang", "audio_wav"],
+       ...                                           output_format=ParquetBatchFormat.torch)
+       >>> pq_dl = ParquetBasicDataLoader(bpd_config)
+       >>> ei_batch = iter(pq_dl)
+       >>> res = []
+       >>> for i, batch in tqdm(enumerate(ei_batch)): res.append(len(batch))
+
+    """
+
+    config: ParquetBasicDataloaderConfig
+    source_ds: pq.ParquetDataset
+    _epoch: int = 0
+
+    def __init__(
+        self,
+        config: ParquetBasicDataloaderConfig,
+    ) -> None:
+        self.config = config
+
+        # split_row_groups=True is not supported yet
+        self.source_ds = pq.ParquetDataset(
+            self.config.parquet_path, validate_schema=True, filters=self.config.filters
+        )
+
+        self.columns = self.config.columns or self.source_ds.schema.names
+        assert set(self.columns).issubset(set(self.source_ds.schema.names))
+
+        if self.config.order_by is not None:
+            assert self.config.order_by in self.source_ds.schema.names
+
+        partitioning_keys = (
+            [
+                name
+                for (name, dd) in zip(
+                    self.source_ds.partitioning.schema.names,
+                    self.source_ds.partitioning.dictionaries,
+                )
+                if dd is not None
+            ]
+            if self.source_ds.partitioning
+            else []
+        )
+        columns_wo_partition_keys = [
+            col for col in self.columns if col not in partitioning_keys
+        ]
+
+        if self.config.order_by is not None:
+            self._columns_to_read = sorted(
+                set(columns_wo_partition_keys) | set([self.config.order_by])
+            )
+        else:
+            self._columns_to_read = columns_wo_partition_keys
+
+        if self.config.split_to_row_groups:
+            self._all_fragments = [
+                piece
+                for fragment in self.source_ds._dataset.get_fragments(
+                    self.config.filters
+                )
+                for piece in fragment.split_by_row_group()
+            ]
+        else:
+            self._all_fragments = list(
+                self.source_ds._dataset.get_fragments(self.config.filters)
+            )
+
+    # def __repr__(self) -> str:
+    #     """ count rows and other simple stats """"
+
+    # def head(self, nb:int=5) -> pa.Table:
+    #     return self.source_ds.head(nb=5)
+
+    def schema(self) -> pa.Schema:
+        """
+        Returns the full schema of the parquet datasource
+        """
+        return self.source_ds.schema
+
+    @staticmethod
+    def _add_partitioning_values(
+        table: pa.Table, fragment: pa.dataset.Fragment
+    ) -> pa.Table:
+        for key, val in get_partition_keys(fragment.partition_expression).items():
+            values = pd.Series([val] * len(table), dtype="category")
+            table = table.append_column(key, pa.Array.from_pandas(values))
+        return table
+
+    @staticmethod
+    def _sanitize_dict(table: pa.Table) -> pa.Table:
+        for i, (name, type) in enumerate(zip(table.schema.names, table.schema.types)):
+            if pa.types.is_dictionary(type):
+                ca = table[name].cast(type.value_type)
+                table = table.remove_column(i)
+                table = table.append_column(name, ca)
+        return table
+
+    @staticmethod
+    def compute_length_splits(
+        length_col: np.ndarray, max_tokens: int
+    ) -> tp.List[np.ndarray]:
+        """split sequence of length_col in the chunks such that total length is ~ max_tokens
+           countint the padding to max length of elements in a chunk
+
+        Args:
+            length_col (np.ndarray):
+            max_tokens (int):
+
+        Returns:
+            tp.List[np.ndarray]: splits that contain indices over the original length_col
+        """
+        argsort_ind = np.argsort(length_col)
+        # TODO: remove 0 lengths
+        sorted_length_col = length_col[argsort_ind]
+
+        splits = []
+        ptr = 0
+        for i, length in enumerate(sorted_length_col):
+            if length * (i - ptr) > max_tokens:
+                splits.append(argsort_ind[ptr : (i - 1)])
+                ptr = i - 1
+        if (
+            length <= max_tokens
+        ):  # we drop the last iteration if it results in a batch greater than max_tokens
+            splits.append(argsort_ind[ptr:])
+        return splits
+
+    @staticmethod
+    def compute_length(pa_array: pa.Array) -> np.ndarray:
+        type_ = pa_array.type
+        if pa.types.is_list(type_) or pa.types.is_large_list(type_):
+            length_col = pa.compute.list_value_length(pa_array).to_numpy()
+        elif pa.types.is_string(type_):
+            length_col = pa.compute.utf8_length(pa_array).to_numpy()
+        else:
+            length_col = np.asarray(pa_array.to_pandas().apply(len))
+
+        length_col = length_col.copy()
+        length_col[np.isnan(length_col)] = 0
+        return length_col.astype(np.int32)
+
+    @staticmethod
+    def concat_table(
+        list_table: tp.List[_TableWrapper], drop_null: bool
+    ) -> _TableWrapper:
+        return _TableWrapper(
+            pa.concat_tables(
+                [tt.table.drop_null() if drop_null else tt.table for tt in list_table]
+            ).combine_chunks()
+        )
+
+    def _load_one_fragement(self, fragment: pa.dataset.Fragment) -> _TableWrapper:
+        fragment_table = fragment.to_table(
+            columns=self._columns_to_read, use_threads=self.config.use_threads
+        )
+        fragment_table = self._add_partitioning_values(fragment_table, fragment)
+        if self.config.filters is not None:
+            fragment_table = fragment_table.filter(self.config.filters)
+        return _TableWrapper(fragment_table)
+
+    def build_iterator_over_concat_table(
+        self, wrap_table: _TableWrapper, random_state: np.random.RandomState
+    ) -> DataPipelineBuilder:
+        order_by = self.config.order_by
+        batch_size = self.config.batch_size
+        max_tokens = self.config.max_tokens
+
+        table: pa.Table = wrap_table.table
+        if order_by is not None:
+            length_col = self.compute_length(table[order_by])
+            # add small perturbation to avoid same sample appear together during different epochs
+            if self.config.shuffle:
+                length_col += random_state.randint(
+                    0, max(np.quantile(length_col, 0.001), 2), len(length_col)
+                )
+        else:
+            if self.config.shuffle:
+                length_col = random_state.randint(0, 2**23, len(table))
+            else:
+                length_col = np.ones(len(table), dtype=np.int32)
+
+        table = table.select(self.columns)
+
+        if batch_size is not None:
+            order_tt = pa.Table.from_arrays(
+                [pa.array(np.argsort(length_col))], ["order"]
+            )
+            batches = [ind["order"] for ind in order_tt.to_batches(batch_size)]
+        elif max_tokens is not None:
+            batches = self.compute_length_splits(length_col, max_tokens)
+        else:
+            raise ValueError("unknown batching method")
+
+        if self.config.shuffle:
+            batches = [batches[i] for i in random_state.permutation(len(batches))]
+
+        return (
+            read_sequence(batches)
+            .map(
+                lambda ind: _TableWrapper(table.take(ind).combine_chunks()),
+                num_parallel_calls=max(self.config.num_parallel_calls // 2, 1),
+            )
+            .and_return(max_num_warnings=4)
+        )
+
+    def build_epoch_iterator_pipeline(
+        self, seed: tp.Optional[int] = None, epoch: int = 0
+    ) -> DataPipelineBuilder:
+        seed = seed if seed is not None else self.config.seed
+        np_rs = np.random.RandomState(
+            hash((seed, epoch)) % 2**32
+        )  # TODO: use stable hashing instead python
+        if self.config.shuffle:
+            all_shuffled_fragments = np_rs.permutation(self._all_fragments)
+        else:
+            all_shuffled_fragments = self._all_fragments
+
+        pipeline_builder = (
+            read_sequence(all_shuffled_fragments)
+            .shard(shard_idx=self.config.rank, num_shards=self.config.world_size)
+            .map(
+                self._load_one_fragement,
+                num_parallel_calls=self.config.num_parallel_calls,
+            )
+            .bucket(self.config.nb_producers)
+            .prefetch(self.config.nb_prefetch)
+            .map(
+                partial(self.concat_table, drop_null=self.config.drop_null),
+                num_parallel_calls=self.config.nb_prefetch,
+            )
+            .yield_from(
+                partial(self.build_iterator_over_concat_table, random_state=np_rs)
+            )
+            .filter(lambda wt: bool(len(wt.table) >= self.config.min_batch_size))
+        )
+
+        if self.config.output_format == ParquetBatchFormat.pandas:
+            pipeline_builder = pipeline_builder.map(
+                lambda wt: _TableWrapper(wt.table.to_pandas())
+            )
+        elif self.config.output_format == ParquetBatchFormat.torch:
+            pipeline_builder = pipeline_builder.map(
+                lambda wt: pyarrow_table_to_torch_dict(wt.table)
+            )
+        return pipeline_builder
+
+    def __iter__(self):
+        def _to_real_object(x):
+            if isinstance(x,  _TableWrapper):
+                return x.table
+            else:
+                return x
+
+        with pyarrow_cpu(self.config.num_parallel_calls):
+            yield from map(_to_real_object, iter(
+                self.build_epoch_iterator_pipeline(self.config.seed, self._epoch)
+                .prefetch(self.config.num_parallel_calls)
+                .and_return(max_num_warnings=4)
+            ))
+        self._epoch += 1

--- a/tests/unit/data/data_pipeline/test_parquet_dataloader.py
+++ b/tests/unit/data/data_pipeline/test_parquet_dataloader.py
@@ -253,3 +253,19 @@ class TestParquetDataloader(unittest.TestCase):
                 "list_float_fixed_size_col",
             ],
         )
+
+    def test_dataload_without_shuffle(self):
+        config = ParquetBasicDataloaderConfig(
+            parquet_path=self._tmp_parquet_ds_path,
+            nb_producers=4,
+            nb_prefetch=2,
+            num_parallel_calls=3,
+            shuffle=False,
+            batch_size=17,
+            columns=["float_col"],
+        )
+        pbdl = ParquetBasicDataLoader(config)
+        res = pa.concat_tables(list(iter(pbdl)))
+        res_relaod = pq.read_table(self._tmp_parquet_ds_path, columns=["float_col"])
+
+        self.assertTrue(res.equals(res_relaod))

--- a/tests/unit/data/data_pipeline/test_parquet_dataloader.py
+++ b/tests/unit/data/data_pipeline/test_parquet_dataloader.py
@@ -1,0 +1,255 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import random
+import shutil
+import string
+import tempfile
+import typing as tp
+import unittest
+from collections import Counter
+
+from fairseq2.utils.parquet_dataloader import (
+    ParquetBasicDataLoader,
+    ParquetBasicDataloaderConfig,
+    ParquetBatchFormat,
+    np,
+    pa,
+    pd,
+    pq,
+)
+
+
+def gen_random_string(length: int) -> str:
+    return "".join(
+        random.choice(string.ascii_letters + string.digits) for n in range(length)
+    )
+
+
+def generate_random_pandas_df(size: int, seed: int = 123) -> pd.DataFrame:
+    np_rs = np.random.RandomState(seed)
+    df: tp.Dict[str, tp.Union[np.ndarray, list]] = {}
+    df["int_col"] = np_rs.randint(0, 200, size)
+    df["float_col"] = np_rs.randn(size)
+
+    df["string_col1"] = [gen_random_string(10) for _ in range(size)]
+    df["string_col2"] = [gen_random_string(2) for _ in range(size)]
+
+    df["list_int_col"] = [
+        np_rs.randint(-10, 10, np_rs.randint(0, 100)) for _ in range(size)
+    ]
+    df["list_float_col"] = [
+        np_rs.rand(np_rs.randint(0, 10)).astype(np.float32) for _ in range(size)
+    ]
+    df["list_float_fixed_size_col"] = [
+        np_rs.rand(7).astype(np.float32) for _ in range(size)
+    ]
+    return pd.DataFrame(df)
+
+
+def generated_partitioned_parquet_file(
+    path: str, size: int, n_partitions: int = 20, seed: int = 123
+) -> None:
+    df = generate_random_pandas_df(size, seed)
+
+    if n_partitions > 0:
+        df["part_key"] = np.arange(size) % n_partitions
+
+    table = pa.Table.from_pandas(df)
+
+    pq.write_to_dataset(
+        table,
+        path,
+        partition_cols=["part_key"] if n_partitions > 0 else None,
+        existing_data_behavior="delete_matching",
+    )
+
+
+class TestParquetDataloader(unittest.TestCase):
+    _tmpdir: str
+    _tmp_parquet_ds_path: str
+    _tmp_parquet_single_path: str
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls._tmpdir = tempfile.mkdtemp()
+        cls._tmp_parquet_ds_path = os.path.join(cls._tmpdir, "test")
+        generated_partitioned_parquet_file(cls._tmp_parquet_ds_path, size=2 * 10**3)
+
+        cls._tmp_parquet_single_path = os.path.join(cls._tmpdir, "single_test.parquet")
+        generated_partitioned_parquet_file(
+            cls._tmp_parquet_single_path, size=10**3, n_partitions=0
+        )
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        # Cleanup temp working dir.
+        if cls._tmpdir is not None:
+            shutil.rmtree(cls._tmpdir)  # type: ignore
+
+    def test_simple_dataload(self):
+        config = ParquetBasicDataloaderConfig(
+            parquet_path=self._tmp_parquet_ds_path,
+            batch_size=11,
+            nb_producers=2,
+            seed=333,
+        )
+        pbdl = ParquetBasicDataLoader(config)
+        res = list(iter(pbdl))
+
+        for x in res:
+            self.assertIsInstance(x, pa.Table)
+
+        self.assertEqual(
+            list(res[0].to_pandas().columns),
+            [
+                "int_col",
+                "float_col",
+                "string_col1",
+                "string_col2",
+                "list_int_col",
+                "list_float_col",
+                "list_float_fixed_size_col",
+                "part_key",
+            ],
+        )
+        self.assertEqual(Counter(map(len, res)), Counter({11: 180, 2: 10}))  # 180 * 11
+        self.assertEqual(sum(map(len, res)), 2000)
+
+        # determinism check
+        config_new = ParquetBasicDataloaderConfig(
+            parquet_path=self._tmp_parquet_ds_path,
+            batch_size=11,
+            nb_producers=2,
+            seed=333,
+            output_format=ParquetBatchFormat.pandas,
+        )
+        pbdl_new = ParquetBasicDataLoader(config_new)
+        res_bis = list(iter(pbdl_new))
+
+        for x in res_bis:
+            self.assertIsInstance(x, pd.DataFrame)
+
+        self.assertTrue(
+            all(
+                (x["float_col"].to_pandas() == y["float_col"]).all()
+                for x, y in zip(res, res_bis)
+            )
+        )
+
+        config_another_seed = ParquetBasicDataloaderConfig(
+            parquet_path=self._tmp_parquet_ds_path,
+            batch_size=11,
+            nb_producers=2,
+            seed=111,
+            output_format=ParquetBatchFormat.pandas,
+        )
+        pbdl_ter = ParquetBasicDataLoader(config_another_seed)
+        res_ter = list(iter(pbdl_ter))
+        self.assertTrue(
+            any((x["float_col"] != y["float_col"]).any() for x, y in zip(res, res_ter))
+        )
+
+    def test_filtered_with_columns_dataload(self):
+        config = ParquetBasicDataloaderConfig(
+            parquet_path=self._tmp_parquet_ds_path,
+            batch_size=3,
+            nb_producers=5,
+            seed=111,
+            columns=["string_col2", "list_int_col", "float_col"],
+            filters=[("float_col", ">", 0)],
+            output_format=ParquetBatchFormat.pandas,
+        )
+        pbdl = ParquetBasicDataLoader(config)
+        res = list(iter(pbdl))
+
+        self.assertEqual(
+            list(res[0].columns), ["string_col2", "list_int_col", "float_col"]
+        )
+        self.assertEqual(Counter(map(len, res)), Counter({3: 340, 2: 1}))
+
+    def test_filtered_with_columns_dataload_min_batch_size(self):
+        config = ParquetBasicDataloaderConfig(
+            parquet_path=self._tmp_parquet_ds_path,
+            batch_size=3,
+            nb_producers=5,
+            seed=111,
+            min_batch_size=3,
+            columns=["string_col2", "list_int_col", "float_col"],
+            filters=[("float_col", ">", 0)],
+            output_format=ParquetBatchFormat.pandas,
+        )
+        pbdl = ParquetBasicDataLoader(config)
+        res = list(iter(pbdl))
+        self.assertEqual(Counter(map(len, res)), Counter({3: 340}))
+
+    def test_ordered_dataload(self):
+        config = ParquetBasicDataloaderConfig(
+            parquet_path=self._tmp_parquet_ds_path,
+            batch_size=20,
+            nb_producers=20,
+            order_by="list_int_col",
+            seed=123,
+            output_format=ParquetBatchFormat.pandas,
+        )
+        pbdl = ParquetBasicDataLoader(config)
+
+        length_by_batches = [tt["list_int_col"].apply(len) for tt in iter(pbdl)]
+        length_by_batches_diff = max(tt.max() - tt.min() for tt in length_by_batches)
+        total_length = sum(map(len, length_by_batches))
+
+        self.assertLess(length_by_batches_diff, 4)
+        self.assertEqual(total_length, 2000)
+        self.assertTrue(all(len(tt) == 20 for tt in length_by_batches))
+
+    def test_ordered_max_token_dataload(self):
+        config = ParquetBasicDataloaderConfig(
+            parquet_path=self._tmp_parquet_ds_path,
+            nb_producers=20,
+            order_by="list_int_col",
+            max_tokens=3000,
+            seed=123,
+            output_format=ParquetBatchFormat.pandas,
+        )
+        pbdl = ParquetBasicDataLoader(config)
+
+        length_by_batches = [tt["list_int_col"].apply(len) for tt in iter(pbdl)]
+        length_by_batches_diff = max(tt.max() - tt.min() for tt in length_by_batches)
+        max_padded_total_length = max(tt.max() * len(tt) for tt in length_by_batches)
+        mean_padded_total_length = np.mean(
+            [tt.max() * len(tt) for tt in length_by_batches]
+        )
+        total_length = sum(map(len, length_by_batches))
+
+        self.assertLessEqual(length_by_batches_diff, 12)
+        self.assertEqual(total_length, 2000)
+        self.assertLessEqual(max_padded_total_length, 3000)
+        self.assertGreater(mean_padded_total_length, 2900)
+
+    def test_ordered_max_token_single_file_dataload(self):
+        config = ParquetBasicDataloaderConfig(
+            parquet_path=self._tmp_parquet_single_path,
+            nb_producers=2,
+            batch_size=10,
+            seed=333,
+        )
+        pbdl = ParquetBasicDataLoader(config)
+        res = list(iter(pbdl))
+
+        self.assertEqual(Counter(map(len, res)), Counter({10: 100}))
+        self.assertEqual(
+            res[0].column_names,
+            [
+                "int_col",
+                "float_col",
+                "string_col1",
+                "string_col2",
+                "list_int_col",
+                "list_float_col",
+                "list_float_fixed_size_col",
+            ],
+        )


### PR DESCRIPTION
**What does this PR do? Please describe:**
We introduce a general purpose Parquet dataloader based on fairseq2 DataPipeline API.
Parquet interface is done via [pyarrow](https://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetDataset.html#pyarrow.parquet.ParquetDataset)

As a usage example, we provide an ASR specific data loader built on top of the generic parquet dataloader.

**Does your PR introduce any breaking changes? If yes, please list them:**
This contribution is completely independent and does not modify other components.

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [ ] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
