### PR TITLE
Add a basic plugin mechanism

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
     python_requires=">=3.8",
     install_requires=[
         "fairseq2n" + fairseq2n_version_spec,
+        "importlib_metadata~=7.0",
         "numpy~=1.23",
         "overrides~=7.3",
         "packaging~=23.1",

--- a/src/fairseq2/__init__.py
+++ b/src/fairseq2/__init__.py
@@ -4,8 +4,24 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from importlib import import_module
 
-# We import fairseq2n to report any initialization error eagerly.
-import fairseq2n
+from importlib_metadata import entry_points
+
+# Report any fairseq2n initialization error eagerly.
+import_module("fairseq2n")
+
 
 __version__ = "0.3.0.dev0"
+
+
+def setup_extensions() -> None:
+    for entry_point in entry_points(group="fairseq2"):
+        setup_fn = entry_point.load()
+
+        try:
+            setup_fn()
+        except TypeError:
+            raise RuntimeError(
+                f"The entry point '{entry_point.value}' is not a valid fairseq2 setup function."
+            )


### PR DESCRIPTION
This PR introduces a basic plugin mechanism. It provides a `setup_extensions()` function that leverages setuptools' entry point feature to discover and call setup functions provided by other packages. Scripts using fairseq2 are expected to call `setup_extensions()` at an early stage to ensure that all extensions are properly loaded.

`my_package/setup.py`:

```python
from setuptools import setup

setup(
    name="my_package",
    ...
    entry_points={
        "fairseq2": [
             "setup = my_package:setup_fairseq2_extensions",
        ]
    },
)
```

`my_package/src/my_package/__init__.py`

```python
from fairseq2.assets import asset_store

...

def setup_fairseq2_extensions() -> None:
    asset_store.metadata_providers.append(...)
```

`run_train.py`

```python
import fairseq2

# Transitively calls `setup_fairseq2()` of `my_package` and other packages
# having a `fairseq2` entrypoint.
fairseq2.setup_extensions()
```