### PR TITLE
Add max_seq_len to decoder and encoder-decoder models

### DIFF
--- a/src/fairseq2/generation/beam_search.py
+++ b/src/fairseq2/generation/beam_search.py
@@ -58,7 +58,7 @@ class BeamSearchSequenceGenerator(AbstractSequenceGenerator):
         beam_size: int = 5,
         min_gen_len: int = 1,
         max_gen_len: int = 128,
-        max_seq_len: int = 1024,
+        max_seq_len: Optional[int] = None,
         echo_prompt: bool = False,
         normalize_scores: bool = True,
         temperature: float = 1.0,
@@ -131,11 +131,16 @@ class BeamSearchSequenceGenerator(AbstractSequenceGenerator):
                 f"`decode_capacity_increment` must be greater than or equal to 1, but is {decode_capacity_increment} instead."
             )
 
+        if max_seq_len is None:
+            effective_max_seq_len = model.max_seq_len
+        else:
+            effective_max_seq_len = min(max_seq_len, model.max_seq_len)
+
         self._algorithm = algorithm or StandardBeamSearchAlgorithm()
         self._beam_size = beam_size
         self._min_gen_len = min_gen_len
         self._max_gen_len = max_gen_len
-        self._max_seq_len = max_seq_len
+        self._max_seq_len = effective_max_seq_len
         self._echo_prompt = echo_prompt
         self._normalize_scores = normalize_scores
         self._temperature = temperature
@@ -205,7 +210,7 @@ class BeamSearchSeq2SeqGenerator(AbstractSeq2SeqGenerator):
         beam_size: int = 5,
         min_gen_len: int = 1,
         max_gen_len: Tuple[int, int] = (1, 128),
-        max_seq_len: int = 1024,
+        max_seq_len: Optional[int] = None,
         echo_prompt: bool = False,
         normalize_scores: bool = True,
         temperature: float = 1.0,
@@ -269,11 +274,16 @@ class BeamSearchSeq2SeqGenerator(AbstractSeq2SeqGenerator):
                 f"`decode_capacity_increment` must be greater than or equal to 1, but is {decode_capacity_increment} instead."
             )
 
+        if max_seq_len is None:
+            effective_max_seq_len = model.max_target_seq_len
+        else:
+            effective_max_seq_len = min(max_seq_len, model.max_target_seq_len)
+
         self._algorithm = algorithm or StandardBeamSearchAlgorithm()
         self._beam_size = beam_size
         self._min_gen_len = min_gen_len
         self._max_gen_len = max_gen_len
-        self._max_seq_len = max_seq_len
+        self._max_seq_len = effective_max_seq_len
         self._echo_prompt = echo_prompt
         self._normalize_scores = normalize_scores
         self._temperature = temperature

--- a/src/fairseq2/generation/sampling.py
+++ b/src/fairseq2/generation/sampling.py
@@ -59,7 +59,7 @@ class SamplingSequenceGenerator(AbstractSequenceGenerator):
         num_gens: int = 1,
         min_gen_len: int = 1,
         max_gen_len: int = 128,
-        max_seq_len: int = 1024,
+        max_seq_len: Optional[int] = None,
         echo_prompt: bool = False,
         compute_scores: bool = False,
         normalize_scores: bool = True,
@@ -135,11 +135,16 @@ class SamplingSequenceGenerator(AbstractSequenceGenerator):
                 f"`decode_capacity_increment` must be greater than or equal to 1, but is {decode_capacity_increment} instead."
             )
 
+        if max_seq_len is None:
+            effective_max_seq_len = model.max_seq_len
+        else:
+            effective_max_seq_len = min(max_seq_len, model.max_seq_len)
+
         self._sampler = sampler
         self._num_gens = num_gens
         self._min_gen_len = min_gen_len
         self._max_gen_len = max_gen_len
-        self._max_seq_len = max_seq_len
+        self._max_seq_len = effective_max_seq_len
         self._echo_prompt = echo_prompt
         self._compute_scores = compute_scores
         self._normalize_scores = normalize_scores
