### PR TITLE
Improve AdamW API

### DIFF
--- a/tests/unit/optim/test_adamw.py
+++ b/tests/unit/optim/test_adamw.py
@@ -67,6 +67,7 @@ class TestAdamW:
                 {"params": net1.conv2.parameters(), "lr": 0.002},
             ],
             lr=0.001,
+            use_fp32=True,
         )
         opt2 = BaseAdamW(
             params=[  # type: ignore[arg-type]


### PR DESCRIPTION
This PR revises and improves the API of `AdamW` with a new `use_fp32` parameter to conditionally enable mixed precision training instead of hardcoding it for fp16 and bf16. This way it can be used as a drop-in placement for PyTorch AdamW.