### PR TITLE
fix the typo in asset type determination

### DIFF
--- a/src/fairseq2/assets/card.py
+++ b/src/fairseq2/assets/card.py
@@ -155,7 +155,7 @@ class AssetCard:
         """Return the type of the asset represented by this card."""
         for field in ["model_type", "dataset_type", "tokenizer_type"]:
             try:
-                return self.field("model_type").as_(str)
+                return self.field(field).as_(str)
             except AssetCardFieldNotFoundError:
                 continue
 


### PR DESCRIPTION
**What does this PR do? Please describe:**
Correctly determine the asset type for non-model cards (i.e. `dataset_type` and `tokenizer_type` instead of `model_type`)

I didn't create an issue for this, because the problem and the solution are pretty self-explaning.

**Does your PR introduce any breaking changes? If yes, please list them:**
No backwards-incompatible changes.

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
