### PR TITLE
Revert generic DataPipeline API

### DIFF
--- a/src/fairseq2/data/data_pipeline.py
+++ b/src/fairseq2/data/data_pipeline.py
@@ -11,7 +11,6 @@ from typing import (
     Any,
     Callable,
     Dict,
-    Iterable,
     Iterator,
     List,
     Mapping,
@@ -19,7 +18,6 @@ from typing import (
     Sequence,
     Tuple,
     TypedDict,
-    TypeVar,
     Union,
 )
 
@@ -31,9 +29,8 @@ from fairseq2.data.typing import PathLike, StringLike
 from fairseq2.memory import MemoryBlock
 
 if TYPE_CHECKING or DOC_MODE:
-    DataT = TypeVar("DataT")
 
-    class DataPipeline(Iterable[DataT]):
+    class DataPipeline:
         """fairseq2 native data pipeline.
 
         The pipeline state can be persisted to the disk, allowing it to be resumed later.
@@ -43,7 +40,7 @@ if TYPE_CHECKING or DOC_MODE:
         and sharing the same state, so it will behave inconcistently.
         """
 
-        def __iter__(self) -> Iterator[DataT]:
+        def __iter__(self) -> Iterator[Any]:
             """Return an iterator over the examples in the data pipeline.
 
             The iterator will modify the internal state of the this DataPipeline,
@@ -79,7 +76,7 @@ if TYPE_CHECKING or DOC_MODE:
             """
 
         @staticmethod
-        def concat(pipelines: Sequence[DataPipeline[Any]]) -> DataPipelineBuilder:
+        def concat(pipelines: Sequence[DataPipeline]) -> DataPipelineBuilder:
             """Concatenate examples from ``pipelines``.
 
             :param pipelines:
@@ -98,7 +95,7 @@ if TYPE_CHECKING or DOC_MODE:
 
         @staticmethod
         def round_robin(
-            pipelines: Sequence[DataPipeline[Any]], stop_at_shortest: bool = False
+            pipelines: Sequence[DataPipeline], stop_at_shortest: bool = False
         ) -> DataPipelineBuilder:
             """Extract examples from ``pipelines`` in round robin.
 
@@ -112,7 +109,7 @@ if TYPE_CHECKING or DOC_MODE:
 
         @staticmethod
         def sample(
-            pipelines: Sequence[DataPipeline[Any]],
+            pipelines: Sequence[DataPipeline],
             weights: Optional[Sequence[float]] = None,
         ) -> DataPipelineBuilder:
             """Extract examples from ``pipelines`` by sampling based on ``weights``.
@@ -125,7 +122,7 @@ if TYPE_CHECKING or DOC_MODE:
 
         @staticmethod
         def zip(
-            pipelines: Sequence[DataPipeline[Any]],
+            pipelines: Sequence[DataPipeline],
             names: Optional[Sequence[str]] = None,
             zip_to_shortest: bool = False,
             flatten: bool = False,
@@ -260,7 +257,7 @@ if TYPE_CHECKING or DOC_MODE:
         def take(self, num_examples: int) -> Self:
             """Return at most ``num_examples`` examples."""
 
-        def yield_from(self, fn: Callable[[Any], DataPipeline[Any]]) -> Self:
+        def yield_from(self, fn: Callable[[Any], DataPipeline]) -> Self:
             """
             Map every example to a data pipeline and yield the examples returned
             from the mapped data pipelines.
@@ -269,7 +266,7 @@ if TYPE_CHECKING or DOC_MODE:
                 The function to map examples to data pipelines.
             """
 
-        def and_return(self, max_num_warnings: int = 0) -> DataPipeline[DataT]:
+        def and_return(self, max_num_warnings: int = 0) -> DataPipeline:
             """Return a new :class:`DataPipeline` instance."""
 
     class DataPipelineError(RuntimeError):

--- a/src/fairseq2/datasets/multilingual_text_dataset.py
+++ b/src/fairseq2/datasets/multilingual_text_dataset.py
@@ -14,7 +14,6 @@ from fairseq2.data import DataPipeline
 from fairseq2.data.text import TextTokenizer
 from fairseq2.datasets.loader import CompositeDatasetLoader
 from fairseq2.gang import Gang
-from fairseq2.models.seq2seq import Seq2SeqBatch
 
 
 class LangPair(NamedTuple):
@@ -46,7 +45,7 @@ class MultilingualTextDataset(ABC):
         eval_batch_size: int = 32,
         num_prefetch: int = 10,
         lang_pairs: Optional[Sequence[LangPair]] = None,
-    ) -> DataPipeline[Seq2SeqBatch]:
+    ) -> DataPipeline:
         """Read the dataset.
 
         :param split:

--- a/tests/unit/data/data_pipeline/test_bucket.py
+++ b/tests/unit/data/data_pipeline/test_bucket.py
@@ -4,11 +4,9 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import List
-
 import pytest
 
-from fairseq2.data import DataPipeline, read_sequence
+from fairseq2.data import read_sequence
 
 
 class TestBucketOp:
@@ -17,9 +15,7 @@ class TestBucketOp:
 
         bucket_size = 4
 
-        pipeline: DataPipeline[List[int]] = (
-            read_sequence(seq).bucket(bucket_size).and_return()
-        )
+        pipeline = read_sequence(seq).bucket(bucket_size).and_return()
 
         for _ in range(2):
             it = iter(pipeline)
@@ -39,7 +35,7 @@ class TestBucketOp:
     def test_op_works_when_bucket_size_is_1(self) -> None:
         seq = list(range(100))
 
-        pipeline: DataPipeline[List[int]] = read_sequence(seq).bucket(1).and_return()
+        pipeline = read_sequence(seq).bucket(1).and_return()
 
         for _ in range(2):
             it = iter(pipeline)
@@ -60,9 +56,7 @@ class TestBucketOp:
 
         seq = list(range(100))
 
-        pipeline: DataPipeline[List[int]] = (
-            read_sequence(seq).bucket(bucket_size, drop).and_return()
-        )
+        pipeline = read_sequence(seq).bucket(bucket_size, drop).and_return()
 
         for _ in range(2):
             it = iter(pipeline)
@@ -93,7 +87,7 @@ class TestBucketOp:
     def test_op_saves_and_restores_its_state(self) -> None:
         seq = list(range(1, 10))
 
-        pipeline: DataPipeline[List[int]] = read_sequence(seq).bucket(2).and_return()
+        pipeline = read_sequence(seq).bucket(2).and_return()
 
         d = None
 

--- a/tests/unit/data/data_pipeline/test_collate.py
+++ b/tests/unit/data/data_pipeline/test_collate.py
@@ -4,12 +4,10 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any
-
 import pytest
 import torch
 
-from fairseq2.data import Collater, DataPipeline, read_sequence
+from fairseq2.data import Collater, read_sequence
 from tests.common import assert_equal, device
 
 
@@ -32,9 +30,7 @@ class TestCollateOp:
 
         seq = [bucket1, bucket2]
 
-        pipeline: DataPipeline[Any] = (
-            read_sequence(seq).collate(pad_value, pad_to_multiple).and_return()
-        )
+        pipeline = read_sequence(seq).collate(pad_value, pad_to_multiple).and_return()
 
         output1, output2 = list(pipeline)
 

--- a/tests/unit/data/data_pipeline/test_concat.py
+++ b/tests/unit/data/data_pipeline/test_concat.py
@@ -12,35 +12,31 @@ from fairseq2.data.text import read_text
 
 class TestConcatOp:
     def test_op_works(self) -> None:
-        pipeline1: DataPipeline[int] = read_sequence([1, 2, 3, 4]).and_return()
-        pipeline2: DataPipeline[int] = read_sequence([5, 6, 7, 8]).and_return()
+        pipeline1 = read_sequence([1, 2, 3, 4]).and_return()
+        pipeline2 = read_sequence([5, 6, 7, 8]).and_return()
 
-        pipeline3: DataPipeline[int] = DataPipeline.concat(
-            [pipeline1, pipeline2]
-        ).and_return()
+        pipeline = DataPipeline.concat([pipeline1, pipeline2]).and_return()
 
         for _ in range(2):
-            assert list(pipeline3) == [1, 2, 3, 4, 5, 6, 7, 8]
+            assert list(pipeline) == [1, 2, 3, 4, 5, 6, 7, 8]
 
-            pipeline3.reset()
+            pipeline.reset()
 
     def test_op_works_when_pipelines_are_empty(self) -> None:
-        pipeline1: DataPipeline[int] = read_sequence([]).and_return()
-        pipeline2: DataPipeline[int] = read_sequence([]).and_return()
+        pipeline1 = read_sequence([]).and_return()
+        pipeline2 = read_sequence([]).and_return()
 
-        pipeline3: DataPipeline[int] = DataPipeline.concat(
-            [pipeline1, pipeline2]
-        ).and_return()
+        pipeline = DataPipeline.concat([pipeline1, pipeline2]).and_return()
 
         for _ in range(2):
-            assert list(pipeline3) == []
+            assert list(pipeline) == []
 
-            pipeline3.reset()
+            pipeline.reset()
 
     def test_op_raises_error_when_one_of_the_pipelines_is_broken(self) -> None:
         # Force a non-recoverable error.
-        pipeline1: DataPipeline[str] = read_text(pathname=" &^#").and_return()
-        pipeline2: DataPipeline[str] = read_text(pathname=" &^#").and_return()
+        pipeline1 = read_text(pathname=" &^#").and_return()
+        pipeline2 = read_text(pathname=" &^#").and_return()
 
         # Break the first pipeline.
         try:
@@ -55,16 +51,14 @@ class TestConcatOp:
             DataPipeline.concat([pipeline1, pipeline2]).and_return()
 
     def test_op_saves_and_restores_its_state(self) -> None:
-        pipeline1: DataPipeline[int] = read_sequence([1, 2, 3, 4]).and_return()
-        pipeline2: DataPipeline[int] = read_sequence([5, 6, 7, 8]).and_return()
+        pipeline1 = read_sequence([1, 2, 3, 4]).and_return()
+        pipeline2 = read_sequence([5, 6, 7, 8]).and_return()
 
-        pipeline3: DataPipeline[int] = DataPipeline.concat(
-            [pipeline1, pipeline2]
-        ).and_return()
+        pipeline = DataPipeline.concat([pipeline1, pipeline2]).and_return()
 
         d = None
 
-        it = iter(pipeline3)
+        it = iter(pipeline)
 
         # Move to the second example.
         for _ in range(6):
@@ -72,7 +66,7 @@ class TestConcatOp:
 
         assert d == 6
 
-        state_dict = pipeline3.state_dict()
+        state_dict = pipeline.state_dict()
 
         # Read one more example before we roll back.
         d = next(it)
@@ -80,7 +74,7 @@ class TestConcatOp:
         assert d == 7
 
         # Expected to roll back to the second example.
-        pipeline3.load_state_dict(state_dict)
+        pipeline.load_state_dict(state_dict)
 
         # Move to EOD.
         for _ in range(2):
@@ -88,12 +82,12 @@ class TestConcatOp:
 
         assert d == 8
 
-        state_dict = pipeline3.state_dict()
+        state_dict = pipeline.state_dict()
 
-        pipeline3.reset()
+        pipeline.reset()
 
         # Expected to be EOD.
-        pipeline3.load_state_dict(state_dict)
+        pipeline.load_state_dict(state_dict)
 
         with pytest.raises(StopIteration):
-            next(iter(pipeline3))
+            next(iter(pipeline))

--- a/tests/unit/data/data_pipeline/test_constant.py
+++ b/tests/unit/data/data_pipeline/test_constant.py
@@ -9,7 +9,7 @@ from fairseq2.data import DataPipeline
 
 class TestConstantOp:
     def test_op_works(self) -> None:
-        pipeline: DataPipeline[str] = DataPipeline.constant("foo").take(10).and_return()
+        pipeline = DataPipeline.constant("foo").take(10).and_return()
 
         for _ in range(2):
             list(pipeline) == ["foo"] * 10

--- a/tests/unit/data/data_pipeline/test_count.py
+++ b/tests/unit/data/data_pipeline/test_count.py
@@ -11,7 +11,7 @@ from fairseq2.data import DataPipeline
 
 class TestCountOp:
     def test_op_works(self) -> None:
-        pipeline: DataPipeline[int] = DataPipeline.count(start=4).take(10).and_return()
+        pipeline = DataPipeline.count(start=4).take(10).and_return()
 
         for _ in range(2):
             assert list(pipeline) == list(range(4, 14))
@@ -19,9 +19,7 @@ class TestCountOp:
             pipeline.reset()
 
     def test_op_works_when_step_is_greater_than_1(self) -> None:
-        pipeline: DataPipeline[int] = (
-            DataPipeline.count(start=4, step=3).take(10).and_return()
-        )
+        pipeline = DataPipeline.count(start=4, step=3).take(10).and_return()
 
         for _ in range(2):
             assert list(pipeline) == list(range(4, 34, 3))
@@ -29,7 +27,7 @@ class TestCountOp:
             pipeline.reset()
 
     def test_op_saves_and_restores_its_state(self) -> None:
-        pipeline: DataPipeline[int] = DataPipeline.count(start=4).take(10).and_return()
+        pipeline = DataPipeline.count(start=4).take(10).and_return()
 
         d = None
 

--- a/tests/unit/data/data_pipeline/test_data_pipeline.py
+++ b/tests/unit/data/data_pipeline/test_data_pipeline.py
@@ -6,12 +6,7 @@
 
 import pytest
 
-from fairseq2.data import (
-    DataPipeline,
-    DataPipelineError,
-    get_last_failed_example,
-    read_sequence,
-)
+from fairseq2.data import DataPipelineError, get_last_failed_example, read_sequence
 
 
 class TestDataPipeline:
@@ -22,7 +17,7 @@ class TestDataPipeline:
 
             return True
 
-        pipeline: DataPipeline[int] = read_sequence([3, 4]).filter(fn).and_return()
+        pipeline = read_sequence([3, 4]).filter(fn).and_return()
 
         it = iter(pipeline)
 
@@ -55,7 +50,7 @@ class TestDataPipeline:
 
         seq = [1, 2, 3, 4, 5]
 
-        pipeline: DataPipeline[int] = read_sequence(seq).filter(fn).and_return()
+        pipeline = read_sequence(seq).filter(fn).and_return()
 
         output = []
 
@@ -82,9 +77,7 @@ class TestDataPipeline:
 
         seq = list(range(1, 9))
 
-        pipeline: DataPipeline[int] = (
-            read_sequence(seq).filter(fn).and_return(max_num_warnings=3)
-        )
+        pipeline = read_sequence(seq).filter(fn).and_return(max_num_warnings=3)
 
         assert list(pipeline) == [1, 2, 4, 6, 7, 8]
 
@@ -108,9 +101,7 @@ class TestDataPipeline:
 
         seq = [1, 2, 3, 4, 5]
 
-        pipeline: DataPipeline[int] = (
-            read_sequence(seq).filter(fn).and_return(max_num_warnings)
-        )
+        pipeline = read_sequence(seq).filter(fn).and_return(max_num_warnings)
 
         with pytest.raises(DataPipelineError):
             for _ in pipeline:
@@ -121,7 +112,7 @@ class TestDataPipeline:
     def test_load_state_dict_raises_error_when_tape_is_corrupt(self) -> None:
         seq = [1, 2, 3, 4, 5]
 
-        pipeline: DataPipeline[int] = read_sequence(seq).and_return()
+        pipeline = read_sequence(seq).and_return()
 
         next(iter(pipeline))
 

--- a/tests/unit/data/data_pipeline/test_filter.py
+++ b/tests/unit/data/data_pipeline/test_filter.py
@@ -6,7 +6,7 @@
 
 import pytest
 
-from fairseq2.data import DataPipeline, DataPipelineError, read_sequence
+from fairseq2.data import DataPipelineError, read_sequence
 
 
 class TestFilterOp:
@@ -14,9 +14,7 @@ class TestFilterOp:
         def fn(d: int) -> bool:
             return d % 2 == 1
 
-        pipeline: DataPipeline[int] = (
-            read_sequence([1, 2, 3, 4, 5, 6, 7, 8, 9]).filter(fn).and_return()
-        )
+        pipeline = read_sequence([1, 2, 3, 4, 5, 6, 7, 8, 9]).filter(fn).and_return()
 
         for _ in range(2):
             assert list(pipeline) == [1, 3, 5, 7, 9]
@@ -30,9 +28,7 @@ class TestFilterOp:
 
             return True
 
-        pipeline: DataPipeline[int] = (
-            read_sequence([1, 2, 3, 4]).filter(fn).and_return()
-        )
+        pipeline = read_sequence([1, 2, 3, 4]).filter(fn).and_return()
 
         with pytest.raises(DataPipelineError) as exc_info:
             for d in pipeline:

--- a/tests/unit/data/data_pipeline/test_map.py
+++ b/tests/unit/data/data_pipeline/test_map.py
@@ -7,11 +7,10 @@
 import copy
 import re
 from dataclasses import dataclass
-from typing import Any, List
 
 import pytest
 
-from fairseq2.data import DataPipeline, DataPipelineError, read_sequence
+from fairseq2.data import DataPipelineError, read_sequence
 from fairseq2.data.text.converters import StrToIntConverter
 
 
@@ -23,9 +22,7 @@ class TestMapOp:
 
         seq = list(range(1, 10))
 
-        pipeline: DataPipeline[int] = (
-            read_sequence(seq).map(fn, num_parallel_calls=num_parallel_calls).and_return()  # fmt: skip
-        )
+        pipeline = read_sequence(seq).map(fn, num_parallel_calls=num_parallel_calls).and_return()  # fmt: skip
 
         for _ in range(2):
             assert list(pipeline) == [i**2 for i in seq]
@@ -35,9 +32,7 @@ class TestMapOp:
     def test_op_works_when_callable_is_native(self) -> None:
         fn = StrToIntConverter()
 
-        pipeline: DataPipeline[int] = (
-            read_sequence(["1", "2", "3", "4"]).map(fn).and_return()
-        )
+        pipeline = read_sequence(["1", "2", "3", "4"]).map(fn).and_return()
 
         for _ in range(2):
             assert list(pipeline) == [1, 2, 3, 4]
@@ -50,9 +45,7 @@ class TestMapOp:
         def fn2(d: int) -> int:
             return d**2
 
-        pipeline: DataPipeline[int] = (
-            read_sequence(["1", "2", "3", "4"]).map([fn1, fn2]).and_return()
-        )
+        pipeline = read_sequence(["1", "2", "3", "4"]).map([fn1, fn2]).and_return()
 
         for _ in range(2):
             assert list(pipeline) == [1, 4, 9, 16]
@@ -69,9 +62,7 @@ class TestMapOp:
 
             return d
 
-        pipeline: DataPipeline[Foo] = (
-            read_sequence([Foo(1), Foo(2)]).map(fn).and_return()
-        )
+        pipeline = read_sequence([Foo(1), Foo(2)]).map(fn).and_return()
 
         it = iter(pipeline)
 
@@ -90,9 +81,7 @@ class TestMapOp:
 
         seq = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
 
-        pipeline: DataPipeline[List[int]] = (
-            read_sequence(seq).map([fn1, fn2], selector="[1]").and_return()
-        )
+        pipeline = read_sequence(seq).map([fn1, fn2], selector="[1]").and_return()
 
         for _ in range(2):
             it = iter(pipeline)
@@ -124,9 +113,7 @@ class TestMapOp:
         e1["foo2"][2]["foo4"] = 14  # type: ignore[index]
         e2["foo2"][2]["foo4"] = 19  # type: ignore[index]
 
-        pipeline: DataPipeline[Any] = (
-            read_sequence([d1, d2]).map(fn, selector="foo2[2].foo4").and_return()
-        )
+        pipeline = read_sequence([d1, d2]).map(fn, selector="foo2[2].foo4").and_return()
 
         for _ in range(2):
             it = iter(pipeline)
@@ -167,9 +154,7 @@ class TestMapOp:
 
         selector = "foo2[2].foo4,foo3[0], foo1,foo5.foo6.foo7"
 
-        pipeline: DataPipeline[Any] = (
-            read_sequence([d1, d2]).map(fn, selector=selector).and_return()
-        )
+        pipeline = read_sequence([d1, d2]).map(fn, selector=selector).and_return()
 
         for _ in range(2):
             it = iter(pipeline)
@@ -235,9 +220,7 @@ class TestMapOp:
             "foo3": [5],
         }
 
