### PR TITLE
Remove PyTorch 1.13.1 support

### DIFF
--- a/.github/workflows/_build_wheels.yaml
+++ b/.github/workflows/_build_wheels.yaml
@@ -15,23 +15,6 @@ on:
         required: true
 
 jobs:
-  build_pt131_wheel-linux:
-    name: Build wheels (pt${{ matrix.torch }}, py${{ matrix.py }}, linux-x86_64, ${{ matrix.variant }}, ${{ matrix.sanitizers }})
-    uses: ./.github/workflows/_build_wheel-linux.yaml
-    strategy:
-      fail-fast: false
-      matrix:
-        torch: ['1.13.1']
-        py: ['3.8', '3.9', '3.10']
-        variant: ['cpu', 'cu116']
-        sanitizers: ['nosan']
-    with:
-      torch: ${{ matrix.torch }}
-      py: ${{ matrix.py }}
-      variant: ${{ matrix.variant }}
-      sanitizers: ${{ matrix.sanitizers }}
-      version_override: ${{ inputs.version_override }}
-
   build_pt20_wheel-linux:
     name: Build wheels (pt${{ matrix.torch }}, py${{ matrix.py }}, linux-x86_64, ${{ matrix.variant }}, ${{ matrix.sanitizers }})
     uses: ./.github/workflows/_build_wheel-linux.yaml
@@ -55,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        torch: ['2.1.0', '2.1.2']
+        torch: ['2.1.2']
         py: ['3.8', '3.9', '3.10', '3.11']
         variant: ['cpu', 'cu118', 'cu121']
         sanitizers: ['nosan']

--- a/.github/workflows/_publish.yaml
+++ b/.github/workflows/_publish.yaml
@@ -12,22 +12,6 @@ on:
         required: true
 
 jobs:
-  publish_pt113_s3-linux:
-    name: Publish to S3 (pt${{ matrix.torch }}, py${{ matrix.py }}, linux-x86_64, ${{ matrix.variant }})
-    strategy:
-      matrix:
-        torch: ['1.13.1']
-        py: ['3.8', '3.9', '3.10']
-        variant: ['cpu', 'cu116']
-      max-parallel: 1
-    uses: ./.github/workflows/_publish_s3.yaml
-    with:
-      os: 'linux'
-      torch: ${{ matrix.torch }}
-      py: ${{ matrix.py }}
-      variant: ${{ matrix.variant }}
-      release_type: ${{ inputs.release_type }}
-
   publish_pt20_s3-linux:
     name: Publish to S3 (pt${{ matrix.torch }}, py${{ matrix.py }}, linux-x86_64, ${{ matrix.variant }})
     strategy:
@@ -48,7 +32,7 @@ jobs:
     name: Publish to S3 (pt${{ matrix.torch }}, py${{ matrix.py }}, linux-x86_64, ${{ matrix.variant }})
     strategy:
       matrix:
-        torch: ['2.1.0', '2.1.2']
+        torch: ['2.1.2']
         py: ['3.8', '3.9', '3.10', '3.11']
         variant: ['cpu', 'cu118', 'cu121']
       max-parallel: 1
@@ -63,7 +47,6 @@ jobs:
   publish_pypi-linux:
     name: Publish to PyPI (pt${{ matrix.torch }}, py${{ matrix.py }}, linux-x86_64, ${{ matrix.variant }})
     needs:
-      - publish_pt113_s3-linux
       - publish_pt20_s3-linux
       - publish_pt21_s3-linux
     if: inputs.release_type == 'stable'

--- a/.github/workflows/ci_build_wheels.yaml
+++ b/.github/workflows/ci_build_wheels.yaml
@@ -42,7 +42,7 @@ jobs:
             run_integration_tests: false
 
           # Lowest Supported Version
-          - torch: '1.13.1'
+          - torch: '2.0.1'
             py: '3.8'
             variant: 'cpu'
             sanitizers: 'nosan'
@@ -65,7 +65,7 @@ jobs:
             py: '3.11'
 
           # Lowest Supported Version
-          - torch: '1.13.1'
+          - torch: '2.0.1'
             py: '3.8'
     with:
       torch: ${{ matrix.torch }}

--- a/README.md
+++ b/README.md
@@ -96,11 +96,49 @@ Besides PyPI, fairseq2 also has pre-built packages available for different
 PyTorch and CUDA versions hosted on FAIR's package repository. The following
 matrix shows the supported combinations.
 
-| PyTorch          | Python            | Variant*               | Arch     |
-| ---------------- | ----------------- | ---------------------- | -------- |
-| `2.1.0`, `2.1.2` | `>=3.8`, `<=3.11` | `cpu`, `cu118` `cu121` | `x86_64` |
-| `2.0.0`, `2.0.1` | `>=3.8`, `<=3.11` | `cpu`, `cu117` `cu118` | `x86_64` |
-| `1.13.1`         | `>=3.8`, `<=3.10` | `cpu`, `cu116`         | `x86_64` |
+<table>
+  <thead>
+    <th>fairseq2</th>
+    <th>PyTorch</th>
+    <th>Python</th>
+    <th>Variant*</th>
+    <th>Arch</th>
+  </thead>
+  <tbody>
+    <tr>
+      <td rowspan=2><code>HEAD</code></td>
+      <td><code>2.1.2</code></td>
+      <td><code>&gt;=3.8</code>, <code>&lt;=3.11</code></td>
+      <td><code>cpu</code>, <code>cu118</code>, <code>cu121</code></td>
+      <td><code>x86_64</code></td>
+    </tr>
+    <tr>
+      <td><code>2.0.1</code></td>
+      <td><code>&gt;=3.8</code>, <code>&lt;=3.11</code></td>
+      <td><code>cpu</code>, <code>cu117</code>, <code>cu118</code></td>
+      <td><code>x86_64</code></td>
+    </tr>
+    <tr>
+      <td rowspan=3><code>0.2.0</code></td>
+      <td><code>2.1.1</code></td>
+      <td><code>&gt;=3.8</code>, <code>&lt;=3.11</code></td>
+      <td><code>cpu</code>, <code>cu118</code>, <code>cu121</code></td>
+      <td><code>x86_64</code></td>
+    </tr>
+    <tr>
+      <td><code>2.0.1</code></td>
+      <td><code>&gt;=3.8</code>, <code>&lt;=3.11</code></td>
+      <td><code>cpu</code>, <code>cu117</code>, <code>cu118</code></td>
+      <td><code>x86_64</code></td>
+    </tr>
+    <tr>
+      <td><code>1.13.1</code></td>
+      <td><code>&gt;=3.8</code>, <code>&lt;=3.10</code></td>
+      <td><code>cpu</code>, <code>cu116</code></td>
+      <td><code>x86_64</code></td>
+    </tr>
+  </tbody>
+</table>
 
 *\* cuXYZ refers to CUDA XY.Z (e.g. cu118 means CUDA 11.8)*
 


### PR DESCRIPTION
This PR removes PyTorch 1.13.1 support from HEAD. v0.2.x releases will continue to have support for 1.13.1.