### PR TITLE
Use incremental capacity in attention decoding states

### DIFF
--- a/src/fairseq2/generation/beam_search.py
+++ b/src/fairseq2/generation/beam_search.py
@@ -46,6 +46,7 @@ class BeamSearchSequenceGenerator(SequenceGenerator):
     temperature: float
     unk_penalty: float
     len_penalty: float
+    capacity_increment: int
     step_processors: List[StepProcessor]
 
     def __init__(
@@ -62,6 +63,7 @@ class BeamSearchSequenceGenerator(SequenceGenerator):
         temperature: float = 1.0,
         unk_penalty: float = 0.0,
         len_penalty: float = 1.0,
+        capacity_increment: int = 16,
         step_processors: Optional[Sequence[StepProcessor]] = None,
     ) -> None:
         """
@@ -90,6 +92,9 @@ class BeamSearchSequenceGenerator(SequenceGenerator):
         :param len_penalty:
             The length penalty, where values less than 1.0 favor shorter
             sequences; values greater than 1.0 favor longer sequences.
+        :param capacity_increment:
+            The sequence length capacity of state tensors will be incremented by
+            multiples of this value.
         :param step_processors:
             The processors to call at each generation step.
         """
@@ -120,6 +125,7 @@ class BeamSearchSequenceGenerator(SequenceGenerator):
         self.temperature = temperature
         self.unk_penalty = unk_penalty
         self.len_penalty = len_penalty
+        self.capacity_increment = capacity_increment
 
         if step_processors:
             self.step_processors = list(step_processors)
@@ -145,6 +151,7 @@ class BeamSearchSequenceGenerator(SequenceGenerator):
             self.temperature,
             self.unk_penalty,
             self.len_penalty,
+            self.capacity_increment,
             self.step_processors,
             self._step_hooks,
         )
@@ -168,6 +175,7 @@ class BeamSearchSeq2SeqGenerator(Seq2SeqGenerator):
     temperature: float
     unk_penalty: float
     len_penalty: float
+    capacity_increment: int
     step_processors: List[StepProcessor]
 
     def __init__(
@@ -184,6 +192,7 @@ class BeamSearchSeq2SeqGenerator(Seq2SeqGenerator):
         temperature: float = 1.0,
         unk_penalty: float = 0.0,
         len_penalty: float = 1.0,
+        capacity_increment: int = 16,
         step_processors: Optional[Sequence[StepProcessor]] = None,
     ) -> None:
         """
@@ -213,6 +222,9 @@ class BeamSearchSeq2SeqGenerator(Seq2SeqGenerator):
         :param len_penalty:
             The length penalty, where values less than 1.0 favor shorter
             sequences; values greater than 1.0 favor longer sequences.
+        :param capacity_increment:
+            The sequence length capacity of state tensors will be incremented by
+            multiples of this value.
         :param step_processors:
             The processors to call at each generation step.
         """
@@ -233,6 +245,7 @@ class BeamSearchSeq2SeqGenerator(Seq2SeqGenerator):
         self.temperature = temperature
         self.unk_penalty = unk_penalty
         self.len_penalty = len_penalty
+        self.capacity_increment = capacity_increment
 
         if step_processors:
             self.step_processors = list(step_processors)
@@ -290,6 +303,7 @@ class BeamSearchSeq2SeqGenerator(Seq2SeqGenerator):
             self.temperature,
             self.unk_penalty,
             self.len_penalty,
+            self.capacity_increment,
             self.step_processors,
             self._step_hooks,
         )
@@ -432,6 +446,7 @@ class _BeamSearchSequenceGeneratorOpBase(ABC):
         temperature: float,
         unk_penalty: float,
         len_penalty: float,
+        capacity_increment: int,
         step_processors: Sequence[StepProcessor],
         step_hooks: Dict[int, StepHook],
     ) -> None:
@@ -484,7 +499,9 @@ class _BeamSearchSequenceGeneratorOpBase(ABC):
 
         self.step_nr = 0
 
-        self.state_bag = IncrementalStateBag(self.max_seq_len)
+        self.state_bag = IncrementalStateBag(
+            self.max_seq_len, capacity_increment=capacity_increment
+        )
 
         if prompt_padding_mask is None:
             self.prompt_lens = None
@@ -841,6 +858,7 @@ class _BeamSearchSequenceGeneratorOp(_BeamSearchSequenceGeneratorOpBase):
         temperature: float,
         unk_penalty: float,
         len_penalty: float,
+        capacity_increment: int,
         step_processors: Sequence[StepProcessor],
         step_hooks: Dict[int, StepHook],
     ) -> None:
