### PR TITLE
Use mmap with torch.load

### DIFF
--- a/src/fairseq2/models/utils/checkpoint.py
+++ b/src/fairseq2/models/utils/checkpoint.py
@@ -14,6 +14,7 @@ from typing_extensions import TypeAlias
 
 from fairseq2.data.typing import PathLike
 from fairseq2.typing import Device
+from fairseq2.utils.version import _is_pt21_or_greater
 
 MapLocation: TypeAlias = Optional[
     Union[Callable[[Tensor, str], Tensor], Device, str, Dict[str, str]]
@@ -60,8 +61,13 @@ def load_checkpoint(
         # Suppress the noisy deprecated `TypedStorage` warning.
         warnings.simplefilter("ignore")
 
+        kwargs = {}
+
+        if _is_pt21_or_greater():
+            kwargs["mmap"] = True
+
         checkpoint: Mapping[str, Any] = torch.load(
-            str(pathname), map_location, weights_only=restrict
+            str(pathname), map_location, weights_only=restrict, **kwargs
         )
 
     if converter is not None:

--- a/src/fairseq2/nn/transformer/attention.py
+++ b/src/fairseq2/nn/transformer/attention.py
@@ -18,7 +18,6 @@ from torch.nn.functional import dropout, softmax
 from fairseq2.nn.padding import PaddingMask
 from fairseq2.nn.transformer.attention_mask import AttentionMask, CausalAttentionMask
 from fairseq2.typing import finaloverride
-from fairseq2.utils.version import is_pt2_or_greater
 
 logger = logging.getLogger(__name__)
 
@@ -86,9 +85,6 @@ class TorchSDPA(SDPA):
             The dropout probability on attention weights.
         """
         super().__init__()
-
-        if not is_pt2_or_greater():
-            raise ValueError("`TorchSDPA` requires PyTorch 2.0.0 or greater.")
 
         self._has_warned = False
 
@@ -275,10 +271,7 @@ class SDPAFactory(Protocol):
 
 
 def _get_fallback_sdpa_factory() -> SDPAFactory:
-    if is_pt2_or_greater():
-        return TorchSDPA
-    else:
-        return NaiveSDPA
+    return TorchSDPA
 
 
 _sdpa_factory: SDPAFactory = _get_fallback_sdpa_factory()

--- a/src/fairseq2/optim/adamw.py
+++ b/src/fairseq2/optim/adamw.py
@@ -13,7 +13,6 @@ from torch.optim.adamw import adamw  # type: ignore[attr-defined]
 
 from fairseq2.optim.optimizer_base import OptimizerBase
 from fairseq2.typing import finaloverride
-from fairseq2.utils.version import is_pt2_or_greater
 
 
 @final
@@ -82,15 +81,7 @@ class AdamW(OptimizerBase):
 
         super().__init__(params, defaults)
 
-        if differentiable and not is_pt2_or_greater():
-            raise RuntimeError("`differentiable` requires PyTorch 2.0 or greater.")
-
         if impl == "fused":
-            if not is_pt2_or_greater():
-                raise RuntimeError(
-                    "`fused` implementation requires PyTorch 2.0 or greater."
-                )
-
             if differentiable:
                 raise RuntimeError(
                     "`fused` implementation does not support `differentiable`."

--- a/src/fairseq2/utils/version.py
+++ b/src/fairseq2/utils/version.py
@@ -18,9 +18,8 @@ def _get_torch_version() -> Version:
         return Version("0.0.0")
 
 
-TORCH_VERSION: Final[Version] = _get_torch_version()
+TORCH_VERSION: Final = _get_torch_version()
 
 
-def is_pt2_or_greater() -> bool:
-    """Return ``True`` if the version of PyTorch is 2.0 or greater."""
-    return TORCH_VERSION.major >= 2
+def _is_pt21_or_greater() -> bool:
+    return TORCH_VERSION.major >= 2 and TORCH_VERSION.major >= 1

--- a/tests/unit/nn/transformer/test_attention.py
+++ b/tests/unit/nn/transformer/test_attention.py
@@ -12,14 +12,10 @@ from torch import Tensor
 
 from fairseq2.nn.padding import PaddingMask
 from fairseq2.nn.transformer import CustomAttentionMask, NaiveSDPA, TorchSDPA
-from fairseq2.utils.version import is_pt2_or_greater
 from tests.common import assert_close, device
 
 
 class TestScaledDotProductAttention:
-    @pytest.mark.skipif(
-        not is_pt2_or_greater(), reason="requires PyTorch 2.0.0 or greater"
-    )
     # fmt: off
     @pytest.mark.parametrize("use_key_padding_mask,use_attn_mask,training",
         [


### PR DESCRIPTION
This PR uses `mmap=True` in `torch.load()` for Pytorch 2.1 or later.