### PR TITLE
Improve PyTorch version checks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ If you have changes in C++ or CUDA, in addition to `pytest`, also run the native
 tests:
 
 ```sh
-fairseq2n/build/tests/run-tests
+native/build/tests/run-tests
 ```
 
 
@@ -125,7 +125,7 @@ If you have touched C++ or CUDA files, lint your code with an up-to-date version
 of the clang toolkit and address any issues reported:
 
 ```sh
-cd fairseq2n
+cd native
 
 CC=clang CXX=clang++ cmake -GNinja -DFAIRSEQ2N_RUN_CLANG_TIDY=ON -B build
 
@@ -135,7 +135,7 @@ cmake --build build
 Alternatively:
 
 ```sh
-cd fairseq2n
+cd native
 
 CC=clang CXX=clang++ cmake -GNinja -B build
 

--- a/INSTALL_FROM_SOURCE.md
+++ b/INSTALL_FROM_SOURCE.md
@@ -79,9 +79,9 @@ brew install libsndfile
 ```
 
 ### 3.2 PyTorch
-Follow the instructions on [pytorch.org](https://pytorch.org) to install the
-desired PyTorch version. Make sure that the version you install is
-[supported](.#variants) by fairseq2.
+Follow the instructions on [pytorch.org](https://pytorch.org/get-started/locally/)
+to install the desired PyTorch version. Make sure that the version you install
+is [supported](.#variants) by fairseq2.
 
 ### 3.3 CUDA
 If you plan to build fairseq2 in a CUDA environment, you first have to install
@@ -97,7 +97,7 @@ instructions for different toolkit versions can be found on NVIDIA’s website.
 Finally, to install fairseq2’s C++ build dependencies (e.g. cmake, ninja), use:
 
 ```sh
-pip install -r fairseq2n/python/requirements-build.txt
+pip install -r native/python/requirements-build.txt
 ```
 
 
@@ -109,7 +109,7 @@ library. Run the following command at the root directory of your repository to
 configure the build:
 
 ```sh
-cd fairseq2n
+cd native
 
 cmake -GNinja -B build
 ```
@@ -123,7 +123,7 @@ cmake --build build
 fairseq2 uses reasonable defaults, so the command above is sufficient for a
 standard installation; however, if you are familiar with CMake, you can check
 out the advanced build options in
-[`fairseq2n/CMakeLists.txt`](fairseq2n/CMakeLists.txt).
+[`native/CMakeLists.txt`](native/CMakeLists.txt).
 
 ### CUDA Builds
 
@@ -162,7 +162,7 @@ Once you have built fairseq2n, the actual Python package installation is
 straightforward. First install fairseq2n:
 
 ```sh
-cd fairseq2n/python
+cd native/python
 
 pip install .
 
@@ -180,7 +180,7 @@ In case you want to modify and test fairseq2, installing it in editable mode
 will be more convenient:
 
 ```sh
-cd fairseq2n/python
+cd native/python
 
 pip install -e .
 

--- a/README.md
+++ b/README.md
@@ -105,8 +105,9 @@ matrix shows the supported combinations.
 *\* cuXYZ refers to CUDA XY.Z (e.g. cu118 means CUDA 11.8)*
 
 To install a specific combination, first follow the installation instructions on
-[pytorch.org](https://pytorch.org) for the desired PyTorch version, and then use
-the following command (shown for PyTorch `2.1.1` and variant `cu118`):
+[pytorch.org](https://pytorch.org/get-started/locally) for the desired PyTorch
+version, and then use the following command (shown for PyTorch `2.1.1` and
+variant `cu118`):
 
 ```sh
 pip install fairseq2\

--- a/native/python/requirements-build.txt
+++ b/native/python/requirements-build.txt
@@ -1,5 +1,6 @@
 cmake~=3.26
 ninja~=1.11
+packaging~=23.1
 pip~=23.2
 setuptools~=67.8
 tbb-devel==2021.8;platform_machine=='x86_64'

--- a/native/python/setup.py
+++ b/native/python/setup.py
@@ -8,6 +8,7 @@ from os import path
 from typing import Final, List, Optional
 
 import torch
+from packaging import version
 from setuptools import Command, find_packages, setup
 from setuptools.command.install import install as install_base
 from setuptools.dist import Distribution as DistributionBase
@@ -167,6 +168,6 @@ setup(
         # PyTorch has no ABI compatibility between releases; this means we have
         # to ensure that we depend on the exact same version that we used to
         # build fairseq2n.
-        "torch==" + torch.__version__,
+        "torch==" + version.parse(torch.__version__).public,
     ],
 )


### PR DESCRIPTION
This PR fixes/improves PyTorch runtime checks in Conda environments and also fixes the documentation where we refer to fairseq2n directory as fairseq2n instead of native.