### PR TITLE
Remove print from unit test

### DIFF
--- a/tests/unit/data/data_pipeline/test_round_robin.py
+++ b/tests/unit/data/data_pipeline/test_round_robin.py
@@ -102,9 +102,7 @@ class TestRoundRobinOp:
         seq = [1, 5, 7, 2, 6, 8]
 
         for _ in range(2):
-            a = list(pipeline)
-            print(a)
-            assert a == seq
+            assert list(pipeline) == seq
 
             pipeline.reset()
 


### PR DESCRIPTION
A nit PR that removes the print statement from the round_robin unit test.