### PR TITLE
Parametrize wav2vec2 `min_num_spans`

### DIFF
--- a/src/fairseq2/models/wav2vec2/builder.py
+++ b/src/fairseq2/models/wav2vec2/builder.py
@@ -417,6 +417,10 @@ class Wav2Vec2Config:
     max_spatial_mask_prob: float
     """The maximum probability of masking a feature. Note that, due to mask span
     overlap, the effective probability might be smaller."""
+    
+    min_num_spans: int
+    """The minimum number of mask sampled per sequences. Note that it is suggested
+    to have this value == 2"""
 
     # Quantization
     quantized_dim: int
@@ -460,6 +464,7 @@ def _base() -> Wav2Vec2Config:
         max_temporal_mask_prob=0.65,
         spatial_mask_span_len=10,
         max_spatial_mask_prob=0.0,
+        min_num_spans=2,
         quantized_dim=256,
         num_codebooks=2,
         num_codebook_entries=320,
@@ -539,6 +544,7 @@ class Wav2Vec2Builder:
             self.config.max_temporal_mask_prob,
             self.config.spatial_mask_span_len,
             self.config.max_spatial_mask_prob,
+            self.config.min_num_spans,
             device=self.device,
             dtype=self.dtype,
         )

--- a/src/fairseq2/models/wav2vec2/masker.py
+++ b/src/fairseq2/models/wav2vec2/masker.py
@@ -33,6 +33,7 @@ class Wav2Vec2Masker(Module):
         max_temporal_mask_prob: float = 0.65,
         spatial_span_len: int = 10,
         max_spatial_mask_prob: float = 0.0,
+        min_num_spans: int = 2,
         *,
         device: Optional[Device] = None,
         dtype: Optional[DataType] = None,
@@ -59,6 +60,7 @@ class Wav2Vec2Masker(Module):
 
         self.temporal_span_len = temporal_span_len
         self.max_temporal_mask_prob = max_temporal_mask_prob
+        self.min_num_spans = min_num_spans
 
         self.temporal_mask_embed = Parameter(
             torch.empty((model_dim,), device=device, dtype=dtype)
@@ -100,7 +102,7 @@ class Wav2Vec2Masker(Module):
             span_len=self.temporal_span_len,
             max_mask_prob=self.max_temporal_mask_prob,
             row_lens=padding_mask.seq_lens if padding_mask is not None else None,
-            min_num_spans=2,
+            min_num_spans=self.min_num_spans,
             device=seqs.device,
         )
 
@@ -115,7 +117,7 @@ class Wav2Vec2Masker(Module):
                 shape=(batch_size, model_dim),
                 span_len=self.spatial_span_len,
                 max_mask_prob=self.max_spatial_mask_prob,
-                min_num_spans=2,
+                min_num_spans=self.min_num_spans,
                 device=seqs.device,
             )
 

--- a/src/fairseq2/models/wav2vec2/model.py
+++ b/src/fairseq2/models/wav2vec2/model.py
@@ -113,7 +113,7 @@ class Wav2Vec2Model(Module):
         self.logit_temp = logit_temp
         self.diversity_loss_weight = diversity_loss_weight
 
-    def extract_features(self, batch: SequenceBatch):
+    def extract_features(self, batch: SequenceBatch) -> Wav2Vec2Features:
         seqs, padding_mask, targets, temporal_mask = self.run_frontend(
             batch.seqs, batch.padding_mask
         )

--- a/src/fairseq2/models/wav2vec2/model.py
+++ b/src/fairseq2/models/wav2vec2/model.py
@@ -113,7 +113,9 @@ class Wav2Vec2Model(Module):
         self.logit_temp = logit_temp
         self.diversity_loss_weight = diversity_loss_weight
 
-    def forward(self, batch: SequenceBatch) -> Wav2Vec2Output:
+    def forward(
+        self, batch: SequenceBatch, return_features: bool = False
+    ) -> Wav2Vec2Output | Tuple[Wav2Vec2Output, torch.Tensor]:
         """
         :param batch:
             The batch of sequences to process.
@@ -125,7 +127,13 @@ class Wav2Vec2Model(Module):
         # TODO: Should pad for fp16?
         encoder_output, _ = self.encoder(seqs, padding_mask)
 
-        return self.quantize_and_contrast(encoder_output, targets, temporal_mask)
+        if return_features:
+            return (
+                self.quantize_and_contrast(encoder_output, targets, temporal_mask),
+                encoder_output,
+            )
+        else:
+            return self.quantize_and_contrast(encoder_output, targets, temporal_mask)
 
     def run_frontend(
         self, seqs: Tensor, padding_mask: Optional[PaddingMask]

--- a/src/fairseq2/models/wav2vec2/model.py
+++ b/src/fairseq2/models/wav2vec2/model.py
@@ -134,21 +134,12 @@ class Wav2Vec2Model(Module):
         """
         feats = self.extract_features(batch)
 
-        if return_features:
-            return (
-                self.quantize_and_contrast(
-                    feats.encoder_output, feats.targets, feats.temporal_mask
-                ),
-                feats.encoder_output,
-                return_features,
-            )
-        else:
-            return self.quantize_and_contrast(
-                feats.encoder_output,
-                feats.targets,
-                feats.temporal_mask,
-                return_features,
-            )
+        return self.quantize_and_contrast(
+            feats.encoder_output,
+            feats.targets,
+            feats.temporal_mask,
+            return_features,
+        )
 
     def run_frontend(
         self, seqs: Tensor, padding_mask: Optional[PaddingMask]
@@ -242,7 +233,7 @@ class Wav2Vec2Model(Module):
             self.diversity_loss_weight,
         )
         if return_features:
-            out.features = encoder_output
+            out.encoder_output = encoder_output
 
         return out
 


### PR DESCRIPTION
**What does this PR do? Please describe:**
Simple parametrization of the `min_num_spans` in the definition of wav2vec2. This enables more modeling flexibility for users.

This should not induce any breakage, as a default value was added in place of what was hard coded before.

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
