### PR TITLE
Refactory ChatbotRegistry

### DIFF
--- a/recipes/mistral/chatbot.py
+++ b/recipes/mistral/chatbot.py
@@ -17,21 +17,25 @@ from fairseq2.generation import (
     ChatMessage,
     SamplingSequenceGenerator,
     TopPSampler,
-    create_chatbot,
 )
-from fairseq2.models.mistral import load_mistral_model
+from fairseq2.models import create_chatbot, load_model
+from fairseq2.models.decoder import DecoderModel
+from fairseq2.typing import Device
 
 
-def run_mistral_chatbot(checkpoint_dir: Optional[Path] = None) -> None:
-    model_card = default_asset_store.retrieve_card("mistral_7b_instruct")
+def run_chatbot(checkpoint_dir: Optional[Path] = None) -> None:
+    model_name = "mistral_7b_instruct"
+
+    model_card = default_asset_store.retrieve_card(model_name)
 
     if checkpoint_dir is not None:
         model_card.field("checkpoint").set(checkpoint_dir / "consolidated.00.pth")
         model_card.field("tokenizer").set(checkpoint_dir / "tokenizer.model")
 
-    model = load_mistral_model(
-        model_card, dtype=torch.float16, device=torch.device("cuda:0")
-    )
+    model = load_model(model_card, dtype=torch.float16, device=Device("cuda:0"))
+
+    if not isinstance(model, DecoderModel):
+        raise ValueError("The model must be a decoder model.")
 
     tokenizer = load_text_tokenizer(model_card)
 
@@ -41,30 +45,39 @@ def run_mistral_chatbot(checkpoint_dir: Optional[Path] = None) -> None:
         model, sampler, temperature=0.6, max_gen_len=1024
     )
 
-    chatbot = create_chatbot(model_card.asset_type(), generator, tokenizer, stdout=True)  # type: ignore[arg-type]
+    # compat
+    chatbot = create_chatbot(generator, tokenizer)  # type: ignore[arg-type]
 
-    run_chatbot(chatbot)
+    do_run_chatbot(model_name, chatbot)
 
 
-def run_chatbot(chatbot: Chatbot) -> None:
+def do_run_chatbot(name: str, chatbot: Chatbot) -> None:
     dialog = []
 
-    print("\nYou can end the chat by typing 'bye'.\n")
+    if chatbot.supports_system_prompt:
+        system_prompt = input("System Prompt (press enter to skip): ")
+
+        if system_prompt:
+            dialog.append(ChatMessage(role="system", content=system_prompt))
+
+        print()
+
+    print("You can end the chat by typing 'bye'.\n")
 
     while (prompt := input("You> ")) != "bye":
         message = ChatMessage(role="user", content=prompt)
 
         dialog.append(message)
 
-        print("\nMistral> ", end="")
+        print(f"\n{name}> ", end="")
 
-        response, _ = chatbot(dialog)
+        response, _ = chatbot(dialog, stdout=True)
 
         print("\n")
 
         dialog.append(response)
 
-    print("\nMistral> Bye!")
+    print(f"\n{name}> Bye!")
 
 
 def main() -> None:
@@ -74,11 +87,11 @@ def main() -> None:
     param = parser.add_argument(
         "-c", "--checkpoint-dir", metavar="DIR", dest="checkpoint_dir", type=Path
     )
-    param.help = "path to the Mistral checkpoint directory"
+    param.help = "path to the model checkpoint directory"
 
     args = parser.parse_args()
 
-    run_mistral_chatbot(args.checkpoint_dir)
+    run_chatbot(args.checkpoint_dir)
 
 
 if __name__ == "__main__":

--- a/src/fairseq2/__init__.py
+++ b/src/fairseq2/__init__.py
@@ -17,6 +17,8 @@ import_module("fairseq2.models.llama")
 import_module("fairseq2.models.mistral")
 import_module("fairseq2.models.nllb")
 import_module("fairseq2.models.s2t_transformer")
+import_module("fairseq2.models.w2vbert")
+import_module("fairseq2.models.wav2vec2")
 
 import_module("fairseq2.datasets.nllb")
 

