### PR TITLE
Remove sharding_strategy from to_fsdp

### DIFF
--- a/src/fairseq2/nn/fsdp.py
+++ b/src/fairseq2/nn/fsdp.py
@@ -41,7 +41,6 @@ def to_fsdp(
     ignored_param_names: Optional[Sequence[str]] = None,
     skip_init: bool = False,
     broadcast_state: bool = False,
-    sharding_strategy: Optional[ShardingStrategy] = None,
     memory_policy: Optional[FSDPMemoryPolicy] = None,
 ) -> FSDP:
     """Wrap ``module`` with FSDP.
@@ -52,7 +51,8 @@ def to_fsdp(
         The gang over which the module will be sharded.
     :param wrap_policy:
         The policy to apply FSDP to ``module``.  If ``None``, ``module`` will be
-        wrapped with only a top-level FSDP instance.
+        wrapped with only a top-level FSDP instance and no sharding will applied
+        (i.e. ``NO_SHARD``).
     :param ignored_param_names:
         The ignored parameter names. Can contain regular expressions.
     :param skip_init:
@@ -61,23 +61,13 @@ def to_fsdp(
     :param broadcast_state:
         If ``True``, each FSDP module will broadcast its parameters and buffers
         from rank 0 to ensure that they are replicated across all processes.
-    :param sharding_strategy:
-        The sharding strategy to trade off memory saving and communication
-        overhead. If ``None``; if ``wrap_policy`` is specified, ``module`` will
-        be fully sharded (``FULL_SHARDED``); otherwise, it will not be sharded
-        at all (``NO_SHARD``).
     :param memory_policy:
         The policy to instruct FSDP when and how to allocate memory.
     """
-    if sharding_strategy is None:
-        if wrap_policy is None:
-            sharding_strategy = ShardingStrategy.NO_SHARD
-        else:
-            sharding_strategy = ShardingStrategy.FULL_SHARD
-    elif sharding_strategy == ShardingStrategy.NO_SHARD and wrap_policy is not None:
-        raise ValueError(
-            "`wrap_policy` must be `None` when `sharding_strategy` is `NO_SHARD`."
-        )
+    if wrap_policy is None:
+        sharding_strategy = ShardingStrategy.NO_SHARD
+    else:
+        sharding_strategy = ShardingStrategy.FULL_SHARD
 
     if memory_policy is None:
         memory_policy = FSDP_STANDARD_MEMORY_POLICY


### PR DESCRIPTION
This PR removes the `sharding_strategy` parameter from `to_fsdp`. For now, we set the strategy to either `FULL_SHARD` or `NO_SHARD` based on the `wrap_policy`. In the near future, depending on the passed `gang`, we will infer whether we should use `FULL_SHARD` or `HYBRID_SHARD` when `wrap_policy` is not None. This means the user does not need to pass the strategy explicitly which also simplifies the API.