### PR TITLE
Revise the implementation of as_uri

### DIFF
--- a/src/fairseq2/assets/store.py
+++ b/src/fairseq2/assets/store.py
@@ -6,7 +6,6 @@
 
 from __future__ import annotations
 
-import logging
 import os
 from abc import ABC, abstractmethod
 from pathlib import Path
@@ -18,6 +17,7 @@ from fairseq2.assets.metadata_provider import (
     AssetNotFoundError,
     FileAssetMetadataProvider,
 )
+from fairseq2.assets.utils import _get_path_from_env
 from fairseq2.typing import finaloverride
 
 
@@ -151,30 +151,6 @@ def _create_asset_store() -> ProviderBackedAssetStore:
 
 
 asset_store = _create_asset_store()
-
-
-def _get_path_from_env(var_name: str) -> Optional[Path]:
-    pathname = os.getenv(var_name)
-    if not pathname:
-        return None
-
-    try:
-        path = Path(pathname)
-    except ValueError as ex:
-        raise RuntimeError(
-            f"The value of the `{var_name}` environment variable must be a valid pathname, but is '{pathname}' instead."
-        ) from ex
-
-    if not path.exists():
-        logger = logging.getLogger("fairseq2.assets")
-
-        logger.warning(
-            f"The path '{path}' pointed to by the `{var_name}` environment variable does not exist."
-        )
-
-        return None
-
-    return path
 
 
 def _load_asset_directory() -> None:

--- a/src/fairseq2/assets/utils.py
+++ b/src/fairseq2/assets/utils.py
@@ -1,0 +1,41 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+import os
+import re
+from pathlib import Path
+from typing import Final, Optional
+
+_SCHEME_REGEX: Final = re.compile("^[a-zA-Z0-9]+://")
+
+
+def _starts_with_scheme(s: str) -> bool:
+    return re.match(_SCHEME_REGEX, s) is not None
+
+
+def _get_path_from_env(var_name: str) -> Optional[Path]:
+    pathname = os.getenv(var_name)
+    if not pathname:
+        return None
+
+    try:
+        path = Path(pathname)
+    except ValueError as ex:
+        raise RuntimeError(
+            f"The value of the `{var_name}` environment variable must be a pathname, but is '{pathname}' instead."
+        ) from ex
+
+    if not path.exists():
+        logger = logging.getLogger("fairseq2.assets")
+
+        logger.warning(
+            f"The path '{path}' pointed to by the `{var_name}` environment variable does not exist."
+        )
+
+        return None
+
+    return path

--- a/tests/unit/assets/test_card.py
+++ b/tests/unit/assets/test_card.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import os
+from os import PathLike
 from pathlib import Path
 
 import pytest
@@ -177,9 +177,11 @@ class TestAssetCard:
             self.card.field("field1").as_one_of({"foo3", "foo2"})
 
     def test_as_uri_works(self) -> None:
+        self.card.field("field1").set("/foo1/foo2/")
+
         value = self.card.field("field1").as_uri()
 
-        assert value == "file:///foo1"
+        assert value == "file:///foo1/foo2"
 
         value = self.card.field("field9").as_uri()
 
@@ -194,9 +196,16 @@ class TestAssetCard:
     def test_as_uri_raises_error_when_field_type_is_incorrect(self) -> None:
         with pytest.raises(
             AssetCardError,
-            match=rf"The value of the field 'field3' of the asset card 'test-card' must be of type `{str}` or `{os.PathLike}`, but is of type `{int}` instead\.$",
+            match=rf"The value of the field 'field3' of the asset card 'test-card' must be of type `{str}` or `{PathLike}`, but is of type `{int}` instead\.$",
         ):
             self.card.field("field3").as_uri()
+
+    def test_as_uri_raises_error_when_field_is_not_uri_or_absolute_path(self) -> None:
+        with pytest.raises(
+            AssetCardError,
+            match=r"The value of the field 'field1' of the asset card 'test-card' must be a URI or an absolute pathname, but is 'foo1' instead\.$",
+        ):
+            self.card.field("field1").as_uri()
 
     def test_as_filename_works(self) -> None:
         value = self.card.field("field1").as_filename()


### PR DESCRIPTION
This PR revises the implementation of `AssetCard.as_uri()` to use `Path.as_uri()`.