### PR TITLE
Add support for checkpoint metadata

### DIFF
--- a/src/fairseq2/models/llama/loader.py
+++ b/src/fairseq2/models/llama/loader.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Mapping
+from typing import Any, Dict
 
 from fairseq2.assets import asset_store, download_manager
 from fairseq2.models.llama.builder import LLaMAConfig, create_llama_model, llama_archs
@@ -15,8 +15,8 @@ from fairseq2.models.utils.checkpoint import convert_model_state_dict
 
 
 def convert_llama_checkpoint(
-    checkpoint: Mapping[str, Any], config: LLaMAConfig
-) -> Mapping[str, Any]:
+    checkpoint: Dict[str, Any], config: LLaMAConfig
+) -> Dict[str, Any]:
     """Convert a reference LLaMA checkpoint to fairseq2."""
     key_map = {
         # fmt: off

--- a/src/fairseq2/models/mistral/loader.py
+++ b/src/fairseq2/models/mistral/loader.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Mapping
+from typing import Any, Dict
 
 from fairseq2.assets import asset_store, download_manager
 from fairseq2.models.mistral.builder import (
@@ -19,8 +19,8 @@ from fairseq2.models.utils.checkpoint import convert_model_state_dict
 
 
 def convert_mistral_checkpoint(
-    checkpoint: Mapping[str, Any], config: MistralConfig
-) -> Mapping[str, Any]:
+    checkpoint: Dict[str, Any], config: MistralConfig
+) -> Dict[str, Any]:
     """Convert a reference Mistral checkpoint to fairseq2."""
     key_map = {
         # fmt: off

--- a/src/fairseq2/models/nllb/loader.py
+++ b/src/fairseq2/models/nllb/loader.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from pathlib import Path
-from typing import Any, Mapping, final
+from typing import Any, Dict, final
 
 import torch
 
@@ -19,8 +19,8 @@ from fairseq2.typing import finaloverride
 
 
 def convert_nllb_checkpoint(
-    checkpoint: Mapping[str, Any], config: NllbConfig
-) -> Mapping[str, Any]:
+    checkpoint: Dict[str, Any], config: NllbConfig
+) -> Dict[str, Any]:
     """Convert a fairseq NLLB checkpoint to fairseq2."""
     state_dict = checkpoint["model"]
 

--- a/src/fairseq2/models/s2t_transformer/loader.py
+++ b/src/fairseq2/models/s2t_transformer/loader.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from pathlib import Path
-from typing import Any, Mapping, final
+from typing import Any, Dict, final
 
 from fairseq2.assets import AssetCard, asset_store, download_manager
 from fairseq2.models.s2t_transformer.builder import (
@@ -21,8 +21,8 @@ from fairseq2.typing import finaloverride
 
 
 def convert_s2t_transformer_checkpoint(
-    checkpoint: Mapping[str, Any], config: S2TTransformerConfig
-) -> Mapping[str, Any]:
+    checkpoint: Dict[str, Any], config: S2TTransformerConfig
+) -> Dict[str, Any]:
     """Convert a fairseq S2T Transformer checkpoint to fairseq2."""
     key_map = {
         # fmt: off

--- a/src/fairseq2/models/utils/checkpoint.py
+++ b/src/fairseq2/models/utils/checkpoint.py
@@ -24,7 +24,7 @@ MapLocation: TypeAlias = Optional[
 class CheckpointConverter(Protocol):
     """Converts checkpoints to fairseq2."""
 
-    def __call__(self, checkpoint: Mapping[str, Any]) -> Mapping[str, Any]:
+    def __call__(self, checkpoint: Dict[str, Any]) -> Dict[str, Any]:
         """
         :param checkpoint:
             The checkpoint to convert.
@@ -40,7 +40,7 @@ def load_checkpoint(
     map_location: MapLocation = None,
     restrict: bool = False,
     converter: Optional[CheckpointConverter] = None,
-) -> Mapping[str, Any]:
+) -> Dict[str, Any]:
     """Load the checkpoint stored in ``pathname``.
 
     :param pathname:
@@ -66,7 +66,7 @@ def load_checkpoint(
         if _is_pt21_or_greater():
             kwargs["mmap"] = True
 
-        checkpoint: Mapping[str, Any] = torch.load(
+        checkpoint: Dict[str, Any] = torch.load(
             str(pathname), map_location, weights_only=restrict, **kwargs
         )
 
@@ -77,7 +77,7 @@ def load_checkpoint(
 
 
 def convert_model_state_dict(
-    state_dict: Mapping[str, Any], key_map: Mapping[str, str]
+    state_dict: Dict[str, Any], key_map: Mapping[str, str]
 ) -> Dict[str, Any]:
     """Convert a model state dictionary to fairseq2.
 
@@ -108,7 +108,7 @@ def convert_model_state_dict(
 
 
 def convert_fairseq_checkpoint(
-    checkpoint: Mapping[str, Any], key_map: Mapping[str, str]
+    checkpoint: Dict[str, Any], key_map: Mapping[str, str]
 ) -> Dict[str, Any]:
     """Convert a fairseq checkpoint to fairseq2.
 

--- a/src/fairseq2/models/utils/generic_loaders.py
+++ b/src/fairseq2/models/utils/generic_loaders.py
@@ -10,7 +10,7 @@ from copy import deepcopy
 from functools import partial
 from pathlib import Path
 from pickle import PickleError
-from typing import Any, Generic, Mapping, Optional, Protocol, TypeVar, Union, final
+from typing import Any, Dict, Generic, Optional, Protocol, TypeVar, Union, final
 
 from torch.nn import Module
 
@@ -134,8 +134,8 @@ class CheckpointConverter(Protocol[ConfigT_contra]):
     """Converts checkpoints to fairseq2."""
 
     def __call__(
-        self, checkpoint: Mapping[str, Any], config: ConfigT_contra
-    ) -> Mapping[str, Any]:
+        self, checkpoint: Dict[str, Any], config: ConfigT_contra
+    ) -> Dict[str, Any]:
         """
         :param checkpoint:
             The checkpoint to convert.

--- a/src/fairseq2/models/w2vbert/loader.py
+++ b/src/fairseq2/models/w2vbert/loader.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Mapping
+from typing import Any, Dict
 
 import torch
 
@@ -20,8 +20,8 @@ from fairseq2.models.w2vbert.model import W2VBertModel
 
 
 def convert_w2vbert_checkpoint(
-    checkpoint: Mapping[str, Any], config: W2VBertConfig
-) -> Mapping[str, Any]:
+    checkpoint: Dict[str, Any], config: W2VBertConfig
+) -> Dict[str, Any]:
     """Convert a fairseq w2v-BERT checkpoint to fairseq2."""
     state_dict = checkpoint["model"]
 

--- a/src/fairseq2/models/wav2vec2/loader.py
+++ b/src/fairseq2/models/wav2vec2/loader.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Mapping
+from typing import Any, Dict
 
 import torch
 
@@ -21,8 +21,8 @@ from fairseq2.nn.transformer import TransformerNormOrder
 
 
 def convert_wav2vec2_checkpoint(
-    checkpoint: Mapping[str, Any], config: Wav2Vec2Config
-) -> Mapping[str, Any]:
+    checkpoint: Dict[str, Any], config: Wav2Vec2Config
+) -> Dict[str, Any]:
     """Convert a fairseq wav2vec 2.0 checkpoint to fairseq2."""
     state_dict = checkpoint["model"]
 

--- a/src/fairseq2/utils/profiler.py
+++ b/src/fairseq2/utils/profiler.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 
 from time import perf_counter
-from typing import Optional
+from typing import Any, Optional
 
 import torch
 from torch.profiler import (
@@ -16,7 +16,7 @@ from torch.profiler import (
     schedule,
     tensorboard_trace_handler,
 )
-from typing_extensions import Any, Self
+from typing_extensions import Self
 
 from fairseq2.data.typing import PathLike
 from fairseq2.gang import Gang


### PR DESCRIPTION
This PR introduces support for saving and restoring metadata associated with a checkpoint in `CheckpointManager`. Metadata typically entails job configuration, git commit id, and other information relevant to identify and troubleshoot issues.