### PR TITLE
Introduce convert_to_llama_checkpoint

### DIFF
--- a/src/fairseq2/models/llama/integ.py
+++ b/src/fairseq2/models/llama/integ.py
@@ -1,0 +1,33 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, Dict
+
+from fairseq2.models.utils.checkpoint import convert_model_state_dict
+
+
+def convert_to_reference_checkpoint(checkpoint: Dict[str, Any]) -> Dict[str, Any]:
+    """Convert a fairseq2 LLaMA checkpoint to the reference format."""
+    state_dict = checkpoint["model"]
+
+    key_map = {
+        # fmt: off
+        r"^decoder\.layers\.([0-9]+)\.self_attn\.q_proj\.":      r"layers.\1.attention.wq.",
+        r"^decoder\.layers\.([0-9]+)\.self_attn\.k_proj\.":      r"layers.\1.attention.wk.",
+        r"^decoder\.layers\.([0-9]+)\.self_attn\.v_proj\.":      r"layers.\1.attention.wv.",
+        r"^decoder\.layers\.([0-9]+)\.self_attn\.output_proj\.": r"layers.\1.attention.wo.",
+        r"^decoder\.layers\.([0-9]+)\.self_attn_layer_norm\.":   r"layers.\1.attention_norm.",
+        r"^decoder\.layers\.([0-9]+)\.ffn\.gate_proj\.":         r"layers.\1.feed_forward.w1.",
+        r"^decoder\.layers\.([0-9]+)\.ffn\.output_proj\.":       r"layers.\1.feed_forward.w2.",
+        r"^decoder\.layers\.([0-9]+)\.ffn\.inner_proj\.":        r"layers.\1.feed_forward.w3.",
+        r"^decoder\.layers\.([0-9]+)\.ffn_layer_norm\.":         r"layers.\1.ffn_norm.",
+        r"^decoder\.layer_norm\.":                               r"norm.",
+        r"^decoder_frontend\.embed\.":                           r"tok_embeddings.",
+        r"^final_proj\.":                                        r"output.",
+        # fmt: on
+    }
+
+    return convert_model_state_dict(state_dict, key_map)

--- a/src/fairseq2/models/llama/loader.py
+++ b/src/fairseq2/models/llama/loader.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 from fairseq2.assets import asset_store, download_manager
 from fairseq2.models.llama.builder import LLaMAConfig, create_llama_model, llama_archs
