### PR TITLE
Make mmap optional

### DIFF
--- a/src/fairseq2/assets/download_manager.py
+++ b/src/fairseq2/assets/download_manager.py
@@ -310,7 +310,7 @@ class _AssetDownloadOp:
 
     def _try_uri_as_path(self) -> Optional[Path]:
         if self.uri.startswith("file://"):
-            return Path(self.uri[7:])
+            return Path(unquote(self.uri[7:]))
 
         return None
 
@@ -485,6 +485,8 @@ class _AssetDownloadOp:
 
             try:
                 filename = Path(urlparse(response.geturl()).path).name
+
+                filename = unquote(filename)
             except ValueError:
                 filename = "asset"
 

--- a/src/fairseq2/checkpoint.py
+++ b/src/fairseq2/checkpoint.py
@@ -292,7 +292,9 @@ class FileCheckpointManager(CheckpointManager):
         checkpoint_file = self.checkpoint_dir.joinpath(f"step_{step_nr}/replicated.pt")
 
         try:
-            replicated_checkpoint = load_checkpoint(checkpoint_file, map_location=CPU)
+            replicated_checkpoint = load_checkpoint(
+                checkpoint_file, map_location=CPU, mmap=True
+            )
         except FileNotFoundError:
             replicated_checkpoint = None
         except (RuntimeError, OSError, PickleError) as ex:
@@ -307,7 +309,9 @@ class FileCheckpointManager(CheckpointManager):
         )
 
         try:
-            rank_checkpoint = load_checkpoint(checkpoint_file, map_location=CPU)
+            rank_checkpoint = load_checkpoint(
+                checkpoint_file, map_location=CPU, mmap=True
+            )
         except FileNotFoundError:
             rank_checkpoint = None
         except (RuntimeError, OSError, PickleError) as ex:

--- a/src/fairseq2/models/llama/loader.py
+++ b/src/fairseq2/models/llama/loader.py
@@ -52,6 +52,7 @@ load_llama_model = ModelLoader[TransformerDecoderModel, LLaMAConfig](
     load_llama_config,
     create_llama_model,
     convert_llama_checkpoint,
+    mmap=True,
 )
 
 load_llama_tokenizer = BasicTextTokenizerLoader[LLaMATokenizer](

--- a/src/fairseq2/models/mistral/loader.py
+++ b/src/fairseq2/models/mistral/loader.py
@@ -53,6 +53,7 @@ load_mistral_model = ModelLoader[TransformerDecoderModel, MistralConfig](
     load_mistral_config,
     create_mistral_model,
     convert_mistral_checkpoint,
+    mmap=True,
 )
 
 load_mistral_tokenizer = BasicTextTokenizerLoader[MistralTokenizer](

--- a/src/fairseq2/models/nllb/loader.py
+++ b/src/fairseq2/models/nllb/loader.py
@@ -99,6 +99,7 @@ load_nllb_model = ModelLoader[TransformerModel, NllbConfig](
     load_nllb_config,
     create_nllb_model,
     convert_nllb_checkpoint,
+    mmap=True,
     restrict_checkpoints=False,
 )
 

--- a/src/fairseq2/models/s2t_transformer/loader.py
+++ b/src/fairseq2/models/s2t_transformer/loader.py
@@ -99,6 +99,7 @@ load_s2t_transformer_model = ModelLoader[TransformerModel, S2TTransformerConfig]
     load_s2t_transformer_config,
     create_s2t_transformer_model,
     convert_s2t_transformer_checkpoint,
+    mmap=True,
     restrict_checkpoints=False,
 )
 

--- a/src/fairseq2/models/utils/checkpoint.py
+++ b/src/fairseq2/models/utils/checkpoint.py
@@ -38,6 +38,7 @@ def load_checkpoint(
     pathname: PathLike,
     *,
     map_location: MapLocation = None,
+    mmap: bool = False,
     restrict: bool = False,
     converter: Optional[CheckpointConverter] = None,
 ) -> Dict[str, Any]:
@@ -47,6 +48,8 @@ def load_checkpoint(
         The pathname of the checkpoint.
     :param map_location:
         Same as the ``map_location`` parameter of :meth:`torch.load`.
+    :param mmap:
+        If ``True``, indicates whether the checkpoint should be memory mapped.
     :param restrict:
         If ``True``, restricts the Python unpickler to load only tensors,
         primitive types, and dictionaries.
@@ -63,7 +66,7 @@ def load_checkpoint(
 
         kwargs = {}
 
-        if _is_pt21_or_greater():
+        if mmap and _is_pt21_or_greater():
             kwargs["mmap"] = True
 
         checkpoint: Dict[str, Any] = torch.load(

--- a/src/fairseq2/models/utils/generic_loaders.py
+++ b/src/fairseq2/models/utils/generic_loaders.py
@@ -160,6 +160,7 @@ class ModelLoader(Generic[ModelT, ConfigT]):
         config_loader: ConfigLoader[ConfigT],
         model_factory: ModelFactory[ConfigT, ModelT],
         checkpoint_converter: Optional[CheckpointConverter[ConfigT]] = None,
+        mmap: bool = False,
         restrict_checkpoints: bool = True,
     ) -> None:
         """
@@ -174,6 +175,9 @@ class ModelLoader(Generic[ModelT, ConfigT]):
         :param checkpoint_converter:
             The converter to which loaded checkpoints will be passed for further
             processing.
+        :param mmap:
+            If ``True``, indicates whether the checkpoint should be memory
+            mapped.
         :param restrict_checkpoints:
             If ``True``, restricts the Python unpickler to load only tensors,
             primitive types, and dictionaries.
@@ -183,6 +187,7 @@ class ModelLoader(Generic[ModelT, ConfigT]):
         self.config_loader = config_loader
         self.model_factory = model_factory
         self.checkpoint_converter = checkpoint_converter
+        self.mmap = mmap
         self.restrict_checkpoints = restrict_checkpoints
 
     def __call__(
@@ -244,6 +249,7 @@ class ModelLoader(Generic[ModelT, ConfigT]):
             checkpoint = load_checkpoint(
                 path,
                 map_location=CPU,
+                mmap=self.mmap,
                 restrict=self.restrict_checkpoints,
                 converter=checkpoint_converter,
             )

--- a/src/fairseq2/models/w2vbert/loader.py
+++ b/src/fairseq2/models/w2vbert/loader.py
@@ -74,4 +74,5 @@ load_w2vbert_model = ModelLoader[W2VBertModel, W2VBertConfig](
     load_w2vbert_config,
     create_w2vbert_model,
     convert_w2vbert_checkpoint,
+    mmap=True,
 )

--- a/src/fairseq2/models/wav2vec2/loader.py
+++ b/src/fairseq2/models/wav2vec2/loader.py
@@ -73,4 +73,5 @@ load_wav2vec2_model = ModelLoader[Wav2Vec2Model, Wav2Vec2Config](
     load_wav2vec2_config,
     create_wav2vec2_model,
     convert_wav2vec2_checkpoint,
+    mmap=True,
 )


### PR DESCRIPTION
This PR exposes PyTorch's `mmap` parameter in `load_checkpoint` and makes it optional. Also fixes a subtle bug in treating a uri as a filesystem path.