### PR TITLE
Remove validate_schema from ParquetDataset

### DIFF
--- a/src/fairseq2/data/parquet_tools.py
+++ b/src/fairseq2/data/parquet_tools.py
@@ -114,13 +114,7 @@ def init_parquet_dataset(
     filters: Optional[pa.dataset.Expression] = None,
     filesystem: Optional[pa.fs.FileSystem] = None,
 ) -> pq.ParquetDataset:
-    source_ds = pq.ParquetDataset(
-        parquet_path,
-        validate_schema=True,
-        filters=filters,
-        filesystem=filesystem,
-    )
-    return source_ds
+    return pq.ParquetDataset(parquet_path, filters=filters, filesystem=filesystem)
 
 
 def get_dataset_fragments(


### PR DESCRIPTION
This PR removes `validate_schema` from `ParquetDataset` call which was removed in Parquet v15.0 (which is a BC-breaking change). The default in previous versions was `True`, so removing it does not change the behavior.