### PR TITLE
Add runtime torch version check

### DIFF
--- a/native/cmake/modules/FindTorch.cmake
+++ b/native/cmake/modules/FindTorch.cmake
@@ -18,7 +18,7 @@ macro(__torch_determine_version)
     )
 
     if(result GREATER 0)
-        message(FATAL_ERROR "fairseq2 cannot determine PEP 440 version of PyTorch!")
+        message(FATAL_ERROR "fairseq2n cannot determine PEP 440 version of PyTorch!")
     endif()
 
     if(TORCH_PEP440_VERSION MATCHES "^[0-9]+\.[0-9]+(\.[0-9]+)?")
@@ -40,7 +40,7 @@ macro(__torch_determine_cuda_version)
     )
 
     if(result GREATER 0)
-        message(FATAL_ERROR "fairseq2 cannot determine CUDA version of PyTorch!")
+        message(FATAL_ERROR "fairseq2n cannot determine CUDA version of PyTorch!")
     endif()
 
     # We ignore the patch since it is not relevant for compatibility checks.

--- a/native/python/requirements-build.txt
+++ b/native/python/requirements-build.txt
@@ -1,6 +1,5 @@
 cmake~=3.26
 ninja~=1.11
-packaging~=23.1
 pip~=23.2
 setuptools~=67.8
 tbb-devel==2021.8;platform_machine=='x86_64'

--- a/native/python/setup.py
+++ b/native/python/setup.py
@@ -8,7 +8,6 @@ from os import path
 from typing import Final, List, Optional
 
 import torch
-from packaging import version
 from setuptools import Command, find_packages, setup
 from setuptools.command.install import install as install_base
 from setuptools.dist import Distribution as DistributionBase
@@ -167,7 +166,7 @@ setup(
         "tbb>=2021.8;platform_machine=='x86_64'",
         # PyTorch has no ABI compatibility between releases; this means we have
         # to ensure that we depend on the exact same version that we used to
-        # build our extension module.
-        "torch==" + version.parse(torch.__version__).public,
+        # build fairseq2n.
+        "torch==" + torch.__version__,
     ],
 )

--- a/native/python/src/fairseq2n/config.py.in
+++ b/native/python/src/fairseq2n/config.py.in
@@ -6,6 +6,8 @@
 
 from typing import Final
 
+_TORCH_VERSION: Final = "@TORCH_PEP440_VERSION@"
+
 _SUPPORTS_IMAGE: Final = @SUPPORTS_IMAGE@
 
 _SUPPORTS_CUDA: Final = @USES_CUDA@

--- a/native/src/fairseq2n-config.cmake.in
+++ b/native/src/fairseq2n-config.cmake.in
@@ -10,6 +10,6 @@ include(CMakeFindDependencyMacro)
 
 find_dependency(Torch @TORCH_VERSION@)
 
-include(${CMAKE_CURRENT_LIST_DIR}/fairseq2-targets.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/fairseq2n-targets.cmake)
 
-check_required_components(fairseq2)
+check_required_components(fairseq2n)

--- a/native/src/fairseq2n/config.h.in
+++ b/native/src/fairseq2n/config.h.in
@@ -15,6 +15,8 @@ constexpr std::int32_t version_major = @PROJECT_VERSION_MAJOR@;
 constexpr std::int32_t version_minor = @PROJECT_VERSION_MINOR@;
 constexpr std::int32_t version_patch = @PROJECT_VERSION_PATCH@;
 
+constexpr char torch_version[] = "@TORCH_PEP440_VERSION@";
+
 constexpr bool supports_image = @SUPPORTS_IMAGE@;
 
 constexpr bool supports_cuda = @USES_CUDA@;


### PR DESCRIPTION
This PR attempts to improve the user experience at runtime by reporting a version mismatch between PyTorch and fairseq2 instead of failing later by a non-descriptive error.