### PR TITLE
Introduce is_infinite in DataPipeline

### DIFF
--- a/native/python/src/fairseq2n/bindings/data/data_pipeline.cc
+++ b/native/python/src/fairseq2n/bindings/data/data_pipeline.cc
@@ -217,6 +217,8 @@ def_data_pipeline(py::module_ &data_module)
 
         .def("reset", &data_pipeline::reset, py::call_guard<py::gil_scoped_release>{})
 
+        .def("is_infinite", &data_pipeline::is_infinite)
+
         .def_property_readonly("is_broken", &data_pipeline::is_broken)
 
         // state_dict

--- a/native/src/fairseq2n/data/bucket_by_length_data_source.cc
+++ b/native/src/fairseq2n/data/bucket_by_length_data_source.cc
@@ -106,4 +106,10 @@ bucket_by_length_data_source::reload_position(tape &t)
     inner_->reload_position(t);
 }
 
+bool
+bucket_by_length_data_source::is_infinite() const noexcept
+{
+    return inner_->is_infinite();
+}
+
 }  // namespace fairseq2n::detail

--- a/native/src/fairseq2n/data/bucket_by_length_data_source.h
+++ b/native/src/fairseq2n/data/bucket_by_length_data_source.h
@@ -38,6 +38,9 @@ public:
     void
     reload_position(tape &t) override;
 
+    bool
+    is_infinite() const noexcept override;
+
 private:
     std::unique_ptr<data_source> inner_;
     std::vector<std::pair<std::size_t, std::size_t>> bucket_sizes_;

--- a/native/src/fairseq2n/data/bucket_data_source.cc
+++ b/native/src/fairseq2n/data/bucket_data_source.cc
@@ -57,4 +57,10 @@ bucket_data_source::reload_position(tape &t)
     inner_->reload_position(t);
 }
 
+bool
+bucket_data_source::is_infinite() const noexcept
+{
+    return inner_->is_infinite();
+}
+
 }  // namespace fairseq2n::detail

--- a/native/src/fairseq2n/data/bucket_data_source.h
+++ b/native/src/fairseq2n/data/bucket_data_source.h
@@ -34,6 +34,9 @@ public:
     void
     reload_position(tape &t) override;
 
+    bool
+    is_infinite() const noexcept override;
+
 private:
     std::unique_ptr<data_source> inner_;
     std::size_t bucket_size_;

--- a/native/src/fairseq2n/data/concat_data_source.cc
+++ b/native/src/fairseq2n/data/concat_data_source.cc
@@ -6,7 +6,19 @@
 
 #include "fairseq2n/data/concat_data_source.h"
 
+#include <algorithm>
+
 namespace fairseq2n::detail {
+
+concat_data_source::concat_data_source(std::vector<data_pipeline> &&pipelines) noexcept
+  : pipelines_(std::move(pipelines))
+{
+    is_infinite_ = std::any_of(
+        pipelines_.begin(), pipelines_.end(), [](const data_pipeline &p)
+        {
+            return p.is_infinite();
+        });
+}
 
 std::optional<data>
 concat_data_source::next()
@@ -21,8 +33,8 @@ concat_data_source::next()
 
 void concat_data_source::reset()
 {
-    for (data_pipeline &p : pipelines_)
-        p.reset();
+    for (data_pipeline &pipeline : pipelines_)
+        pipeline.reset();
 }
 
 void concat_data_source::record_position(tape &t) const
@@ -35,6 +47,12 @@ void concat_data_source::reload_position(tape &t)
 {
     for (data_pipeline &pipeline : pipelines_)
         pipeline.reload_position(t);
+}
+
+bool
+concat_data_source::is_infinite() const noexcept
+{
+    return is_infinite_;
 }
 
 } // namespace fairseq2n::detail

