### PR TITLE
Fix infinite pipeline handling in zip

### DIFF
--- a/native/src/fairseq2n/data/zip_data_source.cc
+++ b/native/src/fairseq2n/data/zip_data_source.cc
@@ -64,13 +64,13 @@ zip_data_source::next()
 
     // Check whether all data pipelines are in sync.
     bool are_eod = std::all_of(
-        is_eod.begin(), is_eod.end(), [&is_eod](std::int8_t b)
+        is_eod.begin(), is_eod.end(), [](std::int8_t b)
         {
             return b == 2 || b == 1;
         });
 
     bool are_not_eod = std::all_of(
-        is_eod.begin(), is_eod.end(), [&is_eod](std::int8_t b)
+        is_eod.begin(), is_eod.end(), [](std::int8_t b)
         {
             return b == 2 || b == 0;
         });

--- a/native/src/fairseq2n/data/zip_data_source.cc
+++ b/native/src/fairseq2n/data/zip_data_source.cc
@@ -63,11 +63,19 @@ zip_data_source::next()
         parallel_for<std::size_t>(fetch_next, pipelines_.size());
 
     // Check whether all data pipelines are in sync.
-    bool are_in_sync = std::all_of(
-        is_eod.begin() + 1, is_eod.end(), [&is_eod](std::int8_t b)
+    bool are_eod = std::all_of(
+        is_eod.begin(), is_eod.end(), [&is_eod](std::int8_t b)
         {
-            return b == 2 || b == is_eod[0];
+            return b == 2 || b == 1;
         });
+
+    bool are_not_eod = std::all_of(
+        is_eod.begin(), is_eod.end(), [&is_eod](std::int8_t b)
+        {
+            return b == 2 || b == 0;
+        });
+
+    bool are_in_sync = are_eod || are_not_eod;
 
     if (!are_in_sync) {
         if (zip_to_shortest_)
@@ -80,7 +88,7 @@ zip_data_source::next()
                 not_eod.push_back(i);
 
         throw_<data_pipeline_error>(
-            "The zipped data pipelines must all have the same length, but the data pipelines at the following indices have more examples than the others. Indices: {}", fmt::join(not_eod, ", "));
+            "The zipped data pipelines must all have the same number of examples, but the data pipelines at the indices [{}] have more examples than the others.", fmt::join(not_eod, ", "));
     }
 
     if (is_eod[0] == 1)

--- a/tests/unit/data/data_pipeline/test_zip.py
+++ b/tests/unit/data/data_pipeline/test_zip.py
@@ -129,7 +129,7 @@ class TestZipOp:
 
         with pytest.raises(
             DataPipelineError,
-            match=r"^The zipped data pipelines must all have the same length, but the data pipelines at the following indices have more examples than the others\. Indices: 1, 2$",
+            match=r"^The zipped data pipelines must all have the same number of examples, but the data pipelines at the indices \[1, 2\] have more examples than the others\.$",
         ):
             for d in pipeline:
                 pass


### PR DESCRIPTION
This PR fixes the infinite pipeline handling bug in the `zip()` operator.