### PR TITLE
Introduce to_empty and FSDPParameterInitializer

### DIFF
--- a/src/fairseq2/models/utils/generic_loaders.py
+++ b/src/fairseq2/models/utils/generic_loaders.py
@@ -25,8 +25,12 @@ from fairseq2.data import PathLike
 from fairseq2.data.text import TextTokenizer
 from fairseq2.models.utils.arch_registry import ArchitectureRegistry
 from fairseq2.models.utils.checkpoint import load_checkpoint
-from fairseq2.nn.utils.module import infer_device, reset_non_persistent_buffers
-from fairseq2.typing import DataType, Device, finaloverride
+from fairseq2.nn.utils.module import (
+    infer_device,
+    reset_non_persistent_buffers,
+    to_empty,
+)
+from fairseq2.typing import CPU, DataType, Device, finaloverride
 from fairseq2.utils.dataclass import update_dataclass
 
 logger = logging.getLogger("fairseq2.models")
@@ -271,7 +275,7 @@ class ModelLoader(Generic[ModelT, ConfigT]):
         if is_meta:
             # Move the model to the actual device without initializing. Its
             # state will be overwritten by the checkpoint anyways.
-            model = model.to_empty(device=device or "cpu")
+            to_empty(model, device=device or CPU)
 
         # Load the model.
         try:

--- a/src/fairseq2/nn/utils/module.py
+++ b/src/fairseq2/nn/utils/module.py
@@ -4,11 +4,13 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Callable, Optional, Protocol, Set, runtime_checkable
+from typing import Callable, Dict, Optional, Protocol, Set, runtime_checkable
 
-from torch.nn import Module
+import torch
+from torch import Tensor
+from torch.nn import Module, Parameter
 
-from fairseq2.typing import Device
+from fairseq2.typing import CPU, Device
 
 
 @runtime_checkable
@@ -17,18 +19,23 @@ class ModuleWithParameter(Protocol):
         """Reset the parameters and buffers of the module."""
 
 
-def reset_parameters(module: Module) -> None:
+def reset_parameters(module: Module, *, recurse: bool = True) -> None:
     """Reset the parameters and buffers of ``module`` and its submodules.
 
     :param module:
         The module to reset.
+    :param recurse:
+        If ``True``, resets the parameters of all descendant modules.
     """
 
-    def maybe_reset(module: Module) -> None:
-        if isinstance(module, ModuleWithParameter):
-            module.reset_parameters()
+    def maybe_reset(m: Module) -> None:
+        if isinstance(m, ModuleWithParameter):
+            m.reset_parameters()
 
-    apply_depth_first(module, maybe_reset)
+    if recurse:
+        apply_depth_first(module, maybe_reset)
+    else:
+        maybe_reset(module)
 
 
 @runtime_checkable
@@ -37,18 +44,84 @@ class ModuleWithNonPersistentBuffer(Protocol):
         """Reset the non-persistent buffers of the module."""
 
 
-def reset_non_persistent_buffers(module: Module) -> None:
+def reset_non_persistent_buffers(module: Module, *, recurse: bool = True) -> None:
     """Reset the non-persistent buffers of ``module`` and its submodules.
 
     :param module:
         The module to reset.
+    :param recurse:
+        If ``True``, resets the non-persistent buffers of all descendant modules.
     """
 
-    def maybe_reset(module: Module) -> None:
-        if isinstance(module, ModuleWithNonPersistentBuffer):
-            module.reset_non_persistent_buffers()
+    def maybe_reset(m: Module) -> None:
+        if isinstance(m, ModuleWithNonPersistentBuffer):
+            m.reset_non_persistent_buffers()
 
