### PR TITLE
Add num_examples to seq2seq model metrics

### DIFF
--- a/src/fairseq2/metrics.py
+++ b/src/fairseq2/metrics.py
@@ -206,6 +206,7 @@ _metric_formatters: Dict[str, Tuple[str, Callable[[Any], str]]] = {
     "grad_scale":          ("Grad Scale",                format_as_float),
     "loss":                ("Loss",                      format_as_loss),
     "lr":                  ("Learning Rate",             format_as_float),
+    "num_examples":        ("Number of Examples",        format_as_int),
     "num_source_elements": ("Number of Source Elements", format_as_int),
     "num_target_elements": ("Number of Target Elements", format_as_int),
     "wall_time":           ("Wall Time",                 format_as_seconds),

--- a/src/fairseq2/models/seq2seq.py
+++ b/src/fairseq2/models/seq2seq.py
@@ -129,6 +129,7 @@ class Seq2SeqModelMetricBag(MetricBag):
     batch_size: Mean
     elements_per_batch: Mean
     elements_per_second: Throughput
+    num_examples: Sum
     num_source_elements: Sum
     num_target_elements: Sum
 
@@ -150,6 +151,8 @@ class Seq2SeqModelMetricBag(MetricBag):
         self.register_metric("elements_per_batch", Mean(device=d), persistent=False)
 
         self.register_metric("elements_per_second", Throughput(device=d), persistent=False)  # fmt: skip
+
+        self.num_examples = Sum(device=d)
 
         self.num_source_elements = Sum(device=d)
         self.num_target_elements = Sum(device=d)
@@ -196,6 +199,8 @@ class Seq2SeqModelMetricBag(MetricBag):
         self.elements_per_batch.update(num_target_elements * self.gang.size)
 
         self.elements_per_second.update(int(num_target_elements), elapsed_time)
+
+        self.num_examples.update(batch_size)
 
         self.num_source_elements.update(num_source_elements)
         self.num_target_elements.update(num_target_elements)


### PR DESCRIPTION
A nit PR that adds a new `num_examples` metric to `Seq2SeqModelMetricBag`.