--- a/native/src/fairseq2n/data/concat_data_source.h
+++ b/native/src/fairseq2n/data/concat_data_source.h
@@ -17,9 +17,7 @@ namespace fairseq2n::detail {
 class concat_data_source final : public data_source {
 public:
     explicit
-    concat_data_source(std::vector<data_pipeline> &&pipelines) noexcept
-      : pipelines_(std::move(pipelines))
-    {}
+    concat_data_source(std::vector<data_pipeline> &&pipelines) noexcept;
 
     std::optional<data>
     next() override;
@@ -33,8 +31,12 @@ public:
     void
     reload_position(tape &t) override;
 
+    bool
+    is_infinite() const noexcept override;
+
 private:
     std::vector<data_pipeline> pipelines_;
+    bool is_infinite_;
 };
 
 }  // namespace fairseq2n::detail

--- a/native/src/fairseq2n/data/constant_data_source.cc
+++ b/native/src/fairseq2n/data/constant_data_source.cc
@@ -31,4 +31,10 @@ void
 constant_data_source::reload_position(tape &)
 {}
 
+bool
+constant_data_source::is_infinite() const noexcept
+{
+    return true;
+}
+
 }

--- a/native/src/fairseq2n/data/constant_data_source.h
+++ b/native/src/fairseq2n/data/constant_data_source.h
@@ -33,6 +33,9 @@ public:
     void
     reload_position(tape &t) override;
 
+    bool
+    is_infinite() const noexcept override;
+
 private:
     data example_;
     std::optional<std::string> key_;

--- a/native/src/fairseq2n/data/count_data_source.cc
+++ b/native/src/fairseq2n/data/count_data_source.cc
@@ -37,4 +37,10 @@ count_data_source::reload_position(tape &t)
     counter_ = t.read<std::int64_t>();
 }
 
+bool
+count_data_source::is_infinite() const noexcept
+{
+    return true;
+}
+
 }

--- a/native/src/fairseq2n/data/count_data_source.h
+++ b/native/src/fairseq2n/data/count_data_source.h
@@ -31,6 +31,9 @@ public:
     void
     reload_position(tape &t) override;
 
+    bool
+    is_infinite() const noexcept override;
+
 private:
     std::int64_t start_;
     std::int64_t counter_;

--- a/native/src/fairseq2n/data/data_pipeline.cc
+++ b/native/src/fairseq2n/data/data_pipeline.cc
@@ -136,6 +136,19 @@ data_pipeline::reload_position(tape &t)
         reset();
 }
 
+bool
+data_pipeline::is_infinite() const
+{
+    check_if_broken();
+
+    ensure_initialized();
+
+    if (!source_)
+        return false;
+
+    return source_->is_infinite();
+}
+
 inline bool
 data_pipeline::is_initialized() const noexcept
 {
@@ -143,7 +156,7 @@ data_pipeline::is_initialized() const noexcept
 }
 
 void
-data_pipeline::ensure_initialized()
+data_pipeline::ensure_initialized() const
 {
     if (factory_ == nullptr)
         return;

--- a/native/src/fairseq2n/data/data_pipeline.h
+++ b/native/src/fairseq2n/data/data_pipeline.h
@@ -53,6 +53,9 @@ public:
     reload_position(tape &t);
 
     bool
+    is_infinite() const;
+
+    bool
     is_broken() const noexcept
     {
         return is_broken_;
@@ -63,13 +66,10 @@ private:
     is_initialized() const noexcept;
 
     void
-    ensure_initialized();
+    ensure_initialized() const;
 
     void
     check_if_broken() const;
-
-    [[noreturn]] static void
-    throw_broken();
 
 public:
     static data_pipeline_builder
@@ -96,8 +96,8 @@ public:
         bool disable_parallelism = false);
 
 private:
-    data_source_factory factory_{};
-    std::unique_ptr<data_source> source_{};
+    mutable data_source_factory factory_{};
+    mutable std::unique_ptr<data_source> source_{};
     std::size_t max_num_warnings_{};
     std::size_t warning_count_{};
     mutable bool is_broken_ = false;

--- a/native/src/fairseq2n/data/data_source.h
+++ b/native/src/fairseq2n/data/data_source.h
@@ -39,6 +39,9 @@ public:
 
     virtual void
     reload_position(tape &t) = 0;
+
+    virtual bool
+    is_infinite() const noexcept = 0;
 };
 
 }  // namespace fairseq2n

--- a/native/src/fairseq2n/data/filter_data_source.cc
+++ b/native/src/fairseq2n/data/filter_data_source.cc
@@ -41,6 +41,12 @@ filter_data_source::reload_position(tape &t)
 }
 
 bool
