### PR TITLE
Fix batch loss bug

### DIFF
--- a/src/fairseq2/models/seq2seq.py
+++ b/src/fairseq2/models/seq2seq.py
@@ -177,7 +177,7 @@ class Seq2SeqModelMetricBag(MetricBag):
         num_target_elements = torch.zeros((), dtype=torch.float64)
 
         for batch, batch_loss in zip(batches, losses):
-            loss += int(batch_loss)
+            loss += float(batch_loss)
 
             batch_size += batch.batch_size
 


### PR DESCRIPTION
This PR fixes a (serious) bug in `Seq2SeqModelMetricBag` where we accidentally use `int` instead of `float` for accumulating loss. A remnant of a recent fp16 debugging work.