### PR TITLE
Use fixed _legacy_pad_idx for fairseq reproducibility

### DIFF
--- a/src/fairseq2/models/nllb/builder.py
+++ b/src/fairseq2/models/nllb/builder.py
@@ -191,7 +191,7 @@ class NllbBuilder:
         pos_encoder = SinusoidalPositionEncoder(
             self.config.model_dim,
             self.config.max_seq_len,
-            _legacy_pad_idx=self.config.vocab_info.pad_idx,
+            _legacy_pad_idx=1,
             device=self.device,
         )
 

--- a/src/fairseq2/models/s2t_transformer/builder.py
+++ b/src/fairseq2/models/s2t_transformer/builder.py
@@ -316,7 +316,7 @@ class S2TTransformerBuilder:
         return SinusoidalPositionEncoder(
             self.config.model_dim,
             self.config.max_seq_len,
-            _legacy_pad_idx=self.config.target_vocab_info.pad_idx,
+            _legacy_pad_idx=1,
             device=self.device,
         )
 

--- a/tests/integration/models/test_nllb.py
+++ b/tests/integration/models/test_nllb.py
@@ -13,7 +13,7 @@ from fairseq2.models.nllb import load_nllb_model, load_nllb_tokenizer
 from tests.common import device
 
 ENG_SENTENCE: Final = "On Monday, scientists from the Stanford University School of Medicine announced the invention of a new diagnostic tool that can sort cells by type: a tiny printable chip that can be manufactured using standard inkjet printers for possibly about one U.S. cent each."
-DEU_SENTENCE: Final = "Am Montag kündigten Wissenschaftler der Medizinischen Fakultät der Universität Stanford die Erfindung eines neuen Diagnosetools an, das Zellen nach Typ sortieren kann: Ein winziger druckbarer Chip, der mit standardmäßigen Inkjet-Drucker für möglicherweise etwa einen US-Cent pro Stück hergestellt werden kann."
+DEU_SENTENCE: Final = "Am Montag kündigten Wissenschaftler der Medizinischen Fakultät der Stanford University die Erfindung eines neuen Diagnosetools an, das Zellen nach Typ sortieren kann: Ein winziger druckbarer Chip, der mit standardmäßigen Inkjet-Drucker für möglicherweise etwa einen US-Cent pro Stück hergestellt werden kann."
 
 
 def test_load_dense_distill_600m() -> None:


### PR DESCRIPTION
This PR uses "1" as `_legacy_pad_idx` argument for NLLB and S2T Transformer instead of pad_idx to ensure full parity with fairseq model outputs.