--- a/src/fairseq2/generation/__init__.py
+++ b/src/fairseq2/generation/__init__.py
@@ -14,15 +14,10 @@ from fairseq2.generation.beam_search import (
 from fairseq2.generation.beam_search import (
     StandardBeamSearchAlgorithm as StandardBeamSearchAlgorithm,
 )
-from fairseq2.generation.chat import AbstractChatbot as AbstractChatbot
-from fairseq2.generation.chat import Chatbot as Chatbot
-from fairseq2.generation.chat import ChatbotFactory as ChatbotFactory
-from fairseq2.generation.chat import ChatDialog as ChatDialog
-from fairseq2.generation.chat import ChatMessage as ChatMessage
-from fairseq2.generation.chat import (
-    DelegatingChatbotFactory as DelegatingChatbotFactory,
-)
-from fairseq2.generation.chat import create_chatbot as create_chatbot
+from fairseq2.generation.chatbot import AbstractChatbot as AbstractChatbot
+from fairseq2.generation.chatbot import Chatbot as Chatbot
+from fairseq2.generation.chatbot import ChatDialog as ChatDialog
+from fairseq2.generation.chatbot import ChatMessage as ChatMessage
 from fairseq2.generation.generator import (
     AbstractSeq2SeqGenerator as AbstractSeq2SeqGenerator,
 )

--- a/src/fairseq2/generation/utils.py
+++ b/src/fairseq2/generation/utils.py
@@ -31,10 +31,7 @@ class _StdOutPrintHook:
         step_scores: Optional[Tensor],
         prefill: bool,
     ) -> None:
-        if len(prompt_indices) > 1:
-            raise RuntimeError(
-                "`StdOutPrintHook` can only be used with a single prompt."
-            )
+        assert len(prompt_indices) == 1
 
         # Do not print anything during prompt prefill.
         if prefill:
@@ -59,8 +56,6 @@ class _StdOutPrintHook:
         # No need to print if we decoded a control symbol (e.g. EOS).
         if text_len == prev_text_len:
             return
-
-        text = str(text)
 
         text = text[prev_text_len - text_len :]
 

--- a/src/fairseq2/metrics.py
+++ b/src/fairseq2/metrics.py
@@ -366,6 +366,7 @@ class TensorBoardRecorder(MetricRecorder):
         """
         if not has_tensorboard:
             logger = logging.getLogger(__name__)
+
             logger.warning("tensorboard not found. Please install it with `pip install tensorboard`.")  # fmt: skip
 
         self._log_dir = log_dir

--- a/src/fairseq2/models/__init__.py
+++ b/src/fairseq2/models/__init__.py
@@ -10,6 +10,10 @@ from fairseq2.models.architecture_registry import (
 from fairseq2.models.architecture_registry import (
     ModelConfigFactory as ModelConfigFactory,
 )
+from fairseq2.models.chatbot import ChatbotFactory as ChatbotFactory
+from fairseq2.models.chatbot import DelegatingChatbotFactory as DelegatingChatbotFactory
+from fairseq2.models.chatbot import create_chatbot as create_chatbot
+from fairseq2.models.chatbot import register_chatbot as register_chatbot
 from fairseq2.models.config_loader import ModelConfigLoader as ModelConfigLoader
 from fairseq2.models.config_loader import (
     StandardModelConfigLoader as StandardModelConfigLoader,

--- a/src/fairseq2/models/chatbot.py
+++ b/src/fairseq2/models/chatbot.py
@@ -1,0 +1,69 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Dict, Protocol
+
+from fairseq2.data.text import TextTokenizer
+from fairseq2.generation import Chatbot, SequenceGenerator
+
+
+class ChatbotFactory(Protocol):
+    """Constructs instances of :class:`Chatbot`."""
+
+    def __call__(
+        self, generator: SequenceGenerator, tokenizer: TextTokenizer
+    ) -> Chatbot:
+        """
+        :param generator:
+            The sequence generator.
+        :param tokenizer:
+            The text tokenizer.
+        """
+
+
+class DelegatingChatbotFactory(ChatbotFactory):
+    """Constructs instances of :class:`Chatbot` using registered factories."""
+
+    _factories: Dict[str, ChatbotFactory]
+
+    def __init__(self) -> None:
+        self._factories = {}
+
+    def __call__(
+        self, generator: SequenceGenerator, tokenizer: TextTokenizer
+    ) -> Chatbot:
+        family = generator.model.family
+        if family is None:
+            raise ValueError("`generator.model.family` must not be `None`.")
+
+        try:
+            factory = self._factories[family]
+        except KeyError:
+            raise ValueError(
+                f"`generator.model.family` must be a supported model family, but '{family}' has no registered chatbot."
+            )
+
+        return factory(generator, tokenizer)
+
+    def register_factory(self, family: str, factory: ChatbotFactory) -> None:
+        """Register a chatbot factory to use with this factory.
+
+        :param family:
+            The model family supported by ``factory``.
+        :param factory:
+            The chatbot factory.
+        """
+        if family in self._factories:
+            raise ValueError(
+                f"`family` must be a unique model family, but '{family}' has already a registered chatbot."
+            )
+
+        self._factories[family] = factory
+
+
+create_chatbot = DelegatingChatbotFactory()
+
+register_chatbot = create_chatbot.register_factory

--- a/src/fairseq2/models/llama/__init__.py
+++ b/src/fairseq2/models/llama/__init__.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from fairseq2.models.llama.chat import LLaMAChatbot as LLaMAChatbot
+from fairseq2.models.llama.chatbot import LLaMAChatbot as LLaMAChatbot
 from fairseq2.models.llama.factory import LLaMABuilder as LLaMABuilder
 from fairseq2.models.llama.factory import LLaMAConfig as LLaMAConfig
 from fairseq2.models.llama.factory import create_llama_model as create_llama_model

--- a/src/fairseq2/models/llama/chatbot.py
+++ b/src/fairseq2/models/llama/chatbot.py
@@ -13,37 +13,31 @@ from fairseq2.data.text import TextTokenEncoder, TextTokenizer
 from fairseq2.generation import (
     AbstractChatbot,
     ChatDialog,
+    ChatMessage,
     SequenceGenerator,
-    create_chatbot,
 )
+from fairseq2.models.chatbot import register_chatbot
+from fairseq2.models.llama.factory import LLAMA_FAMILY
 from fairseq2.nn.utils.module import infer_device
 from fairseq2.typing import override
 
 
 @final
-class MistralChatbot(AbstractChatbot):
-    """Represents a Mistral chatbot."""
+class LLaMAChatbot(AbstractChatbot):
+    """Represents a LLaMA chatbot."""
 
     _bos_idx: Tensor
     _eos_idx: Tensor
     _text_encoder: TextTokenEncoder
 
-    def __init__(
-        self,
-        generator: SequenceGenerator,
-        tokenizer: TextTokenizer,
-        *,
-        stdout: bool = False,
-    ) -> None:
+    def __init__(self, generator: SequenceGenerator, tokenizer: TextTokenizer) -> None:
         """
         :param generator:
             The sequence generator.
         :param tokenizer:
             The text tokenizer.
