### PR TITLE
Follow same naming convention for all abstract classes

### DIFF
--- a/doc/reference/classes.rst
+++ b/doc/reference/classes.rst
@@ -9,7 +9,6 @@ Classes
     :nosignatures:
 
     optim.lr_scheduler.CosineAnnealingLR
-    optim.lr_scheduler.LRSchedulerBase
     optim.lr_scheduler.MyleLR
     optim.lr_scheduler.NoamLR
     optim.lr_scheduler.PolynomialDecayLR

--- a/src/fairseq2/assets/__init__.py
+++ b/src/fairseq2/assets/__init__.py
@@ -16,7 +16,9 @@ from fairseq2.assets.download_manager import (
 from fairseq2.assets.download_manager import (
     InProcAssetDownloadManager as InProcAssetDownloadManager,
 )
-from fairseq2.assets.download_manager import download_manager as download_manager
+from fairseq2.assets.download_manager import (
+    default_download_manager as default_download_manager,
+)
 from fairseq2.assets.error import AssetError as AssetError
 from fairseq2.assets.metadata_provider import AssetMetadataError as AssetMetadataError
 from fairseq2.assets.metadata_provider import (
@@ -31,4 +33,8 @@ from fairseq2.assets.metadata_provider import (
 )
 from fairseq2.assets.store import AssetStore as AssetStore
 from fairseq2.assets.store import ProviderBackedAssetStore as ProviderBackedAssetStore
-from fairseq2.assets.store import asset_store as asset_store
+from fairseq2.assets.store import default_asset_store as default_asset_store
+
+# For backwards-compatibility with v0.2
+asset_store = default_asset_store
+download_manager = default_download_manager

--- a/src/fairseq2/assets/download_manager.py
+++ b/src/fairseq2/assets/download_manager.py
@@ -657,4 +657,4 @@ class AssetDownloadError(AssetError):
     """Raised when an asset download operation fails."""
 
 
-download_manager = InProcAssetDownloadManager()
+default_download_manager = InProcAssetDownloadManager()

--- a/src/fairseq2/assets/store.py
+++ b/src/fairseq2/assets/store.py
@@ -142,7 +142,7 @@ class EnvironmentResolver(Protocol):
         ...
 
 
-def _create_asset_store() -> ProviderBackedAssetStore:
+def _create_default_asset_store() -> ProviderBackedAssetStore:
     cards_dir = Path(__file__).parent.joinpath("cards")
 
     metadata_provider = FileAssetMetadataProvider(cards_dir)
@@ -150,7 +150,7 @@ def _create_asset_store() -> ProviderBackedAssetStore:
     return ProviderBackedAssetStore(metadata_provider)
 
 
-asset_store = _create_asset_store()
+default_asset_store = _create_default_asset_store()
 
 
 def _load_asset_directory() -> None:
@@ -160,7 +160,7 @@ def _load_asset_directory() -> None:
         if not asset_dir.exists():
             return
 
-    asset_store.metadata_providers.append(FileAssetMetadataProvider(asset_dir))
+    default_asset_store.metadata_providers.append(FileAssetMetadataProvider(asset_dir))
 
 
 _load_asset_directory()
@@ -177,7 +177,9 @@ def _load_user_asset_directory() -> None:
         if not asset_dir.exists():
             return
 
-    asset_store.user_metadata_providers.append(FileAssetMetadataProvider(asset_dir))
+    default_asset_store.user_metadata_providers.append(
+        FileAssetMetadataProvider(asset_dir)
+    )
 
 
 _load_user_asset_directory()
@@ -188,12 +190,14 @@ def _load_faircluster() -> None:
     if "FAIR_ENV_CLUSTER" not in os.environ:
         return
 
-    asset_store.env_resolvers.append(lambda: "faircluster")
+    default_asset_store.env_resolvers.append(lambda: "faircluster")
 
     # This directory is meant to store cluster-wide asset cards.
     asset_dir = Path("/checkpoint/balioglu/fairseq2-ext/cards")
     if asset_dir.exists():
-        asset_store.metadata_providers.append(FileAssetMetadataProvider(asset_dir))
+        default_asset_store.metadata_providers.append(
+            FileAssetMetadataProvider(asset_dir)
+        )
 
 
 _load_faircluster()

--- a/src/fairseq2/data/text/__init__.py
+++ b/src/fairseq2/data/text/__init__.py
@@ -18,7 +18,7 @@ from fairseq2.data.text.sentencepiece import (
 )
 from fairseq2.data.text.sentencepiece import SentencePieceModel as SentencePieceModel
 from fairseq2.data.text.sentencepiece import (
-    SentencePieceTokenizerBase as SentencePieceTokenizerBase,
+    SentencePieceTokenizer as SentencePieceTokenizer,
 )
 from fairseq2.data.text.sentencepiece import (
     vocab_info_from_sentencepiece as vocab_info_from_sentencepiece,

--- a/src/fairseq2/data/text/sentencepiece.py
+++ b/src/fairseq2/data/text/sentencepiece.py
@@ -125,8 +125,8 @@ else:
     _set_module_name()
 
 
-class SentencePieceTokenizerBase(TextTokenizer):
-    """Represents an abstract base class for SentencePiece tokenizers."""
+class SentencePieceTokenizer(TextTokenizer):
+    """Represents a SentencePiece tokenizer."""
 
     model: SentencePieceModel
 
@@ -156,7 +156,7 @@ class SentencePieceTokenizerBase(TextTokenizer):
         return SentencePieceDecoder(self.model)
 
 
-class BasicSentencePieceTokenizer(SentencePieceTokenizerBase):
+class BasicSentencePieceTokenizer(SentencePieceTokenizer):
     """Represents a SentencePiece tokenizer that encodes text with BOS and EOS."""
 
     # protected

--- a/src/fairseq2/data/text/text_tokenizer.py
+++ b/src/fairseq2/data/text/text_tokenizer.py
@@ -29,8 +29,8 @@ from fairseq2.assets import (
     AssetDownloadManager,
     AssetError,
     AssetStore,
+    default_asset_store,
 )
-from fairseq2.assets import asset_store as default_asset_store
 from fairseq2.data.typing import PathLike, StringLike
 from fairseq2.data.vocabulary_info import VocabularyInfo
 from fairseq2.typing import Device, finaloverride
@@ -176,7 +176,7 @@ TextTokenizerT_co = TypeVar("TextTokenizerT_co", bound=TextTokenizer, covariant=
 
 
 class GenericTextTokenizerLoader(TextTokenizerLoader, Generic[TextTokenizerT]):
-    """Represents an abstract base class for text tokenizer loaders."""
+    """Loads text tokenizers of type ``TokenizerT``."""
 
     asset_store: AssetStore
     download_manager: AssetDownloadManager
@@ -246,7 +246,7 @@ class BasicTextTokenizerFactory(Protocol[TextTokenizerT_co]):
 
 @final
 class BasicTextTokenizerLoader(GenericTextTokenizerLoader[TextTokenizerT]):
-    """Loads text tokenizers of type ``TokenizerT``."""
+    """Loads text tokenizers of type ``TokenizerT`` via provided path."""
 
     tokenizer_factory: BasicTextTokenizerFactory[TextTokenizerT]
 

--- a/src/fairseq2/generation/beam_search.py
+++ b/src/fairseq2/generation/beam_search.py
@@ -440,7 +440,7 @@ class StandardBeamSearchAlgorithm(BeamSearchAlgorithm):
         return BeamStep(top_indices // vocab_size, top_indices % vocab_size, top_scores)
 
 
-class _BeamSearchSequenceGeneratorOpBase(ABC):
+class _BeamSearchGeneratorOp(ABC):
     algorithm: BeamSearchAlgorithm
     eos_idx: int
     pad_idx: Optional[int]
@@ -894,7 +894,7 @@ class _BeamSearchSequenceGeneratorOpBase(ABC):
         self.step_scores = self.step_scores.index_select(dim=0, index=new_order)
 
 
-class _BeamSearchSequenceGeneratorOp(_BeamSearchSequenceGeneratorOpBase):
+class _BeamSearchSequenceGeneratorOp(_BeamSearchGeneratorOp):
     model: DecoderModel
 
     def __init__(
@@ -950,7 +950,7 @@ class _BeamSearchSequenceGeneratorOp(_BeamSearchSequenceGeneratorOpBase):
         return self.model.project(decoder_output, decoder_padding_mask)
 
 
-class _BeamSearchSeq2SeqGeneratorOp(_BeamSearchSequenceGeneratorOpBase):
+class _BeamSearchSeq2SeqGeneratorOp(_BeamSearchGeneratorOp):
     model: EncoderDecoderModel
     encoder_output: Tensor
     encoder_padding_mask: Optional[PaddingMask]

--- a/src/fairseq2/generation/sampling.py
+++ b/src/fairseq2/generation/sampling.py
@@ -455,7 +455,7 @@ class TopKSampler(Sampler):
         return indices.squeeze(-1)
 
 
-class _SamplingSequenceGeneratorOpBase(ABC):
+class _SamplingGeneratorOp(ABC):
     sampler: Sampler
     eos_idx: int
     pad_idx: Optional[int]
@@ -870,7 +870,7 @@ class _SamplingSequenceGeneratorOpBase(ABC):
             self.step_scores = self.step_scores.index_select(dim=0, index=new_order)
 
 
-class _SamplingSequenceGeneratorOp(_SamplingSequenceGeneratorOpBase):
+class _SamplingSequenceGeneratorOp(_SamplingGeneratorOp):
     model: DecoderModel
 
     def __init__(
@@ -928,7 +928,7 @@ class _SamplingSequenceGeneratorOp(_SamplingSequenceGeneratorOpBase):
         return self.model.project(decoder_output, decoder_padding_mask)
 
 
-class _SamplingSeq2SeqGeneratorOp(_SamplingSequenceGeneratorOpBase):
+class _SamplingSeq2SeqGeneratorOp(_SamplingGeneratorOp):
     model: EncoderDecoderModel
     encoder_output: Tensor
     encoder_padding_mask: Optional[PaddingMask]

--- a/src/fairseq2/models/llama/loader.py
+++ b/src/fairseq2/models/llama/loader.py
@@ -6,7 +6,7 @@
 
 from typing import Any, Dict
 
-from fairseq2.assets import asset_store, download_manager
+from fairseq2.assets import default_asset_store, default_download_manager
 from fairseq2.data.text import BasicTextTokenizerLoader, load_text_tokenizer
 from fairseq2.models.llama.builder import LLaMAConfig, create_llama_model, llama_archs
 from fairseq2.models.llama.tokenizer import LLaMATokenizer
@@ -44,11 +44,11 @@ def convert_llama_checkpoint(
     return {"model": checkpoint}
 
 
-load_llama_config = ConfigLoader[LLaMAConfig](asset_store, llama_archs)
+load_llama_config = ConfigLoader[LLaMAConfig](default_asset_store, llama_archs)
 
 load_llama_model = ModelLoader[TransformerDecoderModel, LLaMAConfig](
-    asset_store,
-    download_manager,
+    default_asset_store,
+    default_download_manager,
     load_llama_config,
     create_llama_model,
     convert_llama_checkpoint,
@@ -56,7 +56,7 @@ load_llama_model = ModelLoader[TransformerDecoderModel, LLaMAConfig](
 )
 
 load_llama_tokenizer = BasicTextTokenizerLoader[LLaMATokenizer](
-    asset_store, download_manager, LLaMATokenizer
+    default_asset_store, default_download_manager, LLaMATokenizer
 )
 
 load_text_tokenizer.register_loader("llama", load_llama_tokenizer)

--- a/src/fairseq2/models/mistral/loader.py
+++ b/src/fairseq2/models/mistral/loader.py
@@ -6,7 +6,7 @@
 
 from typing import Any, Dict
 
-from fairseq2.assets import asset_store, download_manager
+from fairseq2.assets import default_asset_store, default_download_manager
 from fairseq2.data.text import BasicTextTokenizerLoader, load_text_tokenizer
 from fairseq2.models.mistral.builder import (
     MistralConfig,
@@ -45,11 +45,11 @@ def convert_mistral_checkpoint(
     return {"model": checkpoint}
 
 
-load_mistral_config = ConfigLoader[MistralConfig](asset_store, mistral_archs)
+load_mistral_config = ConfigLoader[MistralConfig](default_asset_store, mistral_archs)
 
 load_mistral_model = ModelLoader[TransformerDecoderModel, MistralConfig](
-    asset_store,
-    download_manager,
+    default_asset_store,
+    default_download_manager,
     load_mistral_config,
     create_mistral_model,
     convert_mistral_checkpoint,
@@ -57,7 +57,7 @@ load_mistral_model = ModelLoader[TransformerDecoderModel, MistralConfig](
 )
 
 load_mistral_tokenizer = BasicTextTokenizerLoader[MistralTokenizer](
-    asset_store, download_manager, MistralTokenizer
+    default_asset_store, default_download_manager, MistralTokenizer
 )
 
 load_text_tokenizer.register_loader("mistral", load_mistral_tokenizer)

--- a/src/fairseq2/models/nllb/loader.py
+++ b/src/fairseq2/models/nllb/loader.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, final
 
 import torch
 
-from fairseq2.assets import AssetCard, asset_store, download_manager
+from fairseq2.assets import AssetCard, default_asset_store, default_download_manager
 from fairseq2.data.text import GenericTextTokenizerLoader, load_text_tokenizer
 from fairseq2.models.nllb.builder import NllbConfig, create_nllb_model, nllb_archs
 from fairseq2.models.nllb.tokenizer import NllbTokenizer
@@ -91,11 +91,11 @@ class NllbTokenizerLoader(GenericTextTokenizerLoader[NllbTokenizer]):
         return NllbTokenizer(pathname, langs, default_lang)
 
 
-load_nllb_config = ConfigLoader[NllbConfig](asset_store, nllb_archs)
+load_nllb_config = ConfigLoader[NllbConfig](default_asset_store, nllb_archs)
 
 load_nllb_model = ModelLoader[TransformerModel, NllbConfig](
-    asset_store,
-    download_manager,
+    default_asset_store,
+    default_download_manager,
     load_nllb_config,
     create_nllb_model,
     convert_nllb_checkpoint,
@@ -103,6 +103,6 @@ load_nllb_model = ModelLoader[TransformerModel, NllbConfig](
     restrict_checkpoints=False,
 )
 
-load_nllb_tokenizer = NllbTokenizerLoader(asset_store, download_manager)
+load_nllb_tokenizer = NllbTokenizerLoader(default_asset_store, default_download_manager)
 
 load_text_tokenizer.register_loader("nllb", load_nllb_tokenizer)

--- a/src/fairseq2/models/nllb/tokenizer.py
+++ b/src/fairseq2/models/nllb/tokenizer.py
@@ -6,14 +6,14 @@
 
 from typing import Optional, Sequence, Set, final
 
-from fairseq2.data.text import SentencePieceEncoder, SentencePieceTokenizerBase
+from fairseq2.data.text import SentencePieceEncoder, SentencePieceTokenizer
 from fairseq2.data.typing import PathLike
 from fairseq2.typing import Device, finaloverride
 
 
 @final
-class NllbTokenizer(SentencePieceTokenizerBase):
-    """Represents the tokenizer used by NLLB models."""
+class NllbTokenizer(SentencePieceTokenizer):
+    """Represents a tokenizer used by NLLB models."""
 
     langs: Set[str]
     default_lang: str

--- a/src/fairseq2/models/s2t_transformer/loader.py
+++ b/src/fairseq2/models/s2t_transformer/loader.py
@@ -7,7 +7,7 @@
 from pathlib import Path
 from typing import Any, Dict, final
 
-from fairseq2.assets import AssetCard, asset_store, download_manager
+from fairseq2.assets import AssetCard, default_asset_store, default_download_manager
 from fairseq2.data.text import GenericTextTokenizerLoader, load_text_tokenizer
 from fairseq2.models.s2t_transformer.builder import (
     S2TTransformerConfig,
@@ -90,12 +90,12 @@ class S2TTransformerTokenizerLoader(
 
 
 load_s2t_transformer_config = ConfigLoader[S2TTransformerConfig](
-    asset_store, s2t_transformer_archs
+    default_asset_store, s2t_transformer_archs
 )
 
 load_s2t_transformer_model = ModelLoader[TransformerModel, S2TTransformerConfig](
-    asset_store,
-    download_manager,
+    default_asset_store,
+    default_download_manager,
     load_s2t_transformer_config,
     create_s2t_transformer_model,
     convert_s2t_transformer_checkpoint,
@@ -104,7 +104,7 @@ load_s2t_transformer_model = ModelLoader[TransformerModel, S2TTransformerConfig]
 )
 
 load_s2t_transformer_tokenizer = S2TTransformerTokenizerLoader(
-    asset_store, download_manager
+    default_asset_store, default_download_manager
 )
 
 load_text_tokenizer.register_loader("s2t_transformer", load_s2t_transformer_tokenizer)

--- a/src/fairseq2/models/s2t_transformer/tokenizer.py
+++ b/src/fairseq2/models/s2t_transformer/tokenizer.py
@@ -6,14 +6,14 @@
 
 from typing import Optional, Set, final
 
-from fairseq2.data.text import SentencePieceEncoder, SentencePieceTokenizerBase
+from fairseq2.data.text import SentencePieceEncoder, SentencePieceTokenizer
 from fairseq2.data.typing import PathLike
 from fairseq2.typing import Device, finaloverride
 
 
 @final
-class S2TTransformerTokenizer(SentencePieceTokenizerBase):
-    """Represents the tokenizer used by S2T Transformer models."""
+class S2TTransformerTokenizer(SentencePieceTokenizer):
+    """Represents a tokenizer used by S2T Transformer models."""
 
     task: str
     target_langs: Set[str]

--- a/src/fairseq2/models/w2vbert/loader.py
+++ b/src/fairseq2/models/w2vbert/loader.py
@@ -8,7 +8,7 @@ from typing import Any, Dict
 
 import torch
 
-from fairseq2.assets import asset_store, download_manager
+from fairseq2.assets import default_asset_store, default_download_manager
 from fairseq2.models.utils import ConfigLoader, ModelLoader
 from fairseq2.models.utils.checkpoint import convert_fairseq_checkpoint
 from fairseq2.models.w2vbert.builder import (
@@ -66,11 +66,11 @@ def convert_w2vbert_checkpoint(
     return convert_fairseq_checkpoint(checkpoint, key_map)
 
 
-load_w2vbert_config = ConfigLoader[W2VBertConfig](asset_store, w2vbert_archs)
+load_w2vbert_config = ConfigLoader[W2VBertConfig](default_asset_store, w2vbert_archs)
 
 load_w2vbert_model = ModelLoader[W2VBertModel, W2VBertConfig](
-    asset_store,
-    download_manager,
+    default_asset_store,
+    default_download_manager,
     load_w2vbert_config,
     create_w2vbert_model,
     convert_w2vbert_checkpoint,

--- a/src/fairseq2/models/wav2vec2/loader.py
+++ b/src/fairseq2/models/wav2vec2/loader.py
@@ -8,7 +8,7 @@ from typing import Any, Dict
 
 import torch
 
-from fairseq2.assets import asset_store, download_manager
+from fairseq2.assets import default_asset_store, default_download_manager
 from fairseq2.models.utils import ConfigLoader, ModelLoader
 from fairseq2.models.utils.checkpoint import convert_fairseq_checkpoint
 from fairseq2.models.wav2vec2.builder import (
@@ -65,11 +65,11 @@ def convert_wav2vec2_checkpoint(
     return convert_fairseq_checkpoint(checkpoint, key_map)
 
 
-load_wav2vec2_config = ConfigLoader[Wav2Vec2Config](asset_store, wav2vec2_archs)
+load_wav2vec2_config = ConfigLoader[Wav2Vec2Config](default_asset_store, wav2vec2_archs)
 
 load_wav2vec2_model = ModelLoader[Wav2Vec2Model, Wav2Vec2Config](
-    asset_store,
-    download_manager,
+    default_asset_store,
+    default_download_manager,
     load_wav2vec2_config,
     create_wav2vec2_model,
     convert_wav2vec2_checkpoint,

--- a/src/fairseq2/nn/module_list.py
+++ b/src/fairseq2/nn/module_list.py
@@ -8,13 +8,13 @@ from typing import Iterable, Iterator, Optional, final
 
 import torch
 from torch.nn import Module
-from torch.nn import ModuleList as ModuleListBase
+from torch.nn import ModuleList as TorchModuleList
 
 from fairseq2.typing import CPU
 
 
 @final
-class ModuleList(ModuleListBase):
+class ModuleList(TorchModuleList):
     """Holds submodules in a list.
 
     This class extends :class:`torch.nn.ModuleList` with an extra feature that

--- a/src/fairseq2/optim/__init__.py
+++ b/src/fairseq2/optim/__init__.py
@@ -7,4 +7,4 @@
 from fairseq2.optim.adamw import AdamW as AdamW
 from fairseq2.optim.dynamic_loss_scaler import DynamicLossScaler as DynamicLossScaler
 from fairseq2.optim.dynamic_loss_scaler import LossScaleResult as LossScaleResult
-from fairseq2.optim.optimizer_base import OptimizerBase as OptimizerBase
+from fairseq2.optim.optimizer import Fairseq2Optimizer as Fairseq2Optimizer

--- a/src/fairseq2/optim/adamw.py
+++ b/src/fairseq2/optim/adamw.py
@@ -11,13 +11,13 @@ import torch
 from torch import Tensor
 from torch.optim.adamw import adamw  # type: ignore[attr-defined]
 
-from fairseq2.optim.optimizer_base import OptimizerBase
+from fairseq2.optim.optimizer import Fairseq2Optimizer
 from fairseq2.typing import finaloverride
 
 
 @final
-class AdamW(OptimizerBase):
-    """Implements AdamW algorithm.
+class AdamW(Fairseq2Optimizer):
+    """Represents an AdamW optimizer.
 
     This class uses the same functional AdamW implementation as
     :class:`torch.optim.AdamW`. The main difference is that it also supports

--- a/src/fairseq2/optim/lr_scheduler.py
+++ b/src/fairseq2/optim/lr_scheduler.py
@@ -23,8 +23,8 @@ def get_effective_lr(scheduler: LRScheduler) -> float:
     return scheduler.get_last_lr()[0]
 
 
-class LRSchedulerBase(ABC, LRScheduler):
-    """Represents the abstract base class for learning rate schedulers."""
+class Fairseq2LRScheduler(ABC, LRScheduler):
+    """Represents a learning rate scheduler."""
 
     @finaloverride
     def get_lr(self) -> List[float]:  # type: ignore[override]
@@ -41,7 +41,7 @@ class LRSchedulerBase(ABC, LRScheduler):
 
 
 @final
-class NoamLR(LRSchedulerBase):
+class NoamLR(Fairseq2LRScheduler):
     """Represents the learning rate schedule described in Section 5.3 of
     :cite:t:`https://doi.org/10.48550/arxiv.1706.03762`.
 
@@ -101,7 +101,7 @@ class NoamLR(LRSchedulerBase):
 
 
 @final
-class MyleLR(LRSchedulerBase):
+class MyleLR(Fairseq2LRScheduler):
     """Represents a scaled version of :class:`NoamLR` that preserves the base
     learning rate of the associated optimizer.
 
@@ -167,7 +167,7 @@ class MyleLR(LRSchedulerBase):
 
 
 @final
-class PolynomialDecayLR(LRSchedulerBase):
+class PolynomialDecayLR(Fairseq2LRScheduler):
     """Represents the polynomial decay learning rate schedule.
 
     **During warmup:**
@@ -261,7 +261,7 @@ class PolynomialDecayLR(LRSchedulerBase):
 
 
 @final
-class CosineAnnealingLR(LRSchedulerBase):
+class CosineAnnealingLR(Fairseq2LRScheduler):
     """Represents the learning rate schedule described in
     :cite:t:`https://doi.org/10.48550/arxiv.1608.03983`.
 

--- a/src/fairseq2/optim/optimizer.py
+++ b/src/fairseq2/optim/optimizer.py
@@ -11,8 +11,8 @@ import torch
 from torch.optim import Optimizer
 
 
-class OptimizerBase(ABC, Optimizer):
-    """Represents the base class for all optimizers."""
+class Fairseq2Optimizer(ABC, Optimizer):
+    """Represents an optimizer."""
 
     def step(  # type: ignore[override]
         self, closure: Optional[Callable[[], float]] = None


### PR DESCRIPTION
A nit PR that ensure that all abstract classes the same naming convention (i.e. no redundant "Base" suffix). Also introduces two new aliases `default_asset_store` and `default_download_manager` to avoid variable name conflicts where the default asset store or download manager is used.