### PR TITLE
F.SDPA support on all devices

### DIFF
--- a/src/fairseq2/nn/transformer/attention.py
+++ b/src/fairseq2/nn/transformer/attention.py
@@ -105,7 +105,6 @@ class TorchSDPA(SDPA):
         attn_mask: Optional[AttentionMask] = None,
         needs_weights: bool = False,
     ) -> Tuple[Tensor, Optional[Tensor]]:
-
         if needs_weights:
             if not self._has_warned:
                 logger.warning(

--- a/src/fairseq2/nn/transformer/attention.py
+++ b/src/fairseq2/nn/transformer/attention.py
@@ -105,17 +105,6 @@ class TorchSDPA(SDPA):
         attn_mask: Optional[AttentionMask] = None,
         needs_weights: bool = False,
     ) -> Tuple[Tensor, Optional[Tensor]]:
-        if not seqs.is_cuda:
-            return _naive_scaled_dot_product_attention(
-                seqs,
-                keys,
-                key_padding_mask,
-                values,
-                attn_mask,
-                self.attn_dropout_p,
-                needs_weights,
-                self.training,
-            )
 
         if needs_weights:
             if not self._has_warned:


### PR DESCRIPTION
Current FS2 attention.py restricts use of F.SDPA to cuda.  SDPA is available on all devices, offering speedups over a Python-level description, e.g., for CPU.

**What does this PR do? Please describe:**
Remove the fallback to _naive_SDPA for non-CUDA inputs

Fixes #{issue number}

**Does your PR introduce any breaking changes? If yes, please list them:**
No.

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [X] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [X] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [n/a] Did you make sure to **update the documentation** with your changes? (if necessary)
- [n/a] Did you write any **new necessary tests**?
- [ ] Did you verify new and **existing tests pass** locally with your changes?
Collecting jiwer~=3.0
  Downloading jiwer-3.0.3-py3-none-any.whl (21 kB)
ERROR: Could not find a version that satisfies the requirement fairseq2n<=0.3.0,>=0.3.0.dev0 (from fairseq2) (from versions: 0.1.0, 0.1.1, 0.2.0)
ERROR: No matching distribution found for fairseq2n<=0.3.0,>=0.3.0.dev0
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