+filter_data_source::is_infinite() const noexcept
+{
+    return inner_->is_infinite();
+}
+
+bool
 filter_data_source::invoke_function(data &example)
 {
     try {

--- a/native/src/fairseq2n/data/filter_data_source.h
+++ b/native/src/fairseq2n/data/filter_data_source.h
@@ -33,6 +33,9 @@ public :
     void
     reload_position(tape &t) override;
 
+    bool
+    is_infinite() const noexcept override;
+
 private:
     bool
     invoke_function(data &example);

--- a/native/src/fairseq2n/data/list_data_source.cc
+++ b/native/src/fairseq2n/data/list_data_source.cc
@@ -37,4 +37,10 @@ list_data_source::reload_position(tape &t)
     iter_ = list_.begin() + t.read<std::ptrdiff_t>();
 }
 
+bool
+list_data_source::is_infinite() const noexcept
+{
+    return false;
+}
+
 }

--- a/native/src/fairseq2n/data/list_data_source.h
+++ b/native/src/fairseq2n/data/list_data_source.h
@@ -32,6 +32,9 @@ public:
     void
     reload_position(tape &t) override;
 
+    bool
+    is_infinite() const noexcept override;
+
 private:
     data_list list_;
     data_list::iterator iter_;

--- a/native/src/fairseq2n/data/map_data_source.cc
+++ b/native/src/fairseq2n/data/map_data_source.cc
@@ -79,6 +79,12 @@ map_data_source::reload_position(tape &t)
 }
 
 bool
+map_data_source::is_infinite() const noexcept
+{
+    return inner_->is_infinite();
+}
+
+bool
 map_data_source::fill_buffer()
 {
     buffer_.clear();

--- a/native/src/fairseq2n/data/map_data_source.h
+++ b/native/src/fairseq2n/data/map_data_source.h
@@ -35,6 +35,9 @@ public:
     void
     reload_position(tape &t) override;
 
+    bool
+    is_infinite() const noexcept override;
+
 private:
     bool
     fill_buffer();

--- a/native/src/fairseq2n/data/prefetch_data_source.cc
+++ b/native/src/fairseq2n/data/prefetch_data_source.cc
@@ -106,6 +106,12 @@ prefetch_data_source::reload_position(tape &t)
     inner_->reload_position(t);
 }
 
+bool
+prefetch_data_source::is_infinite() const noexcept
+{
+    return inner_->is_infinite();
+}
+
 void
 prefetch_data_source::ensure_prefetch_thread_running()
 {

--- a/native/src/fairseq2n/data/prefetch_data_source.h
+++ b/native/src/fairseq2n/data/prefetch_data_source.h
@@ -48,6 +48,9 @@ public:
     void
     reload_position(tape &t) override;
 
+    bool
+    is_infinite() const noexcept override;
+
 private:
     void
     ensure_prefetch_thread_running();

--- a/native/src/fairseq2n/data/round_robin_data_source.h
+++ b/native/src/fairseq2n/data/round_robin_data_source.h
@@ -32,6 +32,9 @@ public:
     void
     reload_position(tape &t) override;
 
+    bool
+    is_infinite() const noexcept override;
+
 private:
     std::optional<data>
     next_in_pipeline(std::size_t pipeline_idx);
@@ -46,6 +49,7 @@ private:
     std::vector<bool> is_epoch_done_;
     bool is_eod_ = false;
     bool stop_at_shortest_;
+    bool is_infinite_;
 };
 
 }  // namespace fairseq2n::detail

--- a/native/src/fairseq2n/data/sample_data_source.h
+++ b/native/src/fairseq2n/data/sample_data_source.h
@@ -33,6 +33,9 @@ public:
     void
     reload_position(tape &t) override;
 
+    bool
+    is_infinite() const noexcept override;
+
 private:
     std::size_t
     random_pipeline_index();
@@ -50,6 +53,7 @@ private:
     std::vector<data> buffer_{};
     std::vector<bool> is_epoch_done_;
     bool is_eod_ = false;
+    bool is_infinite_;
 };
 
 }  // namespace fairseq2::detail