@@ -858,6 +876,7 @@ class _BeamSearchSequenceGeneratorOp(_BeamSearchSequenceGeneratorOpBase):
             temperature,
             unk_penalty,
             len_penalty,
+            capacity_increment,
             step_processors,
             step_hooks,
         )
@@ -897,6 +916,7 @@ class _BeamSearchSeq2SeqGeneratorOp(_BeamSearchSequenceGeneratorOpBase):
         temperature: float,
         unk_penalty: float,
         len_penalty: float,
+        capacity_increment: int,
         step_processors: Sequence[StepProcessor],
         step_hooks: Dict[int, StepHook],
     ) -> None:
@@ -914,6 +934,7 @@ class _BeamSearchSeq2SeqGeneratorOp(_BeamSearchSequenceGeneratorOpBase):
             temperature,
             unk_penalty,
             len_penalty,
+            capacity_increment,
             step_processors,
             step_hooks,
         )

--- a/src/fairseq2/generation/sampling.py
+++ b/src/fairseq2/generation/sampling.py
@@ -47,6 +47,7 @@ class SamplingSequenceGenerator(SequenceGenerator):
     temperature: float
     unk_penalty: float
     len_penalty: float
+    capacity_increment: int
     step_processors: List[StepProcessor]
 
     def __init__(
@@ -64,6 +65,7 @@ class SamplingSequenceGenerator(SequenceGenerator):
         temperature: float = 0.6,
         unk_penalty: float = 0.0,
         len_penalty: float = 1.0,
+        capacity_increment: int = 16,
         step_processors: Optional[Sequence[StepProcessor]] = None,
     ) -> None:
         """
@@ -94,6 +96,9 @@ class SamplingSequenceGenerator(SequenceGenerator):
         :param len_penalty:
             The length penalty, where values less than 1.0 favor shorter
             sequences; values greater than 1.0 favor longer sequences.
+        :param capacity_increment:
+            The sequence length capacity of state tensors will be incremented by
+            multiples of this value.
         :param step_processors:
             The processors to call at each generation step.
         """
@@ -125,6 +130,7 @@ class SamplingSequenceGenerator(SequenceGenerator):
         self.temperature = temperature
         self.unk_penalty = unk_penalty
         self.len_penalty = len_penalty
+        self.capacity_increment = capacity_increment
 
         if step_processors:
             self.step_processors = list(step_processors)
@@ -151,6 +157,7 @@ class SamplingSequenceGenerator(SequenceGenerator):
             self.temperature,
             self.unk_penalty,
             self.len_penalty,
+            self.capacity_increment,
             self.step_processors,
             self._step_hooks,
         )
@@ -175,6 +182,7 @@ class SamplingSeq2SeqGenerator(Seq2SeqGenerator):
     temperature: float
     unk_penalty: float
     len_penalty: float
+    capacity_increment: int
     step_processors: List[StepProcessor]
 
     def __init__(
@@ -192,6 +200,7 @@ class SamplingSeq2SeqGenerator(Seq2SeqGenerator):
         temperature: float = 0.6,
         unk_penalty: float = 0.0,
         len_penalty: float = 1.0,
+        capacity_increment: int = 16,
         step_processors: Optional[Sequence[StepProcessor]] = None,
     ) -> None:
         """
@@ -223,6 +232,9 @@ class SamplingSeq2SeqGenerator(Seq2SeqGenerator):
         :param len_penalty:
             The length penalty, where values less than 1.0 favor shorter
             sequences; values greater than 1.0 favor longer sequences.
+        :param capacity_increment:
+            The sequence length capacity of state tensors will be incremented by
+            multiples of this value.
         :param step_processors:
             The processors to call at each generation step.
         """
@@ -244,6 +256,7 @@ class SamplingSeq2SeqGenerator(Seq2SeqGenerator):
         self.temperature = temperature
         self.unk_penalty = unk_penalty
         self.len_penalty = len_penalty
+        self.capacity_increment = capacity_increment
 
         if step_processors:
             self.step_processors = list(step_processors)
@@ -302,6 +315,7 @@ class SamplingSeq2SeqGenerator(Seq2SeqGenerator):
             self.temperature,
             self.unk_penalty,
             self.len_penalty,
+            self.capacity_increment,
             self.step_processors,
             self._step_hooks,
         )
@@ -448,6 +462,7 @@ class _SamplingSequenceGeneratorOpBase(ABC):
         temperature: float,
         unk_penalty: float,
         len_penalty: float,
+        capacity_increment: int,
         step_processors: Sequence[StepProcessor],
         step_hooks: Dict[int, StepHook],
     ) -> None:
@@ -501,7 +516,9 @@ class _SamplingSequenceGeneratorOpBase(ABC):
 
         self.step_nr = 0
 
