### PR TITLE
Introduce MetricRecorder

### DIFF
--- a/native/src/fairseq2n/data/sample_data_source.cc
+++ b/native/src/fairseq2n/data/sample_data_source.cc
@@ -170,4 +170,4 @@ sample_data_source::are_all_done() noexcept
     return is_eod_;
 }
 
-}  // namespace fairseq2::detail
+}  // namespace fairseq2n::detail

--- a/native/src/fairseq2n/data/sample_data_source.h
+++ b/native/src/fairseq2n/data/sample_data_source.h
@@ -56,4 +56,4 @@ private:
     bool is_infinite_;
 };
 
-}  // namespace fairseq2::detail
+}  // namespace fairseq2n::detail

--- a/src/fairseq2/nn/fsdp.py
+++ b/src/fairseq2/nn/fsdp.py
@@ -139,7 +139,7 @@ class FSDPWrapPolicy(Protocol):
         """
 
 
-@dataclass
+@dataclass(frozen=True)
 class FSDPMemoryPolicy:
     """Specifies the device memory usage policy of an FSDP module."""
 

--- a/src/fairseq2/optim/lr_scheduler.py
+++ b/src/fairseq2/optim/lr_scheduler.py
@@ -18,6 +18,11 @@ from fairseq2.typing import finaloverride
 LRScheduler: TypeAlias = _LRScheduler
 
 
+def get_effective_lr(scheduler: LRScheduler) -> float:
+    """Return the effective learning rate computed by ``scheduler``."""
+    return scheduler.get_last_lr()[0]
+
+
 class LRSchedulerBase(ABC, LRScheduler):
     """Represents the abstract base class for learning rate schedulers."""
 
@@ -33,11 +38,6 @@ class LRSchedulerBase(ABC, LRScheduler):
     @abstractmethod
     def _compute_lrs(self) -> List[float]:
         """Compute the learning rate of each parameter group."""
-
-
-def get_effective_lr(scheduler: LRScheduler) -> float:
-    """Return the effective learning rate computed by ``scheduler``."""
-    return scheduler.get_last_lr()[0]
 
 
 @final


### PR DESCRIPTION
This PR:
- introduces a new `MetricRecorder` interface and `LogMetricRecorder` and `TensorBoardRecorder` classes.
- revises how we format metric values and extracts the relevant functions from `MetricBag`.
- performs a couple nit readability updates in other parts of the code.