### PR TITLE
Rename examples to recipes

### DIFF
--- a/.github/workflows/_lint_py.yaml
+++ b/.github/workflows/_lint_py.yaml
@@ -102,5 +102,5 @@ jobs:
           mypy
           mypy setup.py
           mypy fairseq2n/python/setup.py
-          mypy examples/llama
-          mypy examples/mistral
+          mypy recipes/llama
+          mypy recipes/mistral

--- a/README.md
+++ b/README.md
@@ -24,12 +24,11 @@ For recent changes, you can check out our [changelog](CHANGELOG.md).
 
 
 ## Models
-As of today, the following pre-trained models are available in fairseq2 (in
-alphabetical order):
+As of today, the following models are available in fairseq2:
 
- * [LLaMA](src/fairseq2/models/llama)
- * [LLaMA 2](src/fairseq2/models/llama)
- * [Mistral 7B](src/fairseq2/models/mistral)
+ * [LLaMA](recipes/llama)
+ * [LLaMA 2](recipes/llama)
+ * [Mistral 7B](recipes/mistral)
  * [NLLB-200](src/fairseq2/models/nllb)
  * [S2T Transformer + Conformer](src/fairseq2/models/s2t_transformer)
  * [w2v-BERT](src/fairseq2/models/w2vbert)
@@ -37,7 +36,7 @@ alphabetical order):
 
 fairseq2 is also used by various external projects such as:
 