--- a/native/src/fairseq2n/data/shard_data_source.cc
+++ b/native/src/fairseq2n/data/shard_data_source.cc
@@ -44,4 +44,10 @@ shard_data_source::reload_position(tape &t)
     inner_->reload_position(t);
 }
 
+bool
+shard_data_source::is_infinite() const noexcept
+{
+    return inner_->is_infinite();
+}
+
 }  // namespace fairseq2n::detail

--- a/native/src/fairseq2n/data/shard_data_source.h
+++ b/native/src/fairseq2n/data/shard_data_source.h
@@ -36,6 +36,9 @@ public:
     void
     reload_position(tape &t) override;
 
+    bool
+    is_infinite() const noexcept override;
+
 private:
     std::unique_ptr<data_source> inner_;
     std::size_t shard_idx_;

--- a/native/src/fairseq2n/data/shuffle_data_source.cc
+++ b/native/src/fairseq2n/data/shuffle_data_source.cc
@@ -115,6 +115,12 @@ shuffle_data_source::reload_position(tape &t)
     inner_->reload_position(t);
 }
 
+bool
+shuffle_data_source::is_infinite() const noexcept
+{
+    return inner_->is_infinite();
+}
+
 std::size_t
 shuffle_data_source::random_index()
 {

--- a/native/src/fairseq2n/data/shuffle_data_source.h
+++ b/native/src/fairseq2n/data/shuffle_data_source.h
@@ -36,6 +36,9 @@ public:
     void
     reload_position(tape &t) override;
 
+    bool
+    is_infinite() const noexcept override;
+
 private:
     std::size_t
     random_index();

--- a/native/src/fairseq2n/data/skip_data_source.cc
+++ b/native/src/fairseq2n/data/skip_data_source.cc
@@ -46,4 +46,10 @@ skip_data_source::reload_position(tape &t)
     inner_->reload_position(t);
 }
 
+bool
+skip_data_source::is_infinite() const noexcept
+{
+    return inner_->is_infinite();
+}
+
 }  // namespace fairseq2n::detail

--- a/native/src/fairseq2n/data/skip_data_source.h
+++ b/native/src/fairseq2n/data/skip_data_source.h
@@ -33,6 +33,9 @@ public:
     void
     reload_position(tape &t) override;
 
+    bool
+    is_infinite() const noexcept override;
+
 private:
     std::unique_ptr<data_source> inner_;
     std::size_t num_examples_;

--- a/native/src/fairseq2n/data/take_data_source.cc
+++ b/native/src/fairseq2n/data/take_data_source.cc
@@ -45,4 +45,10 @@ take_data_source::reload_position(tape &t)
     inner_->reload_position(t);
 }
 
+bool
+take_data_source::is_infinite() const noexcept
+{
+    return false;
+}
+
 }  // namespace fairseq2n::detail

--- a/native/src/fairseq2n/data/take_data_source.h
+++ b/native/src/fairseq2n/data/take_data_source.h
@@ -33,6 +33,9 @@ public:
     void
     reload_position(tape &t) override;
 
+    bool
+    is_infinite() const noexcept override;
+
 private:
     std::unique_ptr<data_source> inner_;
     std::size_t num_examples_;

--- a/native/src/fairseq2n/data/text/text_data_source.cc
+++ b/native/src/fairseq2n/data/text/text_data_source.cc
@@ -86,6 +86,12 @@ text_data_source::reload_position(tape &t)
         read_next_line();
 }
 
+bool
+text_data_source::is_infinite() const noexcept
+{
+    return false;
+}
+
 std::unique_ptr<text_line_reader>
 text_data_source::make_text_line_reader()
 {

--- a/native/src/fairseq2n/data/text/text_data_source.h
+++ b/native/src/fairseq2n/data/text/text_data_source.h
@@ -36,6 +36,9 @@ public:
     void
     reload_position(tape &t) override;
 
+    bool
+    is_infinite() const noexcept override;
+
 private:
     std::unique_ptr<text_line_reader>
     make_text_line_reader();

--- a/native/src/fairseq2n/data/yield_from_data_source.cc
+++ b/native/src/fairseq2n/data/yield_from_data_source.cc
@@ -65,6 +65,12 @@ yield_from_data_source::reload_position(tape &t)
 }
 
 bool
