### PR TITLE
Revise log_file handling in setup_logging

### DIFF
--- a/src/fairseq2/gang.py
+++ b/src/fairseq2/gang.py
@@ -384,8 +384,6 @@ def _get_int_from_env(var_name: str) -> Optional[int]:
         )
 
 
-def is_coordinator_process() -> int:
-    """Return ``True`` if this process is the coordinator of the running job."""
-    rank = _get_int_from_env("RANK")
-
-    return rank is None or rank == 0
+def get_global_rank() -> int:
+    """Return the global rank of this process in the running job."""
+    return _get_int_from_env("RANK") or 0


### PR DESCRIPTION
This PR revises (again) the `log_file` handling in `setup_logging()`. After @shagunsodhani's feedback and giving it more thought, I decided to roll back the last commit that used the log file only for rank 0. In this revision, `log_file` is expected to include a "rank" replacement field (e.g. /path/to/train_{rank}.log) which will then create an individual log file per rank (like before). Note that for most real-world use cases where a launcher is used (e.g. torchrun, submitit), `log_file` is not really needed since that functionality is already provided by the launchers. It is mostly meant to be used for jobs that are manually launched (e.g. for local debugs).