### PR TITLE
Reorder CMake Python binding dependencies

### DIFF
--- a/fairseq2n/python/src/fairseq2n/bindings/CMakeLists.txt
+++ b/fairseq2n/python/src/fairseq2n/bindings/CMakeLists.txt
@@ -36,7 +36,7 @@ target_include_directories(py_bindings PRIVATE ${PROJECT_SOURCE_DIR}/python/src)
 
 target_link_libraries(py_bindings
     PRIVATE
-        pybind11::module fairseq2n fmt::fmt torch_python kuba-zip
+        pybind11::module fmt::fmt kuba-zip fairseq2n torch_python
 )
 
 fairseq2n_set_link_options(py_bindings ALLOW_UNDEFINED_SYMBOLS)


### PR DESCRIPTION
This PR changes the CMake dependency order for the Python C extension library to avoid header file conflicts with PyTorch. See #170, #152.