+yield_from_data_source::is_infinite() const noexcept
+{
+    return inner_->is_infinite();
+}
+
+bool
 yield_from_data_source::load_next_data_pipeline()
 {
     maybe_current_example_ = inner_->next();
@@ -73,6 +79,13 @@ yield_from_data_source::load_next_data_pipeline()
         data_pipeline_ = invoke_function(*maybe_current_example_);
     else
         data_pipeline_ = {};
+
+    if (data_pipeline_.is_infinite()) {
+        data_pipeline_ = {};
+
+        throw_data_pipeline_error(std::move(maybe_current_example_), /*recoverable=*/true,
+            "The data pipeline to yield from cannot be infinite.");
+    }
 
     return maybe_current_example_.has_value();
 }

--- a/native/src/fairseq2n/data/yield_from_data_source.h
+++ b/native/src/fairseq2n/data/yield_from_data_source.h
@@ -33,6 +33,9 @@ public:
     void
     reload_position(tape &t) override;
 
+    bool
+    is_infinite() const noexcept override;
+
 private:
     bool
     load_next_data_pipeline();

--- a/native/src/fairseq2n/data/zip_data_source.h
+++ b/native/src/fairseq2n/data/zip_data_source.h
@@ -37,6 +37,9 @@ public:
     void
     reload_position(tape &t) override;
 
+    bool
+    is_infinite() const noexcept override;
+
 private:
     static std::optional<data>
     flatten_to_dict(data_list &zip);

--- a/native/src/fairseq2n/data/zip_file_data_source.cc
+++ b/native/src/fairseq2n/data/zip_file_data_source.cc
@@ -77,6 +77,12 @@ zip_file_data_source::reload_position(tape &t)
         next();
 }
 
