### PR TITLE
Revise shuffle op

### DIFF
--- a/native/src/fairseq2n/data/file_mapper.cc
+++ b/native/src/fairseq2n/data/file_mapper.cc
@@ -42,13 +42,13 @@ file_mapper::operator()(data &&d) const
 
     std::array<immutable_string, 3> parts{};
 
-    auto iter = parts.begin();
+    auto pos = parts.begin();
 
     // The pathname can optionally contain offset and size specifiers separated
     // by semicolons (i.e. `pathname:offset:size`).
-    pathname.split(':', [&pathname, &parts, &iter](immutable_string &&part)
+    pathname.split(':', [&pathname, &parts, &pos](immutable_string &&part)
     {
-        if (iter == parts.end())
+        if (pos == parts.end())
             throw_<std::invalid_argument>(
                 "The input string must be a pathname with optional offset and size specifiers, but is '{}' instead.", pathname);
 
@@ -58,7 +58,7 @@ file_mapper::operator()(data &&d) const
             throw_<std::invalid_argument>(
                 "The input string must be a pathname with optional offset and size specifiers, but is '{}' instead.", pathname);
 
-        *iter++ = std::move(part);
+        *pos++ = std::move(part);
 
         return true;
     });

--- a/native/src/fairseq2n/data/list_data_source.cc
+++ b/native/src/fairseq2n/data/list_data_source.cc
@@ -13,28 +13,28 @@ namespace fairseq2n::detail {
 std::optional<data>
 list_data_source::next()
 {
-    if (iter_ == list_.end())
+    if (pos_ == list_.end())
         return std::nullopt;
 
-    return *iter_++;
+    return *pos_++;
 }
 
 void
 list_data_source::reset()
 {
-    iter_ = list_.begin();
+    pos_ = list_.begin();
 }
 
 void
 list_data_source::record_position(tape &t) const
 {
-    t.record(iter_ - list_.begin());
+    t.record(pos_ - list_.begin());
 }
 
 void
 list_data_source::reload_position(tape &t)
 {
-    iter_ = list_.begin() + t.read<std::ptrdiff_t>();
+    pos_ = list_.begin() + t.read<std::ptrdiff_t>();
 }
 
 bool

--- a/native/src/fairseq2n/data/list_data_source.h
+++ b/native/src/fairseq2n/data/list_data_source.h
@@ -17,7 +17,7 @@ class list_data_source final : public data_source {
 public:
     explicit
     list_data_source(data_list &&list) noexcept
-      : list_(std::move(list)), iter_{list_.begin()}
+      : list_(std::move(list)), pos_{list_.begin()}
     {}
 
     std::optional<data>
@@ -37,7 +37,7 @@ public:
 
 private:
     data_list list_;
-    data_list::iterator iter_;
+    data_list::iterator pos_;
 };
 
 }  // namespace fairseq2n::detail

--- a/native/src/fairseq2n/data/map_data_source.cc
+++ b/native/src/fairseq2n/data/map_data_source.cc
@@ -20,7 +20,7 @@ map_data_source::map_data_source(
 {
     buffer_.reserve(num_parallel_calls);
 
-    buffer_iter_ = buffer_.begin();
+    buffer_pos_ = buffer_.begin();
 }
 
 std::optional<data>
@@ -38,9 +38,9 @@ map_data_source::next()
 
     do {
         // Yield a buffered example.
-        for (; buffer_iter_ < buffer_.end(); ++buffer_iter_) {
-            if (*buffer_iter_)
-                return std::move(*buffer_iter_++);
+        for (; buffer_pos_ < buffer_.end(); ++buffer_pos_) {
+            if (*buffer_pos_)
+                return std::move(*buffer_pos_++);
         }
     // If we have exhausted all buffered examples, try to refill the buffer.
     } while (fill_buffer());
@@ -53,7 +53,7 @@ map_data_source::reset()
 {
     buffer_.clear();
 
-    buffer_iter_ = buffer_.begin();
+    buffer_pos_ = buffer_.begin();
 
     inner_->reset();
 }
@@ -63,7 +63,7 @@ map_data_source::record_position(tape &t) const
 {
     t.record(buffer_);
 
-    t.record(buffer_iter_ - buffer_.begin());
+    t.record(buffer_pos_ - buffer_.begin());
 
     inner_->record_position(t);
 }
@@ -73,7 +73,7 @@ map_data_source::reload_position(tape &t)
 {
     buffer_ = t.read<std::vector<std::optional<data>>>();
 
-    buffer_iter_ = buffer_.begin() + t.read<std::ptrdiff_t>();
+    buffer_pos_ = buffer_.begin() + t.read<std::ptrdiff_t>();
 
     inner_->reload_position(t);
 }
@@ -113,7 +113,7 @@ map_data_source::fill_buffer()
     else
         parallel_for<std::size_t>(apply_function, buffer_.size());
 
-    buffer_iter_ = buffer_.begin();
+    buffer_pos_ = buffer_.begin();
 
     return true;
 }

--- a/native/src/fairseq2n/data/map_data_source.h
+++ b/native/src/fairseq2n/data/map_data_source.h
@@ -50,7 +50,7 @@ private:
     map_fn map_fn_;
     std::size_t num_parallel_calls_;
     std::vector<std::optional<data>> buffer_{};
-    std::vector<std::optional<data>>::iterator buffer_iter_{};
+    std::vector<std::optional<data>>::iterator buffer_pos_{};
 };
 
 }  // namespace fairseq2n::detail

