### PR TITLE
Allow build-id version suffix in nightlies

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,9 @@ on:
           - 'nightly'
           - 'rc'
           - 'stable'
+        build_id:
+          type: string
+          description: 'Appends the specified value to the package version. Only used in nightly builds.'
 
 jobs:
   process_version:
@@ -49,11 +52,13 @@ jobs:
       - name: Stamp version with current date if nightly
         id: stamp_version
         if: inputs.release_type == 'nightly'
+        env:
+          BUILD_ID: ${{ inputs.build_id }}
         run: |
           version=$(cat VERSION)
 
           # Append date-stamped dev segment.
-          echo version_override=${version%.dev*}.dev$(date +%Y%m%d) >> "$GITHUB_OUTPUT"
+          echo version_override=${version%.dev*}.dev$(date +%Y%m%d)${BUILD_ID:+.$BUILD_ID} >> "$GITHUB_OUTPUT"
 
   lint:
     name: Lint


### PR DESCRIPTION
This PR allows adding a user-specified build-id suffix to nightly package versions to avoid edge cases where we build more than one nightly in a day.