@@ -212,7 +217,7 @@ class SamplingSeq2SeqGenerator(AbstractSeq2SeqGenerator):
         num_gens: int = 1,
         min_gen_len: int = 1,
         max_gen_len: Tuple[int, int] = (1, 128),
-        max_seq_len: int = 1024,
+        max_seq_len: Optional[int] = None,
         echo_prompt: bool = False,
         compute_scores: bool = False,
         normalize_scores: bool = True,
@@ -279,11 +284,16 @@ class SamplingSeq2SeqGenerator(AbstractSeq2SeqGenerator):
                 f"`decode_capacity_increment` must be greater than or equal to 1, but is {decode_capacity_increment} instead."
             )
 
+        if max_seq_len is None:
+            effective_max_seq_len = model.max_target_seq_len
+        else:
+            effective_max_seq_len = min(max_seq_len, model.max_target_seq_len)
+
         self._sampler = sampler
         self._num_gens = num_gens
         self._min_gen_len = min_gen_len
         self._max_gen_len = max_gen_len
-        self._max_seq_len = max_seq_len
+        self._max_seq_len = effective_max_seq_len
         self._echo_prompt = echo_prompt
         self._compute_scores = compute_scores
         self._normalize_scores = normalize_scores

--- a/src/fairseq2/models/decoder.py
+++ b/src/fairseq2/models/decoder.py
@@ -21,14 +21,18 @@ class DecoderModel(SequenceModel):
 
     model_dim: int
 
-    def __init__(self, model_dim: int, vocab_info: VocabularyInfo) -> None:
+    def __init__(
+        self, model_dim: int, max_seq_len: int, vocab_info: VocabularyInfo
+    ) -> None:
         """
         :param model_dim:
             The dimensionality of the model.
+        :param max_seq_len:
+            The maximum length of sequences produced by the model.
         :param vocab_info:
             The vocabulary information of sequences produced by the model.
         """
-        super().__init__(vocab_info)
+        super().__init__(max_seq_len, vocab_info)
 
         self.model_dim = model_dim
 

--- a/src/fairseq2/models/encoder_decoder.py
+++ b/src/fairseq2/models/encoder_decoder.py
@@ -22,14 +22,18 @@ class EncoderDecoderModel(Seq2SeqModel):
 
     model_dim: int
 
-    def __init__(self, model_dim: int, target_vocab_info: VocabularyInfo) -> None:
+    def __init__(
+        self, model_dim: int, max_target_seq_len: int, target_vocab_info: VocabularyInfo
+    ) -> None:
         """
         :param model_dim:
             The dimensionality of the model.
+        :param max_target_seq_len:
+            The maximum length of sequences produced by the model.
         :param target_vocab_info:
             The vocabulary information of sequences produced by the model.
         """
-        super().__init__(target_vocab_info)
+        super().__init__(max_target_seq_len, target_vocab_info)
 
         self.model_dim = model_dim
 

--- a/src/fairseq2/models/llama/builder.py
+++ b/src/fairseq2/models/llama/builder.py
@@ -43,7 +43,7 @@ class LLaMAConfig:
     """The dimensionality of the model."""
 
     max_seq_len: int
-    """The expected maximum sequence length."""
+    """The maximum allowed sequence length."""
 
     vocab_info: VocabularyInfo
     """The vocabulary information."""
@@ -230,7 +230,7 @@ class LLaMABuilder:
 
     def build_model(self) -> TransformerDecoderModel:
         """Build a model."""
-        frontend = self.build_frontend()
+        decoder_frontend = self.build_decoder_frontend()
 
         decoder = self.build_decoder()
 
@@ -244,10 +244,14 @@ class LLaMABuilder:
         )
 
         return TransformerDecoderModel(
-            frontend, decoder, final_proj, self._config.vocab_info
+            decoder_frontend,
+            decoder,
+            final_proj,
+            self._config.max_seq_len,
+            self._config.vocab_info,
         )
 
