### PR TITLE
Fix home directory bug

### DIFF
--- a/src/fairseq2/assets/store.py
+++ b/src/fairseq2/assets/store.py
@@ -197,13 +197,13 @@ def _load_user_asset_directory() -> None:
     if asset_dir is None:
         asset_dir = _get_path_from_env("XDG_CONFIG_HOME")
         if asset_dir is None:
-            asset_dir = Path("~/.config").expanduser()
-            if not asset_dir.exists():
-                return
+            asset_dir = Path("~/.config")
 
-        asset_dir = asset_dir.joinpath("fairseq2/assets")
-
-    asset_dir = asset_dir.expanduser()
+        asset_dir = asset_dir.expanduser().joinpath("fairseq2/assets")
+        if not asset_dir.exists():
+            return
+    else:
+        asset_dir = asset_dir.expanduser()
 
     asset_store.user_metadata_providers.append(FileAssetMetadataProvider(asset_dir))
 


### PR DESCRIPTION
This PR fixes the bug where we accidentally check the existence of ~/.config instead of ~/.config/fairseq2/assets