### PR TITLE
Refactor text tokenizers

### DIFF
--- a/src/fairseq2/data/text/__init__.py
+++ b/src/fairseq2/data/text/__init__.py
@@ -8,12 +8,18 @@ from fairseq2.data.text.converters import StrSplitter as StrSplitter
 from fairseq2.data.text.converters import StrToIntConverter as StrToIntConverter
 from fairseq2.data.text.converters import StrToTensorConverter as StrToTensorConverter
 from fairseq2.data.text.sentencepiece import (
+    BasicSentencePieceTokenizer as BasicSentencePieceTokenizer,
+)
+from fairseq2.data.text.sentencepiece import (
     SentencePieceDecoder as SentencePieceDecoder,
 )
 from fairseq2.data.text.sentencepiece import (
     SentencePieceEncoder as SentencePieceEncoder,
 )
 from fairseq2.data.text.sentencepiece import SentencePieceModel as SentencePieceModel
+from fairseq2.data.text.sentencepiece import (
+    SentencePieceTokenizerBase as SentencePieceTokenizerBase,
+)
 from fairseq2.data.text.sentencepiece import (
     vocab_info_from_sentencepiece as vocab_info_from_sentencepiece,
 )

--- a/src/fairseq2/data/text/text_tokenizer.py
+++ b/src/fairseq2/data/text/text_tokenizer.py
@@ -17,7 +17,7 @@ from fairseq2.typing import Device
 
 
 class TextTokenizer(ABC):
-    """Represents a tokenizer to encode and decode texts."""
+    """Represents a tokenizer to encode and decode text."""
 
     vocab_info: VocabularyInfo
 
@@ -80,7 +80,7 @@ class TextTokenizer(ABC):
 
 
 class TextTokenEncoder(ABC):
-    """Encodes texts into tokens or token indices."""
+    """Encodes text into tokens or token indices."""
 
     @abstractmethod
     def __call__(self, text: StringLike) -> Tensor:
@@ -110,7 +110,7 @@ class TextTokenEncoder(ABC):
 
 
 class TextTokenDecoder(ABC):
-    """Decodes texts from tokens or token indices."""
+    """Decodes text from tokens or token indices."""
 
     @abstractmethod
     def __call__(self, token_indices: Tensor) -> StringLike:

--- a/src/fairseq2/data/vocabulary_info.py
+++ b/src/fairseq2/data/vocabulary_info.py
@@ -16,13 +16,13 @@ class VocabularyInfo:
     """The size of the vocabulary."""
 
     unk_idx: Optional[int]
-    """The index of the symbol that represents an unknown element."""
+    """The index of the symbol that represents an unknown element (UNK)."""
 
     bos_idx: Optional[int]
-    """The index of the symbol that represents the beginning of a sequence."""
+    """The index of the symbol that represents the beginning of a sequence (BOS)."""
 
     eos_idx: Optional[int]
-    """The index of the symbol that represents the end of a sequence."""
+    """The index of the symbol that represents the end of a sequence (EOS)."""
 
     pad_idx: Optional[int]
-    """The index of the symbol that is used to pad a sequence."""
+    """The index of the symbol that is used to pad a sequence (PAD)."""

--- a/src/fairseq2/models/llama/tokenizer.py
+++ b/src/fairseq2/models/llama/tokenizer.py
@@ -4,93 +4,11 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Optional, final
+from typing import final
 
-from fairseq2.data.text import (
-    SentencePieceDecoder,
-    SentencePieceEncoder,
-    SentencePieceModel,
-    TextTokenDecoder,
-    TextTokenEncoder,
-    TextTokenizer,
-    vocab_info_from_sentencepiece,
-)
-from fairseq2.data.typing import PathLike
-from fairseq2.typing import Device, finaloverride
+from fairseq2.data.text import BasicSentencePieceTokenizer
 
 
 @final
-class LLaMATokenizer(TextTokenizer):
+class LLaMATokenizer(BasicSentencePieceTokenizer):
     """Represents the tokenizer used by LLaMA models."""