- * [SeamlessM4T](https://github.com/facebookresearch/seamless_communication)
+ * [Seamless Communication](https://github.com/facebookresearch/seamless_communication)
  * [SONAR](https://github.com/facebookresearch/SONAR)
 
 

--- a/recipes/llama/README.md
+++ b/recipes/llama/README.md
@@ -1,0 +1,78 @@
+# LLaMA and LLaMA 2
+[LLaMA](https://ai.meta.com/llama/) ([arXiv](https://arxiv.org/abs/2302.13971)) and [LLaMA 2](https://ai.meta.com/llama/) ([arXiv](https://arxiv.org/abs/2307.09288)) family of large language models by Meta are a collection of pretrained and fine-tuned generative text models ranging in scale from 7 billion to 70 billion parameters. Their implementation can be found under [`fairseq2.models.llama`](https://github.com/facebookresearch/fairseq2/tree/main/src/fairseq2/models/llama).
+
+- [Supported Models](#supported-models)
+- [Loading the Checkpoints](#loading-the-checkpoints)
+- [Use in Code](#use-in-code)
+- [Chatbot](#chatbot)
+- [Fine-tuning](#fine-tuning)
+
+## Supported Models
+As of today the following LLaMA 7B models are available in fairseq2. The larger variants will be made available soon:
+
+- `llama_7b`
+- `llama2_7b`
+- `llama2_7b_chat`
+
+## Loading the Checkpoints
+LLaMA checkpoints are gated and can only be downloaded after filling out the form [here](https://ai.meta.com/resources/models-and-libraries/llama-downloads/). Once downloaded, there are two simple ways to access them in fairseq2:
+
+### Option 1
+For the recipes under this directory, you can pass the checkpoint path using the `--checkpoint-dir` option.
+
+### Option 2
+For general use, you can set them permanently by creating a YAML file (e.g. `llama.yaml`) with the following template under `~/.config/fairseq2/assets` (shown for `llama2_7b` and `llama2_7b_chat`):
+
+```yaml
+name: llama2_7b@user
+checkpoint: "<path/to/checkpoint>"
+tokenizer: "<path/to/tokenizer>"
+
+---
+
+name: llama2_7b_chat@user
+checkpoint: "<path/to/checkpoint>"
+tokenizer: "<path/to/tokenizer>"
+```
+
+## Use in Code
+The short example below shows how you can complete a small batch of prompts using `llama2_7b`.
+
+```python
+import torch
+
+from fairseq2.generation import TopPSampler, SamplingSequenceGenerator, TextCompleter
+from fairseq2.models.llama import load_llama_model, load_llama_tokenizer
+
+model = load_llama_model("llama2_7b", device=torch.device("cuda"), dtype=torch.float16)
+
+tokenizer = load_llama_tokenizer("llama2_7b")
+
+sampler = TopPSampler(p=0.6)
+
+generator = SamplingSequenceGenerator(model, sampler, echo_prompt=True)
+
+text_completer = TextCompleter(generator, tokenizer)
+
+prompts = [
+    "I believe the meaning of life is",
+    "Simply put, the theory of relativity states that ",
+]
+
+output, _ = text_completer.batch_complete(prompts)
+
+for text in output:
+  print(text)
+```
+
+## Chatbot
+The [`chatbot.py`](./chatbot.py) script demonstrates how you can build a simple terminal-based chat application using LLaMA 2 and fairseq2. To try it out, run:
+
+```sh
+python recipes/llama/chatbot.py --checkpoint-dir <path/to/llama/checkpoint/dir>
+```
+
+Note that you can omit `--checkpoint-dir` if you have set the checkpoint in a YAML file (option 2 above).
+
+## Fine-tuning
+Coming soon. Stay tuned.

--- a/recipes/llama/chatbot.py
+++ b/recipes/llama/chatbot.py
@@ -21,12 +21,12 @@ from fairseq2.generation.utils import StdOutPrintHook
 from fairseq2.models.llama import LLaMAChatbot, load_llama_model, load_llama_tokenizer
 
 
-def run_llama_chatbot(checkpoint_path: Optional[Path] = None) -> None:
+def run_llama_chatbot(checkpoint_dir: Optional[Path] = None) -> None:
     model_card = asset_store.retrieve_card("llama2_7b_chat")
 
-    if checkpoint_path is not None:
-        model_card.field("checkpoint").set(checkpoint_path / "consolidated.pth")
-        model_card.field("tokenizer").set(checkpoint_path / "tokenizer.model")
+    if checkpoint_dir is not None:
+        model_card.field("checkpoint").set(checkpoint_dir / "consolidated.pth")
+        model_card.field("tokenizer").set(checkpoint_dir / "tokenizer.model")
 
     model = load_llama_model(
         model_card, dtype=torch.float16, device=torch.device("cuda")
@@ -79,13 +79,13 @@ def main() -> None:
 
     # checkpoint
     param = parser.add_argument(
-        "-c", "--checkpoint", metavar="CHECKPOINT", dest="checkpoint_path", type=Path
+        "-c", "--checkpoint-dir", metavar="DIR", dest="checkpoint_dir", type=Path
     )
     param.help = "path to the LLaMA checkpoint directory"
 
     args = parser.parse_args()
 
-    run_llama_chatbot(args.checkpoint_path)
+    run_llama_chatbot(args.checkpoint_dir)
 
 
 if __name__ == "__main__":

--- a/recipes/mistral/README.md
+++ b/recipes/mistral/README.md
@@ -1,0 +1,76 @@
+# Mistral 7B
+The [Mistral 7B](https://mistral.ai/news/announcing-mistral-7b)  ([arXiv](https://arxiv.org/abs/2310.06825)) large language model is a pretrained generative text model with 7 billion parameters. It uses Grouped-Query Attention for fast inference, and Sliding-Window Attention for handling sequences of arbitrary length.
+Its implementation can be found under [`fairseq2.models.mistral`](https://github.com/facebookresearch/fairseq2/tree/main/src/fairseq2/models/mistral).
+
+- [Supported Models](#supported-models)
+- [Loading the Checkpoints](#loading-the-checkpoints)
+- [Use in Code](#use-in-code)
+- [Chatbot](#chatbot)
+- [Fine-tuning](#fine-tuning)
+
+## Supported Models
+The following Mistral 7B models are available in fairseq2:
+
+- `mistral_7b`
+- `mistral_7b_instruct`
+
+## Loading the Checkpoints
+The checkpoints of Mistral 7B models are publicly available and, by default, fairseq2 will automatically download them to its cache directory at `~/.cache/fairseq2`. However, if you have already downloaded them in the past, you can instruct fairseq2 to skip the download using one of the following options:
+
+### Option 1
+For the recipes under this directory, you can pass the checkpoint path using the `--checkpoint-dir` option.
+
+### Option 2
+For general use, you can set them permanently by creating a YAML file (e.g. `mistral.yaml`) with the following template under `~/.config/fairseq2/assets`:
+
+```yaml
+name: mistral_7b@user
+checkpoint: "<path/to/checkpoint>"
+tokenizer: "<path/to/tokenizer>"
+
+---
+
+name: mistral_7b_instruct@user
+checkpoint: "<path/to/checkpoint>"
+tokenizer: "<path/to/tokenizer>"
+```
+
+## Use in Code
+The short example below shows how you can complete a small batch of prompts using `mistral_7b`.
+
+```python
+import torch
+
+from fairseq2.generation import TopPSampler, SamplingSequenceGenerator, TextCompleter
+from fairseq2.models.mistral import load_mistral_model, load_mistral_tokenizer
+
+model = load_mistral_model("mistral_7b", device=torch.device("cuda"), dtype=torch.float16)
+
+tokenizer = load_mistral_tokenizer("mistral_7b")
+
+sampler = TopPSampler(p=0.6)
+
+generator = SamplingSequenceGenerator(model, sampler, echo_prompt=True)
+
+text_completer = TextCompleter(generator, tokenizer)
+
+prompts = [
+    "I believe the meaning of life is",
+    "Simply put, the theory of relativity states that ",
+]
+
+output, _ = text_completer.batch_complete(prompts)
+
+for text in output:
+  print(text)
+```
+
+## Chatbot
+The [`chatbot.py`](./chatbot.py) script demonstrates how you can build a simple terminal-based chat application using Mistral 7B and fairseq2. To try it out, run:
+
+```sh
+python recipes/mistral/chatbot.py
+```
+
+## Fine-tuning
+Coming soon. Stay tuned.

--- a/recipes/mistral/chatbot.py
+++ b/recipes/mistral/chatbot.py
@@ -25,12 +25,12 @@ from fairseq2.models.mistral import (
 )
 
 
-def run_mistral_chatbot(checkpoint_path: Optional[Path] = None) -> None:
+def run_mistral_chatbot(checkpoint_dir: Optional[Path] = None) -> None:
     model_card = asset_store.retrieve_card("mistral_7b_instruct")
 
-    if checkpoint_path is not None:
-        model_card.field("checkpoint").set(checkpoint_path / "consolidated.00.pth")
-        model_card.field("tokenizer").set(checkpoint_path / "tokenizer.model")
+    if checkpoint_dir is not None:
+        model_card.field("checkpoint").set(checkpoint_dir / "consolidated.00.pth")
+        model_card.field("tokenizer").set(checkpoint_dir / "tokenizer.model")
 
     model = load_mistral_model(
         model_card, dtype=torch.float16, device=torch.device("cuda:0")
@@ -78,13 +78,13 @@ def main() -> None:
 
     # checkpoint
     param = parser.add_argument(
-        "-c", "--checkpoint", metavar="CHECKPOINT", dest="checkpoint_path", type=Path
+        "-c", "--checkpoint-dir", metavar="DIR", dest="checkpoint_dir", type=Path
     )
     param.help = "path to the Mistral checkpoint directory"
 
     args = parser.parse_args()
 
-    run_mistral_chatbot(args.checkpoint_path)
+    run_mistral_chatbot(args.checkpoint_dir)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR renames "examples" to "recipes" and adds README files for LLaMA and Mistral.