-    def build_frontend(self) -> TransformerFrontend:
+    def build_decoder_frontend(self) -> TransformerFrontend:
         """Build a Transformer decoder front-end."""
         embed = StandardEmbedding(
             num_embeddings=self._config.vocab_info.size,

--- a/src/fairseq2/models/mistral/builder.py
+++ b/src/fairseq2/models/mistral/builder.py
@@ -44,7 +44,7 @@ class MistralConfig:
     """The dimensionality of the model."""
 
     max_seq_len: int
-    """The expected maximum sequence length."""
+    """The maximum allowed sequence length."""
 
     vocab_info: VocabularyInfo
     """The vocabulary information."""
@@ -127,7 +127,7 @@ class MistralBuilder:
 
     def build_model(self) -> TransformerDecoderModel:
         """Build a model."""
-        frontend = self.build_frontend()
+        decoder_frontend = self.build_decoder_frontend()
 
         decoder = self.build_decoder()
 
@@ -141,10 +141,14 @@ class MistralBuilder:
         )
 
         return TransformerDecoderModel(
-            frontend, decoder, final_proj, self._config.vocab_info
+            decoder_frontend,
+            decoder,
+            final_proj,
+            self._config.max_seq_len,
+            self._config.vocab_info,
         )
 
-    def build_frontend(self) -> TransformerFrontend:
+    def build_decoder_frontend(self) -> TransformerFrontend:
         """Build a Transformer decoder front-end."""
         embed = StandardEmbedding(
             num_embeddings=self._config.vocab_info.size,

--- a/src/fairseq2/models/nllb/builder.py
+++ b/src/fairseq2/models/nllb/builder.py
@@ -49,7 +49,7 @@ class NllbConfig:
     """The dimensionality of the model."""
 
     max_seq_len: int
-    """The expected maximum sequence length."""
+    """The maximum allowed sequence length."""
 
     vocab_info: VocabularyInfo
     """The vocabulary information."""
@@ -177,6 +177,7 @@ class NllbBuilder:
             frontend,
             decoder,
             final_proj,
+            self._config.max_seq_len,
             self._config.vocab_info,
         )
 

--- a/src/fairseq2/models/seq2seq.py
+++ b/src/fairseq2/models/seq2seq.py
@@ -27,15 +27,21 @@ from fairseq2.typing import override
 class Seq2SeqModel(Module, ABC):
     """Represents a sequence-to-sequence model."""
 
+    max_target_seq_len: int
     target_vocab_info: VocabularyInfo
 
-    def __init__(self, target_vocab_info: VocabularyInfo) -> None:
+    def __init__(
+        self, max_target_seq_len: int, target_vocab_info: VocabularyInfo
+    ) -> None:
         """
+        :param max_target_seq_len:
+            The maximum length of sequences produced by the model.
         :param target_vocab_info:
             The vocabulary information of sequences produced by the model.
         """
         super().__init__()
 
+        self.max_target_seq_len = max_target_seq_len
         self.target_vocab_info = target_vocab_info
 
     @abstractmethod

--- a/src/fairseq2/models/sequence.py
+++ b/src/fairseq2/models/sequence.py
@@ -23,15 +23,19 @@ from fairseq2.nn.padding import PaddingMask
 class SequenceModel(Module, ABC):
     """Represents a sequence model."""
 
+    max_seq_len: int
     vocab_info: VocabularyInfo
 
-    def __init__(self, vocab_info: VocabularyInfo) -> None:
+    def __init__(self, max_seq_len: int, vocab_info: VocabularyInfo) -> None:
         """
+        :param max_seq_len:
+            The maximum length of sequences produced by the model.
         :param vocab_info:
             The vocabulary information of sequences produced by the model.
         """
         super().__init__()
 
+        self.max_seq_len = max_seq_len
         self.vocab_info = vocab_info
 
     @abstractmethod

