### PR TITLE
Perform KV cache reordering only when we need to remove beams

### DIFF
--- a/src/fairseq2/nn/transformer/multihead_attention.py
+++ b/src/fairseq2/nn/transformer/multihead_attention.py
@@ -885,5 +885,6 @@ class StaticAttentionState(AttentionState):
 
     @finaloverride
     def reorder(self, new_order: Tensor) -> None:
-        self.k = self.k.index_select(0, new_order)
-        self.v = self.v.index_select(0, new_order)
+        if new_order.size(0) != self.k.size(0):
+            self.k = self.k.index_select(0, new_order)
+            self.v = self.v.index_select(0, new_order)


### PR DESCRIPTION
**What does this PR do? Please describe:**
Currently, fairseq2 performs reordering StaticAttentionState (KV cache for cross attention layers) with selected beam indices for each beam search decoding step. The purpose of reordering StaticAttentionState is to remove beams when there are finished inference samples in a batch. Unlike other KV caches for self-attention layers whose contents are different across beams, the contents of StaticAttentionState is always the same for different beams for given an inference sample since key and values of cross-attention layers are based on encoder output. 

Thus, I propose to reorder StaticAttentionState only when we need to remove beams instead of performing it for every decoding step. Since reordering time grows exponentially as the batch size grows, the benefit of this proposal will become larger when batch size grows.

![image](https://github.com/facebookresearch/fairseq2/assets/28900943/67fbb6f5-631c-45b7-9550-47aa30b96bc4)

The proposal reduces the KV cache reordering time by **2.85x, 1.96x, 1.82x** for batch size=32, 64, 96. And this translates to the end-to-end text_decoder speedup **1.09x, 1.17x, 1.16x** for batch size=32, 64, 96.

**Does your PR introduce any breaking changes? If yes, please list them:**
No

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
