### PR TITLE
Add step parameter to count data pipeline op

### DIFF
--- a/native/python/src/fairseq2n/bindings/data/data_pipeline.cc
+++ b/native/python/src/fairseq2n/bindings/data/data_pipeline.cc
@@ -306,11 +306,12 @@ def_data_pipeline(py::module_ &data_module)
             py::arg("key") = std::nullopt)
         .def_static(
             "count",
-            [](std::int64_t start, std::optional<std::string> key)
+            [](std::int64_t start, std::int64_t step, std::optional<std::string> key)
             {
-                return data_pipeline::count(start, std::move(key));
+                return data_pipeline::count(start, step, std::move(key));
             },
             py::arg("start") = 0,
+            py::arg("step") = 1,
             py::arg("key") = std::nullopt)
         .def_static(
             "round_robin",

--- a/native/src/fairseq2n/data/count_data_source.cc
+++ b/native/src/fairseq2n/data/count_data_source.cc
@@ -13,10 +13,14 @@ namespace fairseq2n::detail {
 std::optional<data>
 count_data_source::next()
 {
-    if (key_)
-        return data_dict{{*key_, counter_++}};
+    std::int64_t output = counter_;
 
-    return counter_++;
+    counter_ += step_;
+
+    if (key_)
+        return data_dict{{*key_, output}};
+
+    return output;
 }
 
 void

--- a/native/src/fairseq2n/data/count_data_source.h
+++ b/native/src/fairseq2n/data/count_data_source.h
@@ -15,8 +15,8 @@ namespace fairseq2n::detail {
 class count_data_source final : public data_source {
 public:
     explicit
-    count_data_source(std::int64_t start, std::optional<std::string> key) noexcept
-      : start_{start}, counter_{start}, key_{std::move(key)}
+    count_data_source(std::int64_t start, std::int64_t step, std::optional<std::string> key) noexcept
+      : start_{start}, step_{step}, counter_{start}, key_{std::move(key)}
     {}
 
     std::optional<data>
@@ -36,6 +36,7 @@ public:
 
 private:
     std::int64_t start_;
+    std::int64_t step_;
     std::int64_t counter_;
     std::optional<std::string> key_;
 };

--- a/native/src/fairseq2n/data/data_pipeline.cc
+++ b/native/src/fairseq2n/data/data_pipeline.cc
@@ -215,11 +215,11 @@ data_pipeline::constant(data example, std::optional<std::string> key)
 }
 
 data_pipeline_builder
-data_pipeline::count(std::int64_t start, std::optional<std::string> key)
+data_pipeline::count(std::int64_t start, std::int64_t step, std::optional<std::string> key)
 {
-    auto factory = [start, key = std::move(key)]() mutable
+    auto factory = [start, step, key = std::move(key)]() mutable
     {
-        return std::make_unique<count_data_source>(start, std::move(key));
+        return std::make_unique<count_data_source>(start, step, std::move(key));
     };
 
     return data_pipeline_builder{std::move(factory)};

--- a/native/src/fairseq2n/data/data_pipeline.h
+++ b/native/src/fairseq2n/data/data_pipeline.h
@@ -79,7 +79,7 @@ public:
     constant(data example, std::optional<std::string> key = {});
 
     static data_pipeline_builder
-    count(std::int64_t start = 0, std::optional<std::string> key = {});
+    count(std::int64_t start = 0, std::int64_t step = 1, std::optional<std::string> key = {});
 
     static data_pipeline_builder
     round_robin(std::vector<data_pipeline> pipelines, bool stop_at_shortest = false);

--- a/src/fairseq2/data/data_pipeline.py
+++ b/src/fairseq2/data/data_pipeline.py
@@ -89,7 +89,9 @@ if TYPE_CHECKING or DOC_MODE:
             ...
 
         @staticmethod
-        def count(start: int = 0, key: Optional[str] = None) -> DataPipelineBuilder:
+        def count(
+            start: int = 0, step: int = 1, key: Optional[str] = None
+        ) -> DataPipelineBuilder:
             ...
 
         @staticmethod

--- a/tests/unit/data/data_pipeline/test_count.py
+++ b/tests/unit/data/data_pipeline/test_count.py
@@ -18,6 +18,14 @@ class TestCountOp:
 
             pipeline.reset()
 
+    def test_op_works_when_step_is_greater_than_1(self) -> None:
+        pipeline = DataPipeline.count(start=4, step=3).take(10).and_return()
+
+        for _ in range(2):
+            assert list(pipeline) == list(range(4, 34, 3))
+
+            pipeline.reset()
+
     def test_op_saves_and_restores_its_state(self) -> None:
         pipeline = DataPipeline.count(start=4).take(10).and_return()
 


### PR DESCRIPTION
This PR introduces a new `step` parameter to the `count()` data pipeline operator.