-
-    model: SentencePieceModel
-
-    def __init__(self, pathname: PathLike) -> None:
-        """
-        :param pathname:
-            The pathname of the SentencePiece model file.
-        """
-        self.model = SentencePieceModel(pathname)
-
-        vocab_info = vocab_info_from_sentencepiece(self.model)
-
-        super().__init__(vocab_info)
-
-    @finaloverride
-    def create_encoder(
-        self,
-        *,
-        task: Optional[str] = None,
-        lang: Optional[str] = None,
-        mode: Optional[str] = None,
-        device: Optional[Device] = None,
-        pin_memory: bool = False,
-    ) -> TextTokenEncoder:
-        """Create a token encoder.
-
-        :param task:
-            Not used.
-        :param lang:
-            Not used.
-        :param mode:
-            Must be 'default' or 'prompt'. If ``None``, defaults to 'default'.
-        :param device:
-            The device on which to construct tensors.
-        :param pin_memory:
-            If ``True``, uses pinned memory while constructing tensors.
-        """
-        if task is not None:
-            raise ValueError(f"`task` must be `None`, but is '{task}' instead.")
-
-        if lang is not None:
-            raise ValueError(f"`lang` must be `None`, but is '{lang}' instead.")
-
-        if mode is None or mode == "default":
-            prefix_tokens = ["<s>"]
-            suffix_tokens = ["</s>"]
-        elif mode == "prompt":
-            prefix_tokens = ["<s>"]
-            # In prompt mode, we expect the generator to finish the sequence.
-            suffix_tokens = None
-        else:
-            raise ValueError(
-                f"`mode` must be 'default' or 'prompt', but is '{mode}' instead."
-            )
-
-        return SentencePieceEncoder(
-            self.model,
-            prefix_tokens=prefix_tokens,
-            suffix_tokens=suffix_tokens,
-            device=device,
-            pin_memory=pin_memory,
-        )
-
-    @finaloverride
-    def create_raw_encoder(
-        self, *, device: Optional[Device] = None, pin_memory: bool = False
-    ) -> TextTokenEncoder:
-        return SentencePieceEncoder(self.model, device=device, pin_memory=pin_memory)
-
-    @finaloverride
-    def create_decoder(self) -> TextTokenDecoder:
-        return SentencePieceDecoder(self.model)

--- a/src/fairseq2/models/mistral/tokenizer.py
+++ b/src/fairseq2/models/mistral/tokenizer.py
@@ -4,93 +4,11 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Optional, final
+from typing import final
 
-from fairseq2.data.text import (
-    SentencePieceDecoder,
-    SentencePieceEncoder,
-    SentencePieceModel,
-    TextTokenDecoder,
-    TextTokenEncoder,
-    TextTokenizer,
-    vocab_info_from_sentencepiece,
-)
-from fairseq2.data.typing import PathLike
-from fairseq2.typing import Device, finaloverride
+from fairseq2.data.text import BasicSentencePieceTokenizer
 
 
 @final
-class MistralTokenizer(TextTokenizer):
+class MistralTokenizer(BasicSentencePieceTokenizer):
     """Represents the tokenizer used by Mistral models."""
