### PR TITLE
Introduce load_state_dict

### DIFF
--- a/src/fairseq2/checkpoint.py
+++ b/src/fairseq2/checkpoint.py
@@ -20,6 +20,7 @@ from fairseq2.gang import Gang
 from fairseq2.models.utils.checkpoint import load_checkpoint
 from fairseq2.nn.utils.module import (
     infer_device,
+    load_state_dict,
     reset_non_persistent_buffers,
     to_empty,
 )
@@ -484,7 +485,7 @@ class FileCheckpointManager(CheckpointManager):
             )
 
         try:
-            out.load_state_dict(state_dict)
+            load_state_dict(out, state_dict)
         except (KeyError, ValueError) as ex:
             raise RuntimeError(
                 f"The consolidated model of training step {step_nr} cannot be loaded. See nested exception for details."

--- a/src/fairseq2/models/utils/generic_loaders.py
+++ b/src/fairseq2/models/utils/generic_loaders.py
@@ -24,6 +24,7 @@ from fairseq2.models.utils.arch_registry import ArchitectureRegistry
 from fairseq2.models.utils.checkpoint import load_checkpoint
 from fairseq2.nn.utils.module import (
     infer_device,
+    load_state_dict,
     reset_non_persistent_buffers,
     to_empty,
 )
@@ -307,7 +308,7 @@ class ModelLoader(Generic[ModelT, ConfigT]):
             )
 
         try:
-            model.load_state_dict(state_dict)
+            load_state_dict(model, state_dict)
         except (KeyError, ValueError) as ex:
             raise AssetError(
                 f"{card.name} cannot be loaded. See nested exception for details."


### PR DESCRIPTION
This PR fixes a subtle, but important bug in PyTorch's `load_state_dict` implementation where keys in `state_dict` that correspond to descendant modules that are set to `None` in `module` are simply ignored instead of being marked as "unexpected". This bug bit us several times last year while working on porting fairseq models to fairseq2. Here we introduce a `load_state_dict()` version that correctly checks *all* keys in `state_dict`.