-        :param stdout:
-            If ``True``, prints generated messages to stdout in real-time.
         """
-        super().__init__(generator, tokenizer, stdout=stdout)
+        super().__init__(generator, tokenizer)
 
         assert tokenizer.vocab_info.bos_idx is not None
         assert tokenizer.vocab_info.eos_idx is not None
@@ -67,25 +61,38 @@ class MistralChatbot(AbstractChatbot):
                 f"The last message of `{param_name}` must have the role 'user'."
             )
 
-        dialog_contents: List[Tensor] = [self._bos_idx]
+        # Merge the system message, if any, with the first user message.
+        if dialog[0].role == "system":
+            content = f"<<SYS>>\n{dialog[0].content}\n<</SYS>>\n\n{dialog[1].content}"
+
+            first_message = ChatMessage(dialog[1].role, content)
+
+            dialog = [first_message] + list(dialog[2:])
+
+        dialog_contents: List[Tensor] = []
 
         for user, bot in zip(dialog[::2], dialog[1::2]):
             if user.role != "user" or bot.role != "bot":
                 raise ValueError(
-                    f"The messages of `{param_name}` must alternate between the roles 'user' and 'bot'."
+                    f"The messages of `{param_name}` might optionally start with the role 'system', and then must alternate between the roles 'user' and 'bot'."
                 )
 
             user_bot_seq = self._text_encoder(
                 f"[INST] {user.content.strip()} [/INST] {bot.content.strip()}"
             )
 
-            dialog_contents += [user_bot_seq, self._eos_idx]
+            dialog_contents += [self._bos_idx, user_bot_seq, self._eos_idx]
 
         user_seq = self._text_encoder(f"[INST] {dialog[-1].content.strip()} [/INST]")
 
-        dialog_contents.append(user_seq)
+        dialog_contents += [self._bos_idx, user_seq]
 
         return torch.cat(dialog_contents, dim=0)
 
+    @property
+    @override
+    def supports_system_prompt(self) -> bool:
+        return True
 
-create_chatbot.register("mistral", MistralChatbot)
+
+register_chatbot(LLAMA_FAMILY, LLaMAChatbot)

--- a/src/fairseq2/models/mistral/__init__.py
+++ b/src/fairseq2/models/mistral/__init__.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from fairseq2.models.mistral.chat import MistralChatbot as MistralChatbot
+from fairseq2.models.mistral.chatbot import MistralChatbot as MistralChatbot
 from fairseq2.models.mistral.factory import MistralBuilder as MistralBuilder
 from fairseq2.models.mistral.factory import MistralConfig as MistralConfig
 from fairseq2.models.mistral.factory import create_mistral_model as create_mistral_model

--- a/src/fairseq2/models/mistral/chatbot.py
+++ b/src/fairseq2/models/mistral/chatbot.py
@@ -10,41 +10,29 @@ import torch
 from torch import Tensor
 
 from fairseq2.data.text import TextTokenEncoder, TextTokenizer
-from fairseq2.generation import (
-    AbstractChatbot,
-    ChatDialog,
-    ChatMessage,
-    SequenceGenerator,
-    create_chatbot,
-)
+from fairseq2.generation import AbstractChatbot, ChatDialog, SequenceGenerator
+from fairseq2.models.chatbot import register_chatbot
+from fairseq2.models.mistral.factory import MISTRAL_FAMILY
 from fairseq2.nn.utils.module import infer_device
 from fairseq2.typing import override
 
 
 @final
-class LLaMAChatbot(AbstractChatbot):
-    """Represents a LLaMA chatbot."""
+class MistralChatbot(AbstractChatbot):
+    """Represents a Mistral chatbot."""
 
     _bos_idx: Tensor
     _eos_idx: Tensor
     _text_encoder: TextTokenEncoder
 
-    def __init__(
-        self,
-        generator: SequenceGenerator,
-        tokenizer: TextTokenizer,
-        *,
-        stdout: bool = False,
-    ) -> None:
+    def __init__(self, generator: SequenceGenerator, tokenizer: TextTokenizer) -> None:
         """
         :param generator:
             The sequence generator.
         :param tokenizer:
             The text tokenizer.
