### PR TITLE
Update wav2vec2 and w2vbert output loss parameters

### DIFF
--- a/src/fairseq2/models/w2vbert/factory.py
+++ b/src/fairseq2/models/w2vbert/factory.py
@@ -73,7 +73,6 @@ class W2VBertConfig:
             codebook_sampling_temperature=(2.0, 0.1, 0.999995),
             num_distractors=100,
             logit_temp=0.1,
-            diversity_loss_weight=0.2,
         )
     )
     """The configuration of the wav2vec 2.0 model."""
@@ -83,15 +82,6 @@ class W2VBertConfig:
 
     num_target_codebooks: int = 1
     """The number of consecutive codebooks to use as masked prediction targets."""
-
-    w2v2_loss_weight: float = 1.0
-    """The weight of wav2vec 2.0 loss in loss computation."""
-
-    bert_loss_weight: float = 1.0
-    """The weight of masked prediction loss in loss computation."""
-
-    bert_label_smoothing: float = 0.0
-    """The amount of label smoothing when computing masked prediction loss."""
 
 
 w2vbert_archs = ModelArchitectureRegistry[W2VBertConfig]()
@@ -175,9 +165,6 @@ class W2VBertBuilder:
             w2v2_model,
             self._config.num_bert_encoder_layers,
             num_target_codebooks=self._config.num_target_codebooks,
-            w2v2_loss_weight=self._config.w2v2_loss_weight,
-            bert_loss_weight=self._config.bert_loss_weight,
-            bert_label_smoothing=self._config.bert_label_smoothing,
             device=self._device,
             dtype=self._dtype,
         )

--- a/src/fairseq2/models/wav2vec2/factory.py
+++ b/src/fairseq2/models/wav2vec2/factory.py
@@ -208,9 +208,6 @@ class Wav2Vec2Config:
     logit_temp: float = 0.1
     """The temperature to divide logits by."""
 
-    diversity_loss_weight: float = 0.1
-    """The weight of diversity in loss computation."""
-
 
 wav2vec2_archs = ModelArchitectureRegistry[Wav2Vec2Config]()
 
@@ -494,7 +491,6 @@ class Wav2Vec2Builder:
             final_proj_bias=self._config.final_proj_bias,
             num_distractors=self._config.num_distractors,
             logit_temp=self._config.logit_temp,
-            diversity_loss_weight=self._config.diversity_loss_weight,
             device=self._device,
             dtype=self._dtype,
         )


### PR DESCRIPTION
This PR moves loss computation related parameters from the model config dataclass to model output type for wav2vec2 and w2v-bert.