### PR TITLE
Fix eod bug in zip data pipeline op

### DIFF
--- a/native/src/fairseq2n/data/zip_data_source.cc
+++ b/native/src/fairseq2n/data/zip_data_source.cc
@@ -91,7 +91,7 @@ zip_data_source::next()
             "The zipped data pipelines must all have the same number of examples, but the data pipelines at the indices [{}] have more examples than the others.", fmt::join(not_eod, ", "));
     }
 
-    if (is_eod[0] == 1)
+    if (are_eod)
         return std::nullopt;
 
     if (flatten_) {


### PR DESCRIPTION
A nit PR that fixes another subtle issue in `zip()` operator related to the new infinite data pipelines.