### PR TITLE
Refactor TextTokenizerLoader

### DIFF
--- a/src/fairseq2/__init__.py
+++ b/src/fairseq2/__init__.py
@@ -12,6 +12,13 @@ from importlib_metadata import entry_points
 import_module("fairseq2n")
 
 
+# Ensure that model loaders are initialized.
+import_module("fairseq2.models.llama")
+import_module("fairseq2.models.mistral")
+import_module("fairseq2.models.nllb")
+import_module("fairseq2.models.s2t_transformer")
+
+
 __version__ = "0.3.0.dev0"
 
 

--- a/src/fairseq2/data/text/__init__.py
+++ b/src/fairseq2/data/text/__init__.py
@@ -25,6 +25,17 @@ from fairseq2.data.text.sentencepiece import (
 )
 from fairseq2.data.text.text_reader import LineEnding as LineEnding
 from fairseq2.data.text.text_reader import read_text as read_text
+from fairseq2.data.text.text_tokenizer import (
+    BasicTextTokenizerLoader as BasicTextTokenizerLoader,
+)
+from fairseq2.data.text.text_tokenizer import (
+    CompositeTextTokenizerLoader as CompositeTextTokenizerLoader,
+)
+from fairseq2.data.text.text_tokenizer import (
+    GenericTextTokenizerLoader as GenericTextTokenizerLoader,
+)
 from fairseq2.data.text.text_tokenizer import TextTokenDecoder as TextTokenDecoder
 from fairseq2.data.text.text_tokenizer import TextTokenEncoder as TextTokenEncoder
 from fairseq2.data.text.text_tokenizer import TextTokenizer as TextTokenizer
+from fairseq2.data.text.text_tokenizer import TextTokenizerLoader as TextTokenizerLoader
+from fairseq2.data.text.text_tokenizer import load_text_tokenizer as load_text_tokenizer

--- a/src/fairseq2/data/text/sentencepiece.py
+++ b/src/fairseq2/data/text/sentencepiece.py
@@ -159,6 +159,7 @@ class SentencePieceTokenizerBase(TextTokenizer):
 class BasicSentencePieceTokenizer(SentencePieceTokenizerBase):
     """Represents a SentencePiece tokenizer that encodes text with BOS and EOS."""
 
