### PR TITLE
Fix cyclic reference handling during process shutdown

### DIFF
--- a/native/python/src/fairseq2n/bindings/data/data_pipeline.cc
+++ b/native/python/src/fairseq2n/bindings/data/data_pipeline.cc
@@ -121,9 +121,10 @@ data_pipeline_tracker::delete_alive_pipelines()
     for (auto &weakref : alive_pipelines_) {
         py::object pipeline_obj = weakref();
 
+        // If the pipeline has a cyclic reference during interpreter shutdown,
+        // GC skips calling its weakref callback; so this check can be true.
         if (pipeline_obj.is_none())
-            throw_<internal_error>(
-                "One of the tracked data pipelines has already been deleted. Please file a bug report.");
+            continue;
 
         auto &pipeline = pipeline_obj.cast<data_pipeline &>();
 


### PR DESCRIPTION
This PR fixes a subtle edge case where a data pipeline might "leak" till process shutdown if it contains a cyclic reference. Apparently when GC kicks in during interpreter shutdown, it skips calling weakref callbacks. Previously we considered dead pipeline objects at this stage an error since we were expecting weakref callbacks to always execute. This behavior of CPython invalidates our assumption. With this PR, we simply ignore dead pipeline objects during clean up and decref them as usual.