--- a/src/fairseq2/models/transformer/decoder_model.py
+++ b/src/fairseq2/models/transformer/decoder_model.py
@@ -32,6 +32,7 @@ class TransformerDecoderModel(DecoderModel):
         decoder_frontend: TransformerFrontend,
         decoder: TransformerDecoder,
         final_proj: Projection,
+        max_seq_len: int,
         vocab_info: VocabularyInfo,
     ) -> None:
         """
@@ -41,10 +42,12 @@ class TransformerDecoderModel(DecoderModel):
             The decoder.
         :param final_proj:
             The projection to apply to decoder outputs.
+        :param max_seq_len:
+            The maximum length of sequences produced by the model.
         :param vocab_info:
             The vocabulary information of sequences produced by the model.
         """
-        super().__init__(decoder.model_dim, vocab_info)
+        super().__init__(decoder.model_dim, max_seq_len, vocab_info)
 
         self.decoder_frontend = decoder_frontend
         self.decoder = decoder

--- a/src/fairseq2/models/transformer/model.py
+++ b/src/fairseq2/models/transformer/model.py
@@ -38,6 +38,7 @@ class TransformerModel(EncoderDecoderModel):
         decoder_frontend: TransformerFrontend,
         decoder: TransformerDecoder,
         final_proj: Projection,
+        max_target_seq_len: int,
         target_vocab_info: VocabularyInfo,
     ) -> None:
         """
@@ -51,10 +52,12 @@ class TransformerModel(EncoderDecoderModel):
             The decoder.
         :param final_proj:
             The projection to apply to decoder outputs.
+        :param max_target_seq_len:
+            The maximum length of sequences produced by the model.
         :param target_vocab_info:
             The vocabulary information of sequences produced by the model.
         """
-        super().__init__(encoder.model_dim, target_vocab_info)
+        super().__init__(encoder.model_dim, max_target_seq_len, target_vocab_info)
 
         self.encoder_frontend = encoder_frontend
         self.encoder = encoder

--- a/src/fairseq2/models/wav2vec2/builder.py
+++ b/src/fairseq2/models/wav2vec2/builder.py
@@ -54,7 +54,7 @@ class Wav2Vec2EncoderConfig:
     """The dimensionality of the model."""
 
     max_seq_len: int
-    """The expected maximum sequence length after feature extraction."""
+    """The maximum allowed sequence length after feature extraction."""
 
     # Features
     feature_dim: int

--- a/src/fairseq2/nn/position_encoder.py
+++ b/src/fairseq2/nn/position_encoder.py
@@ -31,7 +31,7 @@ class PositionEncoder(Module, ABC):
         :param encoding_dim:
             The dimensionality of positional encodings.
         :param max_seq_len:
-            The expected maximum sequence length.
+            The maximum allowed sequence length.
         """
         super().__init__()
 

--- a/src/fairseq2/nn/transformer/multihead_attention.py
+++ b/src/fairseq2/nn/transformer/multihead_attention.py
@@ -603,7 +603,7 @@ class AttentionStateFactory(Protocol):
         :param v:
             The initial projected values.
         :param max_seq_len:
-            The expected maximum sequence length.
+            The maximum allowed sequence length.
         :param capacity_increment:
             The sequence length capacity of state tensors will be incremented by
             multiples of this value. If ``None``, state tensors will be

--- a/src/fairseq2/nn/transformer/relative_attention.py
+++ b/src/fairseq2/nn/transformer/relative_attention.py
@@ -210,7 +210,7 @@ class RelativePositionalEncoding(Module):
         :param encoding_dim:
             The dimensionality of positional encodings.
         :param max_seq_len:
-            The expected maximum sequence length.
+            The maximum allowed sequence length.
         """
         super().__init__()
 


### PR DESCRIPTION
This PR introduces a new `max_seq_len` attribute in `SequenceModel` and a new `target_max_seq_len` in `Seq2SeqModel`.