-        pipeline: DataPipeline[Any] = (
-            read_sequence([d]).map(lambda x: x, selector=s).and_return()
-        )
+        pipeline = read_sequence([d]).map(lambda x: x, selector=s).and_return()
 
         with pytest.raises(DataPipelineError) as exc_info:
             next(iter(pipeline))
@@ -258,11 +241,7 @@ class TestMapOp:
 
             return d
 
-        pipeline: DataPipeline[int] = (
-            read_sequence([1, 2, 3, 4])
-            .map(fn, num_parallel_calls=num_parallel_calls)
-            .and_return()
-        )
+        pipeline = read_sequence([1, 2, 3, 4]).map(fn, num_parallel_calls=num_parallel_calls).and_return()  # fmt: skip
 
         with pytest.raises(DataPipelineError) as exc_info:
             for d in pipeline:
@@ -281,11 +260,7 @@ class TestMapOp:
 
         seq = list(range(1, 10))
 
-        pipeline: DataPipeline[int] = (
-            read_sequence(seq)
-            .map(fn, num_parallel_calls=num_parallel_calls)
-            .and_return()
-        )
+        pipeline = read_sequence(seq).map(fn, num_parallel_calls=num_parallel_calls).and_return()  # fmt: skip
 
         d = None
 

--- a/tests/unit/data/data_pipeline/test_prefetch.py
+++ b/tests/unit/data/data_pipeline/test_prefetch.py
@@ -8,7 +8,7 @@ from itertools import islice
 
 import pytest
 
