### PR TITLE
Use UTC datetime stamps

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,7 +53,7 @@ jobs:
           version=$(cat VERSION)
 
           # Append datetime-stamped dev segment.
-          echo version_override=${version%.dev*}.dev$(date +%Y%m%d%H%M) >> "$GITHUB_OUTPUT"
+          echo version_override=${version%.dev*}.dev$(date --utc +%Y%m%d%H%M) >> "$GITHUB_OUTPUT"
 
   lint:
     name: Lint


### PR DESCRIPTION
Github Actions runners already use UTC timezone, but let's make sure that we always use UTC regardless of the host system.