### PR TITLE
Rename IncrementalStateBag.step and vocabulary_from_sentencepiece

### DIFF
--- a/doc/reference/data.rst
+++ b/doc/reference/data.rst
@@ -101,5 +101,5 @@ Tools to tokenize text, converting it from bytes to tensors.
     SentencePieceModel
     SentencePieceEncoder
     SentencePieceDecoder
-    vocabulary_from_sentencepiece
+    vocab_info_from_sentencepiece
     LineEnding

--- a/src/fairseq2/data/text/__init__.py
+++ b/src/fairseq2/data/text/__init__.py
@@ -15,7 +15,7 @@ from fairseq2.data.text.sentencepiece import (
 )
 from fairseq2.data.text.sentencepiece import SentencePieceModel as SentencePieceModel
 from fairseq2.data.text.sentencepiece import (
-    vocabulary_from_sentencepiece as vocabulary_from_sentencepiece,
+    vocab_info_from_sentencepiece as vocab_info_from_sentencepiece,
 )
 from fairseq2.data.text.text_reader import LineEnding as LineEnding
 from fairseq2.data.text.text_reader import read_text as read_text

--- a/src/fairseq2/data/text/sentencepiece.py
+++ b/src/fairseq2/data/text/sentencepiece.py
@@ -121,7 +121,7 @@ else:
     _set_module_name()
 
 
-def vocabulary_from_sentencepiece(model: SentencePieceModel) -> VocabularyInfo:
+def vocab_info_from_sentencepiece(model: SentencePieceModel) -> VocabularyInfo:
     """Return the vocabulary information of ``model``."""
     return VocabularyInfo(
         model.vocabulary_size,

--- a/src/fairseq2/generation/sequence_generator.py
+++ b/src/fairseq2/generation/sequence_generator.py
@@ -246,7 +246,7 @@ class Seq2SeqGenerator:
                 state_bag=state_bag,
             )
 
-            state_bag.increment_step()
+            state_bag.increment_step_nr()
 
             model_output = self.decoder.project(decoder_output, decoder_padding_mask)
 
@@ -531,7 +531,7 @@ class Seq2SeqGenerator:
             state_bag=state_bag,
         )
 
-        state_bag.increment_step(self.prefix_seq_len - 1)
+        state_bag.increment_step_nr(self.prefix_seq_len - 1)
 
         model_output = self.decoder.project(decoder_output, decoder_padding_mask)
 

--- a/src/fairseq2/models/llama/tokenizer.py
+++ b/src/fairseq2/models/llama/tokenizer.py
@@ -13,7 +13,7 @@ from fairseq2.data.text import (
     TextTokenDecoder,
     TextTokenEncoder,
     TextTokenizer,
-    vocabulary_from_sentencepiece,
+    vocab_info_from_sentencepiece,
 )
 from fairseq2.data.typing import PathLike
 from fairseq2.typing import Device, finaloverride
@@ -32,9 +32,9 @@ class LLaMATokenizer(TextTokenizer):
         """
         self.model = SentencePieceModel(pathname)
 
-        vocabulary_info = vocabulary_from_sentencepiece(self.model)
+        vocab_info = vocab_info_from_sentencepiece(self.model)
 
-        super().__init__(vocabulary_info)
+        super().__init__(vocab_info)
 
     @finaloverride
     def create_encoder(

--- a/src/fairseq2/models/mistral/tokenizer.py
+++ b/src/fairseq2/models/mistral/tokenizer.py
@@ -13,7 +13,7 @@ from fairseq2.data.text import (
     TextTokenDecoder,
     TextTokenEncoder,
     TextTokenizer,
-    vocabulary_from_sentencepiece,
+    vocab_info_from_sentencepiece,
 )
 from fairseq2.data.typing import PathLike
 from fairseq2.typing import Device, finaloverride
@@ -32,9 +32,9 @@ class MistralTokenizer(TextTokenizer):
         """
         self.model = SentencePieceModel(pathname)
 
-        vocabulary_info = vocabulary_from_sentencepiece(self.model)
+        vocab_info = vocab_info_from_sentencepiece(self.model)
 