--- a/native/src/fairseq2n/data/record_reader.cc
+++ b/native/src/fairseq2n/data/record_reader.cc
@@ -100,14 +100,14 @@ record_reader::copy_split_record()
 {
     writable_memory_block record = allocate_memory(record_len_);
 
-    auto iter = record.begin();
+    auto pos = record.begin();
 
     std::for_each(
-        previous_chunks_.begin(), previous_chunks_.end(), [&iter](const memory_block &block) {
-            iter = std::copy(block.begin(), block.end(), iter);
+        previous_chunks_.begin(), previous_chunks_.end(), [&pos](const memory_block &block) {
+            pos = std::copy(block.begin(), block.end(), pos);
         });
 
-    std::copy(current_chunk_.begin(), current_chunk_.begin() + record_end_offset_, iter);
+    std::copy(current_chunk_.begin(), current_chunk_.begin() + record_end_offset_, pos);
 
     return record;
 }

--- a/native/src/fairseq2n/data/shuffle_data_source.h
+++ b/native/src/fairseq2n/data/shuffle_data_source.h
@@ -40,12 +40,14 @@ public:
     is_infinite() const noexcept override;
 
 private:
-    std::size_t
-    random_index();
+    void
+    shuffle();
 
 private:
     std::unique_ptr<data_source> inner_;
     data_list buffer_{};
+    data_list::iterator buffer_pos_ = buffer_.begin();
+    data_list::iterator buffer_end_ = buffer_.end();
     std::size_t shuffle_window_;
     at::Generator generator_;
     bool strict_;

--- a/native/src/fairseq2n/data/tape.cc
+++ b/native/src/fairseq2n/data/tape.cc
@@ -15,23 +15,23 @@ namespace fairseq2n {
 void
 tape::record_data(const data &d)
 {
-    if (iter_ != storage_.end())
+    if (pos_ != storage_.end())
         throw_<std::domain_error>("New data can only be recorded to the end of the tape.");
 
     storage_.push_back(d);
 
     // The iterator is invalid because of the `push_back()` call; we should not
     // increment it.
-    iter_ = storage_.end();
+    pos_ = storage_.end();
 }
 
 data
 tape::read_data()
 {
-    if (iter_ == storage_.end())
+    if (pos_ == storage_.end())
         throw_corrupt();
 
-    return *iter_++;
+    return *pos_++;
 }
 
 corrupt_tape_error::~corrupt_tape_error() = default;

--- a/native/src/fairseq2n/data/tape.h
+++ b/native/src/fairseq2n/data/tape.h
@@ -48,7 +48,7 @@ public:
     void
     rewind() noexcept
     {
-        iter_ = storage_.begin();
+        pos_ = storage_.begin();
     }
 
     const data_list &
@@ -63,7 +63,7 @@ private:
 
 private:
     data_list storage_;
-    data_list::iterator iter_ = storage_.begin();
+    data_list::iterator pos_ = storage_.begin();
 };
 
 class FAIRSEQ2_API corrupt_tape_error : public std::domain_error {

--- a/native/src/fairseq2n/data/text/detail/utf.cc
+++ b/native/src/fairseq2n/data/text/detail/utf.cc
@@ -18,10 +18,10 @@ compute_code_point_length(std::string_view s)
 {
     std::size_t len = 0;
 
-    for (auto iter = s.begin(); iter < s.end();) {
+    for (auto pos = s.begin(); pos < s.end();) {
         std::size_t size = 0;
 
-        auto lead = static_cast<std::uint8_t>(*iter);
+        auto lead = static_cast<std::uint8_t>(*pos);
              if ((lead & 0x80) == 0x00)
             size = 1;
         else if ((lead & 0xe0) == 0xc0)
@@ -31,10 +31,10 @@ compute_code_point_length(std::string_view s)
         else if ((lead & 0xf8) == 0xf0)
             size = 4;
 
-        if (size == 0 || static_cast<std::size_t>(s.end() - iter) < size)
+        if (size == 0 || static_cast<std::size_t>(s.end() - pos) < size)
             throw_<std::invalid_argument>("`s` has an invalid UTF-8 code point.");
 
-        iter += size;
+        pos += size;
 
         len++;
     }

--- a/native/src/fairseq2n/data/text/string_splitter.cc
+++ b/native/src/fairseq2n/data/text/string_splitter.cc
@@ -43,25 +43,25 @@ string_splitter::operator()(data &&d) const
 
     data_list fields{};
 
-    auto idx_iter = indices_.begin();
+    auto idx_pos = indices_.begin();
 
     std::size_t idx = 0;
 
-    d.as_string().split(separator_, [this, &fields, &idx_iter, &idx](immutable_string &&s) {
-        if (idx_iter == indices_.end()) {
+    d.as_string().split(separator_, [this, &fields, &idx_pos, &idx](immutable_string &&s) {
+        if (idx_pos == indices_.end()) {
             fields.emplace_back(std::move(s));
         } else {
             if (exclude_) {
-                if (idx != *idx_iter)
+                if (idx != *idx_pos)
                     fields.emplace_back(std::move(s));
                 else
-                    ++idx_iter;
+                    ++idx_pos;
             } else {
-                if (idx == *idx_iter) {
+                if (idx == *idx_pos) {
                     fields.emplace_back(std::move(s));
 
                     // We got all fields we need, no need to process the rest.
-                    if (++idx_iter == indices_.end())
+                    if (++idx_pos == indices_.end())
                         return false;
                 }
             }
@@ -72,7 +72,7 @@ string_splitter::operator()(data &&d) const
         return true;
     });
 
-    if (idx_iter != indices_.end())
+    if (idx_pos != indices_.end())
         throw_<std::invalid_argument>(
             "The input string must have at least {} field(s), but has {} instead.", indices_.back(), idx);
 

--- a/native/src/fairseq2n/data/text/text_line_reader.cc
+++ b/native/src/fairseq2n/data/text/text_line_reader.cc
@@ -20,12 +20,12 @@ text_line_reader::maybe_find_record_end(memory_span chunk, bool)
         if (!infer_line_ending(chars))
             return std::nullopt;
 
-    auto iter = chars.begin();
+    auto pos = chars.begin();
 
     switch (line_ending_) {
     case line_ending::lf: {
-        for (; iter < chars.end(); ++iter)
-            if (*iter == '\n')
+        for (; pos < chars.end(); ++pos)
+            if (*pos == '\n')
                 break;
 
         break;
@@ -33,12 +33,12 @@ text_line_reader::maybe_find_record_end(memory_span chunk, bool)
     case line_ending::crlf: {
         bool has_cr = false;
 
-        for (; iter < chars.end(); ++iter) {
-            if (*iter == '\n') {
+        for (; pos < chars.end(); ++pos) {
+            if (*pos == '\n') {
                 if (has_cr)
                     break;
             } else
-                has_cr = *iter == '\r';
+                has_cr = *pos == '\r';
         }
 
         break;
@@ -48,10 +48,10 @@ text_line_reader::maybe_find_record_end(memory_span chunk, bool)
             "`text_line_reader` has not set the line ending. Please file a bug report.");
     }
 
-    if (iter == chars.end())
+    if (pos == chars.end())
         return std::nullopt;
 
-    return static_cast<std::size_t>(iter - chars.begin() + 1);
+    return static_cast<std::size_t>(pos - chars.begin() + 1);
 }
 
 bool

--- a/native/src/fairseq2n/data/text/utf8_stream.cc
+++ b/native/src/fairseq2n/data/text/utf8_stream.cc
@@ -132,9 +132,9 @@ utf8_stream::move_leftover_bits()
 
     writable_memory_block block = allocate_memory(leftover_bits_.size() + encoded_chunk_.size());
 
-    auto iter = std::copy(leftover_bits_.begin(), leftover_bits_.end(), block.begin());
+    auto pos = std::copy(leftover_bits_.begin(), leftover_bits_.end(), block.begin());
 
-    std::copy(encoded_chunk_.begin(), encoded_chunk_.end(), iter);
+    std::copy(encoded_chunk_.begin(), encoded_chunk_.end(), pos);
 
     encoded_chunk_ = block;
 

--- a/native/src/fairseq2n/utils/string.h
+++ b/native/src/fairseq2n/utils/string.h
@@ -21,12 +21,12 @@ template <typename StringViewLike, typename It>
 auto
 find_first_non_space(It first, It last) noexcept
 {
-    auto iter = std::find_if_not(first, last, [](int chr)
+    auto pos = std::find_if_not(first, last, [](int chr)
     {
         return std::isspace(chr);
     });
 
-    return static_cast<typename StringViewLike::size_type>(iter - first);
+    return static_cast<typename StringViewLike::size_type>(pos - first);
 }
 
 }  // namespace detail

--- a/tests/integration/parquet/test_parquet_dataloader.py
+++ b/tests/integration/parquet/test_parquet_dataloader.py
@@ -166,7 +166,7 @@ class TestParquetDataloader:
 
         assert list(res[0].columns) == ["string_col2", "list_int_col", "float_col"]
 
-        assert Counter(map(len, res)) == Counter({3: 339, 1: 3, 2: 1})
+        assert Counter(map(len, res)) == Counter({3: 340, 1: 2})
 
     def test_filtered_with_columns_dataload_min_batch_size(
         self, multi_partition_file: str
@@ -182,7 +182,7 @@ class TestParquetDataloader:
             output_format=ParquetBatchFormat.pandas,
         )
         res = list(parquet_iterator(config))
-        assert Counter(map(len, res)) == Counter({3: 339})
+        assert Counter(map(len, res)) == Counter({3: 340})
 
     def test_ordered_dataload(self, multi_partition_file: str) -> None:
         config = ParquetBasicDataloaderConfig(

--- a/tests/unit/data/data_pipeline/test_shuffle.py
+++ b/tests/unit/data/data_pipeline/test_shuffle.py
@@ -7,82 +7,78 @@
 from itertools import islice
 
 import pytest
-import torch
 
 from fairseq2.data import read_sequence
+from fairseq2.typing import CPU
 from tests.common import tmp_rng_seed
 
 
 class TestShuffleOp:
     def test_op_works(self) -> None:
-        cpu_device = torch.device("cpu")
-
         seq = list(range(1, 10))
 
         pipeline = read_sequence(seq).shuffle(100).and_return()
 
         for _ in range(2):
-            with tmp_rng_seed(cpu_device, seed=2):
-                assert list(pipeline) == [7, 1, 3, 2, 6, 5, 8, 4, 9]
+            with tmp_rng_seed(CPU, seed=1234):
+                assert list(pipeline) == [8, 9, 3, 7, 5, 4, 2, 6, 1]
 
                 pipeline.reset()
 
         pipeline = read_sequence(seq).shuffle(0).and_return()
 
         for _ in range(2):
-            with tmp_rng_seed(cpu_device, seed=2):
-                assert list(pipeline) == [7, 1, 3, 2, 6, 5, 8, 4, 9]
+            with tmp_rng_seed(CPU, seed=1234):
+                assert list(pipeline) == [8, 9, 3, 7, 5, 4, 2, 6, 1]
 
                 pipeline.reset()
 
-        pipeline = read_sequence(seq).shuffle(3).and_return()
+        pipeline = read_sequence(seq).shuffle(4).and_return()
 
         for _ in range(2):
-            with tmp_rng_seed(cpu_device, seed=2):
-                assert list(pipeline) == [1, 3, 5, 2, 6, 7, 4, 9, 8]
+            with tmp_rng_seed(CPU, seed=1234):
+                assert list(pipeline) == [2, 1, 3, 4, 5, 7, 8, 6, 9]
 
                 pipeline.reset()
 
         pipeline = read_sequence(seq).shuffle(1).and_return()
 
         for _ in range(2):
-            with tmp_rng_seed(cpu_device, seed=2):
+            with tmp_rng_seed(CPU, seed=1234):
                 assert list(pipeline) == [1, 2, 3, 4, 5, 6, 7, 8, 9]
 
                 pipeline.reset()
 
     @pytest.mark.parametrize("window", [10, 100, 1000])
     def test_op_saves_and_restores_its_state(self, window: int) -> None:
-        cpu_device = torch.device("cpu")
-
         seq = list(range(5000))
 
         pipeline1 = read_sequence(seq).shuffle(window).and_return()
         pipeline2 = read_sequence(seq).shuffle(window).and_return()
 
-        with tmp_rng_seed(cpu_device, seed=2):
+        with tmp_rng_seed(CPU, seed=1234):
             expected_output1 = list(islice(pipeline1, 4000))
 
-        with tmp_rng_seed(cpu_device, seed=3):
+        with tmp_rng_seed(CPU, seed=5678):
             expected_output2 = list(islice(pipeline1, 1000))
 
-        with tmp_rng_seed(cpu_device, seed=2):
+        with tmp_rng_seed(CPU, seed=1234):
             assert list(islice(pipeline2, 4000)) == expected_output1
 
         state_dict = pipeline2.state_dict()
 
-        with tmp_rng_seed(cpu_device, seed=3):
+        with tmp_rng_seed(CPU, seed=5678):
             assert list(islice(pipeline2, 1000)) == expected_output2
 
         pipeline2.load_state_dict(state_dict)
 
-        with tmp_rng_seed(cpu_device, seed=3):
+        with tmp_rng_seed(CPU, seed=5678):
             assert list(islice(pipeline2, 1000)) == expected_output2
 
         pipeline2.reset()
         pipeline2.load_state_dict(state_dict)
 
-        with tmp_rng_seed(cpu_device, seed=3):
+        with tmp_rng_seed(CPU, seed=5678):
             assert list(islice(pipeline2, 1000)) == expected_output2
 
         state_dict = pipeline2.state_dict()


### PR DESCRIPTION
This PR revises the implementation of the `shuffle()` data pipeline op that gives significant performance boost due to better hardware cache utilization. Instead of random sampling per call, it shuffles the buffer window per fill and iterates through the buffer sequentially which makes it much more likely to have relevant memory pages in hardware cache(s).