### PR TITLE
Make checkpoint manager return the model path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [0.2.1] - TBD
 - Introduced `kv_dim` option to `StandardMultiheadAttention` (for different sizes of encoder and decoder)
+- Added the `CheckpointManager.get_model_checkpoint_path` method
 
 ## [0.2.0] - 2023-11-29
 - Introduced LLaMA and LLaMA 2

--- a/src/fairseq2/checkpoint.py
+++ b/src/fairseq2/checkpoint.py
@@ -554,7 +554,7 @@ class FileCheckpointManager(CheckpointManager):
         if step_nr is None:
             step_nr = self.get_last_step_number()
         if step_nr is None:
-            return
+            return None
         return self._checkpoint_dir.joinpath(f"step_{step_nr}/model.pt")
 
     def _iter_step_numbers(self, with_model: bool) -> Iterator[int]:

--- a/src/fairseq2/checkpoint.py
+++ b/src/fairseq2/checkpoint.py
@@ -155,12 +155,15 @@ class CheckpointManager(ABC):
         """
 
     @abstractmethod
-    def get_model_checkpoint_path(self, step_nr: Optional[int] = None) -> Optional[Path]:
+    def get_model_checkpoint_path(
+        self, step_nr: Optional[int] = None
+    ) -> Optional[Path]:
         """
         Return the path for the model checkpoint (by default, the last one).
         :param step_nr: 
             The step for which to load the model. If ``None``, then the last checkpoint is loaded.
         """
+
 
 @final
 class FileCheckpointManager(CheckpointManager):
@@ -466,9 +469,7 @@ class FileCheckpointManager(CheckpointManager):
         model_file = self.get_model_checkpoint_path(step_nr=step_nr)
         if model_file is None:
             # This should never happen, because if the step_nr is provided, model_file is always non-empty.
-            raise CheckpointNotFoundError(
-                f"Training step {step_nr} not found."
-            )
+            raise CheckpointNotFoundError(f"Training step {step_nr} not found.")
 
         try:
             checkpoint = load_checkpoint(model_file, map_location=CPU, restrict=True)
@@ -547,7 +548,9 @@ class FileCheckpointManager(CheckpointManager):
         return None
 
     @override
-    def get_model_checkpoint_path(self, step_nr: Optional[int] = None) -> Optional[Path]:
+    def get_model_checkpoint_path(
+        self, step_nr: Optional[int] = None
+    ) -> Optional[Path]:
         if step_nr is None:
             step_nr = self.get_last_step_number()
         if step_nr is None:


### PR DESCRIPTION
**What does this PR do? Please describe:**
After training a model, I would like to automatically create a model card for it, which includes the path to the model checkpoint.
Currently, to determine this path, I use `checkpoint_manager._checkpoint_dir / f"step_{n_steps}" / "model.pt"`, which is not great for several reasons:
- It accesses a private attribute
- It makes an assumption that all the training steps have completed (so it wouldn't work e.g. in case of early stopping).
- It uses the hardcoded `"model.pt"` filename; if ever CheckpointManager changes it, my code will break.

To avoid all these inconveniences, I make `CheckpointManager` explicitly provide the model path for its last checkpoint.

**Does your PR introduce any breaking changes? If yes, please list them:**
List of all backwards-incompatible changes.

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)

Regarding the tests: currently, they don't seem to be any for the `CheckpointManager`. Do I need to create one?