-from fairseq2.data import DataPipeline, DataPipelineError, read_sequence
+from fairseq2.data import DataPipelineError, read_sequence
 
 
 class TestPrefetchOp:
@@ -16,9 +16,7 @@ class TestPrefetchOp:
     def test_op_works(self, num_examples: int) -> None:
         seq = list(range(1, 100))
 
-        pipeline: DataPipeline[int] = (
-            read_sequence(seq).prefetch(num_examples).and_return()
-        )
+        pipeline = read_sequence(seq).prefetch(num_examples).and_return()
 
         for _ in range(2):
             assert list(pipeline) == seq
@@ -29,9 +27,7 @@ class TestPrefetchOp:
     def test_op_works_after_reset(self, num_examples: int) -> None:
         seq = list(range(1, 100))
 
-        pipeline: DataPipeline[int] = (
-            read_sequence(seq).prefetch(num_examples).and_return()
-        )
+        pipeline = read_sequence(seq).prefetch(num_examples).and_return()
 
         for _ in range(2):
             assert list(islice(pipeline, 50)) == seq[:50]
@@ -40,9 +36,7 @@ class TestPrefetchOp:
 
     @pytest.mark.parametrize("num_examples", [0, 1, 4, 20])
     def test_op_works_when_no_data_is_specified(self, num_examples: int) -> None:
-        pipeline: DataPipeline[int] = (
-            read_sequence([]).prefetch(num_examples).and_return()
-        )
+        pipeline = read_sequence([]).prefetch(num_examples).and_return()
 
         for _ in range(2):
             assert list(pipeline) == []
@@ -59,9 +53,7 @@ class TestPrefetchOp:
 
         seq = list(range(1, 100))
 
-        pipeline: DataPipeline[int] = (
-            read_sequence(seq).map(fn).prefetch(num_examples).and_return()
-        )
+        pipeline = read_sequence(seq).map(fn).prefetch(num_examples).and_return()
 
         with pytest.raises(DataPipelineError) as exc_info:
             for d in pipeline:
@@ -77,9 +69,7 @@ class TestPrefetchOp:
     def test_op_saves_and_restores_its_state(self, num_examples: int) -> None:
         seq = list(range(1, 100))
 
-        pipeline: DataPipeline[int] = (
-            read_sequence(seq).prefetch(num_examples).and_return()
-        )
+        pipeline = read_sequence(seq).prefetch(num_examples).and_return()
 
         d = None
 

--- a/tests/unit/data/data_pipeline/test_read_sequence.py
+++ b/tests/unit/data/data_pipeline/test_read_sequence.py
@@ -6,14 +6,14 @@
 
 import pytest
 
-from fairseq2.data import DataPipeline, read_sequence
+from fairseq2.data import read_sequence
 
 
 class TestReadSequenceOp:
     def test_op_works(self) -> None:
         seq = list(range(1, 10))
 
-        pipeline: DataPipeline[int] = read_sequence(seq).and_return()
+        pipeline = read_sequence(seq).and_return()
 
         for _ in range(2):
             assert list(pipeline) == seq
@@ -21,7 +21,7 @@ class TestReadSequenceOp:
             pipeline.reset()
 
     def test_op_works_when_input_sequence_is_empty(self) -> None:
-        pipeline: DataPipeline[int] = read_sequence([]).and_return()
+        pipeline = read_sequence([]).and_return()
 
         for _ in range(2):
             assert list(pipeline) == []
@@ -31,7 +31,7 @@ class TestReadSequenceOp:
     def test_op_saves_and_restores_its_state(self) -> None:
         seq = list(range(1, 10))
 
-        pipeline: DataPipeline[int] = read_sequence(seq).and_return()
+        pipeline = read_sequence(seq).and_return()
 
         d = None
 

--- a/tests/unit/data/data_pipeline/test_round_robin.py
+++ b/tests/unit/data/data_pipeline/test_round_robin.py
@@ -12,33 +12,31 @@ from fairseq2.data.text import read_text
 
 class TestRoundRobinOp:
     def test_op_works(self) -> None:
-        pipeline1: DataPipeline[int] = read_sequence([1, 2, 3, 4]).and_return()
-        pipeline2: DataPipeline[int] = read_sequence([5, 6, 7, 8]).and_return()
-        pipeline3: DataPipeline[int] = read_sequence([0, 2, 4, 6]).and_return()
+        pipeline1 = read_sequence([1, 2, 3, 4]).and_return()
+        pipeline2 = read_sequence([5, 6, 7, 8]).and_return()
+        pipeline3 = read_sequence([0, 2, 4, 6]).and_return()
 
