### PR TITLE
Make DataPipeline generic

### DIFF
--- a/src/fairseq2/data/data_pipeline.py
+++ b/src/fairseq2/data/data_pipeline.py
@@ -19,6 +19,7 @@ from typing import (
     Sequence,
     Tuple,
     TypedDict,
+    TypeVar,
     Union,
 )
 
@@ -30,8 +31,9 @@ from fairseq2.data.typing import PathLike, StringLike
 from fairseq2.memory import MemoryBlock
 
 if TYPE_CHECKING or DOC_MODE:
+    DataT = TypeVar("DataT")
 
-    class DataPipeline(Iterable[Any]):
+    class DataPipeline(Iterable[DataT]):
         """fairseq2 native data pipeline.
 
         The pipeline state can be persisted to the disk, allowing it to be resumed later.
@@ -41,7 +43,7 @@ if TYPE_CHECKING or DOC_MODE:
         and sharing the same state, so it will behave inconcistently.
         """
 
-        def __iter__(self) -> Iterator[Any]:
+        def __iter__(self) -> Iterator[DataT]:
             """Return an iterator over the examples in the data pipeline.
 
             The iterator will modify the internal state of the this DataPipeline,
@@ -77,7 +79,7 @@ if TYPE_CHECKING or DOC_MODE:
             """
 
         @staticmethod
-        def concat(pipelines: Sequence[DataPipeline]) -> DataPipelineBuilder:
+        def concat(pipelines: Sequence[DataPipeline[Any]]) -> DataPipelineBuilder:
             """Concatenate examples from ``pipelines``.
 
             :param pipelines:
@@ -96,7 +98,7 @@ if TYPE_CHECKING or DOC_MODE:
 
         @staticmethod
         def round_robin(
-            pipelines: Sequence[DataPipeline], stop_at_shortest: bool = False
+            pipelines: Sequence[DataPipeline[Any]], stop_at_shortest: bool = False
         ) -> DataPipelineBuilder:
             """Extract examples from ``pipelines`` in round robin.
 
@@ -110,7 +112,8 @@ if TYPE_CHECKING or DOC_MODE:
 
         @staticmethod
         def sample(
-            pipelines: Sequence[DataPipeline], weights: Optional[Sequence[float]] = None
+            pipelines: Sequence[DataPipeline[Any]],
+            weights: Optional[Sequence[float]] = None,
         ) -> DataPipelineBuilder:
             """Extract examples from ``pipelines`` by sampling based on ``weights``.
 
@@ -122,7 +125,7 @@ if TYPE_CHECKING or DOC_MODE:
 
         @staticmethod
         def zip(
-            pipelines: Sequence[DataPipeline],
+            pipelines: Sequence[DataPipeline[Any]],
             names: Optional[Sequence[str]] = None,
             zip_to_shortest: bool = False,
             flatten: bool = False,
@@ -257,7 +260,7 @@ if TYPE_CHECKING or DOC_MODE:
         def take(self, num_examples: int) -> Self:
             """Return at most ``num_examples`` examples."""
 
-        def yield_from(self, fn: Callable[[Any], DataPipeline]) -> Self:
+        def yield_from(self, fn: Callable[[Any], DataPipeline[Any]]) -> Self:
             """
             Map every example to a data pipeline and yield the examples returned
             from the mapped data pipelines.
@@ -266,7 +269,7 @@ if TYPE_CHECKING or DOC_MODE:
                 The function to map examples to data pipelines.
             """
 
-        def and_return(self, max_num_warnings: int = 0) -> DataPipeline:
+        def and_return(self, max_num_warnings: int = 0) -> DataPipeline[DataT]:
             """Return a new :class:`DataPipeline` instance."""
 
     class DataPipelineError(RuntimeError):
@@ -286,7 +289,7 @@ if TYPE_CHECKING or DOC_MODE:
             If non-empty, a pattern that follows the syntax of :mod:`fnmatch`.
         """
 
