### PR TITLE
Add skip_long_examples to bucket_by_length

### DIFF
--- a/native/python/src/fairseq2n/bindings/data/data_pipeline.cc
+++ b/native/python/src/fairseq2n/bindings/data/data_pipeline.cc
@@ -405,17 +405,20 @@ def_data_pipeline(py::module_ &data_module)
                 data_pipeline_builder &self,
                 std::vector<std::pair<std::size_t, std::size_t>> bucket_sizes,
                 std::optional<std::string> maybe_selector,
+                bool skip_long_examples,
                 bool drop_remainder) -> data_pipeline_builder &
             {
                 self = std::move(self).bucket_by_length(
                     std::move(bucket_sizes),
                     data_length_extractor{std::move(maybe_selector)},
+                    skip_long_examples,
                     drop_remainder);
 
                 return self;
             },
             py::arg("bucket_sizes"),
             py::arg("selector") = std::nullopt,
+            py::arg("skip_long_examples") = false,
             py::arg("drop_remainder") = false)
         .def(
             "collate",

--- a/native/src/fairseq2n/data/bucket_by_length_data_source.h
+++ b/native/src/fairseq2n/data/bucket_by_length_data_source.h
@@ -24,6 +24,7 @@ public:
         std::unique_ptr<data_source> &&inner,
         std::vector<std::pair<std::size_t, std::size_t>> &&bucket_sizes,
         data_length_fn &&fn,
+        bool skip_long_examples,
         bool drop_remainder);
 
     std::optional<data>
@@ -46,6 +47,7 @@ private:
     std::vector<std::pair<std::size_t, std::size_t>> bucket_sizes_;
     std::size_t max_data_len_;
     data_length_fn data_length_fn_;
+    bool skip_long_examples_;
     bool drop_remainder_;
     std::vector<data_list> buckets_{};
 };

--- a/native/src/fairseq2n/data/data_pipeline.cc
+++ b/native/src/fairseq2n/data/data_pipeline.cc
@@ -351,6 +351,7 @@ data_pipeline_builder
 data_pipeline_builder::bucket_by_length(
     std::vector<std::pair<std::size_t, std::size_t>> bucket_sizes,
     data_length_fn fn,
+    bool skip_long_examples,
     bool drop_remainder) &&
 {
     if (bucket_sizes.empty())
@@ -369,7 +370,7 @@ data_pipeline_builder::bucket_by_length(
         inner = std::move(factory_)]() mutable
     {
         return std::make_unique<bucket_by_length_data_source>(
-            inner(), std::move(bucket_sizes), std::move(fn), drop_remainder);
+            inner(), std::move(bucket_sizes), std::move(fn), skip_long_examples, drop_remainder);
     };
 
     return std::move(*this);

--- a/native/src/fairseq2n/data/data_pipeline.h
+++ b/native/src/fairseq2n/data/data_pipeline.h
@@ -133,6 +133,7 @@ public:
     bucket_by_length(
         std::vector<std::pair<std::size_t, std::size_t>> bucket_sizes,
         data_length_fn fn,
+        bool skip_long_examples = false,
         bool drop_remainder = false) &&;
 
     data_pipeline_builder

--- a/src/fairseq2/data/data_pipeline.py
+++ b/src/fairseq2/data/data_pipeline.py
@@ -159,6 +159,7 @@ if TYPE_CHECKING or DOC_MODE:
             self,
             bucket_sizes: Sequence[Tuple[int, int]],
             selector: Optional[str] = None,
+            skip_long_examples: bool = False,
             drop_remainder: bool = False,
         ) -> Self:
             """Combine examples of similar shape into batches."""


### PR DESCRIPTION
This PR adds a new `skip_long_examples` to `bucket_by_length` data pipeline op. As its name suggest, it skips examples longer than the specified value without raising an error. Logging is marked as TODO and will be handled in a future PR.