-        :param stdout:
-            If ``True``, prints generated messages to stdout in real-time.
         """
-        super().__init__(generator, tokenizer, stdout=stdout)
+        super().__init__(generator, tokenizer)
 
         assert tokenizer.vocab_info.bos_idx is not None
         assert tokenizer.vocab_info.eos_idx is not None
@@ -68,33 +56,30 @@ class LLaMAChatbot(AbstractChatbot):
                 f"The last message of `{param_name}` must have the role 'user'."
             )
 
-        # Merge the system message, if any, with the first user message.
-        if dialog[0].role == "system":
-            content = f"<<SYS>>\n{dialog[0].content}\n<</SYS>>\n\n{dialog[1].content}"
-
-            first_message = ChatMessage(dialog[1].role, content)
-
-            dialog = [first_message] + list(dialog[2:])
-
-        dialog_contents: List[Tensor] = []
+        dialog_contents: List[Tensor] = [self._bos_idx]
 
         for user, bot in zip(dialog[::2], dialog[1::2]):
             if user.role != "user" or bot.role != "bot":
                 raise ValueError(
-                    f"The messages of `{param_name}` might optionally start with the role 'system', and then must alternate between the roles 'user' and 'bot'."
+                    f"The messages of `{param_name}` must alternate between the roles 'user' and 'bot'."
                 )
 
             user_bot_seq = self._text_encoder(
                 f"[INST] {user.content.strip()} [/INST] {bot.content.strip()}"
             )
 
-            dialog_contents += [self._bos_idx, user_bot_seq, self._eos_idx]
+            dialog_contents += [user_bot_seq, self._eos_idx]
 
         user_seq = self._text_encoder(f"[INST] {dialog[-1].content.strip()} [/INST]")
 
-        dialog_contents += [self._bos_idx, user_seq]
+        dialog_contents.append(user_seq)
 
         return torch.cat(dialog_contents, dim=0)
 
+    @property
+    @override
+    def supports_system_prompt(self) -> bool:
+        return False
 
-create_chatbot.register("llama", LLaMAChatbot)
+
+register_chatbot(MISTRAL_FAMILY, MistralChatbot)


### PR DESCRIPTION
This PR refactors `ChatbotRegistry` and moves it to `fairseq2.models` to avoid circular imports with `fairseq2.generation`. The recipes are also temporarily updated, but a later PR will consolidate the LLaMA and Mistral chatbot recipes to a generic terminal-based chat app.