-    apply_depth_first(module, maybe_reset)
+    if recurse:
+        apply_depth_first(module, maybe_reset)
+    else:
+        maybe_reset(module)
+
+
+def to_empty(
+    module: Module,
+    device: Device,
+    *,
+    recurse: bool = True,
+    memo: Optional[Dict[Tensor, Tensor]] = None,
+) -> None:
+    """Move the parameters and buffers of ``module`` to ``device`` without
+    copying storage.
+
+    :param module:
+        The module to move.
+    :param device:
+        The target device of the parameters and buffers.
+    :param recurse:
+        If ``True``, moves the parameters and buffers of all descendant modules.
+    :param memo:
+        The memoization dictionary to use to detect shared parameters and
+        buffers. If ``None``, constructs an internal one.
+    """
+    if memo is None:
+        memo = {}
+
+    def empty_like(src: Tensor) -> Tensor:
+        if src in memo:
+            return memo[src]
+
+        tgt = torch.empty_like(src, device=device)
+
+        memo[src] = tgt
+
+        return tgt
+
+    def to_empty_(m: Module) -> None:
+        for name, prm in m.named_parameters(recurse=False):
+            if prm is None:
+                continue
+
+            with torch.no_grad():
+                new_prm = Parameter(empty_like(prm), prm.requires_grad)
+
+            setattr(m, name, new_prm)
+
+            if (grad := prm.grad) is not None:
+                with torch.no_grad():
+                    new_grad = empty_like(grad).requires_grad_(grad.requires_grad)
+
+                new_prm.grad = new_grad
+
+        for name, buf in m.named_buffers(recurse=False):
+            if buf is None:
+                continue
+
+            setattr(m, name, empty_like(buf))
+
+    if recurse:
+        apply_depth_first(module, to_empty_)
+    else:
+        to_empty_(module)
 
 
 def apply_depth_first(
@@ -79,6 +152,43 @@ def apply_depth_first(
     fn(module)
 
 
+class FSDPParameterInitializer:
+    """Initializes the parameters and buffers of an FSDP module.
+
+    This is a convenience callable to pass to the ``param_init_fn`` parameter of
+    the FSDP constructor. It moves the parameters and buffers residing on a meta
+    device to ``device`` and initializes them.
+
+    Usage:
+
+    >>> model = MyModel(..., device=Device("meta"))
+    >>>
+    >>> fsdp_model = FullyShardedDataParallel(
+    ...     ..., param_init_fn=FSDPParameterInitializer(Device("cuda:0"))
+    ... )
+    """
+
+    memo: Dict[Tensor, Tensor]
+    device: Device
+
+    def __init__(self, device: Device) -> None:
+        """
+        :param device:
+            The device on which to initialize the parameters and buffers.
+        """
+        self.memo = {}
+        self.device = device
+
+    def __call__(self, module: Module) -> None:
+        """
+        :param module:
+            An FSDP module or submodule.
+        """
+        to_empty(module, self.device, recurse=False, memo=self.memo)
+
+        reset_parameters(module, recurse=False)
+
+
 def freeze(module: Module, value: bool) -> None:
     """Change if ``module`` and its submodules should freeze (i.e. stop learning)."""
     for param in module.parameters():
@@ -90,6 +200,6 @@ def infer_device(module: Module) -> Device:
     try:
         param = next(iter(module.parameters()))
     except StopIteration:
-        return Device("cpu")
+        return CPU
 
     return param.device

--- a/src/fairseq2/typing.py
+++ b/src/fairseq2/typing.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Final
+
 from overrides import final
 from overrides import override as override  # noqa: F401
 from torch import device, dtype
@@ -14,3 +16,5 @@ finaloverride = final
 Device: TypeAlias = device
 
 DataType: TypeAlias = dtype
+
+CPU: Final = Device("cpu")


### PR DESCRIPTION
This PR introduces:

- A new `to_empty()` function that is an advanced version of `Module.to_empty()` that can detect shared parameters/buffers and avoid duplicate initialization. It also has a `recurse` parameter that can be used with older PyTorch versions.
- A new `FSDPParameterInitializer` callable that can be passed to `param_init_fn` of FSDP constructor to skip full model initialization which can significantly reduce memory load and speed up model initialization (in particular for extra large language models)