-    def read_sequence(seq: Sequence[Any]) -> "DataPipelineBuilder":
+    def read_sequence(seq: Sequence[Any]) -> DataPipelineBuilder:
         """Read every element in ``seq``.
 
         :param seq:

--- a/tests/unit/data/data_pipeline/test_bucket.py
+++ b/tests/unit/data/data_pipeline/test_bucket.py
@@ -4,9 +4,11 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import List
+
 import pytest
 
-from fairseq2.data import read_sequence
+from fairseq2.data import DataPipeline, read_sequence
 
 
 class TestBucketOp:
@@ -15,7 +17,9 @@ class TestBucketOp:
 
         bucket_size = 4
 
-        pipeline = read_sequence(seq).bucket(bucket_size).and_return()
+        pipeline: DataPipeline[List[int]] = (
+            read_sequence(seq).bucket(bucket_size).and_return()
+        )
 
         for _ in range(2):
             it = iter(pipeline)
@@ -35,7 +39,7 @@ class TestBucketOp:
     def test_op_works_when_bucket_size_is_1(self) -> None:
         seq = list(range(100))
 
-        pipeline = read_sequence(seq).bucket(1).and_return()
+        pipeline: DataPipeline[List[int]] = read_sequence(seq).bucket(1).and_return()
 
         for _ in range(2):
             it = iter(pipeline)
@@ -56,7 +60,9 @@ class TestBucketOp:
 
         seq = list(range(100))
 
-        pipeline = read_sequence(seq).bucket(bucket_size, drop).and_return()
+        pipeline: DataPipeline[List[int]] = (
+            read_sequence(seq).bucket(bucket_size, drop).and_return()
+        )
 
         for _ in range(2):
             it = iter(pipeline)
@@ -87,7 +93,7 @@ class TestBucketOp:
     def test_op_saves_and_restores_its_state(self) -> None:
         seq = list(range(1, 10))
 
-        pipeline = read_sequence(seq).bucket(2).and_return()
+        pipeline: DataPipeline[List[int]] = read_sequence(seq).bucket(2).and_return()
 
         d = None
 

--- a/tests/unit/data/data_pipeline/test_collate.py
+++ b/tests/unit/data/data_pipeline/test_collate.py
@@ -4,10 +4,12 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Any
+
 import pytest
 import torch
 
-from fairseq2.data import Collater, read_sequence
+from fairseq2.data import Collater, DataPipeline, read_sequence
 from tests.common import assert_equal, device
 
 
@@ -30,7 +32,9 @@ class TestCollateOp:
 
         seq = [bucket1, bucket2]
 
-        pipeline = read_sequence(seq).collate(pad_value, pad_to_multiple).and_return()
+        pipeline: DataPipeline[Any] = (
+            read_sequence(seq).collate(pad_value, pad_to_multiple).and_return()
+        )
 
         output1, output2 = list(pipeline)
 

--- a/tests/unit/data/data_pipeline/test_constant.py
+++ b/tests/unit/data/data_pipeline/test_constant.py
@@ -9,7 +9,7 @@ from fairseq2.data import DataPipeline
 
 class TestConstantOp:
     def test_op_works(self) -> None:
-        pipeline = DataPipeline.constant("foo").take(10).and_return()
+        pipeline: DataPipeline[str] = DataPipeline.constant("foo").take(10).and_return()
 
         for _ in range(2):
             list(pipeline) == ["foo"] * 10

--- a/tests/unit/data/data_pipeline/test_count.py
+++ b/tests/unit/data/data_pipeline/test_count.py
@@ -11,7 +11,7 @@ from fairseq2.data import DataPipeline
 
 class TestCountOp:
     def test_op_works(self) -> None:
-        pipeline = DataPipeline.count(start=4).take(10).and_return()
+        pipeline: DataPipeline[int] = DataPipeline.count(start=4).take(10).and_return()
 
         for _ in range(2):
             assert list(pipeline) == list(range(4, 14))
@@ -19,7 +19,9 @@ class TestCountOp:
             pipeline.reset()
 
     def test_op_works_when_step_is_greater_than_1(self) -> None:
-        pipeline = DataPipeline.count(start=4, step=3).take(10).and_return()
+        pipeline: DataPipeline[int] = (
+            DataPipeline.count(start=4, step=3).take(10).and_return()
+        )
 
         for _ in range(2):
             assert list(pipeline) == list(range(4, 34, 3))
@@ -27,7 +29,7 @@ class TestCountOp:
             pipeline.reset()
 
     def test_op_saves_and_restores_its_state(self) -> None:
-        pipeline = DataPipeline.count(start=4).take(10).and_return()
+        pipeline: DataPipeline[int] = DataPipeline.count(start=4).take(10).and_return()
 
         d = None
 

--- a/tests/unit/data/data_pipeline/test_data_pipeline.py
+++ b/tests/unit/data/data_pipeline/test_data_pipeline.py
@@ -6,7 +6,12 @@
 
 import pytest
 
-from fairseq2.data import DataPipelineError, get_last_failed_example, read_sequence
+from fairseq2.data import (
+    DataPipeline,
+    DataPipelineError,
+    get_last_failed_example,
+    read_sequence,
+)
 
 
 class TestDataPipeline:
@@ -17,7 +22,7 @@ class TestDataPipeline:
 
             return True
 
-        pipeline = read_sequence([3, 4]).filter(fn).and_return()
+        pipeline: DataPipeline[int] = read_sequence([3, 4]).filter(fn).and_return()
 
         it = iter(pipeline)
 
@@ -50,7 +55,7 @@ class TestDataPipeline:
 
         seq = [1, 2, 3, 4, 5]
 
-        pipeline = read_sequence(seq).filter(fn).and_return()
+        pipeline: DataPipeline[int] = read_sequence(seq).filter(fn).and_return()
 
         output = []
 
@@ -77,7 +82,9 @@ class TestDataPipeline:
 
         seq = list(range(1, 9))
 
-        pipeline = read_sequence(seq).filter(fn).and_return(max_num_warnings=3)
+        pipeline: DataPipeline[int] = (
+            read_sequence(seq).filter(fn).and_return(max_num_warnings=3)
+        )
 
         assert list(pipeline) == [1, 2, 4, 6, 7, 8]
 
@@ -101,7 +108,9 @@ class TestDataPipeline:
 
         seq = [1, 2, 3, 4, 5]
 
-        pipeline = read_sequence(seq).filter(fn).and_return(max_num_warnings)
+        pipeline: DataPipeline[int] = (
+            read_sequence(seq).filter(fn).and_return(max_num_warnings)
+        )
 
         with pytest.raises(DataPipelineError):
             for _ in pipeline:
@@ -112,7 +121,7 @@ class TestDataPipeline:
     def test_load_state_dict_raises_error_when_tape_is_corrupt(self) -> None:
         seq = [1, 2, 3, 4, 5]
 
-        pipeline = read_sequence(seq).and_return()
+        pipeline: DataPipeline[int] = read_sequence(seq).and_return()
 
         next(iter(pipeline))
 

--- a/tests/unit/data/data_pipeline/test_filter.py
+++ b/tests/unit/data/data_pipeline/test_filter.py
@@ -6,7 +6,7 @@
 
 import pytest
 
-from fairseq2.data import DataPipelineError, read_sequence
+from fairseq2.data import DataPipeline, DataPipelineError, read_sequence
 
 
 class TestFilterOp:
@@ -14,7 +14,9 @@ class TestFilterOp:
         def fn(d: int) -> bool:
             return d % 2 == 1
 
-        pipeline = read_sequence([1, 2, 3, 4, 5, 6, 7, 8, 9]).filter(fn).and_return()
+        pipeline: DataPipeline[int] = (
+            read_sequence([1, 2, 3, 4, 5, 6, 7, 8, 9]).filter(fn).and_return()
+        )
 
         for _ in range(2):
             assert list(pipeline) == [1, 3, 5, 7, 9]
@@ -28,7 +30,9 @@ class TestFilterOp:
 
             return True
 
-        pipeline = read_sequence([1, 2, 3, 4]).filter(fn).and_return()
+        pipeline: DataPipeline[int] = (
+            read_sequence([1, 2, 3, 4]).filter(fn).and_return()
+        )
 
         with pytest.raises(DataPipelineError) as exc_info:
             for d in pipeline:

--- a/tests/unit/data/data_pipeline/test_map.py
+++ b/tests/unit/data/data_pipeline/test_map.py
@@ -7,10 +7,11 @@
 import copy
 import re
 from dataclasses import dataclass
+from typing import Any, List
 
 import pytest
 
-from fairseq2.data import DataPipelineError, read_sequence
+from fairseq2.data import DataPipeline, DataPipelineError, read_sequence
 from fairseq2.data.text.converters import StrToIntConverter
 
 
@@ -22,10 +23,8 @@ class TestMapOp:
 
         seq = list(range(1, 10))
 
-        pipeline = (
-            read_sequence(seq)
-            .map(fn, num_parallel_calls=num_parallel_calls)
-            .and_return()
+        pipeline: DataPipeline[int] = (
+            read_sequence(seq).map(fn, num_parallel_calls=num_parallel_calls).and_return()  # fmt: skip
         )
 
         for _ in range(2):
@@ -36,7 +35,9 @@ class TestMapOp:
     def test_op_works_when_callable_is_native(self) -> None:
         fn = StrToIntConverter()
 
-        pipeline = read_sequence(["1", "2", "3", "4"]).map(fn).and_return()
+        pipeline: DataPipeline[int] = (
+            read_sequence(["1", "2", "3", "4"]).map(fn).and_return()
+        )
 
         for _ in range(2):
             assert list(pipeline) == [1, 2, 3, 4]
@@ -49,7 +50,9 @@ class TestMapOp:
         def fn2(d: int) -> int:
             return d**2
 
-        pipeline = read_sequence(["1", "2", "3", "4"]).map([fn1, fn2]).and_return()
+        pipeline: DataPipeline[int] = (
+            read_sequence(["1", "2", "3", "4"]).map([fn1, fn2]).and_return()
+        )
 
         for _ in range(2):
             assert list(pipeline) == [1, 4, 9, 16]
@@ -66,7 +69,9 @@ class TestMapOp:
 
             return d
 
-        pipeline = read_sequence([Foo(1), Foo(2)]).map(fn).and_return()
+        pipeline: DataPipeline[Foo] = (
+            read_sequence([Foo(1), Foo(2)]).map(fn).and_return()
+        )
 
         it = iter(pipeline)
 
@@ -85,7 +90,9 @@ class TestMapOp:
 
         seq = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
 
-        pipeline = read_sequence(seq).map([fn1, fn2], selector="[1]").and_return()
+        pipeline: DataPipeline[List[int]] = (
+            read_sequence(seq).map([fn1, fn2], selector="[1]").and_return()
+        )
 
         for _ in range(2):
             it = iter(pipeline)
@@ -117,7 +124,9 @@ class TestMapOp:
         e1["foo2"][2]["foo4"] = 14  # type: ignore[index]
         e2["foo2"][2]["foo4"] = 19  # type: ignore[index]
 
-        pipeline = read_sequence([d1, d2]).map(fn, selector="foo2[2].foo4").and_return()
+        pipeline: DataPipeline[Any] = (
+            read_sequence([d1, d2]).map(fn, selector="foo2[2].foo4").and_return()
+        )
 
         for _ in range(2):
             it = iter(pipeline)
@@ -158,7 +167,9 @@ class TestMapOp:
 
         selector = "foo2[2].foo4,foo3[0], foo1,foo5.foo6.foo7"
 
-        pipeline = read_sequence([d1, d2]).map(fn, selector=selector).and_return()
+        pipeline: DataPipeline[Any] = (
+            read_sequence([d1, d2]).map(fn, selector=selector).and_return()
+        )
 
         for _ in range(2):
             it = iter(pipeline)
@@ -224,7 +235,9 @@ class TestMapOp:
             "foo3": [5],
         }
 
-        pipeline = read_sequence([d]).map(lambda x: x, selector=s).and_return()
+        pipeline: DataPipeline[Any] = (
+            read_sequence([d]).map(lambda x: x, selector=s).and_return()
+        )
 
         with pytest.raises(DataPipelineError) as exc_info:
             next(iter(pipeline))
@@ -245,7 +258,7 @@ class TestMapOp:
 
             return d
 
-        pipeline = (
+        pipeline: DataPipeline[int] = (
             read_sequence([1, 2, 3, 4])
             .map(fn, num_parallel_calls=num_parallel_calls)
             .and_return()
@@ -268,7 +281,7 @@ class TestMapOp:
 
         seq = list(range(1, 10))
 
-        pipeline = (
+        pipeline: DataPipeline[int] = (
             read_sequence(seq)
             .map(fn, num_parallel_calls=num_parallel_calls)
             .and_return()

--- a/tests/unit/data/data_pipeline/test_prefetch.py
+++ b/tests/unit/data/data_pipeline/test_prefetch.py
@@ -8,7 +8,7 @@ from itertools import islice
 
 import pytest
 
-from fairseq2.data import DataPipelineError, read_sequence
+from fairseq2.data import DataPipeline, DataPipelineError, read_sequence
 
 
 class TestPrefetchOp:
@@ -16,7 +16,9 @@ class TestPrefetchOp:
     def test_op_works(self, num_examples: int) -> None:
         seq = list(range(1, 100))
 
-        pipeline = read_sequence(seq).prefetch(num_examples).and_return()
+        pipeline: DataPipeline[int] = (
+            read_sequence(seq).prefetch(num_examples).and_return()
+        )
 
         for _ in range(2):
             assert list(pipeline) == seq
@@ -27,7 +29,9 @@ class TestPrefetchOp:
     def test_op_works_after_reset(self, num_examples: int) -> None:
         seq = list(range(1, 100))
 
-        pipeline = read_sequence(seq).prefetch(num_examples).and_return()
+        pipeline: DataPipeline[int] = (
+            read_sequence(seq).prefetch(num_examples).and_return()
+        )
 
         for _ in range(2):
             assert list(islice(pipeline, 50)) == seq[:50]
@@ -36,7 +40,9 @@ class TestPrefetchOp:
 
     @pytest.mark.parametrize("num_examples", [0, 1, 4, 20])
     def test_op_works_when_no_data_is_specified(self, num_examples: int) -> None:
-        pipeline = read_sequence([]).prefetch(num_examples).and_return()
+        pipeline: DataPipeline[int] = (
+            read_sequence([]).prefetch(num_examples).and_return()
+        )
 
         for _ in range(2):
             assert list(pipeline) == []
@@ -53,7 +59,9 @@ class TestPrefetchOp:
 
         seq = list(range(1, 100))
 
-        pipeline = read_sequence(seq).map(fn).prefetch(num_examples).and_return()
+        pipeline: DataPipeline[int] = (
+            read_sequence(seq).map(fn).prefetch(num_examples).and_return()
+        )
 
         with pytest.raises(DataPipelineError) as exc_info:
             for d in pipeline:
@@ -69,7 +77,9 @@ class TestPrefetchOp:
     def test_op_saves_and_restores_its_state(self, num_examples: int) -> None:
         seq = list(range(1, 100))
 
-        pipeline = read_sequence(seq).prefetch(num_examples).and_return()
+        pipeline: DataPipeline[int] = (
+            read_sequence(seq).prefetch(num_examples).and_return()
+        )
 
         d = None
 

--- a/tests/unit/data/data_pipeline/test_read_sequence.py
+++ b/tests/unit/data/data_pipeline/test_read_sequence.py
@@ -6,14 +6,14 @@
 
 import pytest
 
-from fairseq2.data import read_sequence
+from fairseq2.data import DataPipeline, read_sequence
 
 
 class TestReadSequenceOp:
     def test_op_works(self) -> None:
         seq = list(range(1, 10))
 
-        pipeline = read_sequence(seq).and_return()
+        pipeline: DataPipeline[int] = read_sequence(seq).and_return()
 
         for _ in range(2):
             assert list(pipeline) == seq
@@ -21,7 +21,7 @@ class TestReadSequenceOp:
             pipeline.reset()
 
     def test_op_works_when_input_sequence_is_empty(self) -> None:
-        pipeline = read_sequence([]).and_return()
+        pipeline: DataPipeline[int] = read_sequence([]).and_return()
 
         for _ in range(2):
             assert list(pipeline) == []
@@ -31,7 +31,7 @@ class TestReadSequenceOp:
     def test_op_saves_and_restores_its_state(self) -> None:
         seq = list(range(1, 10))
 
-        pipeline = read_sequence(seq).and_return()
+        pipeline: DataPipeline[int] = read_sequence(seq).and_return()
 
         d = None
 

--- a/tests/unit/data/data_pipeline/test_round_robin.py
+++ b/tests/unit/data/data_pipeline/test_round_robin.py
@@ -12,31 +12,33 @@ from fairseq2.data.text import read_text
 
 class TestRoundRobinOp:
     def test_op_works(self) -> None:
-        pipeline1 = read_sequence([1, 2, 3, 4]).and_return()
-        pipeline2 = read_sequence([5, 6, 7, 8]).and_return()
-        pipeline3 = read_sequence([0, 2, 4, 6]).and_return()
+        pipeline1: DataPipeline[int] = read_sequence([1, 2, 3, 4]).and_return()
+        pipeline2: DataPipeline[int] = read_sequence([5, 6, 7, 8]).and_return()
+        pipeline3: DataPipeline[int] = read_sequence([0, 2, 4, 6]).and_return()
 
-        pipeline = DataPipeline.round_robin(
+        pipeline4: DataPipeline[int] = DataPipeline.round_robin(
             [pipeline1, pipeline2, pipeline3]
         ).and_return()
 
         for _ in range(2):
-            assert list(pipeline) == [1, 5, 0, 2, 6, 2, 3, 7, 4, 4, 8, 6]
+            assert list(pipeline4) == [1, 5, 0, 2, 6, 2, 3, 7, 4, 4, 8, 6]
 
-            pipeline.reset()
+            pipeline4.reset()
 
     def test_op_works_when_a_single_pipeline_is_specified(self) -> None:
-        pipeline1 = read_sequence([1, 2, 3, 4]).and_return()
+        pipeline1: DataPipeline[int] = read_sequence([1, 2, 3, 4]).and_return()
 
-        pipeline = DataPipeline.round_robin([pipeline1]).and_return()
+        pipeline2: DataPipeline[int] = DataPipeline.round_robin(
+            [pipeline1]
+        ).and_return()
 
         for _ in range(2):
-            assert list(pipeline) == [1, 2, 3, 4]
+            assert list(pipeline2) == [1, 2, 3, 4]
 
-            pipeline.reset()
+            pipeline2.reset()
 
     def test_op_works_when_no_pipeline_is_specified(self) -> None:
-        pipeline = DataPipeline.round_robin([]).and_return()
+        pipeline: DataPipeline[int] = DataPipeline.round_robin([]).and_return()
 
         for _ in range(2):
             with pytest.raises(StopIteration):
@@ -45,71 +47,71 @@ class TestRoundRobinOp:
             pipeline.reset()
 
     def test_op_works_when_infinite_pipeline_is_specified(self) -> None:
-        pipeline1 = read_sequence([1, 2, 3, 4]).and_return()
-        pipeline2 = DataPipeline.constant(0).and_return()
-        pipeline3 = read_sequence([0, 2, 4, 6]).and_return()
+        pipeline1: DataPipeline[int] = read_sequence([1, 2, 3, 4]).and_return()
+        pipeline2: DataPipeline[int] = DataPipeline.constant(0).and_return()
+        pipeline3: DataPipeline[int] = read_sequence([0, 2, 4, 6]).and_return()
 
-        pipeline = DataPipeline.round_robin(
+        pipeline4: DataPipeline[int] = DataPipeline.round_robin(
             [pipeline1, pipeline2, pipeline3]
         ).and_return()
 
         for _ in range(2):
-            assert list(pipeline) == [1, 0, 0, 2, 0, 2, 3, 0, 4, 4, 0, 6]
+            assert list(pipeline4) == [1, 0, 0, 2, 0, 2, 3, 0, 4, 4, 0, 6]
 
-            pipeline.reset()
+            pipeline4.reset()
 
     def test_op_works_when_pipelines_are_empty(self) -> None:
-        pipeline1 = read_sequence([]).and_return()
-        pipeline2 = read_sequence([]).and_return()
-        pipeline3 = read_sequence([]).and_return()
+        pipeline1: DataPipeline[int] = read_sequence([]).and_return()
+        pipeline2: DataPipeline[int] = read_sequence([]).and_return()
+        pipeline3: DataPipeline[int] = read_sequence([]).and_return()
 
-        pipeline = DataPipeline.round_robin(
+        pipeline4: DataPipeline[int] = DataPipeline.round_robin(
             [pipeline1, pipeline2, pipeline3]
         ).and_return()
 
         for _ in range(2):
             with pytest.raises(StopIteration):
-                next(iter(pipeline))
+                next(iter(pipeline4))
 
-            pipeline.reset()
+            pipeline4.reset()
 
     def test_op_works_when_pipelines_have_different_lengths(self) -> None:
-        pipeline1 = read_sequence([1, 2, 3, 4]).and_return()
-        pipeline2 = read_sequence([5, 6]).and_return()
-        pipeline3 = read_sequence([]).and_return()
-        pipeline4 = read_sequence([7, 8, 9, 0, 1, 2]).and_return()
+        pipeline1: DataPipeline[int] = read_sequence([1, 2, 3, 4]).and_return()
+        pipeline2: DataPipeline[int] = read_sequence([5, 6]).and_return()
+        pipeline3: DataPipeline[int] = read_sequence([]).and_return()
+        pipeline4: DataPipeline[int] = read_sequence([7, 8, 9, 0, 1, 2]).and_return()
 
-        pipeline = DataPipeline.round_robin(
+        pipeline5: DataPipeline[int] = DataPipeline.round_robin(
             [pipeline1, pipeline2, pipeline3, pipeline4]
         ).and_return()
 
         seq = [1, 5, 7, 2, 6, 8, 3, 5, 9, 4, 6, 0, 1, 5, 1, 2, 6, 2]
 
         for _ in range(2):
-            assert list(pipeline) == seq
+            assert list(pipeline5) == seq
 
-            pipeline.reset()
+            pipeline5.reset()
 
     def test_op_works_when_pipelines_stop_at_shortest_is_specified(self) -> None:
-        pipeline1 = read_sequence([1, 2, 3, 4]).and_return()
-        pipeline2 = read_sequence([5, 6]).and_return()
-        pipeline3 = read_sequence([7, 8, 9, 0, 1, 2]).and_return()
+        pipeline1: DataPipeline[int] = read_sequence([1, 2, 3, 4]).and_return()
+        pipeline2: DataPipeline[int] = read_sequence([5, 6]).and_return()
+        pipeline3: DataPipeline[int] = read_sequence([7, 8, 9, 0, 1, 2]).and_return()
 
-        pipeline = DataPipeline.round_robin(
+        pipeline4: DataPipeline[int] = DataPipeline.round_robin(
             [pipeline1, pipeline2, pipeline3], stop_at_shortest=True
         ).and_return()
 
         seq = [1, 5, 7, 2, 6, 8]
 
         for _ in range(2):
-            assert list(pipeline) == seq
+            assert list(pipeline4) == seq
 
-            pipeline.reset()
+            pipeline4.reset()
 
     def test_op_raises_error_when_one_of_the_pipelines_is_broken(self) -> None:
         # Force a non-recoverable error.
-        pipeline1 = read_text(pathname=" &^#").and_return()
-        pipeline2 = read_text(pathname=" &^#").and_return()
+        pipeline1: DataPipeline[int] = read_text(pathname=" &^#").and_return()
+        pipeline2: DataPipeline[int] = read_text(pathname=" &^#").and_return()
 
         # Break the first pipeline.
         try:
@@ -124,18 +126,18 @@ class TestRoundRobinOp:
             DataPipeline.round_robin([pipeline1, pipeline2]).and_return()
 
     def test_op_saves_and_restores_its_state(self) -> None:
-        pipeline1 = read_sequence([1, 2, 3, 4]).and_return()
-        pipeline2 = read_sequence([5, 6]).and_return()
-        pipeline3 = read_sequence([]).and_return()
-        pipeline4 = read_sequence([7, 8, 9, 0, 1, 2]).and_return()
+        pipeline1: DataPipeline[int] = read_sequence([1, 2, 3, 4]).and_return()
+        pipeline2: DataPipeline[int] = read_sequence([5, 6]).and_return()
+        pipeline3: DataPipeline[int] = read_sequence([]).and_return()
+        pipeline4: DataPipeline[int] = read_sequence([7, 8, 9, 0, 1, 2]).and_return()
 
-        pipeline = DataPipeline.round_robin(
+        pipeline5: DataPipeline[int] = DataPipeline.round_robin(
             [pipeline1, pipeline2, pipeline3, pipeline4]
         ).and_return()
 
         d = None
 
-        it = iter(pipeline)
+        it = iter(pipeline5)
 
         # Move to the fifth example.
         for _ in range(5):
@@ -143,7 +145,7 @@ class TestRoundRobinOp:
 
         assert d == 6
 
-        state_dict = pipeline.state_dict()
+        state_dict = pipeline5.state_dict()
 
         # Read a few examples before we roll back.
         for _ in range(4):
@@ -152,7 +154,7 @@ class TestRoundRobinOp:
         assert d == 9
 
         # Expected to roll back to the fifth example.
-        pipeline.load_state_dict(state_dict)
+        pipeline5.load_state_dict(state_dict)
 
         # Move to EOD.
         for _ in range(13):
@@ -160,12 +162,12 @@ class TestRoundRobinOp:
 
         assert d == 2
 
-        state_dict = pipeline.state_dict()
+        state_dict = pipeline5.state_dict()
 
-        pipeline.reset()
+        pipeline5.reset()
 
         # Expected to be EOD.
-        pipeline.load_state_dict(state_dict)
+        pipeline5.load_state_dict(state_dict)
 
         with pytest.raises(StopIteration):
-            next(iter(pipeline))
+            next(iter(pipeline5))

--- a/tests/unit/data/data_pipeline/test_sample.py
+++ b/tests/unit/data/data_pipeline/test_sample.py
@@ -17,43 +17,47 @@ from tests.common import tmp_rng_seed
 
 class TestSampleOp:
     def test_op_works(self) -> None:
-        pipeline1 = read_sequence([1, 2, 3, 4]).and_return()
-        pipeline2 = read_sequence([5, 6, 7]).and_return()
+        pipeline1: DataPipeline[int] = read_sequence([1, 2, 3, 4]).and_return()
+        pipeline2: DataPipeline[int] = read_sequence([5, 6, 7]).and_return()
 
-        pipeline = DataPipeline.sample([pipeline1, pipeline2], [1.2, 0.8]).and_return()
+        pipeline3: DataPipeline[int] = DataPipeline.sample(
+            [pipeline1, pipeline2], [1.2, 0.8]
+        ).and_return()
 
         for _ in range(2):
             with tmp_rng_seed(CPU, seed=1234):
-                assert list(pipeline) == [1, 2, 3, 4, 1, 5, 2, 3, 6, 4, 7]
+                assert list(pipeline3) == [1, 2, 3, 4, 1, 5, 2, 3, 6, 4, 7]
 
-            pipeline.reset()
+            pipeline3.reset()
 
     def test_op_works_when_no_weight_is_specified(self) -> None:
-        pipeline1 = read_sequence([1, 2, 3]).and_return()
-        pipeline2 = read_sequence([4, 5, 6]).and_return()
-        pipeline3 = read_sequence([7, 8, 9]).and_return()
+        pipeline1: DataPipeline[int] = read_sequence([1, 2, 3]).and_return()
+        pipeline2: DataPipeline[int] = read_sequence([4, 5, 6]).and_return()
+        pipeline3: DataPipeline[int] = read_sequence([7, 8, 9]).and_return()
 
-        pipeline = DataPipeline.sample([pipeline1, pipeline2, pipeline3]).and_return()
+        pipeline4: DataPipeline[int] = DataPipeline.sample(
+            [pipeline1, pipeline2, pipeline3]
+        ).and_return()
 
         for _ in range(2):
             with tmp_rng_seed(CPU, seed=1234):
-                assert list(pipeline) == [1, 4, 2, 5, 3, 7, 1, 6, 8, 2, 9]
+                assert list(pipeline4) == [1, 4, 2, 5, 3, 7, 1, 6, 8, 2, 9]
 
-            pipeline.reset()
+            pipeline4.reset()
 
     def test_op_works_when_a_single_pipeline_is_specified(self) -> None:
-        pipeline1 = read_sequence([1, 2, 3, 4]).and_return()
+        pipeline1: DataPipeline[int] = read_sequence([1, 2, 3, 4]).and_return()
 
-        pipeline = DataPipeline.sample([pipeline1]).and_return()
+        pipeline2: DataPipeline[int] = DataPipeline.sample([pipeline1]).and_return()
 
         for _ in range(2):
             with tmp_rng_seed(CPU, seed=1234):
-                assert list(pipeline) == [1, 2, 3, 4]
+                assert list(pipeline2) == [1, 2, 3, 4]
 
-            pipeline.reset()
+            pipeline2.reset()
 
     def test_op_works_when_no_pipeline_is_specified(self) -> None:
-        pipeline = DataPipeline.sample([]).and_return()
+        pipeline: DataPipeline[int] = DataPipeline.sample([]).and_return()
 
         for _ in range(2):
             with pytest.raises(StopIteration):
@@ -62,34 +66,38 @@ class TestSampleOp:
             pipeline.reset()
 
     def test_op_works_when_infinite_pipeline_is_specified(self) -> None:
-        pipeline1 = read_sequence([1, 2, 3, 4]).and_return()
-        pipeline2 = DataPipeline.count(5).and_return()
+        pipeline1: DataPipeline[int] = read_sequence([1, 2, 3, 4]).and_return()
+        pipeline2: DataPipeline[int] = DataPipeline.count(5).and_return()
 
-        pipeline = DataPipeline.sample([pipeline1, pipeline2], [0.4, 0.6]).and_return()
+        pipeline3: DataPipeline[int] = DataPipeline.sample(
+            [pipeline1, pipeline2], [0.4, 0.6]
+        ).and_return()
 
         for _ in range(2):
             with tmp_rng_seed(CPU, seed=1234):
-                assert list(pipeline) == [1, 5, 2, 3, 4]
+                assert list(pipeline3) == [1, 5, 2, 3, 4]
 
-            pipeline.reset()
+            pipeline3.reset()
 
     def test_op_raises_error_when_pipeline_is_empty(self) -> None:
-        pipeline1 = read_sequence([1, 2]).and_return()
-        pipeline2 = read_sequence([]).and_return()
-        pipeline3 = read_sequence([3, 4]).and_return()
+        pipeline1: DataPipeline[int] = read_sequence([1, 2]).and_return()
+        pipeline2: DataPipeline[int] = read_sequence([]).and_return()
+        pipeline3: DataPipeline[int] = read_sequence([3, 4]).and_return()
 
-        pipeline = DataPipeline.sample([pipeline1, pipeline2, pipeline3]).and_return()
+        pipeline4: DataPipeline[int] = DataPipeline.sample(
+            [pipeline1, pipeline2, pipeline3]
+        ).and_return()
 
         with pytest.raises(
             DataPipelineError,
             match=r"^The data pipeline at index 1 is empty and cannot be sampled\.$",
         ):
-            next(iter(pipeline))
+            next(iter(pipeline4))
 
     def test_op_raises_error_when_weight_is_not_valid(self) -> None:
-        pipeline1 = read_sequence([1, 2]).and_return()
-        pipeline2 = read_sequence([3, 4]).and_return()
-        pipeline3 = read_sequence([5, 6]).and_return()
+        pipeline1: DataPipeline[int] = read_sequence([1, 2]).and_return()
+        pipeline2: DataPipeline[int] = read_sequence([3, 4]).and_return()
+        pipeline3: DataPipeline[int] = read_sequence([5, 6]).and_return()
 
         with pytest.raises(
             ValueError,
@@ -118,8 +126,8 @@ class TestSampleOp:
     def test_op_raises_error_when_the_number_of_pipelines_and_weights_do_not_match(
         self,
     ) -> None:
-        pipeline1 = read_sequence([1, 2, 3]).and_return()
-        pipeline2 = read_sequence([4, 5, 6]).and_return()
+        pipeline1: DataPipeline[int] = read_sequence([1, 2, 3]).and_return()
+        pipeline2: DataPipeline[int] = read_sequence([4, 5, 6]).and_return()
 
         with pytest.raises(
             ValueError,
@@ -129,8 +137,8 @@ class TestSampleOp:
 
     def test_op_raises_error_when_one_of_the_pipelines_is_broken(self) -> None:
         # Force a non-recoverable error.
-        pipeline1 = read_text(pathname=" &^#").and_return()
-        pipeline2 = read_text(pathname=" &^#").and_return()
+        pipeline1: DataPipeline[str] = read_text(pathname=" &^#").and_return()
+        pipeline2: DataPipeline[str] = read_text(pathname=" &^#").and_return()
 
         # Break the first pipeline.
         try:
@@ -145,16 +153,18 @@ class TestSampleOp:
             DataPipeline.sample([pipeline1, pipeline2]).and_return()
 
     def test_op_saves_and_restores_its_state(self) -> None:
-        pipeline1 = read_sequence([1, 2, 3, 4]).and_return()
-        pipeline2 = read_sequence([5, 6, 7, 8]).and_return()
-        pipeline3 = read_sequence([0, 2, 4, 6]).and_return()
+        pipeline1: DataPipeline[int] = read_sequence([1, 2, 3, 4]).and_return()
+        pipeline2: DataPipeline[int] = read_sequence([5, 6, 7, 8]).and_return()
+        pipeline3: DataPipeline[int] = read_sequence([0, 2, 4, 6]).and_return()
 
-        pipeline = DataPipeline.sample([pipeline1, pipeline2, pipeline3]).and_return()
         # [1, 5, 2, 6, 3, 0, 4, 7, 2, 1, 4, 8, 6]
+        pipeline4: DataPipeline[int] = DataPipeline.sample(
+            [pipeline1, pipeline2, pipeline3]
+        ).and_return()
 
         d = None
 
-        it = iter(pipeline)
+        it = iter(pipeline4)
 
         with tmp_rng_seed(CPU, seed=1234):
             # Move to the fifth example.
@@ -165,7 +175,7 @@ class TestSampleOp:
 
             rng = torch.get_rng_state()
 
-            state_dict = pipeline.state_dict()
+            state_dict = pipeline4.state_dict()
 
             # Read a few examples before we roll back.
             for _ in range(3):
@@ -176,7 +186,7 @@ class TestSampleOp:
             torch.set_rng_state(rng)
 
             # Expected to roll back to the fifth example.
-            pipeline.load_state_dict(state_dict)
+            pipeline4.load_state_dict(state_dict)
 
             # Move to EOD.
             for _ in range(8):
@@ -186,14 +196,14 @@ class TestSampleOp:
 
             rng = torch.get_rng_state()
 
-            state_dict = pipeline.state_dict()
+            state_dict = pipeline4.state_dict()
 
-            pipeline.reset()
+            pipeline4.reset()
 
             torch.set_rng_state(rng)
 
             # Expected to be EOD.
-            pipeline.load_state_dict(state_dict)
+            pipeline4.load_state_dict(state_dict)
 
             with pytest.raises(StopIteration):
-                next(iter(pipeline))
+                next(iter(pipeline4))

--- a/tests/unit/data/data_pipeline/test_shard.py
+++ b/tests/unit/data/data_pipeline/test_shard.py
@@ -6,14 +6,14 @@
 
 import pytest
 
-from fairseq2.data import read_sequence
+from fairseq2.data import DataPipeline, read_sequence
 
 
 class TestShardOp:
     def test_op_works(self) -> None:
         seq = list(range(1, 23))
 
-        pipeline = read_sequence(seq).shard(1, 5).and_return()
+        pipeline: DataPipeline[int] = read_sequence(seq).shard(1, 5).and_return()
 
         for _ in range(2):
             assert list(pipeline) == [2, 7, 12, 17]
@@ -47,7 +47,7 @@ class TestShardOp:
     def test_op_saves_and_restores_its_state(self) -> None:
         seq = list(range(1, 23))
 
-        pipeline = read_sequence(seq).shard(2, 5).and_return()
+        pipeline: DataPipeline[int] = read_sequence(seq).shard(2, 5).and_return()
 
         d = None
 

--- a/tests/unit/data/data_pipeline/test_shuffle.py
+++ b/tests/unit/data/data_pipeline/test_shuffle.py
@@ -8,7 +8,7 @@ from itertools import islice
 
 import pytest
 
-from fairseq2.data import read_sequence
+from fairseq2.data import DataPipeline, read_sequence
 from fairseq2.typing import CPU
 from tests.common import tmp_rng_seed
 
@@ -17,7 +17,7 @@ class TestShuffleOp:
     def test_op_works(self) -> None:
         seq = list(range(1, 10))
 
-        pipeline = read_sequence(seq).shuffle(100).and_return()
+        pipeline: DataPipeline[int] = read_sequence(seq).shuffle(100).and_return()
 
         for _ in range(2):
             with tmp_rng_seed(CPU, seed=1234):
@@ -53,8 +53,8 @@ class TestShuffleOp:
     def test_op_saves_and_restores_its_state(self, window: int) -> None:
         seq = list(range(5000))
 
-        pipeline1 = read_sequence(seq).shuffle(window).and_return()
-        pipeline2 = read_sequence(seq).shuffle(window).and_return()
+        pipeline1: DataPipeline[int] = read_sequence(seq).shuffle(window).and_return()
+        pipeline2: DataPipeline[int] = read_sequence(seq).shuffle(window).and_return()
 
         with tmp_rng_seed(CPU, seed=1234):
             expected_output1 = list(islice(pipeline1, 4000))
@@ -97,7 +97,9 @@ class TestShuffleOp:
     def test_record_reload_position_works_as_expected_with_no_strict(self) -> None:
         seq = list(range(100))
 
-        pipeline = read_sequence(seq).shuffle(80, strict=False).and_return()
+        pipeline: DataPipeline[int] = (
+            read_sequence(seq).shuffle(80, strict=False).and_return()
+        )
 
         # Do one dummy iteration to force to fill the buffer.
         next(iter(pipeline))

--- a/tests/unit/data/data_pipeline/test_skip.py
+++ b/tests/unit/data/data_pipeline/test_skip.py
@@ -6,12 +6,14 @@
 
 import pytest
 
-from fairseq2.data import read_sequence
+from fairseq2.data import DataPipeline, read_sequence
 
 
 class TestSkipOp:
     def test_op_works(self) -> None:
-        pipeline = read_sequence([1, 2, 3, 4, 5, 6, 7, 8, 9]).skip(3).and_return()
+        pipeline: DataPipeline[int] = (
+            read_sequence([1, 2, 3, 4, 5, 6, 7, 8, 9]).skip(3).and_return()
+        )
 
         for _ in range(2):
             assert list(pipeline) == [4, 5, 6, 7, 8, 9]
@@ -19,7 +21,7 @@ class TestSkipOp:
             pipeline.reset()
 
     def test_op_works_when_count_is_greater_than_the_number_of_elements(self) -> None:
-        pipeline = read_sequence([1, 2, 3]).skip(5).and_return()
+        pipeline: DataPipeline[int] = read_sequence([1, 2, 3]).skip(5).and_return()
 
         for _ in range(2):
             assert list(pipeline) == []
@@ -27,7 +29,7 @@ class TestSkipOp:
             pipeline.reset()
 
     def test_op_works_when_count_is_zero(self) -> None:
-        pipeline = read_sequence([1, 2, 3]).skip(0).and_return()
+        pipeline: DataPipeline[int] = read_sequence([1, 2, 3]).skip(0).and_return()
 
         for _ in range(2):
             assert list(pipeline) == [1, 2, 3]
@@ -35,7 +37,9 @@ class TestSkipOp:
             pipeline.reset()
 
     def test_op_saves_and_restores_its_state(self) -> None:
-        pipeline = read_sequence([1, 2, 3, 4, 5, 6, 7, 8, 9]).skip(3).and_return()
+        pipeline: DataPipeline[int] = (
+            read_sequence([1, 2, 3, 4, 5, 6, 7, 8, 9]).skip(3).and_return()
+        )
 
         d = None
 

--- a/tests/unit/data/data_pipeline/test_take.py
+++ b/tests/unit/data/data_pipeline/test_take.py
@@ -6,12 +6,14 @@
 
 import pytest
 
-from fairseq2.data import read_sequence
+from fairseq2.data import DataPipeline, read_sequence
 
 
 class TestTakeOp:
     def test_op_works(self) -> None:
-        pipeline = read_sequence([1, 2, 3, 4, 5, 6, 7, 8, 9]).take(5).and_return()
+        pipeline: DataPipeline[int] = (
+            read_sequence([1, 2, 3, 4, 5, 6, 7, 8, 9]).take(5).and_return()
+        )
 
         for _ in range(2):
             assert list(pipeline) == [1, 2, 3, 4, 5]
@@ -19,7 +21,7 @@ class TestTakeOp:
             pipeline.reset()
 
     def test_op_works_when_count_is_greater_than_the_number_of_elements(self) -> None:
-        pipeline = read_sequence([1, 2, 3]).take(5).and_return()
+        pipeline: DataPipeline[int] = read_sequence([1, 2, 3]).take(5).and_return()
 
         for _ in range(2):
             assert list(pipeline) == [1, 2, 3]
@@ -27,7 +29,7 @@ class TestTakeOp:
             pipeline.reset()
 
     def test_op_works_when_count_is_zero(self) -> None:
-        pipeline = read_sequence([1, 2, 3]).take(0).and_return()
+        pipeline: DataPipeline[int] = read_sequence([1, 2, 3]).take(0).and_return()
 
         for _ in range(2):
             assert list(pipeline) == []
@@ -35,7 +37,9 @@ class TestTakeOp:
             pipeline.reset()
 
     def test_op_saves_and_restores_its_state(self) -> None:
-        pipeline = read_sequence([1, 2, 3, 4, 5, 6, 7, 8, 9]).take(5).and_return()
+        pipeline: DataPipeline[int] = (
+            read_sequence([1, 2, 3, 4, 5, 6, 7, 8, 9]).take(5).and_return()
+        )
 
         d = None
 

--- a/tests/unit/data/data_pipeline/test_yield_from.py
+++ b/tests/unit/data/data_pipeline/test_yield_from.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 from typing import Tuple
 
 import pytest
@@ -13,14 +15,16 @@ from fairseq2.data import DataPipeline, DataPipelineError, read_sequence
 
 class TestYieldFromOp:
     def test_op_works(self) -> None:
-        def fn(d: Tuple[int, int]) -> DataPipeline:
+        def fn(d: Tuple[int, int]) -> DataPipeline[int]:
             a, b = d
 
             seq = list(range(a, b))
 
             return read_sequence(seq).and_return()
 
-        pipeline = read_sequence([[1, 5], [9, 14]]).yield_from(fn).and_return()
+        pipeline: DataPipeline[int] = (
+            read_sequence([[1, 5], [9, 14]]).yield_from(fn).and_return()
+        )
 
         for _ in range(2):
             assert list(pipeline) == [1, 2, 3, 4, 9, 10, 11, 12, 13]
@@ -28,10 +32,10 @@ class TestYieldFromOp:
             pipeline.reset()
 
     def test_op_raises_error_when_yield_from_is_infinite(self) -> None:
-        def fn(d: int) -> DataPipeline:
+        def fn(d: int) -> DataPipeline[int]:
             return DataPipeline.constant(0).and_return()
 
-        pipeline = read_sequence([1]).yield_from(fn).and_return()
+        pipeline: DataPipeline[int] = read_sequence([1]).yield_from(fn).and_return()
 
         with pytest.raises(
             DataPipelineError,
@@ -40,14 +44,16 @@ class TestYieldFromOp:
             next(iter(pipeline))
 
     def test_op_saves_and_restores_its_state(self) -> None:
-        def fn(d: Tuple[int, int]) -> DataPipeline:
+        def fn(d: Tuple[int, int]) -> DataPipeline[int]:
             a, b = d
 
             seq = list(range(a, b))
 
             return read_sequence(seq).and_return()
 
-        pipeline = read_sequence([[1, 5], [9, 14]]).yield_from(fn).and_return()
+        pipeline: DataPipeline[int] = (
+            read_sequence([[1, 5], [9, 14]]).yield_from(fn).and_return()
+        )
 
         d = None
 

--- a/tests/unit/data/data_pipeline/test_zip.py
+++ b/tests/unit/data/data_pipeline/test_zip.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Any, Dict, List
+
 import pytest
 
 from fairseq2.data import DataPipeline, DataPipelineError, read_sequence
@@ -12,29 +14,31 @@ from fairseq2.data.text import read_text
 
 class TestZipOp:
     def test_op_works(self) -> None:
-        pipeline1 = read_sequence([1, 2, 3, 4]).and_return()
-        pipeline2 = read_sequence([5, 6, 7, 8]).and_return()
-        pipeline3 = read_sequence([0, 2, 4, 6]).and_return()
+        pipeline1: DataPipeline[int] = read_sequence([1, 2, 3, 4]).and_return()
+        pipeline2: DataPipeline[int] = read_sequence([5, 6, 7, 8]).and_return()
+        pipeline3: DataPipeline[int] = read_sequence([0, 2, 4, 6]).and_return()
 
-        pipeline = DataPipeline.zip([pipeline1, pipeline2, pipeline3]).and_return()
+        pipeline4: DataPipeline[List[int]] = DataPipeline.zip(
+            [pipeline1, pipeline2, pipeline3]
+        ).and_return()
 
         for _ in range(2):
-            assert list(pipeline) == [[1, 5, 0], [2, 6, 2], [3, 7, 4], [4, 8, 6]]
+            assert list(pipeline4) == [[1, 5, 0], [2, 6, 2], [3, 7, 4], [4, 8, 6]]
 
-            pipeline.reset()
+            pipeline4.reset()
 
     def test_op_works_when_a_single_pipeline_is_specified(self) -> None:
-        pipeline1 = read_sequence([1, 2, 3, 4]).and_return()
+        pipeline1: DataPipeline[int] = read_sequence([1, 2, 3, 4]).and_return()
 
-        pipeline = DataPipeline.zip([pipeline1]).and_return()
+        pipeline2: DataPipeline[List[int]] = DataPipeline.zip([pipeline1]).and_return()
 
         for _ in range(2):
-            assert list(pipeline) == [[1], [2], [3], [4]]
+            assert list(pipeline2) == [[1], [2], [3], [4]]
 
-            pipeline.reset()
+            pipeline2.reset()
 
     def test_op_works_when_no_pipeline_is_specified(self) -> None:
-        pipeline = DataPipeline.zip([]).and_return()
+        pipeline: DataPipeline[int] = DataPipeline.zip([]).and_return()
 
         for _ in range(2):
             with pytest.raises(StopIteration):
@@ -43,102 +47,112 @@ class TestZipOp:
             pipeline.reset()
 
     def test_op_works_when_infinite_pipeline_is_specified(self) -> None:
-        pipeline1 = read_sequence([1, 2, 3, 4]).and_return()
-        pipeline2 = DataPipeline.constant(0).and_return()
-        pipeline3 = read_sequence([5, 6, 7, 8]).and_return()
+        pipeline1: DataPipeline[int] = read_sequence([1, 2, 3, 4]).and_return()
+        pipeline2: DataPipeline[int] = DataPipeline.constant(0).and_return()
+        pipeline3: DataPipeline[int] = read_sequence([5, 6, 7, 8]).and_return()
 
-        pipeline = DataPipeline.zip([pipeline1, pipeline2, pipeline3]).and_return()
+        pipeline4: DataPipeline[List[int]] = DataPipeline.zip(
+            [pipeline1, pipeline2, pipeline3]
+        ).and_return()
 
         for _ in range(2):
-            assert list(pipeline) == [[1, 0, 5], [2, 0, 6], [3, 0, 7], [4, 0, 8]]
+            assert list(pipeline4) == [[1, 0, 5], [2, 0, 6], [3, 0, 7], [4, 0, 8]]
 
-            pipeline.reset()
+            pipeline4.reset()
 
     def test_op_works_when_names_are_specified(self) -> None:
-        pipeline1 = read_sequence([1, 2, 3, 4]).and_return()
-        pipeline2 = read_sequence([5, 6, 7, 8]).and_return()
-        pipeline3 = read_sequence([0, 2, 4, 6]).and_return()
+        pipeline1: DataPipeline[int] = read_sequence([1, 2, 3, 4]).and_return()
+        pipeline2: DataPipeline[int] = read_sequence([5, 6, 7, 8]).and_return()
+        pipeline3: DataPipeline[int] = read_sequence([0, 2, 4, 6]).and_return()
 
-        pipeline = DataPipeline.zip(
+        pipeline4: DataPipeline[Dict[str, int]] = DataPipeline.zip(
             [pipeline1, pipeline2, pipeline3], names=["p1", "p2", "p3"]
         ).and_return()
 
         for _ in range(2):
-            assert list(pipeline) == [
+            assert list(pipeline4) == [
                 {"p1": 1, "p2": 5, "p3": 0},
                 {"p1": 2, "p2": 6, "p3": 2},
                 {"p1": 3, "p2": 7, "p3": 4},
                 {"p1": 4, "p2": 8, "p3": 6},
             ]
 
-            pipeline.reset()
+            pipeline4.reset()
 
     def test_op_works_when_zip_to_shortest_is_true(self) -> None:
-        pipeline1 = read_sequence([1, 2, 3]).and_return()
-        pipeline2 = read_sequence([5, 6, 7, 8]).and_return()
-        pipeline3 = read_sequence([3, 4, 5, 6]).and_return()
-        pipeline4 = DataPipeline.count(1).and_return()
+        pipeline1: DataPipeline[int] = read_sequence([1, 2, 3]).and_return()
+        pipeline2: DataPipeline[int] = read_sequence([5, 6, 7, 8]).and_return()
+        pipeline3: DataPipeline[int] = read_sequence([3, 4, 5, 6]).and_return()
+        pipeline4: DataPipeline[int] = DataPipeline.count(1).and_return()
 
-        pipeline = DataPipeline.zip(
+        pipeline5: DataPipeline[List[int]] = DataPipeline.zip(
             [pipeline1, pipeline2, pipeline3, pipeline4], zip_to_shortest=True
         ).and_return()
 
         for _ in range(2):
-            assert list(pipeline) == [[1, 5, 3, 1], [2, 6, 4, 2], [3, 7, 5, 3]]
+            assert list(pipeline5) == [[1, 5, 3, 1], [2, 6, 4, 2], [3, 7, 5, 3]]
 
-            pipeline.reset()
+            pipeline5.reset()
 
     def test_op_works_when_flatten_is_true_and_inputs_are_lists(self) -> None:
-        pipeline1 = read_sequence([1, 2, 3]).and_return()
-        pipeline2 = read_sequence([[1, 2], [3, 4], [5, 6]]).and_return()
-        pipeline3 = read_sequence([[4], [5], [6]]).and_return()
+        pipeline1: DataPipeline[int] = read_sequence([1, 2, 3]).and_return()
+        pipeline2: DataPipeline[List[int]] = read_sequence([[1, 2], [3, 4], [5, 6]]).and_return()  # fmt: skip
+        pipeline3: DataPipeline[List[int]] = read_sequence([[4], [5], [6]]).and_return()
 
-        pipeline = DataPipeline.zip(
+        pipeline4: DataPipeline[List[int]] = DataPipeline.zip(
             [pipeline1, pipeline2, pipeline3], flatten=True
         ).and_return()
 
         for _ in range(2):
-            assert list(pipeline) == [[1, 1, 2, 4], [2, 3, 4, 5], [3, 5, 6, 6]]
+            assert list(pipeline4) == [[1, 1, 2, 4], [2, 3, 4, 5], [3, 5, 6, 6]]
 
-            pipeline.reset()
+            pipeline4.reset()
 
     def test_op_works_when_flatten_is_true_and_inputs_are_dicts(self) -> None:
-        pipeline1 = read_sequence([{"foo1": 1}, {"foo1": 2}, {"foo1": 3}]).and_return()
-        pipeline2 = read_sequence([{"foo2": 4, "foo3": 5}, {"foo2": 6, "foo3": 7}, {"foo2": 8, "foo3": 9}]).and_return()  # fmt: skip
-        pipeline3 = read_sequence([{"foo4": 2}, {"foo4": 3}, {"foo4": 4}]).and_return()
+        pipeline1: DataPipeline[Dict[str, int]] = read_sequence(
+            [{"foo1": 1}, {"foo1": 2}, {"foo1": 3}]
+        ).and_return()
+        pipeline2: DataPipeline[Dict[str, int]] = read_sequence(
+            [{"foo2": 4, "foo3": 5}, {"foo2": 6, "foo3": 7}, {"foo2": 8, "foo3": 9}]
+        ).and_return()
+        pipeline3: DataPipeline[Dict[str, int]] = read_sequence(
+            [{"foo4": 2}, {"foo4": 3}, {"foo4": 4}]
+        ).and_return()
 
-        pipeline = DataPipeline.zip(
+        pipeline4: DataPipeline[Dict[str, int]] = DataPipeline.zip(
             [pipeline1, pipeline2, pipeline3], flatten=True
         ).and_return()
 
         for _ in range(2):
-            assert list(pipeline) == [
+            assert list(pipeline4) == [
                 {"foo1": 1, "foo2": 4, "foo3": 5, "foo4": 2},
                 {"foo1": 2, "foo2": 6, "foo3": 7, "foo4": 3},
                 {"foo1": 3, "foo2": 8, "foo3": 9, "foo4": 4},
             ]
 
-            pipeline.reset()
+            pipeline4.reset()
 
     def test_op_raises_error_when_pipelines_have_different_lengths(self) -> None:
-        pipeline1 = read_sequence([1, 2, 3]).and_return()
-        pipeline2 = read_sequence([5, 6, 7, 8]).and_return()
-        pipeline3 = read_sequence([5, 6, 7, 8]).and_return()
+        pipeline1: DataPipeline[int] = read_sequence([1, 2, 3]).and_return()
+        pipeline2: DataPipeline[int] = read_sequence([5, 6, 7, 8]).and_return()
+        pipeline3: DataPipeline[int] = read_sequence([5, 6, 7, 8]).and_return()
 
-        pipeline = DataPipeline.zip([pipeline1, pipeline2, pipeline3]).and_return()
+        pipeline4: DataPipeline[List[int]] = DataPipeline.zip(
+            [pipeline1, pipeline2, pipeline3]
+        ).and_return()
 
         with pytest.raises(
             DataPipelineError,
             match=r"^The zipped data pipelines must all have the same number of examples, but the data pipelines at the indices \[1, 2\] have more examples than the others\.$",
         ):
-            for d in pipeline:
+            for d in pipeline4:
                 pass
 
     def test_op_raises_error_when_the_number_of_pipelines_and_names_do_not_match(
         self,
     ) -> None:
-        pipeline1 = read_sequence([]).and_return()
-        pipeline2 = read_sequence([]).and_return()
+        pipeline1: DataPipeline[int] = read_sequence([]).and_return()
+        pipeline2: DataPipeline[int] = read_sequence([]).and_return()
 
         with pytest.raises(
             ValueError,
@@ -148,8 +162,8 @@ class TestZipOp:
 
     def test_op_raises_error_when_one_of_the_pipelines_is_broken(self) -> None:
         # Force a non-recoverable error.
-        pipeline1 = read_text(pathname=" &^#").and_return()
-        pipeline2 = read_text(pathname=" &^#").and_return()
+        pipeline1: DataPipeline[str] = read_text(pathname=" &^#").and_return()
+        pipeline2: DataPipeline[str] = read_text(pathname=" &^#").and_return()
 
         # Break the first pipeline.
         try:
@@ -164,8 +178,8 @@ class TestZipOp:
             DataPipeline.zip([pipeline1, pipeline2]).and_return()
 
     def test_op_raises_error_when_both_names_and_flatten_are_specified(self) -> None:
-        pipeline1 = read_sequence([1]).and_return()
-        pipeline2 = read_sequence([1]).and_return()
+        pipeline1: DataPipeline[int] = read_sequence([1]).and_return()
+        pipeline2: DataPipeline[int] = read_sequence([1]).and_return()
 
         with pytest.raises(
             ValueError,
@@ -176,36 +190,40 @@ class TestZipOp:
     def test_op_raises_error_when_flatten_is_true_and_input_has_both_list_and_dict(
         self,
     ) -> None:
-        pipeline1 = read_sequence([1]).and_return()
-        pipeline2 = read_sequence([{"foo1": 1}]).and_return()
+        pipeline1: DataPipeline[int] = read_sequence([1]).and_return()
+        pipeline2: DataPipeline[Dict[str, int]] = read_sequence([{"foo1": 1}]).and_return()  # fmt: skip
 
-        pipeline = DataPipeline.zip([pipeline1, pipeline2], flatten=True).and_return()
-
-        with pytest.raises(
-            DataPipelineError,
-            match=r"^The zipped data pipelines must all return only dicts, or only non-dicts when `flatten` is set\.$",
-        ):
-            next(iter(pipeline))
-
-        pipeline1 = read_sequence([{"foo1": 1}]).and_return()
-        pipeline2 = read_sequence([1]).and_return()
-
-        pipeline = DataPipeline.zip([pipeline1, pipeline2], flatten=True).and_return()
+        pipeline3: DataPipeline[Any] = DataPipeline.zip(
+            [pipeline1, pipeline2], flatten=True
+        ).and_return()
 
         with pytest.raises(
             DataPipelineError,
             match=r"^The zipped data pipelines must all return only dicts, or only non-dicts when `flatten` is set\.$",
         ):
-            next(iter(pipeline))
+            next(iter(pipeline3))
+
+        pipeline4: DataPipeline[Dict[str, int]] = read_sequence([{"foo1": 1}]).and_return()  # fmt: skip
+        pipeline5: DataPipeline[int] = read_sequence([1]).and_return()
+
+        pipeline6: DataPipeline[Any] = DataPipeline.zip(
+            [pipeline4, pipeline5], flatten=True
+        ).and_return()
+
+        with pytest.raises(
+            DataPipelineError,
+            match=r"^The zipped data pipelines must all return only dicts, or only non-dicts when `flatten` is set\.$",
+        ):
+            next(iter(pipeline6))
 
     def test_op_raises_error_when_flatten_is_true_and_dict_keys_are_not_unique(
         self,
     ) -> None:
-        pipeline1 = read_sequence([{"foo1": 1}]).and_return()
-        pipeline2 = read_sequence([{"foo2": 1}]).and_return()
-        pipeline3 = read_sequence([{"foo1": 1}]).and_return()
+        pipeline1: DataPipeline[Dict[str, int]] = read_sequence([{"foo1": 1}]).and_return()  # fmt: skip
+        pipeline2: DataPipeline[Dict[str, int]] = read_sequence([{"foo2": 1}]).and_return()  # fmt: skip
+        pipeline3: DataPipeline[Dict[str, int]] = read_sequence([{"foo1": 1}]).and_return()  # fmt: skip
 
-        pipeline = DataPipeline.zip(
+        pipeline4: DataPipeline[Dict[str, int]] = DataPipeline.zip(
             [pipeline1, pipeline2, pipeline3], flatten=True
         ).and_return()
 
@@ -213,18 +231,20 @@ class TestZipOp:
             DataPipelineError,
             match=r"^The zipped data pipelines must all return unique keys when `flatten` is set, but the key 'foo1' is not unique\.$",
         ):
-            next(iter(pipeline))
+            next(iter(pipeline4))
 
     def test_op_saves_and_restores_its_state(self) -> None:
-        pipeline1 = read_sequence([1, 2, 3, 4]).and_return()
-        pipeline2 = read_sequence([5, 6, 7, 8]).and_return()
-        pipeline3 = read_sequence([0, 2, 4, 6]).and_return()
+        pipeline1: DataPipeline[int] = read_sequence([1, 2, 3, 4]).and_return()
+        pipeline2: DataPipeline[int] = read_sequence([5, 6, 7, 8]).and_return()
+        pipeline3: DataPipeline[int] = read_sequence([0, 2, 4, 6]).and_return()
 
-        pipeline = DataPipeline.zip([pipeline1, pipeline2, pipeline3]).and_return()
+        pipeline4: DataPipeline[List[int]] = DataPipeline.zip(
+            [pipeline1, pipeline2, pipeline3]
+        ).and_return()
 
         d = None
 
-        it = iter(pipeline)
+        it = iter(pipeline4)
 
         # Move to the second example.
         for _ in range(2):
@@ -232,7 +252,7 @@ class TestZipOp:
 
         assert d == [2, 6, 2]
 
-        state_dict = pipeline.state_dict()
+        state_dict = pipeline4.state_dict()
 
         # Read one more example before we roll back.
         d = next(it)
@@ -240,7 +260,7 @@ class TestZipOp:
         assert d == [3, 7, 4]
 
         # Expected to roll back to the second example.
-        pipeline.load_state_dict(state_dict)
+        pipeline4.load_state_dict(state_dict)
 
         # Move to EOD.
         for _ in range(2):
@@ -248,12 +268,12 @@ class TestZipOp:
 
         assert d == [4, 8, 6]
 
-        state_dict = pipeline.state_dict()
+        state_dict = pipeline4.state_dict()
 
-        pipeline.reset()
+        pipeline4.reset()
 
         # Expected to be EOD.
-        pipeline.load_state_dict(state_dict)
+        pipeline4.load_state_dict(state_dict)
 
         with pytest.raises(StopIteration):
-            next(iter(pipeline))
+            next(iter(pipeline4))


### PR DESCRIPTION
This "nit" PR makes `DataPipeline` a generic type to improve its type-safety when used in large data processing pipelines.