### PR TITLE
Improve the API of StatefulObjectBag

### DIFF
--- a/src/fairseq2/models/seq2seq.py
+++ b/src/fairseq2/models/seq2seq.py
@@ -199,9 +199,8 @@ class Seq2SeqModelMetricBag(MetricBag):
 
         self.elements_per_second.update(int(num_target_elements), elapsed_time)
 
-        if self.training:
-            self.num_source_elements.update(num_source_elements)
-            self.num_target_elements.update(num_target_elements)
+        self.num_source_elements.update(num_source_elements)
+        self.num_target_elements.update(num_target_elements)
 
     def reset_performance_metrics(self) -> None:
         """Reset the performance related metrics to their initial state."""

--- a/tests/unit/utils/test_state.py
+++ b/tests/unit/utils/test_state.py
@@ -36,6 +36,8 @@ class TestStatefulObjectBag:
 
         bag.foo3 = Foo()
 
+        bag.register_non_stateful("foo4", Foo())
+
         state_dict = bag.state_dict()
 
         assert state_dict == {


### PR DESCRIPTION
This PR introduces a new `register_non_stateful` method in `StatefulObjectBag` and also drops the idea of "training mode" in `MetricBag`.