### PR TITLE
Improve infer_device logic

### DIFF
--- a/src/fairseq2/checkpoint.py
+++ b/src/fairseq2/checkpoint.py
@@ -468,7 +468,7 @@ class FileCheckpointManager(CheckpointManager):
                 f"The consolidated model checkpoint of training step {step_nr} cannot be loaded. See nested exception for details."
             ) from ex
 
-        model_device = infer_device(out)
+        model_device = infer_device(out, param_name="out")
 
         if model_device == META:
             # Move the model to the actual device without initializing. Its

--- a/src/fairseq2/gang.py
+++ b/src/fairseq2/gang.py
@@ -183,8 +183,8 @@ class ProcessGroupGang(Gang):
         elif device.type == "cuda":
             backend = "nccl"
         else:
-            raise RuntimeError(
-                f"Only CPU and CUDA devices are supported, but `device` is a {device.type.upper()} device."
+            raise ValueError(
+                f"`device` must be of type 'cpu' and 'cuda', but is of type '{device.type}' instead."
             )
 
         if device.type == "cuda":

--- a/src/fairseq2/generation/beam_search.py
+++ b/src/fairseq2/generation/beam_search.py
@@ -457,6 +457,7 @@ class _BeamSearchGeneratorOp(ABC):
     len_penalty: float
     prefill_chunk_size: Optional[int]
     step_processors: List[StepProcessor]
+    step_hooks: Dict[int, StepHook]
     step_nr: int
     state_bag: IncrementalStateBag
     prompt_lens: Optional[Tensor]
@@ -466,7 +467,6 @@ class _BeamSearchGeneratorOp(ABC):
     seqs: Tensor
     step_scores: Tensor
     output: List[List[Hypothesis]]
-    step_hooks: Dict[int, StepHook]
 
     def __init__(
         self,

--- a/src/fairseq2/generation/sampling.py
+++ b/src/fairseq2/generation/sampling.py
@@ -473,6 +473,7 @@ class _SamplingGeneratorOp(ABC):
     len_penalty: float
     prefill_chunk_size: Optional[int]
     step_processors: List[StepProcessor]
+    step_hooks: Dict[int, StepHook]
     step_nr: int
     state_bag: IncrementalStateBag
     prompt_lens: Optional[Tensor]
@@ -481,7 +482,6 @@ class _SamplingGeneratorOp(ABC):
     seqs: Tensor
     step_scores: Optional[Tensor]
     output: List[List[Hypothesis]]
-    step_hooks: Dict[int, StepHook]
 
     def __init__(
         self,

--- a/src/fairseq2/generation/text.py
+++ b/src/fairseq2/generation/text.py
@@ -47,7 +47,7 @@ class SequenceToTextConverterBase(ABC):
         """
         self.generator = generator
 
-        device = infer_device(generator.model)
+        device = infer_device(generator.model, param_name="generator.model")
 
         target_text_encoder = tokenizer.create_encoder(
             task=task, lang=target_lang, mode="target", device=device
@@ -186,7 +186,7 @@ class TextTranslator(SequenceToTextConverterBase):
 
         self.pad_idx = pad_idx
 
-        device = infer_device(generator.model)
+        device = infer_device(generator.model, param_name="generator.model")
 
         self.source_text_encoder = tokenizer.create_encoder(
             task="translation", lang=source_lang, mode="source", device=device
@@ -250,7 +250,7 @@ class TextCompleter:
         """
         self.generator = generator
 
-        device = infer_device(generator.model)
+        device = infer_device(generator.model, param_name="generator.model")
 
         self.text_encoder = tokenizer.create_encoder(mode="prompt", device=device)
         self.text_decoder = tokenizer.create_decoder()

--- a/src/fairseq2/models/llama/chat.py
+++ b/src/fairseq2/models/llama/chat.py
@@ -36,7 +36,7 @@ class LLaMAChatbot(Chatbot):
         assert tokenizer.vocab_info.bos_idx is not None
         assert tokenizer.vocab_info.eos_idx is not None
 
-        device = infer_device(generator.model)
+        device = infer_device(generator.model, param_name="generator.model")
 
         self.bos_idx = torch.tensor([tokenizer.vocab_info.bos_idx], device=device)
         self.eos_idx = torch.tensor([tokenizer.vocab_info.eos_idx], device=device)

--- a/src/fairseq2/models/mistral/chat.py
+++ b/src/fairseq2/models/mistral/chat.py
@@ -38,7 +38,7 @@ class MistralChatbot(Chatbot):
         assert tokenizer.vocab_info.bos_idx is not None
         assert tokenizer.vocab_info.eos_idx is not None
 
-        device = infer_device(generator.model)
+        device = infer_device(generator.model, param_name="generator.model")
 
         self.bos_idx = torch.tensor([tokenizer.vocab_info.bos_idx], device=device)
         self.eos_idx = torch.tensor([tokenizer.vocab_info.eos_idx], device=device)

--- a/src/fairseq2/optim/dynamic_loss_scaler.py
+++ b/src/fairseq2/optim/dynamic_loss_scaler.py
@@ -74,7 +74,7 @@ class DynamicLossScaler:
 
                     if param.device.type != "cuda":
                         raise ValueError(
-                            f"The parameters held by `optimizer` must be on a CUDA device, but at least one parameter is on a {param.device.type.upper()} device."
+                            f"The parameters held by `optimizer` must be on a 'cuda' device, but at least one parameter is on a '{param.device.type}' device."
                         )
 
         if gang.size == 1:

--- a/src/fairseq2/utils/rng.py
+++ b/src/fairseq2/utils/rng.py
@@ -67,7 +67,7 @@ class RNGBag:
                 generators.append(torch.cuda.default_generators[idx])
             else:
                 raise ValueError(
-                    f"`RNGBag` supports only CPU and CUDA devices, but a {device.type.upper()} device is specified."
+                    f"`devices` must be of type 'cpu' or 'cuda', but at least one device is of type '{device.type}' instead."
                 )
 
         return RNGBag(*generators)


### PR DESCRIPTION
This PR improves the implementation `infer_device()` to gracefully handle invalid model initialization in `ModelLoader`.