### PR TITLE
Add system and user asset directories

### DIFF
--- a/src/fairseq2/assets/card.py
+++ b/src/fairseq2/assets/card.py
@@ -302,7 +302,10 @@ class AssetCardField:
                 f"The value of the field '{pathname}' of the asset card '{self.card.name}' must be a URI, but is '{str_value}' instead."
             )
 
-        return str_value
+        if not uri.scheme:
+            uri = uri._replace(scheme="file")
+
+        return uri.geturl()
 
     def as_filename(self) -> str:
         """Return the value of this field as a filename."""

--- a/src/fairseq2/assets/download_manager.py
+++ b/src/fairseq2/assets/download_manager.py
@@ -283,13 +283,12 @@ class _AssetDownloadOp:
     def _init_download_path(self) -> None:
         assert self.download_filename is not None
 
-        cache_root_pathname = os.getenv("FAIRSEQ2_CACHE_DIR")
-        if cache_root_pathname:
+        if pathname := os.getenv("FAIRSEQ2_CACHE_DIR"):
             try:
-                cache_root_path = Path(cache_root_pathname)
+                cache_root_path = Path(pathname)
             except ValueError as ex:
                 raise RuntimeError(
-                    f"`FAIRSEQ2_CACHE_DIR` environment variable must contain a valid pathname, but contains '{cache_root_pathname}' instead."
+                    f"`FAIRSEQ2_CACHE_DIR` environment variable must contain a valid pathname, but contains '{pathname}' instead."
                 ) from ex
         else:
             cache_root_path = Path(torch.hub.get_dir()).joinpath("fairseq2")

--- a/tests/unit/assets/test_card.py
+++ b/tests/unit/assets/test_card.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import os
+from pathlib import Path
 
 import pytest
 
@@ -176,9 +177,19 @@ class TestAssetCard:
             self.card.field("field1").as_one_of({"foo3", "foo2"})
 
     def test_as_uri_works(self) -> None:
+        value = self.card.field("field1").as_uri()
+
+        assert value == "file:///foo1"
+
         value = self.card.field("field9").as_uri()
 
         assert value == "http://foo.com"
+
+        self.card.field("field1").set(Path("/foo1/foo2/"))
+
+        value = self.card.field("field1").as_uri()
+
+        assert value == "file:///foo1/foo2"
 
     def test_as_uri_raises_error_when_field_type_is_incorrect(self) -> None:
         with pytest.raises(


### PR DESCRIPTION
This PR extends the default asset directories beyond "fairseq2/assets/cards" to "/etc/fairseq2/assets" and "~/.config/fairseq2/assets". Both the system- and user-level paths can be overridden by the "FAIRSEQ2_ASSET_DIR" and "FAIRSEQ2_USER_ASSET_DIR" environment variables. It also squeezes one more improvement to `as_uri()` to always use the "file" scheme for pathnames.