-
-    model: SentencePieceModel
-
-    def __init__(self, pathname: PathLike) -> None:
-        """
-        :param pathname:
-            The pathname of the SentencePiece model file.
-        """
-        self.model = SentencePieceModel(pathname)
-
-        vocab_info = vocab_info_from_sentencepiece(self.model)
-
-        super().__init__(vocab_info)
-
-    @finaloverride
-    def create_encoder(
-        self,
-        *,
-        task: Optional[str] = None,
-        lang: Optional[str] = None,
-        mode: Optional[str] = None,
-        device: Optional[Device] = None,
-        pin_memory: bool = False,
-    ) -> TextTokenEncoder:
-        """Create a token encoder.
-
-        :param task:
-            Not used.
-        :param lang:
-            Not used.
-        :param mode:
-            Must be 'default' or 'prompt'. If ``None``, defaults to 'default'.
-        :param device:
-            The device on which to construct tensors.
-        :param pin_memory:
-            If ``True``, uses pinned memory while constructing tensors.
-        """
-        if task is not None:
-            raise ValueError(f"`task` must be `None`, but is '{task}' instead.")
-
-        if lang is not None:
-            raise ValueError(f"`lang` must be `None`, but is '{lang}' instead.")
-
-        if mode is None or mode == "default":
-            prefix_tokens = ["<s>"]
-            suffix_tokens = ["</s>"]
-        elif mode == "prompt":
-            prefix_tokens = ["<s>"]
-            # In prompt mode, we expect the generator to finish the sequence.
-            suffix_tokens = None
-        else:
-            raise ValueError(
-                f"`mode` must be 'default' or 'prompt', but is '{mode}' instead."
-            )
-
-        return SentencePieceEncoder(
-            self.model,
-            prefix_tokens=prefix_tokens,
-            suffix_tokens=suffix_tokens,
-            device=device,
-            pin_memory=pin_memory,
-        )
-
-    @finaloverride
-    def create_raw_encoder(
-        self, *, device: Optional[Device] = None, pin_memory: bool = False
-    ) -> TextTokenEncoder:
-        return SentencePieceEncoder(self.model, device=device, pin_memory=pin_memory)
-
-    @finaloverride
-    def create_decoder(self) -> TextTokenDecoder:
-        return SentencePieceDecoder(self.model)

--- a/src/fairseq2/models/nllb/tokenizer.py
+++ b/src/fairseq2/models/nllb/tokenizer.py
@@ -6,24 +6,15 @@
 
 from typing import Optional, Sequence, Set, final
 
-from fairseq2.data.text import (
-    SentencePieceDecoder,
-    SentencePieceEncoder,
-    SentencePieceModel,
-    TextTokenDecoder,
-    TextTokenEncoder,
-    TextTokenizer,
-    vocab_info_from_sentencepiece,
-)
+from fairseq2.data.text import SentencePieceEncoder, SentencePieceTokenizerBase
 from fairseq2.data.typing import PathLike
 from fairseq2.typing import Device, finaloverride
 
 
 @final
-class NllbTokenizer(TextTokenizer):
+class NllbTokenizer(SentencePieceTokenizerBase):
     """Represents the tokenizer used by NLLB models."""
 
-    model: SentencePieceModel
     langs: Set[str]
     default_lang: str
 
@@ -49,15 +40,11 @@ class NllbTokenizer(TextTokenizer):
         # it to the model at index 0.
         control_symbols.append("<pad>@0")
 
-        self.model = SentencePieceModel(pathname, control_symbols)
+        super().__init__(pathname, control_symbols)
 
         self.langs = set(langs)
 
         self.default_lang = default_lang