-        pipeline4: DataPipeline[int] = DataPipeline.round_robin(
+        pipeline = DataPipeline.round_robin(
             [pipeline1, pipeline2, pipeline3]
         ).and_return()
 
         for _ in range(2):
-            assert list(pipeline4) == [1, 5, 0, 2, 6, 2, 3, 7, 4, 4, 8, 6]
+            assert list(pipeline) == [1, 5, 0, 2, 6, 2, 3, 7, 4, 4, 8, 6]
 
-            pipeline4.reset()
+            pipeline.reset()
 
     def test_op_works_when_a_single_pipeline_is_specified(self) -> None:
-        pipeline1: DataPipeline[int] = read_sequence([1, 2, 3, 4]).and_return()
+        pipeline1 = read_sequence([1, 2, 3, 4]).and_return()
 
-        pipeline2: DataPipeline[int] = DataPipeline.round_robin(
-            [pipeline1]
-        ).and_return()
+        pipeline = DataPipeline.round_robin([pipeline1]).and_return()
 
         for _ in range(2):
-            assert list(pipeline2) == [1, 2, 3, 4]
+            assert list(pipeline) == [1, 2, 3, 4]
 
-            pipeline2.reset()
+            pipeline.reset()
 
     def test_op_works_when_no_pipeline_is_specified(self) -> None:
-        pipeline: DataPipeline[int] = DataPipeline.round_robin([]).and_return()
+        pipeline = DataPipeline.round_robin([]).and_return()
 
         for _ in range(2):
             with pytest.raises(StopIteration):
@@ -47,71 +45,71 @@ class TestRoundRobinOp:
             pipeline.reset()
 
     def test_op_works_when_infinite_pipeline_is_specified(self) -> None:
-        pipeline1: DataPipeline[int] = read_sequence([1, 2, 3, 4]).and_return()
-        pipeline2: DataPipeline[int] = DataPipeline.constant(0).and_return()
-        pipeline3: DataPipeline[int] = read_sequence([0, 2, 4, 6]).and_return()
+        pipeline1 = read_sequence([1, 2, 3, 4]).and_return()
+        pipeline2 = DataPipeline.constant(0).and_return()
+        pipeline3 = read_sequence([0, 2, 4, 6]).and_return()
 
-        pipeline4: DataPipeline[int] = DataPipeline.round_robin(
+        pipeline = DataPipeline.round_robin(
             [pipeline1, pipeline2, pipeline3]
         ).and_return()
 
         for _ in range(2):
-            assert list(pipeline4) == [1, 0, 0, 2, 0, 2, 3, 0, 4, 4, 0, 6]
+            assert list(pipeline) == [1, 0, 0, 2, 0, 2, 3, 0, 4, 4, 0, 6]
 
-            pipeline4.reset()
+            pipeline.reset()
 
     def test_op_works_when_pipelines_are_empty(self) -> None:
-        pipeline1: DataPipeline[int] = read_sequence([]).and_return()
-        pipeline2: DataPipeline[int] = read_sequence([]).and_return()
-        pipeline3: DataPipeline[int] = read_sequence([]).and_return()
+        pipeline1 = read_sequence([]).and_return()
+        pipeline2 = read_sequence([]).and_return()
+        pipeline3 = read_sequence([]).and_return()
 
-        pipeline4: DataPipeline[int] = DataPipeline.round_robin(
+        pipeline = DataPipeline.round_robin(
             [pipeline1, pipeline2, pipeline3]
         ).and_return()
 
         for _ in range(2):
             with pytest.raises(StopIteration):
-                next(iter(pipeline4))
+                next(iter(pipeline))
 
-            pipeline4.reset()
+            pipeline.reset()
 
     def test_op_works_when_pipelines_have_different_lengths(self) -> None:
-        pipeline1: DataPipeline[int] = read_sequence([1, 2, 3, 4]).and_return()
-        pipeline2: DataPipeline[int] = read_sequence([5, 6]).and_return()
-        pipeline3: DataPipeline[int] = read_sequence([]).and_return()
-        pipeline4: DataPipeline[int] = read_sequence([7, 8, 9, 0, 1, 2]).and_return()
+        pipeline1 = read_sequence([1, 2, 3, 4]).and_return()
+        pipeline2 = read_sequence([5, 6]).and_return()
+        pipeline3 = read_sequence([]).and_return()
+        pipeline4 = read_sequence([7, 8, 9, 0, 1, 2]).and_return()
 
-        pipeline5: DataPipeline[int] = DataPipeline.round_robin(
+        pipeline = DataPipeline.round_robin(
             [pipeline1, pipeline2, pipeline3, pipeline4]
         ).and_return()
 
         seq = [1, 5, 7, 2, 6, 8, 3, 5, 9, 4, 6, 0, 1, 5, 1, 2, 6, 2]
 
         for _ in range(2):
-            assert list(pipeline5) == seq
+            assert list(pipeline) == seq
 
-            pipeline5.reset()
+            pipeline.reset()
 
     def test_op_works_when_pipelines_stop_at_shortest_is_specified(self) -> None:
-        pipeline1: DataPipeline[int] = read_sequence([1, 2, 3, 4]).and_return()
-        pipeline2: DataPipeline[int] = read_sequence([5, 6]).and_return()
-        pipeline3: DataPipeline[int] = read_sequence([7, 8, 9, 0, 1, 2]).and_return()
+        pipeline1 = read_sequence([1, 2, 3, 4]).and_return()
+        pipeline2 = read_sequence([5, 6]).and_return()
+        pipeline3 = read_sequence([7, 8, 9, 0, 1, 2]).and_return()
 
-        pipeline4: DataPipeline[int] = DataPipeline.round_robin(
+        pipeline = DataPipeline.round_robin(
             [pipeline1, pipeline2, pipeline3], stop_at_shortest=True
         ).and_return()
 
         seq = [1, 5, 7, 2, 6, 8]
 
         for _ in range(2):
-            assert list(pipeline4) == seq
+            assert list(pipeline) == seq
 
-            pipeline4.reset()
+            pipeline.reset()
 
     def test_op_raises_error_when_one_of_the_pipelines_is_broken(self) -> None:
         # Force a non-recoverable error.
-        pipeline1: DataPipeline[int] = read_text(pathname=" &^#").and_return()
-        pipeline2: DataPipeline[int] = read_text(pathname=" &^#").and_return()
+        pipeline1 = read_text(pathname=" &^#").and_return()
+        pipeline2 = read_text(pathname=" &^#").and_return()
 
         # Break the first pipeline.
         try:
@@ -126,18 +124,18 @@ class TestRoundRobinOp:
             DataPipeline.round_robin([pipeline1, pipeline2]).and_return()
 
     def test_op_saves_and_restores_its_state(self) -> None:
-        pipeline1: DataPipeline[int] = read_sequence([1, 2, 3, 4]).and_return()
-        pipeline2: DataPipeline[int] = read_sequence([5, 6]).and_return()
-        pipeline3: DataPipeline[int] = read_sequence([]).and_return()
-        pipeline4: DataPipeline[int] = read_sequence([7, 8, 9, 0, 1, 2]).and_return()
+        pipeline1 = read_sequence([1, 2, 3, 4]).and_return()
+        pipeline2 = read_sequence([5, 6]).and_return()
+        pipeline3 = read_sequence([]).and_return()
+        pipeline4 = read_sequence([7, 8, 9, 0, 1, 2]).and_return()
 
-        pipeline5: DataPipeline[int] = DataPipeline.round_robin(
+        pipeline = DataPipeline.round_robin(
             [pipeline1, pipeline2, pipeline3, pipeline4]
         ).and_return()
 
         d = None
 
-        it = iter(pipeline5)
+        it = iter(pipeline)
 
         # Move to the fifth example.
         for _ in range(5):
@@ -145,7 +143,7 @@ class TestRoundRobinOp:
 
         assert d == 6
 
-        state_dict = pipeline5.state_dict()
+        state_dict = pipeline.state_dict()
 
         # Read a few examples before we roll back.
         for _ in range(4):
@@ -154,7 +152,7 @@ class TestRoundRobinOp:
         assert d == 9
 
         # Expected to roll back to the fifth example.
-        pipeline5.load_state_dict(state_dict)
+        pipeline.load_state_dict(state_dict)
 
         # Move to EOD.
         for _ in range(13):
@@ -162,12 +160,12 @@ class TestRoundRobinOp:
 
         assert d == 2
 
-        state_dict = pipeline5.state_dict()
+        state_dict = pipeline.state_dict()
 
-        pipeline5.reset()
+        pipeline.reset()
 
         # Expected to be EOD.
-        pipeline5.load_state_dict(state_dict)
+        pipeline.load_state_dict(state_dict)
 
         with pytest.raises(StopIteration):
-            next(iter(pipeline5))
+            next(iter(pipeline))

--- a/tests/unit/data/data_pipeline/test_sample.py
+++ b/tests/unit/data/data_pipeline/test_sample.py
@@ -17,47 +17,43 @@ from tests.common import tmp_rng_seed
 
 class TestSampleOp:
     def test_op_works(self) -> None:
-        pipeline1: DataPipeline[int] = read_sequence([1, 2, 3, 4]).and_return()
-        pipeline2: DataPipeline[int] = read_sequence([5, 6, 7]).and_return()
+        pipeline1 = read_sequence([1, 2, 3, 4]).and_return()
+        pipeline2 = read_sequence([5, 6, 7]).and_return()
 
-        pipeline3: DataPipeline[int] = DataPipeline.sample(
-            [pipeline1, pipeline2], [1.2, 0.8]
-        ).and_return()
+        pipeline = DataPipeline.sample([pipeline1, pipeline2], [1.2, 0.8]).and_return()
 
         for _ in range(2):
             with tmp_rng_seed(CPU, seed=1234):
-                assert list(pipeline3) == [1, 2, 3, 4, 1, 5, 2, 3, 6, 4, 7]
+                assert list(pipeline) == [1, 2, 3, 4, 1, 5, 2, 3, 6, 4, 7]
 
-            pipeline3.reset()
+            pipeline.reset()
 
     def test_op_works_when_no_weight_is_specified(self) -> None:
-        pipeline1: DataPipeline[int] = read_sequence([1, 2, 3]).and_return()
-        pipeline2: DataPipeline[int] = read_sequence([4, 5, 6]).and_return()
-        pipeline3: DataPipeline[int] = read_sequence([7, 8, 9]).and_return()
+        pipeline1 = read_sequence([1, 2, 3]).and_return()
+        pipeline2 = read_sequence([4, 5, 6]).and_return()
+        pipeline3 = read_sequence([7, 8, 9]).and_return()
 
-        pipeline4: DataPipeline[int] = DataPipeline.sample(
-            [pipeline1, pipeline2, pipeline3]
-        ).and_return()
+        pipeline = DataPipeline.sample([pipeline1, pipeline2, pipeline3]).and_return()
 
         for _ in range(2):
             with tmp_rng_seed(CPU, seed=1234):
-                assert list(pipeline4) == [1, 4, 2, 5, 3, 7, 1, 6, 8, 2, 9]
+                assert list(pipeline) == [1, 4, 2, 5, 3, 7, 1, 6, 8, 2, 9]
 
-            pipeline4.reset()
+            pipeline.reset()
 
     def test_op_works_when_a_single_pipeline_is_specified(self) -> None:
-        pipeline1: DataPipeline[int] = read_sequence([1, 2, 3, 4]).and_return()
+        pipeline1 = read_sequence([1, 2, 3, 4]).and_return()
 
-        pipeline2: DataPipeline[int] = DataPipeline.sample([pipeline1]).and_return()
+        pipeline = DataPipeline.sample([pipeline1]).and_return()
 
         for _ in range(2):
             with tmp_rng_seed(CPU, seed=1234):
-                assert list(pipeline2) == [1, 2, 3, 4]
+                assert list(pipeline) == [1, 2, 3, 4]
 
-            pipeline2.reset()
+            pipeline.reset()
 
     def test_op_works_when_no_pipeline_is_specified(self) -> None:
-        pipeline: DataPipeline[int] = DataPipeline.sample([]).and_return()
+        pipeline = DataPipeline.sample([]).and_return()
 
         for _ in range(2):
             with pytest.raises(StopIteration):
@@ -66,38 +62,34 @@ class TestSampleOp:
             pipeline.reset()
 
     def test_op_works_when_infinite_pipeline_is_specified(self) -> None:
-        pipeline1: DataPipeline[int] = read_sequence([1, 2, 3, 4]).and_return()
-        pipeline2: DataPipeline[int] = DataPipeline.count(5).and_return()
+        pipeline1 = read_sequence([1, 2, 3, 4]).and_return()
+        pipeline2 = DataPipeline.count(5).and_return()
 
-        pipeline3: DataPipeline[int] = DataPipeline.sample(
-            [pipeline1, pipeline2], [0.4, 0.6]
-        ).and_return()
+        pipeline = DataPipeline.sample([pipeline1, pipeline2], [0.4, 0.6]).and_return()
 
         for _ in range(2):
             with tmp_rng_seed(CPU, seed=1234):
-                assert list(pipeline3) == [1, 5, 2, 3, 4]
+                assert list(pipeline) == [1, 5, 2, 3, 4]
 
-            pipeline3.reset()
+            pipeline.reset()
 
     def test_op_raises_error_when_pipeline_is_empty(self) -> None:
-        pipeline1: DataPipeline[int] = read_sequence([1, 2]).and_return()
-        pipeline2: DataPipeline[int] = read_sequence([]).and_return()
-        pipeline3: DataPipeline[int] = read_sequence([3, 4]).and_return()
+        pipeline1 = read_sequence([1, 2]).and_return()
+        pipeline2 = read_sequence([]).and_return()
+        pipeline3 = read_sequence([3, 4]).and_return()
 
-        pipeline4: DataPipeline[int] = DataPipeline.sample(
-            [pipeline1, pipeline2, pipeline3]
-        ).and_return()
+        pipeline = DataPipeline.sample([pipeline1, pipeline2, pipeline3]).and_return()
 
         with pytest.raises(
             DataPipelineError,
             match=r"^The data pipeline at index 1 is empty and cannot be sampled\.$",
         ):
-            next(iter(pipeline4))
+            next(iter(pipeline))
 
     def test_op_raises_error_when_weight_is_not_valid(self) -> None:
-        pipeline1: DataPipeline[int] = read_sequence([1, 2]).and_return()
-        pipeline2: DataPipeline[int] = read_sequence([3, 4]).and_return()
-        pipeline3: DataPipeline[int] = read_sequence([5, 6]).and_return()
+        pipeline1 = read_sequence([1, 2]).and_return()
+        pipeline2 = read_sequence([3, 4]).and_return()
+        pipeline3 = read_sequence([5, 6]).and_return()
 
         with pytest.raises(
             ValueError,
@@ -126,8 +118,8 @@ class TestSampleOp:
     def test_op_raises_error_when_the_number_of_pipelines_and_weights_do_not_match(
         self,
     ) -> None:
-        pipeline1: DataPipeline[int] = read_sequence([1, 2, 3]).and_return()
-        pipeline2: DataPipeline[int] = read_sequence([4, 5, 6]).and_return()
+        pipeline1 = read_sequence([1, 2, 3]).and_return()
+        pipeline2 = read_sequence([4, 5, 6]).and_return()
 
         with pytest.raises(
             ValueError,
@@ -137,8 +129,8 @@ class TestSampleOp:
 
     def test_op_raises_error_when_one_of_the_pipelines_is_broken(self) -> None:
         # Force a non-recoverable error.
-        pipeline1: DataPipeline[str] = read_text(pathname=" &^#").and_return()
-        pipeline2: DataPipeline[str] = read_text(pathname=" &^#").and_return()
+        pipeline1 = read_text(pathname=" &^#").and_return()
+        pipeline2 = read_text(pathname=" &^#").and_return()
 
         # Break the first pipeline.
         try:
@@ -153,18 +145,16 @@ class TestSampleOp:
             DataPipeline.sample([pipeline1, pipeline2]).and_return()
 
     def test_op_saves_and_restores_its_state(self) -> None:
-        pipeline1: DataPipeline[int] = read_sequence([1, 2, 3, 4]).and_return()
-        pipeline2: DataPipeline[int] = read_sequence([5, 6, 7, 8]).and_return()
-        pipeline3: DataPipeline[int] = read_sequence([0, 2, 4, 6]).and_return()
+        pipeline1 = read_sequence([1, 2, 3, 4]).and_return()
+        pipeline2 = read_sequence([5, 6, 7, 8]).and_return()
+        pipeline3 = read_sequence([0, 2, 4, 6]).and_return()
 
         # [1, 5, 2, 6, 3, 0, 4, 7, 2, 1, 4, 8, 6]
-        pipeline4: DataPipeline[int] = DataPipeline.sample(
-            [pipeline1, pipeline2, pipeline3]
-        ).and_return()
+        pipeline = DataPipeline.sample([pipeline1, pipeline2, pipeline3]).and_return()
 
         d = None
 
-        it = iter(pipeline4)
+        it = iter(pipeline)
 
         with tmp_rng_seed(CPU, seed=1234):
             # Move to the fifth example.
@@ -175,7 +165,7 @@ class TestSampleOp:
 
             rng = torch.get_rng_state()
 
-            state_dict = pipeline4.state_dict()
+            state_dict = pipeline.state_dict()
 
             # Read a few examples before we roll back.
             for _ in range(3):
@@ -186,7 +176,7 @@ class TestSampleOp:
             torch.set_rng_state(rng)
 
             # Expected to roll back to the fifth example.
-            pipeline4.load_state_dict(state_dict)
+            pipeline.load_state_dict(state_dict)
 
             # Move to EOD.
             for _ in range(8):
@@ -196,14 +186,14 @@ class TestSampleOp:
 
             rng = torch.get_rng_state()
 
-            state_dict = pipeline4.state_dict()
+            state_dict = pipeline.state_dict()
 
-            pipeline4.reset()
+            pipeline.reset()
 
             torch.set_rng_state(rng)
 
             # Expected to be EOD.
-            pipeline4.load_state_dict(state_dict)
+            pipeline.load_state_dict(state_dict)
 
             with pytest.raises(StopIteration):
-                next(iter(pipeline4))
+                next(iter(pipeline))

--- a/tests/unit/data/data_pipeline/test_shard.py
+++ b/tests/unit/data/data_pipeline/test_shard.py
@@ -6,14 +6,14 @@
 
 import pytest
 
-from fairseq2.data import DataPipeline, read_sequence
+from fairseq2.data import read_sequence
 
 
 class TestShardOp:
     def test_op_works(self) -> None:
         seq = list(range(1, 23))
 
-        pipeline: DataPipeline[int] = read_sequence(seq).shard(1, 5).and_return()
+        pipeline = read_sequence(seq).shard(1, 5).and_return()
 
         for _ in range(2):
             assert list(pipeline) == [2, 7, 12, 17]
@@ -47,7 +47,7 @@ class TestShardOp:
     def test_op_saves_and_restores_its_state(self) -> None:
         seq = list(range(1, 23))
 
-        pipeline: DataPipeline[int] = read_sequence(seq).shard(2, 5).and_return()
+        pipeline = read_sequence(seq).shard(2, 5).and_return()
 
         d = None
 

--- a/tests/unit/data/data_pipeline/test_shuffle.py
+++ b/tests/unit/data/data_pipeline/test_shuffle.py
@@ -8,7 +8,7 @@ from itertools import islice
 
 import pytest
 
-from fairseq2.data import DataPipeline, read_sequence
+from fairseq2.data import read_sequence
 from fairseq2.typing import CPU
 from tests.common import tmp_rng_seed
 
@@ -17,7 +17,7 @@ class TestShuffleOp:
     def test_op_works(self) -> None:
         seq = list(range(1, 10))
 
-        pipeline: DataPipeline[int] = read_sequence(seq).shuffle(100).and_return()
+        pipeline = read_sequence(seq).shuffle(100).and_return()
 
         for _ in range(2):
             with tmp_rng_seed(CPU, seed=1234):
@@ -53,8 +53,8 @@ class TestShuffleOp:
     def test_op_saves_and_restores_its_state(self, window: int) -> None:
         seq = list(range(5000))
 
-        pipeline1: DataPipeline[int] = read_sequence(seq).shuffle(window).and_return()
-        pipeline2: DataPipeline[int] = read_sequence(seq).shuffle(window).and_return()
+        pipeline1 = read_sequence(seq).shuffle(window).and_return()
+        pipeline2 = read_sequence(seq).shuffle(window).and_return()
 
         with tmp_rng_seed(CPU, seed=1234):
             expected_output1 = list(islice(pipeline1, 4000))
@@ -97,9 +97,7 @@ class TestShuffleOp:
     def test_record_reload_position_works_as_expected_with_no_strict(self) -> None:
         seq = list(range(100))
 
-        pipeline: DataPipeline[int] = (
-            read_sequence(seq).shuffle(80, strict=False).and_return()
-        )
+        pipeline = read_sequence(seq).shuffle(80, strict=False).and_return()
 
         # Do one dummy iteration to force to fill the buffer.
         next(iter(pipeline))

--- a/tests/unit/data/data_pipeline/test_skip.py
+++ b/tests/unit/data/data_pipeline/test_skip.py
@@ -6,14 +6,12 @@
 
 import pytest
 
-from fairseq2.data import DataPipeline, read_sequence
+from fairseq2.data import read_sequence
 
 
 class TestSkipOp:
     def test_op_works(self) -> None:
-        pipeline: DataPipeline[int] = (
-            read_sequence([1, 2, 3, 4, 5, 6, 7, 8, 9]).skip(3).and_return()
-        )
+        pipeline = read_sequence([1, 2, 3, 4, 5, 6, 7, 8, 9]).skip(3).and_return()
 
         for _ in range(2):
             assert list(pipeline) == [4, 5, 6, 7, 8, 9]
@@ -21,7 +19,7 @@ class TestSkipOp:
             pipeline.reset()
 
     def test_op_works_when_count_is_greater_than_the_number_of_elements(self) -> None:
-        pipeline: DataPipeline[int] = read_sequence([1, 2, 3]).skip(5).and_return()
+        pipeline = read_sequence([1, 2, 3]).skip(5).and_return()
 
         for _ in range(2):
             assert list(pipeline) == []
@@ -29,7 +27,7 @@ class TestSkipOp:
             pipeline.reset()
 
     def test_op_works_when_count_is_zero(self) -> None:
-        pipeline: DataPipeline[int] = read_sequence([1, 2, 3]).skip(0).and_return()
+        pipeline = read_sequence([1, 2, 3]).skip(0).and_return()
 
         for _ in range(2):
             assert list(pipeline) == [1, 2, 3]
@@ -37,9 +35,7 @@ class TestSkipOp:
             pipeline.reset()
 
     def test_op_saves_and_restores_its_state(self) -> None:
-        pipeline: DataPipeline[int] = (
-            read_sequence([1, 2, 3, 4, 5, 6, 7, 8, 9]).skip(3).and_return()
-        )
+        pipeline = read_sequence([1, 2, 3, 4, 5, 6, 7, 8, 9]).skip(3).and_return()
 
         d = None
 

--- a/tests/unit/data/data_pipeline/test_take.py
+++ b/tests/unit/data/data_pipeline/test_take.py
@@ -6,14 +6,12 @@
 
 import pytest
 
-from fairseq2.data import DataPipeline, read_sequence
+from fairseq2.data import read_sequence
 
 
 class TestTakeOp:
     def test_op_works(self) -> None:
-        pipeline: DataPipeline[int] = (
-            read_sequence([1, 2, 3, 4, 5, 6, 7, 8, 9]).take(5).and_return()
-        )
+        pipeline = read_sequence([1, 2, 3, 4, 5, 6, 7, 8, 9]).take(5).and_return()
 
         for _ in range(2):
             assert list(pipeline) == [1, 2, 3, 4, 5]
@@ -21,7 +19,7 @@ class TestTakeOp:
             pipeline.reset()
 
     def test_op_works_when_count_is_greater_than_the_number_of_elements(self) -> None:
-        pipeline: DataPipeline[int] = read_sequence([1, 2, 3]).take(5).and_return()
+        pipeline = read_sequence([1, 2, 3]).take(5).and_return()
 
         for _ in range(2):
             assert list(pipeline) == [1, 2, 3]
@@ -29,7 +27,7 @@ class TestTakeOp:
             pipeline.reset()
 
     def test_op_works_when_count_is_zero(self) -> None:
-        pipeline: DataPipeline[int] = read_sequence([1, 2, 3]).take(0).and_return()
+        pipeline = read_sequence([1, 2, 3]).take(0).and_return()
 
         for _ in range(2):
             assert list(pipeline) == []
@@ -37,9 +35,7 @@ class TestTakeOp:
             pipeline.reset()
 
     def test_op_saves_and_restores_its_state(self) -> None:
-        pipeline: DataPipeline[int] = (
-            read_sequence([1, 2, 3, 4, 5, 6, 7, 8, 9]).take(5).and_return()
-        )
+        pipeline = read_sequence([1, 2, 3, 4, 5, 6, 7, 8, 9]).take(5).and_return()
 
         d = None
 

--- a/tests/unit/data/data_pipeline/test_yield_from.py
+++ b/tests/unit/data/data_pipeline/test_yield_from.py
@@ -15,16 +15,14 @@ from fairseq2.data import DataPipeline, DataPipelineError, read_sequence
 
 class TestYieldFromOp:
     def test_op_works(self) -> None:
-        def fn(d: Tuple[int, int]) -> DataPipeline[int]:
+        def fn(d: Tuple[int, int]) -> DataPipeline:
             a, b = d
 
             seq = list(range(a, b))
 
             return read_sequence(seq).and_return()
 
-        pipeline: DataPipeline[int] = (
-            read_sequence([[1, 5], [9, 14]]).yield_from(fn).and_return()
-        )
+        pipeline = read_sequence([[1, 5], [9, 14]]).yield_from(fn).and_return()
 
         for _ in range(2):
             assert list(pipeline) == [1, 2, 3, 4, 9, 10, 11, 12, 13]
@@ -32,10 +30,10 @@ class TestYieldFromOp:
             pipeline.reset()
 
     def test_op_raises_error_when_yield_from_is_infinite(self) -> None:
-        def fn(d: int) -> DataPipeline[int]:
+        def fn(d: int) -> DataPipeline:
             return DataPipeline.constant(0).and_return()
 
-        pipeline: DataPipeline[int] = read_sequence([1]).yield_from(fn).and_return()
+        pipeline = read_sequence([1]).yield_from(fn).and_return()
 
         with pytest.raises(
             DataPipelineError,
@@ -44,16 +42,14 @@ class TestYieldFromOp:
             next(iter(pipeline))
 
     def test_op_saves_and_restores_its_state(self) -> None:
-        def fn(d: Tuple[int, int]) -> DataPipeline[int]:
+        def fn(d: Tuple[int, int]) -> DataPipeline:
             a, b = d
 
             seq = list(range(a, b))
 
             return read_sequence(seq).and_return()
 
-        pipeline: DataPipeline[int] = (
-            read_sequence([[1, 5], [9, 14]]).yield_from(fn).and_return()
-        )
+        pipeline = read_sequence([[1, 5], [9, 14]]).yield_from(fn).and_return()
 
         d = None
 

--- a/tests/unit/data/data_pipeline/test_zip.py
+++ b/tests/unit/data/data_pipeline/test_zip.py
@@ -4,8 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Dict, List
-
 import pytest
 
 from fairseq2.data import DataPipeline, DataPipelineError, read_sequence
@@ -14,31 +12,29 @@ from fairseq2.data.text import read_text
 
 class TestZipOp:
     def test_op_works(self) -> None:
-        pipeline1: DataPipeline[int] = read_sequence([1, 2, 3, 4]).and_return()
-        pipeline2: DataPipeline[int] = read_sequence([5, 6, 7, 8]).and_return()
-        pipeline3: DataPipeline[int] = read_sequence([0, 2, 4, 6]).and_return()
+        pipeline1 = read_sequence([1, 2, 3, 4]).and_return()
+        pipeline2 = read_sequence([5, 6, 7, 8]).and_return()
+        pipeline3 = read_sequence([0, 2, 4, 6]).and_return()
 
-        pipeline4: DataPipeline[List[int]] = DataPipeline.zip(
-            [pipeline1, pipeline2, pipeline3]
-        ).and_return()
+        pipeline = DataPipeline.zip([pipeline1, pipeline2, pipeline3]).and_return()
 
         for _ in range(2):
-            assert list(pipeline4) == [[1, 5, 0], [2, 6, 2], [3, 7, 4], [4, 8, 6]]
+            assert list(pipeline) == [[1, 5, 0], [2, 6, 2], [3, 7, 4], [4, 8, 6]]
 
-            pipeline4.reset()
+            pipeline.reset()
 
     def test_op_works_when_a_single_pipeline_is_specified(self) -> None:
-        pipeline1: DataPipeline[int] = read_sequence([1, 2, 3, 4]).and_return()
+        pipeline1 = read_sequence([1, 2, 3, 4]).and_return()
 
-        pipeline2: DataPipeline[List[int]] = DataPipeline.zip([pipeline1]).and_return()
+        pipeline = DataPipeline.zip([pipeline1]).and_return()
 
         for _ in range(2):
-            assert list(pipeline2) == [[1], [2], [3], [4]]
+            assert list(pipeline) == [[1], [2], [3], [4]]
 
-            pipeline2.reset()
+            pipeline.reset()
 
     def test_op_works_when_no_pipeline_is_specified(self) -> None:
-        pipeline: DataPipeline[int] = DataPipeline.zip([]).and_return()
+        pipeline = DataPipeline.zip([]).and_return()
 
         for _ in range(2):
             with pytest.raises(StopIteration):
@@ -47,112 +43,102 @@ class TestZipOp:
             pipeline.reset()
 
     def test_op_works_when_infinite_pipeline_is_specified(self) -> None:
-        pipeline1: DataPipeline[int] = read_sequence([1, 2, 3, 4]).and_return()
-        pipeline2: DataPipeline[int] = DataPipeline.constant(0).and_return()
-        pipeline3: DataPipeline[int] = read_sequence([5, 6, 7, 8]).and_return()
+        pipeline1 = read_sequence([1, 2, 3, 4]).and_return()
+        pipeline2 = DataPipeline.constant(0).and_return()
+        pipeline3 = read_sequence([5, 6, 7, 8]).and_return()
 
-        pipeline4: DataPipeline[List[int]] = DataPipeline.zip(
-            [pipeline1, pipeline2, pipeline3]
-        ).and_return()
+        pipeline = DataPipeline.zip([pipeline1, pipeline2, pipeline3]).and_return()
 
         for _ in range(2):
-            assert list(pipeline4) == [[1, 0, 5], [2, 0, 6], [3, 0, 7], [4, 0, 8]]
+            assert list(pipeline) == [[1, 0, 5], [2, 0, 6], [3, 0, 7], [4, 0, 8]]
 
-            pipeline4.reset()
+            pipeline.reset()
 
     def test_op_works_when_names_are_specified(self) -> None:
-        pipeline1: DataPipeline[int] = read_sequence([1, 2, 3, 4]).and_return()
-        pipeline2: DataPipeline[int] = read_sequence([5, 6, 7, 8]).and_return()
-        pipeline3: DataPipeline[int] = read_sequence([0, 2, 4, 6]).and_return()
+        pipeline1 = read_sequence([1, 2, 3, 4]).and_return()
+        pipeline2 = read_sequence([5, 6, 7, 8]).and_return()
+        pipeline3 = read_sequence([0, 2, 4, 6]).and_return()
 
-        pipeline4: DataPipeline[Dict[str, int]] = DataPipeline.zip(
+        pipeline = DataPipeline.zip(
             [pipeline1, pipeline2, pipeline3], names=["p1", "p2", "p3"]
         ).and_return()
 
         for _ in range(2):
-            assert list(pipeline4) == [
+            assert list(pipeline) == [
                 {"p1": 1, "p2": 5, "p3": 0},
                 {"p1": 2, "p2": 6, "p3": 2},
                 {"p1": 3, "p2": 7, "p3": 4},
                 {"p1": 4, "p2": 8, "p3": 6},
             ]
 
-            pipeline4.reset()
+            pipeline.reset()
 
     def test_op_works_when_zip_to_shortest_is_true(self) -> None:
-        pipeline1: DataPipeline[int] = read_sequence([1, 2, 3]).and_return()
-        pipeline2: DataPipeline[int] = read_sequence([5, 6, 7, 8]).and_return()
-        pipeline3: DataPipeline[int] = read_sequence([3, 4, 5, 6]).and_return()
-        pipeline4: DataPipeline[int] = DataPipeline.count(1).and_return()
+        pipeline1 = read_sequence([1, 2, 3]).and_return()
+        pipeline2 = read_sequence([5, 6, 7, 8]).and_return()
+        pipeline3 = read_sequence([3, 4, 5, 6]).and_return()
+        pipeline4 = DataPipeline.count(1).and_return()
 
-        pipeline5: DataPipeline[List[int]] = DataPipeline.zip(
+        pipeline = DataPipeline.zip(
             [pipeline1, pipeline2, pipeline3, pipeline4], zip_to_shortest=True
         ).and_return()
 
         for _ in range(2):
-            assert list(pipeline5) == [[1, 5, 3, 1], [2, 6, 4, 2], [3, 7, 5, 3]]
+            assert list(pipeline) == [[1, 5, 3, 1], [2, 6, 4, 2], [3, 7, 5, 3]]
 
-            pipeline5.reset()
+            pipeline.reset()
 
     def test_op_works_when_flatten_is_true_and_inputs_are_lists(self) -> None:
-        pipeline1: DataPipeline[int] = read_sequence([1, 2, 3]).and_return()
-        pipeline2: DataPipeline[List[int]] = read_sequence([[1, 2], [3, 4], [5, 6]]).and_return()  # fmt: skip
-        pipeline3: DataPipeline[List[int]] = read_sequence([[4], [5], [6]]).and_return()
+        pipeline1 = read_sequence([1, 2, 3]).and_return()
+        pipeline2 = read_sequence([[1, 2], [3, 4], [5, 6]]).and_return()  # fmt: skip
+        pipeline3 = read_sequence([[4], [5], [6]]).and_return()
 
-        pipeline4: DataPipeline[List[int]] = DataPipeline.zip(
+        pipeline = DataPipeline.zip(
             [pipeline1, pipeline2, pipeline3], flatten=True
         ).and_return()
 
         for _ in range(2):
-            assert list(pipeline4) == [[1, 1, 2, 4], [2, 3, 4, 5], [3, 5, 6, 6]]
+            assert list(pipeline) == [[1, 1, 2, 4], [2, 3, 4, 5], [3, 5, 6, 6]]
 
-            pipeline4.reset()
+            pipeline.reset()
 
     def test_op_works_when_flatten_is_true_and_inputs_are_dicts(self) -> None:
-        pipeline1: DataPipeline[Dict[str, int]] = read_sequence(
-            [{"foo1": 1}, {"foo1": 2}, {"foo1": 3}]
-        ).and_return()
-        pipeline2: DataPipeline[Dict[str, int]] = read_sequence(
-            [{"foo2": 4, "foo3": 5}, {"foo2": 6, "foo3": 7}, {"foo2": 8, "foo3": 9}]
-        ).and_return()
-        pipeline3: DataPipeline[Dict[str, int]] = read_sequence(
-            [{"foo4": 2}, {"foo4": 3}, {"foo4": 4}]
-        ).and_return()
+        pipeline1 = read_sequence([{"foo1": 1}, {"foo1": 2}, {"foo1": 3}]).and_return()
+        pipeline2 = read_sequence([{"foo2": 4, "foo3": 5}, {"foo2": 6, "foo3": 7}, {"foo2": 8, "foo3": 9}]).and_return()  # fmt: skip
+        pipeline3 = read_sequence([{"foo4": 2}, {"foo4": 3}, {"foo4": 4}]).and_return()
 
-        pipeline4: DataPipeline[Dict[str, int]] = DataPipeline.zip(
+        pipeline = DataPipeline.zip(
             [pipeline1, pipeline2, pipeline3], flatten=True
         ).and_return()
 
         for _ in range(2):
-            assert list(pipeline4) == [
+            assert list(pipeline) == [
                 {"foo1": 1, "foo2": 4, "foo3": 5, "foo4": 2},
                 {"foo1": 2, "foo2": 6, "foo3": 7, "foo4": 3},
                 {"foo1": 3, "foo2": 8, "foo3": 9, "foo4": 4},
             ]
 
-            pipeline4.reset()
+            pipeline.reset()
 
     def test_op_raises_error_when_pipelines_have_different_lengths(self) -> None:
-        pipeline1: DataPipeline[int] = read_sequence([1, 2, 3]).and_return()
-        pipeline2: DataPipeline[int] = read_sequence([5, 6, 7, 8]).and_return()
-        pipeline3: DataPipeline[int] = read_sequence([5, 6, 7, 8]).and_return()
+        pipeline1 = read_sequence([1, 2, 3]).and_return()
+        pipeline2 = read_sequence([5, 6, 7, 8]).and_return()
+        pipeline3 = read_sequence([5, 6, 7, 8]).and_return()
 
-        pipeline4: DataPipeline[List[int]] = DataPipeline.zip(
-            [pipeline1, pipeline2, pipeline3]
-        ).and_return()
+        pipeline = DataPipeline.zip([pipeline1, pipeline2, pipeline3]).and_return()
 
         with pytest.raises(
             DataPipelineError,
             match=r"^The zipped data pipelines must all have the same number of examples, but the data pipelines at the indices \[1, 2\] have more examples than the others\.$",
         ):
-            for d in pipeline4:
+            for d in pipeline:
                 pass
 
     def test_op_raises_error_when_the_number_of_pipelines_and_names_do_not_match(
         self,
     ) -> None:
-        pipeline1: DataPipeline[int] = read_sequence([]).and_return()
-        pipeline2: DataPipeline[int] = read_sequence([]).and_return()
+        pipeline1 = read_sequence([]).and_return()
+        pipeline2 = read_sequence([]).and_return()
 
         with pytest.raises(
             ValueError,
@@ -162,8 +148,8 @@ class TestZipOp:
 
     def test_op_raises_error_when_one_of_the_pipelines_is_broken(self) -> None:
         # Force a non-recoverable error.
-        pipeline1: DataPipeline[str] = read_text(pathname=" &^#").and_return()
-        pipeline2: DataPipeline[str] = read_text(pathname=" &^#").and_return()
+        pipeline1 = read_text(pathname=" &^#").and_return()
+        pipeline2 = read_text(pathname=" &^#").and_return()
 
         # Break the first pipeline.
         try:
@@ -178,8 +164,8 @@ class TestZipOp:
             DataPipeline.zip([pipeline1, pipeline2]).and_return()
 
     def test_op_raises_error_when_both_names_and_flatten_are_specified(self) -> None:
-        pipeline1: DataPipeline[int] = read_sequence([1]).and_return()
-        pipeline2: DataPipeline[int] = read_sequence([1]).and_return()
+        pipeline1 = read_sequence([1]).and_return()
+        pipeline2 = read_sequence([1]).and_return()
 
         with pytest.raises(
             ValueError,
@@ -190,40 +176,36 @@ class TestZipOp:
     def test_op_raises_error_when_flatten_is_true_and_input_has_both_list_and_dict(
         self,
     ) -> None:
-        pipeline1: DataPipeline[int] = read_sequence([1]).and_return()
-        pipeline2: DataPipeline[Dict[str, int]] = read_sequence([{"foo1": 1}]).and_return()  # fmt: skip
+        pipeline1 = read_sequence([1]).and_return()
+        pipeline2 = read_sequence([{"foo1": 1}]).and_return()  # fmt: skip
 
-        pipeline3: DataPipeline[Any] = DataPipeline.zip(
-            [pipeline1, pipeline2], flatten=True
-        ).and_return()
+        pipeline = DataPipeline.zip([pipeline1, pipeline2], flatten=True).and_return()
 
         with pytest.raises(
             DataPipelineError,
             match=r"^The zipped data pipelines must all return only dicts, or only non-dicts when `flatten` is set\.$",
         ):
-            next(iter(pipeline3))
+            next(iter(pipeline))
 
-        pipeline4: DataPipeline[Dict[str, int]] = read_sequence([{"foo1": 1}]).and_return()  # fmt: skip
-        pipeline5: DataPipeline[int] = read_sequence([1]).and_return()
+        pipeline4 = read_sequence([{"foo1": 1}]).and_return()
+        pipeline5 = read_sequence([1]).and_return()
 
-        pipeline6: DataPipeline[Any] = DataPipeline.zip(
-            [pipeline4, pipeline5], flatten=True
-        ).and_return()
+        pipeline = DataPipeline.zip([pipeline4, pipeline5], flatten=True).and_return()
 
         with pytest.raises(
             DataPipelineError,
             match=r"^The zipped data pipelines must all return only dicts, or only non-dicts when `flatten` is set\.$",
         ):
-            next(iter(pipeline6))
+            next(iter(pipeline))
 
     def test_op_raises_error_when_flatten_is_true_and_dict_keys_are_not_unique(
         self,
     ) -> None:
-        pipeline1: DataPipeline[Dict[str, int]] = read_sequence([{"foo1": 1}]).and_return()  # fmt: skip
-        pipeline2: DataPipeline[Dict[str, int]] = read_sequence([{"foo2": 1}]).and_return()  # fmt: skip
-        pipeline3: DataPipeline[Dict[str, int]] = read_sequence([{"foo1": 1}]).and_return()  # fmt: skip
+        pipeline1 = read_sequence([{"foo1": 1}]).and_return()  # fmt: skip
+        pipeline2 = read_sequence([{"foo2": 1}]).and_return()  # fmt: skip
+        pipeline3 = read_sequence([{"foo1": 1}]).and_return()  # fmt: skip
 
-        pipeline4: DataPipeline[Dict[str, int]] = DataPipeline.zip(
+        pipeline = DataPipeline.zip(
             [pipeline1, pipeline2, pipeline3], flatten=True
         ).and_return()
 
@@ -231,20 +213,18 @@ class TestZipOp:
             DataPipelineError,
             match=r"^The zipped data pipelines must all return unique keys when `flatten` is set, but the key 'foo1' is not unique\.$",
         ):
-            next(iter(pipeline4))
+            next(iter(pipeline))
 
     def test_op_saves_and_restores_its_state(self) -> None:
-        pipeline1: DataPipeline[int] = read_sequence([1, 2, 3, 4]).and_return()
-        pipeline2: DataPipeline[int] = read_sequence([5, 6, 7, 8]).and_return()
-        pipeline3: DataPipeline[int] = read_sequence([0, 2, 4, 6]).and_return()
+        pipeline1 = read_sequence([1, 2, 3, 4]).and_return()
+        pipeline2 = read_sequence([5, 6, 7, 8]).and_return()
+        pipeline3 = read_sequence([0, 2, 4, 6]).and_return()
 
-        pipeline4: DataPipeline[List[int]] = DataPipeline.zip(
-            [pipeline1, pipeline2, pipeline3]
-        ).and_return()
+        pipeline = DataPipeline.zip([pipeline1, pipeline2, pipeline3]).and_return()
 
         d = None
 
-        it = iter(pipeline4)
+        it = iter(pipeline)
 
         # Move to the second example.
         for _ in range(2):
@@ -252,7 +232,7 @@ class TestZipOp:
 
         assert d == [2, 6, 2]
 
-        state_dict = pipeline4.state_dict()
+        state_dict = pipeline.state_dict()
 
         # Read one more example before we roll back.
         d = next(it)
@@ -260,7 +240,7 @@ class TestZipOp:
         assert d == [3, 7, 4]
 
         # Expected to roll back to the second example.
-        pipeline4.load_state_dict(state_dict)
+        pipeline.load_state_dict(state_dict)
 
         # Move to EOD.
         for _ in range(2):
@@ -268,12 +248,12 @@ class TestZipOp:
 
         assert d == [4, 8, 6]
 
-        state_dict = pipeline4.state_dict()
+        state_dict = pipeline.state_dict()
 
-        pipeline4.reset()
+        pipeline.reset()
 
         # Expected to be EOD.
-        pipeline4.load_state_dict(state_dict)
+        pipeline.load_state_dict(state_dict)
 
         with pytest.raises(StopIteration):
-            next(iter(pipeline4))
+            next(iter(pipeline))


### PR DESCRIPTION
This PR revers the recent change of making the DataPipeline API generic. It turns out it causes too much verbosity and there is a simpler way of achieving type safety that will be merged in the PR following this one.