### PR TITLE
Improve ProcessGroupGang initialization

### DIFF
--- a/src/fairseq2/utils/version.py
+++ b/src/fairseq2/utils/version.py
@@ -22,4 +22,4 @@ TORCH_VERSION: Final = _get_torch_version()
 
 
 def _is_pt21_or_greater() -> bool:
-    return TORCH_VERSION.major >= 2 and TORCH_VERSION.major >= 1
+    return TORCH_VERSION.major >= 2 and TORCH_VERSION.minor >= 1


### PR DESCRIPTION
This PR refactors and improves the initialization of `ProcessGroupGang`.

- It splits `from_default_process_group()` into two separate functions `init_default_process_group()` and `from_default_process_group()`
- Partially addresses #103 by explicitly setting the PyTorch thread pool size if not explicitly specified via `OMP_NUM_THREADS`. The remaining work needs to be done in the data pipeline API.
- Allows `CUDA_VISIBLE_DEVICES` to hold more than one device for more flexible distributed setups.
- Fixes the bug in `_is_pt21_or_greater` (not really related to the rest of the PR)