+bool
+zip_file_data_source::is_infinite() const noexcept
+{
+    return false;
+}
+
 void
 zip_file_data_source::handle_error()
 {

--- a/native/src/fairseq2n/data/zip_file_data_source.h
+++ b/native/src/fairseq2n/data/zip_file_data_source.h
@@ -36,6 +36,9 @@ public:
     void
     reload_position(tape &t) override;
 
+    bool
+    is_infinite() const noexcept override;
+
 private:
     memory_block
     next_line();

--- a/src/fairseq2/data/data_pipeline.py
+++ b/src/fairseq2/data/data_pipeline.py
@@ -51,6 +51,9 @@ if TYPE_CHECKING or DOC_MODE:
         def reset(self) -> None:
             """Move back to the first example in the data pipeline."""
 
+        def is_infinite(self) -> bool:
+            ...
+
         @property
         def is_broken(self) -> bool:
             """Return ``True`` if the data pipeline is broken.

--- a/tests/unit/data/data_pipeline/test_round_robin.py
+++ b/tests/unit/data/data_pipeline/test_round_robin.py
@@ -44,6 +44,20 @@ class TestRoundRobinOp:
 
             pipeline.reset()
 
+    def test_op_works_when_infinite_pipeline_is_specified(self) -> None:
+        pipeline1 = read_sequence([1, 2, 3, 4]).and_return()
+        pipeline2 = DataPipeline.constant(0).and_return()
+        pipeline3 = read_sequence([0, 2, 4, 6]).and_return()
+
+        pipeline = DataPipeline.round_robin(
+            [pipeline1, pipeline2, pipeline3]
+        ).and_return()
+
+        for _ in range(2):
+            assert list(pipeline) == [1, 0, 0, 2, 0, 2, 3, 0, 4, 4, 0, 6]
+
+            pipeline.reset()
+
     def test_op_works_when_pipelines_are_empty(self) -> None:
         pipeline1 = read_sequence([]).and_return()
         pipeline2 = read_sequence([]).and_return()

--- a/tests/unit/data/data_pipeline/test_sample.py
+++ b/tests/unit/data/data_pipeline/test_sample.py
@@ -61,6 +61,18 @@ class TestSampleOp:
 
             pipeline.reset()
 
+    def test_op_works_when_infinite_pipeline_is_specified(self) -> None:
+        pipeline1 = read_sequence([1, 2, 3, 4]).and_return()
+        pipeline2 = DataPipeline.count(5).and_return()
+
+        pipeline = DataPipeline.sample([pipeline1, pipeline2], [0.4, 0.6]).and_return()
+
+        for _ in range(2):
+            with tmp_rng_seed(CPU, seed=1234):
+                assert list(pipeline) == [1, 5, 2, 3, 4]
+
+            pipeline.reset()
+
     def test_op_raises_error_when_pipeline_is_empty(self) -> None:
         pipeline1 = read_sequence([1, 2]).and_return()
         pipeline2 = read_sequence([]).and_return()

--- a/tests/unit/data/data_pipeline/test_yield_from.py
+++ b/tests/unit/data/data_pipeline/test_yield_from.py
@@ -8,7 +8,7 @@ from typing import Tuple
 
 import pytest
 
-from fairseq2.data import DataPipeline, read_sequence
+from fairseq2.data import DataPipeline, DataPipelineError, read_sequence
 
 
 class TestYieldFromOp:
@@ -26,6 +26,18 @@ class TestYieldFromOp:
             assert list(pipeline) == [1, 2, 3, 4, 9, 10, 11, 12, 13]
 
             pipeline.reset()
+
+    def test_op_raises_error_when_yield_from_is_infinite(self) -> None:
+        def fn(d: int) -> DataPipeline:
+            return DataPipeline.constant(0).and_return()
+
+        pipeline = read_sequence([1]).yield_from(fn).and_return()
+
+        with pytest.raises(
+            DataPipelineError,
+            match=r"^The data pipeline to yield from cannot be infinite\.$",
+        ):
+            next(iter(pipeline))
 
     def test_op_saves_and_restores_its_state(self) -> None:
         def fn(d: Tuple[int, int]) -> DataPipeline:

--- a/tests/unit/data/data_pipeline/test_zip.py
+++ b/tests/unit/data/data_pipeline/test_zip.py
@@ -42,6 +42,18 @@ class TestZipOp:
 
             pipeline.reset()
 
+    def test_op_works_when_infinite_pipeline_is_specified(self) -> None:
+        pipeline1 = read_sequence([1, 2, 3, 4]).and_return()
+        pipeline2 = DataPipeline.constant(0).and_return()
+        pipeline3 = read_sequence([5, 6, 7, 8]).and_return()
+
+        pipeline = DataPipeline.zip([pipeline1, pipeline2, pipeline3]).and_return()
+
+        for _ in range(2):
+            assert list(pipeline) == [[1, 0, 5], [2, 0, 6], [3, 0, 7], [4, 0, 8]]
+
+            pipeline.reset()
+
     def test_op_works_when_names_are_specified(self) -> None:
         pipeline1 = read_sequence([1, 2, 3, 4]).and_return()
         pipeline2 = read_sequence([5, 6, 7, 8]).and_return()
@@ -61,17 +73,18 @@ class TestZipOp:
 
             pipeline.reset()
 
-    def test_op_raises_error_when_zip_to_shortest_is_true(self) -> None:
+    def test_op_works_when_zip_to_shortest_is_true(self) -> None:
         pipeline1 = read_sequence([1, 2, 3]).and_return()
         pipeline2 = read_sequence([5, 6, 7, 8]).and_return()
         pipeline3 = read_sequence([3, 4, 5, 6]).and_return()
+        pipeline4 = DataPipeline.count(1).and_return()
 
         pipeline = DataPipeline.zip(
-            [pipeline1, pipeline2, pipeline3], zip_to_shortest=True
+            [pipeline1, pipeline2, pipeline3, pipeline4], zip_to_shortest=True
         ).and_return()
 
         for _ in range(2):
-            assert list(pipeline) == [[1, 5, 3], [2, 6, 4], [3, 7, 5]]
+            assert list(pipeline) == [[1, 5, 3, 1], [2, 6, 4, 2], [3, 7, 5, 3]]
 
             pipeline.reset()
 


### PR DESCRIPTION
This PR introduces `is_infinite()` accessor in `DataPipeline` to cleanly handle operators such as `constant()` and `count()` in composite ops such as `zip()`, `sample()`, `round_robin()`.