### PR TITLE
Fail gracefully in Python if DataPipeline state_dict is corrupt

### DIFF
--- a/native/src/fairseq2n/data/sample_data_source.cc
+++ b/native/src/fairseq2n/data/sample_data_source.cc
@@ -122,7 +122,7 @@ sample_data_source::random_pipeline_index()
     float32 sample = at::transformation::uniform_real(gen->random(), 0.0F, 1.0F);
 
     std::size_t lptr = 0;
-    std::size_t rptr = weight_cumsums_.size();
+    std::size_t rptr = weight_cumsums_.size() - 1;
 
     while (rptr - lptr > 0) {
         std::size_t mptr = lptr + (rptr - lptr) / 2;

--- a/native/src/fairseq2n/data/tape-inl.h
+++ b/native/src/fairseq2n/data/tape-inl.h
@@ -7,9 +7,9 @@
 #pragma once
 
 #include <cstdint>
-#include <vector>
 #include <optional>
 #include <type_traits>
+#include <vector>
 
 #include "fairseq2n/float.h"
 #include "fairseq2n/utils/cast.h"

--- a/native/src/fairseq2n/data/tape.cc
+++ b/native/src/fairseq2n/data/tape.cc
@@ -34,6 +34,4 @@ tape::read_data()
     return *pos_++;
 }
 
-corrupt_tape_error::~corrupt_tape_error() = default;
-
 }  // namespace fairseq2n

--- a/native/src/fairseq2n/data/tape.h
+++ b/native/src/fairseq2n/data/tape.h
@@ -51,6 +51,12 @@ public:
         pos_ = storage_.begin();
     }
 
+    bool
+    is_eod() const noexcept
+    {
+        return pos_ == storage_.end();
+    }
+
     const data_list &
     storage() const noexcept
     {
@@ -66,22 +72,11 @@ private:
     data_list::iterator pos_ = storage_.begin();
 };
 
-class FAIRSEQ2_API corrupt_tape_error : public std::domain_error {
-public:
-    using std::domain_error::domain_error;
-
-public:
-    corrupt_tape_error(const corrupt_tape_error &) = default;
-    corrupt_tape_error &operator=(const corrupt_tape_error &) = default;
-
-   ~corrupt_tape_error() override;
-};
-
 inline void
 tape::throw_corrupt()
 {
-    throw corrupt_tape_error{
-        "The tape is corrupt. The state of the data pipeline cannot be restored."};
+    throw std::invalid_argument(
+        "The tape is corrupt. The state of the data pipeline cannot be restored.");
 }
 
 }  // namespace fairseq2n

--- a/native/tests/data/test_tape.cc
+++ b/native/tests/data/test_tape.cc
@@ -8,6 +8,7 @@
 
 #include <cstdint>
 #include <optional>
+#include <stdexcept>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -99,7 +100,7 @@ TEST(test_tape, read_throws_exception_when_record_is_not_called)
 {
     tape t{};
 
-    EXPECT_THROW(t.read_data(), corrupt_tape_error);
+    EXPECT_THROW(t.read_data(), std::invalid_argument);
 }
 
 TEST(test_tape, read_throws_exception_when_record_is_of_different_type)
@@ -110,7 +111,7 @@ TEST(test_tape, read_throws_exception_when_record_is_of_different_type)
 
     t.rewind();
 
-    EXPECT_THROW(t.read<std::int32_t>(), corrupt_tape_error);
+    EXPECT_THROW(t.read<std::int32_t>(), std::invalid_argument);
 }
 
 TEST(test_tape, read_throws_exception_when_end_of_tape_is_reached)
@@ -120,5 +121,5 @@ TEST(test_tape, read_throws_exception_when_end_of_tape_is_reached)
     t.record(4);
 
     // No rewind.
-    EXPECT_THROW(t.read<std::int32_t>(), corrupt_tape_error);
+    EXPECT_THROW(t.read<std::int32_t>(), std::invalid_argument);
 }

--- a/src/fairseq2/data/data_pipeline.py
+++ b/src/fairseq2/data/data_pipeline.py
@@ -69,16 +69,11 @@ if TYPE_CHECKING or DOC_MODE:
             the returned state dictionary to :meth:`load_state_dict`.
             """
 
-        def load_state_dict(
-            self, state_dict: Mapping[str, Any], strict: bool = True
-        ) -> None:
+        def load_state_dict(self, state_dict: Mapping[str, Any]) -> None:
             """Restore the state of the data pipeline from ``state_dict``.
 
             :param state_dict:
                 A state dictionary previously returned by :meth:`state_dict`.
-            :param strict:
-                If ``True``, enforces that the keys in ``state_dict`` match the
-                keys returned by :meth:`state_dict`.
             """
 
         @staticmethod

--- a/tests/unit/data/data_pipeline/test_shuffle.py
+++ b/tests/unit/data/data_pipeline/test_shuffle.py
@@ -76,6 +76,7 @@ class TestShuffleOp:
             assert list(islice(pipeline2, 1000)) == expected_output2
 
         pipeline2.reset()
+
         pipeline2.load_state_dict(state_dict)
 
         with tmp_rng_seed(CPU, seed=5678):


### PR DESCRIPTION
This PR improves the Python binding of `DataPipeline` to grafefully fail with a `ValueError` in case the provided `state_dict` to `load_state_dict` is corrupt.