@@ -15,7 +15,7 @@ from fairseq2.models.utils.checkpoint import convert_model_state_dict
 
 
 def convert_llama_checkpoint(
-    checkpoint: Dict[str, Any], config: Optional[LLaMAConfig] = None
+    checkpoint: Dict[str, Any], config: LLaMAConfig
 ) -> Dict[str, Any]:
     """Convert a reference LLaMA checkpoint to fairseq2."""
     key_map = {
@@ -41,30 +41,6 @@ def convert_llama_checkpoint(
     checkpoint = convert_model_state_dict(checkpoint, key_map)
 
     return {"model": checkpoint}
-
-
-def convert_to_llama_checkpoint(checkpoint: Dict[str, Any]) -> Dict[str, Any]:
-    """Convert a fairseq2 LLaMA checkpoint to the reference format."""
-    state_dict = checkpoint["model"]
-
-    key_map = {
-        # fmt: off
-        r"^decoder\.layers\.([0-9]+)\.self_attn\.q_proj\.":      r"layers.\1.attention.wq.",
-        r"^decoder\.layers\.([0-9]+)\.self_attn\.k_proj\.":      r"layers.\1.attention.wk.",
-        r"^decoder\.layers\.([0-9]+)\.self_attn\.v_proj\.":      r"layers.\1.attention.wv.",
-        r"^decoder\.layers\.([0-9]+)\.self_attn\.output_proj\.": r"layers.\1.attention.wo.",
-        r"^decoder\.layers\.([0-9]+)\.self_attn_layer_norm\.":   r"layers.\1.attention_norm.",
-        r"^decoder\.layers\.([0-9]+)\.ffn\.gate_proj\.":         r"layers.\1.feed_forward.w1.",
-        r"^decoder\.layers\.([0-9]+)\.ffn\.output_proj\.":       r"layers.\1.feed_forward.w2.",
-        r"^decoder\.layers\.([0-9]+)\.ffn\.inner_proj\.":        r"layers.\1.feed_forward.w3.",
-        r"^decoder\.layers\.([0-9]+)\.ffn_layer_norm\.":         r"layers.\1.ffn_norm.",
-        r"^decoder\.layer_norm\.":                               r"norm.",
-        r"^decoder_frontend\.embed\.":                           r"tok_embeddings.",
-        r"^final_proj\.":                                        r"output.",
-        # fmt: on
-    }
-
-    return convert_model_state_dict(state_dict, key_map)
 
 
 load_llama_config = ConfigLoader[LLaMAConfig](asset_store, llama_archs)

--- a/tests/integration/models/test_llama.py
+++ b/tests/integration/models/test_llama.py
@@ -1,0 +1,49 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+
+import pytest
+
+from fairseq2.assets import asset_store, download_manager
+from fairseq2.models.llama import create_llama_model, llama_archs
+from fairseq2.models.llama.loader import (
+    convert_llama_checkpoint,
+    convert_to_llama_checkpoint,
+)
+from fairseq2.models.utils.checkpoint import load_checkpoint
+from fairseq2.typing import CPU
+from tests.common import device
+
+
+@pytest.mark.skipif(
+    "FAIR_ENV_CLUSTER" not in os.environ, reason="checkpoints only on faircluster"
+)
+def test_convert_to_llama_checkpoint() -> None:
+    card = asset_store.retrieve_card("llama2_7b")
+
+    path = download_manager.download_checkpoint(
+        card.field("checkpoint").as_uri(), model_name="llama2_7b", progress=False
+    )
+
+    # Load and convert the reference checkpoint to fairseq2.
+    checkpoint = load_checkpoint(
+        path, map_location=CPU, restrict=True, converter=convert_llama_checkpoint
+    )
+
+    # Convert it back to the reference format.
+    checkpoint = convert_to_llama_checkpoint(checkpoint)
+
+    # Now, convert back to fairseq2 again.
+    checkpoint = convert_llama_checkpoint(checkpoint)
+
+    # Try to load the model with the converted fairseq2 checkpoint.
+    model_config = llama_archs.get_config("llama2_7b")
+
+    model = create_llama_model(model_config, device=device)
+
+    # This should work.
+    model.load_state_dict(checkpoint["model"])

--- a/tests/integration/models/test_llama.py
+++ b/tests/integration/models/test_llama.py
@@ -10,10 +10,8 @@ import pytest
 
 from fairseq2.assets import asset_store, download_manager
 from fairseq2.models.llama import create_llama_model, llama_archs
-from fairseq2.models.llama.loader import (
-    convert_llama_checkpoint,
-    convert_to_llama_checkpoint,
-)
+from fairseq2.models.llama.integ import convert_to_reference_checkpoint
+from fairseq2.models.llama.loader import convert_llama_checkpoint
 from fairseq2.models.utils.checkpoint import load_checkpoint
 from fairseq2.typing import CPU
 from tests.common import device
@@ -22,27 +20,27 @@ from tests.common import device
 @pytest.mark.skipif(
     "FAIR_ENV_CLUSTER" not in os.environ, reason="checkpoints only on faircluster"
 )
-def test_convert_to_llama_checkpoint() -> None:
+def test_convert_to_reference_checkpoint() -> None:
+    model_config = llama_archs.get_config("llama2_7b")
+
     card = asset_store.retrieve_card("llama2_7b")
 
     path = download_manager.download_checkpoint(
         card.field("checkpoint").as_uri(), model_name="llama2_7b", progress=False
     )
 
-    # Load and convert the reference checkpoint to fairseq2.
-    checkpoint = load_checkpoint(
-        path, map_location=CPU, restrict=True, converter=convert_llama_checkpoint
-    )
+    checkpoint = load_checkpoint(path, map_location=CPU, restrict=True)
+
+    # Convert the reference checkpoint to fairseq2.
+    checkpoint = convert_llama_checkpoint(checkpoint, model_config)
 
     # Convert it back to the reference format.
-    checkpoint = convert_to_llama_checkpoint(checkpoint)
+    checkpoint = convert_to_reference_checkpoint(checkpoint)
 
     # Now, convert back to fairseq2 again.
-    checkpoint = convert_llama_checkpoint(checkpoint)
+    checkpoint = convert_llama_checkpoint(checkpoint, model_config)
 
     # Try to load the model with the converted fairseq2 checkpoint.
-    model_config = llama_archs.get_config("llama2_7b")
-
     model = create_llama_model(model_config, device=device)
 
     # This should work.


### PR DESCRIPTION
This PR introduces a new `convert_to_llama_checkpoint()` utility function to convert fairseq2 LLaMA checkpoints to reference format.