-
-        vocab_info = vocab_info_from_sentencepiece(self.model)
-
-        super().__init__(vocab_info)
 
     @finaloverride
     def create_encoder(
@@ -68,7 +55,7 @@ class NllbTokenizer(TextTokenizer):
         mode: Optional[str] = None,
         device: Optional[Device] = None,
         pin_memory: bool = False,
-    ) -> TextTokenEncoder:
+    ) -> SentencePieceEncoder:
         """Create a token encoder.
 
         :param task:
@@ -127,13 +114,3 @@ class NllbTokenizer(TextTokenizer):
             device=device,
             pin_memory=pin_memory,
         )
-
-    @finaloverride
-    def create_raw_encoder(
-        self, *, device: Optional[Device] = None, pin_memory: bool = False
-    ) -> TextTokenEncoder:
-        return SentencePieceEncoder(self.model, device=device, pin_memory=pin_memory)
-
-    @finaloverride
-    def create_decoder(self) -> TextTokenDecoder:
-        return SentencePieceDecoder(self.model)

--- a/src/fairseq2/models/s2t_transformer/loader.py
+++ b/src/fairseq2/models/s2t_transformer/loader.py
@@ -77,7 +77,7 @@ class S2TTransformerTokenizerLoader(TokenizerLoaderBase[S2TTransformerTokenizer]
 
     @finaloverride
     def _load(self, path: Path, card: AssetCard) -> S2TTransformerTokenizer:
-        task = card.field("task").as_one_of({"transcription", "translation"})
+        task = card.field("task").as_one_of({"translation", "transcription"})
 
         target_langs = card.field("target_langs").as_list(str)
 

--- a/src/fairseq2/models/s2t_transformer/tokenizer.py
+++ b/src/fairseq2/models/s2t_transformer/tokenizer.py
@@ -6,24 +6,15 @@
 
 from typing import Optional, Set, final
 
-from fairseq2.data.text import (
-    SentencePieceDecoder,
-    SentencePieceEncoder,
-    SentencePieceModel,
-    TextTokenDecoder,
-    TextTokenEncoder,
-    TextTokenizer,
-)
-from fairseq2.data.text.sentencepiece import vocab_info_from_sentencepiece
+from fairseq2.data.text import SentencePieceEncoder, SentencePieceTokenizerBase
 from fairseq2.data.typing import PathLike
 from fairseq2.typing import Device, finaloverride
 
 
 @final
-class S2TTransformerTokenizer(TextTokenizer):
+class S2TTransformerTokenizer(SentencePieceTokenizerBase):
     """Represents the tokenizer used by S2T Transformer models."""
 
-    model: SentencePieceModel
     task: str
     target_langs: Set[str]
     default_target_lang: str
@@ -46,20 +37,16 @@ class S2TTransformerTokenizer(TextTokenizer):
         :param default_target_lang:
             The fall-back language if no target language is specified.
         """
+        super().__init__(pathname)
+
         if task != "transcription" and task != "translation":
             raise ValueError(
                 f"`task` must be 'transcripton' or 'translation', but is '{task}' instead."
             )
 
-        self.model = SentencePieceModel(pathname)
-
         self.task = task
         self.target_langs = target_langs
         self.default_target_lang = default_target_lang
-
-        vocab_info = vocab_info_from_sentencepiece(self.model)
-
-        super().__init__(vocab_info)
 
     @finaloverride
     def create_encoder(
@@ -70,7 +57,7 @@ class S2TTransformerTokenizer(TextTokenizer):
         mode: Optional[str] = None,
         device: Optional[Device] = None,
         pin_memory: bool = False,
-    ) -> TextTokenEncoder:
+    ) -> SentencePieceEncoder:
         """Create a token encoder.
 
         :param task:
@@ -111,13 +98,3 @@ class S2TTransformerTokenizer(TextTokenizer):
             device=device,
             pin_memory=pin_memory,
         )
-
-    @finaloverride
-    def create_raw_encoder(
-        self, *, device: Optional[Device] = None, pin_memory: bool = False
-    ) -> TextTokenEncoder:
-        return SentencePieceEncoder(self.model, device=device, pin_memory=pin_memory)
-
-    @finaloverride
-    def create_decoder(self) -> TextTokenDecoder:
-        return SentencePieceDecoder(self.model)

--- a/tests/unit/nn/test_position_encoder.py
+++ b/tests/unit/nn/test_position_encoder.py
@@ -323,7 +323,7 @@ class TestRotaryEncoder:
         x = torch.randn((5, 2, 32), device=device)
 
         state_bag = IncrementalStateBag(max_num_steps=30)
-        state_bag.increment_step_nr(value=20)  # out of range
+        state_bag.increment_step_nr(20)  # out of range
 
         y = m(x, padding_mask=None, state_bag=state_bag)
 


### PR DESCRIPTION
This PR refactors the existing text tokenizers. It introduces `SentencePieceTokenizerBase` and `BasicSentencePieceTokenizer` to reduce boilerplate tokenizer implementations in model code.