-        self.state_bag = IncrementalStateBag(self.max_seq_len)
+        self.state_bag = IncrementalStateBag(
+            self.max_seq_len, capacity_increment=capacity_increment
+        )
 
         if prompt_padding_mask is None:
             self.prompt_lens = None
@@ -818,6 +835,7 @@ class _SamplingSequenceGeneratorOp(_SamplingSequenceGeneratorOpBase):
         temperature: float,
         unk_penalty: float,
         len_penalty: float,
+        capacity_increment: int,
         step_processors: Sequence[StepProcessor],
         step_hooks: Dict[int, StepHook],
     ) -> None:
@@ -836,6 +854,7 @@ class _SamplingSequenceGeneratorOp(_SamplingSequenceGeneratorOpBase):
             temperature,
             unk_penalty,
             len_penalty,
+            capacity_increment,
             step_processors,
             step_hooks,
         )
@@ -876,6 +895,7 @@ class _SamplingSeq2SeqGeneratorOp(_SamplingSequenceGeneratorOpBase):
         temperature: float,
         unk_penalty: float,
         len_penalty: float,
+        capacity_increment: int,
         step_processors: Sequence[StepProcessor],
         step_hooks: Dict[int, StepHook],
     ) -> None:
@@ -894,6 +914,7 @@ class _SamplingSeq2SeqGeneratorOp(_SamplingSequenceGeneratorOpBase):
             temperature,
             unk_penalty,
             len_penalty,
+            capacity_increment,
             step_processors,
             step_hooks,
         )

--- a/src/fairseq2/metrics.py
+++ b/src/fairseq2/metrics.py
@@ -34,7 +34,7 @@ class MetricBag:
             return self.metrics[name]
 
         raise AttributeError(
-            f"'{type(self).__name__}' object has no attribute '{name}'."
+            f"`{type(self).__name__}` object has no attribute '{name}'."
         )
 
     def __setattr__(self, name: str, value: Any) -> None:
@@ -72,7 +72,7 @@ class MetricBag:
         """
         if hasattr(self, name):
             raise AttributeError(
-                f"'{type(self).__name__}' object already has an attribute '{name}'."
+                f"`{type(self).__name__}` object already has an attribute '{name}'."
             )
 
         metric.to(self.gang.device)

--- a/src/fairseq2/models/llama/builder.py
+++ b/src/fairseq2/models/llama/builder.py
@@ -63,7 +63,7 @@ class LLaMAConfig:
 
     ffn_inner_dim_to_multiple: int
     """The dimensionality of inner projection layers in Transformer feed-forward
-    networks is rounded up to the nearest multiple of the specified value."""
+    networks is rounded up to the nearest multiple of this value."""
 
     dropout_p: float
     """The dropout probability in Transformer layers."""

--- a/src/fairseq2/nn/incremental_state.py
+++ b/src/fairseq2/nn/incremental_state.py
@@ -43,16 +43,21 @@ class IncrementalStateBag:
 
     step_nr: int
     max_num_steps: int
+    capacity_increment: int
 
     _module_states: Dict[Module, IncrementalState]
 
-    def __init__(self, max_num_steps: int) -> None:
+    def __init__(self, max_num_steps: int, *, capacity_increment: int = 16) -> None:
         """
         :param max_num_steps:
             The expected maximum number of steps to take.
+        :param capacity_increment:
+            The sequence length capacity of state tensors will be incremented by
+            multiples of this value.
         """
         self.step_nr = 0
         self.max_num_steps = max_num_steps
+        self.capacity_increment = capacity_increment
 
         self._module_states = {}
 
@@ -69,7 +74,7 @@ class IncrementalStateBag:
 
         if step_nr >= self.max_num_steps:
             raise ValueError(
-                f"The current step number ({self.step_nr}) with `value` increment must be less than or equal to the maximum number of steps ({self.max_num_steps}), but is {self.step_nr + value} instead."
+                f"The current step number ({self.step_nr}) with `value` increment ({value}) must be less than or equal to the maximum number of steps ({self.max_num_steps}), but is {self.step_nr + value} instead."
             )
 
         self.step_nr = step_nr

--- a/src/fairseq2/nn/transformer/ffn.py
+++ b/src/fairseq2/nn/transformer/ffn.py
@@ -179,7 +179,7 @@ class GLUFeedForwardNetwork(FeedForwardNetwork):
             layer.
         :param inner_dim_to_multiple:
             The dimensionality of the inner projection layer is rounded up to