+    # protected
     def __init__(self, pathname: PathLike) -> None:
         """
         :param pathname:

--- a/src/fairseq2/models/llama/loader.py
+++ b/src/fairseq2/models/llama/loader.py
@@ -7,10 +7,11 @@
 from typing import Any, Dict
 
 from fairseq2.assets import asset_store, download_manager
+from fairseq2.data.text import BasicTextTokenizerLoader, load_text_tokenizer
 from fairseq2.models.llama.builder import LLaMAConfig, create_llama_model, llama_archs
 from fairseq2.models.llama.tokenizer import LLaMATokenizer
 from fairseq2.models.transformer import TransformerDecoderModel
-from fairseq2.models.utils import ConfigLoader, ModelLoader, TokenizerLoader
+from fairseq2.models.utils import ConfigLoader, ModelLoader
 from fairseq2.models.utils.checkpoint import convert_model_state_dict
 
 
@@ -53,6 +54,8 @@ load_llama_model = ModelLoader[TransformerDecoderModel, LLaMAConfig](
     convert_llama_checkpoint,
 )
 
-load_llama_tokenizer = TokenizerLoader[LLaMATokenizer](
+load_llama_tokenizer = BasicTextTokenizerLoader[LLaMATokenizer](
     asset_store, download_manager, LLaMATokenizer
 )
+
+load_text_tokenizer.register_loader("llama", load_llama_tokenizer)

--- a/src/fairseq2/models/mistral/loader.py
+++ b/src/fairseq2/models/mistral/loader.py
@@ -7,6 +7,7 @@
 from typing import Any, Dict
 
 from fairseq2.assets import asset_store, download_manager
+from fairseq2.data.text import BasicTextTokenizerLoader, load_text_tokenizer
 from fairseq2.models.mistral.builder import (
     MistralConfig,
     create_mistral_model,
@@ -14,7 +15,7 @@ from fairseq2.models.mistral.builder import (
 )
 from fairseq2.models.mistral.tokenizer import MistralTokenizer
 from fairseq2.models.transformer import TransformerDecoderModel
-from fairseq2.models.utils import ConfigLoader, ModelLoader, TokenizerLoader
+from fairseq2.models.utils import ConfigLoader, ModelLoader
 from fairseq2.models.utils.checkpoint import convert_model_state_dict
 
 
@@ -54,6 +55,8 @@ load_mistral_model = ModelLoader[TransformerDecoderModel, MistralConfig](
     convert_mistral_checkpoint,
 )
 
-load_mistral_tokenizer = TokenizerLoader[MistralTokenizer](
+load_mistral_tokenizer = BasicTextTokenizerLoader[MistralTokenizer](
     asset_store, download_manager, MistralTokenizer
 )
+
+load_text_tokenizer.register_loader("mistral", load_mistral_tokenizer)

--- a/src/fairseq2/models/nllb/loader.py
+++ b/src/fairseq2/models/nllb/loader.py
@@ -10,10 +10,11 @@ from typing import Any, Dict, final
 import torch
 
 from fairseq2.assets import AssetCard, asset_store, download_manager
+from fairseq2.data.text import GenericTextTokenizerLoader, load_text_tokenizer
 from fairseq2.models.nllb.builder import NllbConfig, create_nllb_model, nllb_archs
 from fairseq2.models.nllb.tokenizer import NllbTokenizer
 from fairseq2.models.transformer import TransformerModel
-from fairseq2.models.utils import ConfigLoader, ModelLoader, TokenizerLoaderBase
+from fairseq2.models.utils import ConfigLoader, ModelLoader
 from fairseq2.models.utils.checkpoint import convert_fairseq_checkpoint
 from fairseq2.typing import finaloverride
 
@@ -78,7 +79,7 @@ def convert_nllb_checkpoint(
 
 
 @final
-class NllbTokenizerLoader(TokenizerLoaderBase[NllbTokenizer]):
+class NllbTokenizerLoader(GenericTextTokenizerLoader[NllbTokenizer]):
     """Loads tokenizers used by NLLB models."""
 
     @finaloverride
@@ -102,3 +103,5 @@ load_nllb_model = ModelLoader[TransformerModel, NllbConfig](
 )
 
 load_nllb_tokenizer = NllbTokenizerLoader(asset_store, download_manager)
+
+load_text_tokenizer.register_loader("nllb", load_nllb_tokenizer)

--- a/src/fairseq2/models/s2t_transformer/loader.py
+++ b/src/fairseq2/models/s2t_transformer/loader.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any, Dict, final
 
 from fairseq2.assets import AssetCard, asset_store, download_manager
+from fairseq2.data.text import GenericTextTokenizerLoader, load_text_tokenizer
 from fairseq2.models.s2t_transformer.builder import (
     S2TTransformerConfig,
     create_s2t_transformer_model,
@@ -15,7 +16,7 @@ from fairseq2.models.s2t_transformer.builder import (
 )
 from fairseq2.models.s2t_transformer.tokenizer import S2TTransformerTokenizer
 from fairseq2.models.transformer import TransformerModel
-from fairseq2.models.utils import ConfigLoader, ModelLoader, TokenizerLoaderBase
+from fairseq2.models.utils import ConfigLoader, ModelLoader
 from fairseq2.models.utils.checkpoint import convert_fairseq_checkpoint
 from fairseq2.typing import finaloverride
 
@@ -72,7 +73,9 @@ def convert_s2t_transformer_checkpoint(
 
 
 @final
-class S2TTransformerTokenizerLoader(TokenizerLoaderBase[S2TTransformerTokenizer]):
+class S2TTransformerTokenizerLoader(
+    GenericTextTokenizerLoader[S2TTransformerTokenizer]
+):
     """Loads tokenizers used by S2T Transformer models."""
 
     @finaloverride
@@ -102,3 +105,5 @@ load_s2t_transformer_model = ModelLoader[TransformerModel, S2TTransformerConfig]
 load_s2t_transformer_tokenizer = S2TTransformerTokenizerLoader(
     asset_store, download_manager
 )
+
+load_text_tokenizer.register_loader("s2t_transformer", load_s2t_transformer_tokenizer)

--- a/src/fairseq2/models/utils/__init__.py
+++ b/src/fairseq2/models/utils/__init__.py
@@ -4,12 +4,13 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from fairseq2.data.text import BasicTextTokenizerLoader, GenericTextTokenizerLoader
 from fairseq2.models.utils.arch_registry import (
     ArchitectureRegistry as ArchitectureRegistry,
 )
 from fairseq2.models.utils.generic_loaders import ConfigLoader as ConfigLoader
 from fairseq2.models.utils.generic_loaders import ModelLoader as ModelLoader
-from fairseq2.models.utils.generic_loaders import TokenizerLoader as TokenizerLoader
-from fairseq2.models.utils.generic_loaders import (
-    TokenizerLoaderBase as TokenizerLoaderBase,
-)
+
+# For backwards-compatibility with v0.2
+TokenizerLoader = BasicTextTokenizerLoader
+TokenizerLoaderBase = GenericTextTokenizerLoader

--- a/src/fairseq2/models/utils/arch_registry.py
+++ b/src/fairseq2/models/utils/arch_registry.py
@@ -43,7 +43,7 @@ class ArchitectureRegistry(Generic[ModelConfigT]):
         """
         if arch_name in self.configs:
             raise ValueError(
-                f"The architecture name '{arch_name}' is already registered for '{self.model_type}'."
+                f"`arch_name` must be a unique architecture name, but '{arch_name}' is already registered for '{self.model_type}'."
             )
 
         self.configs[arch_name] = config_factory