-        super().__init__(vocabulary_info)
+        super().__init__(vocab_info)
 
     @finaloverride
     def create_encoder(

--- a/src/fairseq2/models/nllb/tokenizer.py
+++ b/src/fairseq2/models/nllb/tokenizer.py
@@ -13,7 +13,7 @@ from fairseq2.data.text import (
     TextTokenDecoder,
     TextTokenEncoder,
     TextTokenizer,
-    vocabulary_from_sentencepiece,
+    vocab_info_from_sentencepiece,
 )
 from fairseq2.data.typing import PathLike
 from fairseq2.typing import Device, finaloverride
@@ -55,7 +55,7 @@ class NllbTokenizer(TextTokenizer):
 
         self.default_lang = default_lang
 
-        vocab_info = vocabulary_from_sentencepiece(self.model)
+        vocab_info = vocab_info_from_sentencepiece(self.model)
 
         super().__init__(vocab_info)
 

--- a/src/fairseq2/models/s2t_transformer/tokenizer.py
+++ b/src/fairseq2/models/s2t_transformer/tokenizer.py
@@ -14,7 +14,7 @@ from fairseq2.data.text import (
     TextTokenEncoder,
     TextTokenizer,
 )
-from fairseq2.data.text.sentencepiece import vocabulary_from_sentencepiece
+from fairseq2.data.text.sentencepiece import vocab_info_from_sentencepiece
 from fairseq2.data.typing import PathLike
 from fairseq2.typing import Device, finaloverride
 
@@ -57,7 +57,7 @@ class S2TTransformerTokenizer(TextTokenizer):
         self.target_langs = target_langs
         self.default_target_lang = default_target_lang
 
-        vocab_info = vocabulary_from_sentencepiece(self.model)
+        vocab_info = vocab_info_from_sentencepiece(self.model)
 
         super().__init__(vocab_info)
 

--- a/src/fairseq2/nn/incremental_state.py
+++ b/src/fairseq2/nn/incremental_state.py
@@ -22,7 +22,7 @@ class IncrementalState(ABC):
 
     @abstractmethod
     def reorder(self, new_order: Tensor) -> None:
-        """Rearrange the incremental state according to a new batch order.
+        """Rearrange the state according to a new batch order.
 
         This will be called when the order of the batch has changed. A typical
         use case is beam search, where the batch order changes between steps
@@ -41,7 +41,7 @@ T = TypeVar("T", bound=IncrementalState)
 class IncrementalStateBag:
     """Holds the module states during incremental decoding."""
 
-    step: int
+    step_nr: int
     max_num_steps: int
 
     _module_states: Dict[Module, IncrementalState]
@@ -51,42 +51,40 @@ class IncrementalStateBag:
         :param max_num_steps:
             The expected maximum number of steps to take.
         """
-        self.step = 0
+        self.step_nr = 0
         self.max_num_steps = max_num_steps
 
         self._module_states = {}
 
-    def increment_step(self, delta: int = 1) -> None:
-        """Increment the step.
+    def increment_step_nr(self, value: int = 1) -> None:
+        """Increment the step number.
 
         This method should be called after every decoding step. It is used by
         modules to keep track of the position in the sequence.
 
-        :param delta:
-            The value by which to increment the step.
+        :param value:
+            The value by which to increment the step number.
         """
-        step = self.step + delta
+        step_nr = self.step_nr + value
 
-        if step >= self.max_num_steps:
+        if step_nr >= self.max_num_steps:
             raise ValueError(
-                f"The `delta` increment ({delta}) to the current step ({self.step}) exceeds the maximum number of steps ({self.max_num_steps})."
+                f"The current step number ({self.step_nr}) with `value` increment must be less than or equal to the maximum number of steps ({self.max_num_steps}), but is {self.step_nr + value} instead."
             )
 
-        self.step = step
+        self.step_nr = step_nr
 
     def get_state(self, m: Module, kls: Type[T]) -> Optional[T]:
-        """Get the incremental state of ``m``, or ``None`` if ``m`` is not
-        present in the bag.
+        """Get the state of ``m`` if present in the bag.
 
         :param m:
             The module.
         :param kls:
-            The expected ``type`` of the incremental state. If the type of the
-            incremental state in the bag does not match ``kls``, ``None`` will
-            be returned.
+            The expected ``type`` of the state. If the type of the state in the
+            bag does not match ``kls``, ``None`` will be returned.
 
         :returns:
-            The incremental state of the module.
+            The state of the module.
         """
         state = self._module_states.get(m, None)
         if isinstance(state, kls):
@@ -95,17 +93,17 @@ class IncrementalStateBag:
             return None
 
     def set_state(self, m: Module, state: IncrementalState) -> None:
-        """Set the incremental state of ``m``.
+        """Set the state of ``m``.
 
         :param m:
             The module.
         :param state:
-            The incremental state to store.
+            The state to store.
         """
         self._module_states[m] = state
 
     def reorder(self, new_order: Tensor) -> None:
-        """Reorder all incremental states in the bag.
+        """Reorder all module states in the bag.
 
         See :meth:`IncrementalState.reorder` for more information.
         """

--- a/src/fairseq2/nn/position_encoder.py
+++ b/src/fairseq2/nn/position_encoder.py
@@ -66,7 +66,7 @@ class PositionEncoder(Module, ABC):
             if self.training or state_bag is None:
                 start_step = 0
             else:
-                start_step = state_bag.step
+                start_step = state_bag.step_nr
 
             if (seq_len := start_step + seqs.size(-2)) > self.max_seq_len:
                 raise ValueError(
@@ -232,7 +232,7 @@ class SinusoidalPositionEncoder(PositionEncoder):
         if self.training or state_bag is None:
             start_step = 0
         else:
-            start_step = state_bag.step
+            start_step = state_bag.step_nr
 
         fp32_seqs = seqs.float() + self.freqs[start_step : start_step + seq_len]
 
@@ -294,7 +294,7 @@ class LearnedPositionEncoder(PositionEncoder):
         if self.training or state_bag is None:
             start_step = 0
         else:
-            start_step = state_bag.step
+            start_step = state_bag.step_nr
 
         steps = torch.arange(
             start_step, start_step + seq_len, device=seqs.device, dtype=torch.int64
@@ -376,7 +376,7 @@ class RotaryEncoder(PositionEncoder):
         if self.training or state_bag is None:
             start_step = 0
         else:
-            start_step = state_bag.step
+            start_step = state_bag.step_nr
 
         # (*, S, E) -> (*, S, E / 2, 2)
         seqs = seqs.unflatten(-1, (-1, 2))

--- a/src/fairseq2/nn/transformer/attention_mask.py
+++ b/src/fairseq2/nn/transformer/attention_mask.py
@@ -18,8 +18,6 @@ class AttentionMask(ABC):
     """Represents an attention mask."""
 
     materialized: Optional[Tensor]
-    """The attention mask tensor. Will be ``None`` till the first call to
-    :method:`materialize`."""
 
     def __init__(self) -> None:
         self.materialized = None
@@ -295,7 +293,7 @@ class ALiBiMaskFactory:
         if training or state_bag is None:
             start_step = 0
         else:
-            start_step = state_bag.step
+            start_step = state_bag.step_nr
 
         seq_len = start_step + seqs.size(1)
         if seq_len == 0:

--- a/tests/integration/generation/test_incremental_decode.py
+++ b/tests/integration/generation/test_incremental_decode.py
@@ -84,7 +84,7 @@ def test_incremental_decoding_works() -> None:
 
         assert pos_padding_mask is None
 
-        state_bag.increment_step()
+        state_bag.increment_step_nr()
 
         incremental_output = torch.cat([incremental_output, pos_output], dim=1)
 

--- a/tests/unit/nn/test_position_encoder.py
+++ b/tests/unit/nn/test_position_encoder.py
@@ -125,12 +125,12 @@ class TestSinusoidalPositionEncoder:
 
         assert_close(y - x, m.freqs[:9].expand_as(y))
 
-    @pytest.mark.parametrize("step", [0, 1, 2])
-    def test_forward_works_in_incremental_decode(self, step: int) -> None:
+    @pytest.mark.parametrize("step_nr", [0, 1, 2])
+    def test_forward_works_in_incremental_decode(self, step_nr: int) -> None:
         m = SinusoidalPositionEncoder(encoding_dim=32, max_seq_len=4, device=device)
 
         state_bag = IncrementalStateBag(max_num_steps=3)
-        state_bag.increment_step(delta=step)
+        state_bag.increment_step_nr(step_nr)
 
         seq_len = 2
 
@@ -142,7 +142,7 @@ class TestSinusoidalPositionEncoder:
 
         assert y.shape == (5, seq_len, 32)
 
-        assert_close(y - x, m.freqs[step : step + seq_len].expand_as(y))
+        assert_close(y - x, m.freqs[step_nr : step_nr + seq_len].expand_as(y))
 
     def test_forward_raises_error_when_seq_len_is_out_of_range(self) -> None:
         m = SinusoidalPositionEncoder(encoding_dim=32, max_seq_len=3, device=device)
@@ -161,7 +161,7 @@ class TestSinusoidalPositionEncoder:
         x = torch.randn((5, 2, 32), device=device)
 
         state_bag = IncrementalStateBag(max_num_steps=30)
-        state_bag.increment_step(delta=20)  # out of range
+        state_bag.increment_step_nr(20)  # out of range
 
         y = m(x, padding_mask=None, state_bag=state_bag)
 
@@ -200,12 +200,12 @@ class TestLearnedPositionEncoder:
 
         assert_close(y - x, m.weight[:9].expand_as(y))
 
-    @pytest.mark.parametrize("step", [0, 1, 2])
-    def test_forward_works_in_incremental_decode(self, step: int) -> None:
+    @pytest.mark.parametrize("step_nr", [0, 1, 2])
+    def test_forward_works_in_incremental_decode(self, step_nr: int) -> None:
         m = LearnedPositionEncoder(encoding_dim=32, max_seq_len=4, device=device)
 
         state_bag = IncrementalStateBag(max_num_steps=3)
-        state_bag.increment_step(delta=step)
+        state_bag.increment_step_nr(step_nr)
 
         seq_len = 2
 
@@ -217,7 +217,7 @@ class TestLearnedPositionEncoder:
 
         assert y.shape == (5, seq_len, 32)
 
-        assert_close(y - x, m.weight[step : step + seq_len].expand_as(y))
+        assert_close(y - x, m.weight[step_nr : step_nr + seq_len].expand_as(y))
 
     def test_forward_raises_error_when_seq_len_is_out_of_range(self) -> None:
         m = LearnedPositionEncoder(encoding_dim=32, max_seq_len=3, device=device)
@@ -236,7 +236,7 @@ class TestLearnedPositionEncoder:
         x = torch.randn((5, 2, 32), device=device)
 
         state_bag = IncrementalStateBag(max_num_steps=30)
-        state_bag.increment_step(delta=20)  # out of range
+        state_bag.increment_step_nr(value=20)  # out of range
 
         y = m(x, padding_mask=None, state_bag=state_bag)
 
@@ -283,12 +283,12 @@ class TestRotaryEncoder:
 
         assert_close(dot1, dot2)
 
-    @pytest.mark.parametrize("step", [0, 1, 2])
-    def test_forward_works_in_incremental_decode(self, step: int) -> None:
+    @pytest.mark.parametrize("step_nr", [0, 1, 2])
+    def test_forward_works_in_incremental_decode(self, step_nr: int) -> None:
         m = RotaryEncoder(encoding_dim=32, max_seq_len=4, device=device)
 
         state_bag = IncrementalStateBag(max_num_steps=3)
-        state_bag.increment_step(delta=step)
+        state_bag.increment_step_nr(step_nr)
 
         seq_len = 2
 
@@ -300,11 +300,11 @@ class TestRotaryEncoder:
 
         assert y1.shape == (5, seq_len, 32)
 
-        x2 = torch.ones((5, seq_len + step, 32), device=device)
+        x2 = torch.ones((5, seq_len + step_nr, 32), device=device)
 
         y2 = m(x2, padding_mask=None)
 
-        assert_close(y1, y2[:, step:])
+        assert_close(y1, y2[:, step_nr:])
 
     def test_forward_raises_error_when_seq_len_is_out_of_range(self) -> None:
         m = RotaryEncoder(encoding_dim=32, max_seq_len=3, device=device)
@@ -323,7 +323,7 @@ class TestRotaryEncoder:
         x = torch.randn((5, 2, 32), device=device)
 
         state_bag = IncrementalStateBag(max_num_steps=30)
-        state_bag.increment_step(delta=20)  # out of range
+        state_bag.increment_step_nr(value=20)  # out of range
 
         y = m(x, padding_mask=None, state_bag=state_bag)
 

--- a/tests/unit/nn/transformer/test_attention_mask.py
+++ b/tests/unit/nn/transformer/test_attention_mask.py
@@ -128,7 +128,7 @@ class TestALiBiAttentionMaskGenerator:
 
         state_bag = IncrementalStateBag(max_num_steps=100)
 
-        state_bag.increment_step(3)
+        state_bag.increment_step_nr(3)
 
         mask = factory(seqs=q, keys=k, training=False, state_bag=state_bag)
 


### PR DESCRIPTION
This PR renames `IncrementalStateBag`'s `step` to `step_nr`, and `increment_step` to `increment_step_nr`. It also renames `vocabulary_from_sentencepiece` to `vocab_info_from_sentencepiece`.