-            the nearest multiple of the specified value.
+            the nearest multiple of this value.
         :param inner_dropout_p:
             The dropout probability on outputs of the inner projection layer.
         """

--- a/src/fairseq2/utils/state.py
+++ b/src/fairseq2/utils/state.py
@@ -49,7 +49,7 @@ class StatefulObjectBag:
             return self.stateful_objects[name][0]
 
         raise AttributeError(
-            f"'{type(self).__name__}' object has no attribute '{name}'."
+            f"`{type(self).__name__}` object has no attribute '{name}'."
         )
 
     def __setattr__(self, name: str, value: Any) -> None:
@@ -84,7 +84,7 @@ class StatefulObjectBag:
         """
         if hasattr(self, name):
             raise AttributeError(
-                f"'{type(self).__name__}' object already has an attribute '{name}'."
+                f"`{type(self).__name__}` object already has an attribute '{name}'."
             )
 
         self.stateful_objects[name] = (obj, state_handler)
@@ -99,7 +99,7 @@ class StatefulObjectBag:
         """
         if hasattr(self, name):
             raise AttributeError(
-                f"'{type(self).__name__}' object already has an attribute '{name}'."
+                f"`{type(self).__name__}` object already has an attribute '{name}'."
             )
 
         super().__setattr__(name, obj)

--- a/src/fairseq2/utils/version.py
+++ b/src/fairseq2/utils/version.py
@@ -22,4 +22,10 @@ TORCH_VERSION: Final = _get_torch_version()
 
 
 def _is_pt21_or_greater() -> bool:
-    return TORCH_VERSION.major >= 2 and TORCH_VERSION.minor >= 1
+    if TORCH_VERSION.major <= 1:
+        return False
+
+    if TORCH_VERSION.major == 2 and TORCH_VERSION.minor == 0:
+        return False
+
+    return True

--- a/tests/unit/nn/test_position_encoder.py
+++ b/tests/unit/nn/test_position_encoder.py
@@ -130,6 +130,7 @@ class TestSinusoidalPositionEncoder:
         m = SinusoidalPositionEncoder(encoding_dim=32, max_seq_len=4, device=device)
 
         state_bag = IncrementalStateBag(max_num_steps=3)
+
         state_bag.increment_step_nr(step_nr)
 
         seq_len = 2
@@ -161,6 +162,7 @@ class TestSinusoidalPositionEncoder:
         x = torch.randn((5, 2, 32), device=device)
 
         state_bag = IncrementalStateBag(max_num_steps=30)
+
         state_bag.increment_step_nr(20)  # out of range
 
         y = m(x, padding_mask=None, state_bag=state_bag)
@@ -205,6 +207,7 @@ class TestLearnedPositionEncoder:
         m = LearnedPositionEncoder(encoding_dim=32, max_seq_len=4, device=device)
 
         state_bag = IncrementalStateBag(max_num_steps=3)
+
         state_bag.increment_step_nr(step_nr)
 
         seq_len = 2
@@ -236,6 +239,7 @@ class TestLearnedPositionEncoder:
         x = torch.randn((5, 2, 32), device=device)
 
         state_bag = IncrementalStateBag(max_num_steps=30)
+
         state_bag.increment_step_nr(value=20)  # out of range
 
         y = m(x, padding_mask=None, state_bag=state_bag)
@@ -288,6 +292,7 @@ class TestRotaryEncoder:
         m = RotaryEncoder(encoding_dim=32, max_seq_len=4, device=device)
 
         state_bag = IncrementalStateBag(max_num_steps=3)
+
         state_bag.increment_step_nr(step_nr)
 
         seq_len = 2
@@ -323,6 +328,7 @@ class TestRotaryEncoder:
         x = torch.randn((5, 2, 32), device=device)
 
         state_bag = IncrementalStateBag(max_num_steps=30)
+
         state_bag.increment_step_nr(20)  # out of range
 
         y = m(x, padding_mask=None, state_bag=state_bag)

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -36,7 +36,7 @@ class TestMetricBag:
         bag = MetricBag(gang=FakeGang(device=device))
 
         with pytest.raises(
-            AttributeError, match=r"^'MetricBag' object has no attribute 'foo'\."
+            AttributeError, match=r"^`MetricBag` object has no attribute 'foo'\."
         ):
             bag.foo
 


### PR DESCRIPTION
This PR improves the implementation of `AttentionState` types by replacing the pre-allocated k/v cache tensors with dynamically expanding cache tensors. The user can specify the `capacity_increment` parameter in sequence generators and in `IncrementalStateBag` to adjust the capacity allocation size. For sampling-based sequence generators the performance improvement is subtle, but for beam-search based generators the improvement can be significant (up to %30-40) depending on the batch size. The main cause of regression is that in beam-search we keep reordering the batch at each step that becomes very expensive with a pre-allocated k/v cache. Full credit for investigation and root causing goes to @YJYJLee. This implementation is based on her findings.