--- a/src/fairseq2/models/utils/generic_loaders.py
+++ b/src/fairseq2/models/utils/generic_loaders.py
@@ -5,12 +5,10 @@
 # LICENSE file in the root directory of this source tree.
 
 import logging
-from abc import ABC, abstractmethod
 from copy import deepcopy
 from functools import partial
-from pathlib import Path
 from pickle import PickleError
-from typing import Any, Dict, Generic, Optional, Protocol, TypeVar, Union, final
+from typing import Any, Dict, Generic, Optional, Protocol, TypeVar, Union
 
 from torch.nn import Module
 
@@ -22,8 +20,6 @@ from fairseq2.assets import (
     AssetError,
     AssetStore,
 )
-from fairseq2.data import PathLike
-from fairseq2.data.text import TextTokenizer
 from fairseq2.models.utils.arch_registry import ArchitectureRegistry
 from fairseq2.models.utils.checkpoint import load_checkpoint
 from fairseq2.nn.utils.module import (
@@ -31,7 +27,7 @@ from fairseq2.nn.utils.module import (
     reset_non_persistent_buffers,
     to_empty,
 )
-from fairseq2.typing import CPU, META, DataType, Device, finaloverride
+from fairseq2.typing import CPU, META, DataType, Device
 from fairseq2.utils.dataclass import update_dataclass
 
 logger = logging.getLogger("fairseq2.models")
@@ -297,115 +293,3 @@ class ModelLoader(Generic[ModelT, ConfigT]):
             reset_non_persistent_buffers(model)
 
         return model
-
-
-TokenizerT = TypeVar("TokenizerT", bound=TextTokenizer)
-TokenizerT_co = TypeVar("TokenizerT_co", bound=TextTokenizer, covariant=True)
-
-
-class TokenizerLoaderBase(ABC, Generic[TokenizerT]):
-    """Represents an abstract base class for tokenizer loaders."""
-
-    asset_store: AssetStore
-    download_manager: AssetDownloadManager
-
-    def __init__(
-        self, asset_store: AssetStore, download_manager: AssetDownloadManager
-    ) -> None:
-        """
-        :param asset_store:
-            The asset store where to check for available tokenizers.
-        :param download_manager:
-            The download manager.
-        """
-        self.asset_store = asset_store
-        self.download_manager = download_manager
-
-    def __call__(
-        self,
-        tokenizer_name_or_card: Union[str, AssetCard],
-        *,
-        force: bool = False,
-        cache_only: bool = False,
-        progress: bool = True,
-    ) -> TokenizerT:
-        """
-        :param tokenizer_name_or_card:
-            The name or asset card of the tokenizer to load.
-        :param force:
-            If ``True``, downloads the tokenizer even if it is already in cache.
-        :param cache_only:
-            If ``True``, skips the download and uses the cached tokenizer.
-        :param progress:
-            If ``True``, displays a progress bar to stderr.
-        """
-        if isinstance(tokenizer_name_or_card, AssetCard):
-            card = tokenizer_name_or_card
-        else:
-            card = self.asset_store.retrieve_card(tokenizer_name_or_card)
-
-        uri = card.field("tokenizer").as_uri()
-
-        try:
-            path = self.download_manager.download_tokenizer(
-                uri, card.name, force=force, cache_only=cache_only, progress=progress
-            )
-        except ValueError as ex:
-            raise AssetCardError(
-                f"The value of the field 'tokenizer' of the asset card '{card.name}' is not valid. See nested exception for details."
-            ) from ex
-
-        try:
-            return self._load(path, card)
-        except ValueError as ex:
-            raise AssetError(
-                f"The {card.name} tokenizer cannot be loaded. See nested exception for details."
-            ) from ex
-
-    @abstractmethod
-    def _load(self, path: Path, card: AssetCard) -> TokenizerT:
-        """
-        :param path:
-            The path to the tokenizer.
-        :param card:
-            The asset card of the associated model.
-        """
-
-
-class TokenizerFactory(Protocol[TokenizerT_co]):
-    """Constructs tokenizers of type ``TokenizerT``."""
-
-    def __call__(self, pathname: PathLike) -> TokenizerT_co:
-        """
-        :param pathname:
-            The pathname of the tokenizer.
-        """
-
-
-@final
-class TokenizerLoader(TokenizerLoaderBase[TokenizerT]):
-    """Loads tokenizers of type ``TokenizerT``."""
-
-    tokenizer_factory: TokenizerFactory[TokenizerT]
-
-    def __init__(
-        self,
-        asset_store: AssetStore,
-        download_manager: AssetDownloadManager,
-        tokenizer_factory: TokenizerFactory[TokenizerT],
-    ) -> None:
-        """
-        :param asset_store:
-            The asset store where to check for available tokenizers.
-        :param download_manager:
-            The download manager.
-        :param tokenizer_factory:
-            The factory to construct tokenizers.
-        """
-        super().__init__(asset_store, download_manager)
-
-        self.tokenizer_factory = tokenizer_factory
-
-    @finaloverride
-    def _load(self, path: Path, card: AssetCard) -> TokenizerT:
-        return self.tokenizer_factory(path)

--- a/tests/unit/models/utils/test_arch_registry.py
+++ b/tests/unit/models/utils/test_arch_registry.py
@@ -41,7 +41,7 @@ class TestArchitectureRegistry:
 
         with pytest.raises(
             ValueError,
-            match=r"^The architecture name 'arch' is already registered for 'model'\.$",
+            match=r"^`arch_name` must be a unique architecture name, but 'arch' is already registered for 'model'\.$",
         ):
             registry.register("arch", lambda: "config")
 


### PR DESCRIPTION
This PR refactors tokenizer loaders to `fairseq2.data.text` and introduces a new `load_text_tokenizer` convenience function that can load any type of tokenizer, e.g. `load_text_tokenizer("nllb-200")`.