### PR TITLE
Fix the wav2vec 2.0 ASR asset name

### DIFF
--- a/src/fairseq2/assets/cards/wav2vec2.yaml
+++ b/src/fairseq2/assets/cards/wav2vec2.yaml
@@ -12,7 +12,7 @@ checkpoint: "https://dl.fbaipublicfiles.com/fairseq/wav2vec/wav2vec2_fs2_small.p
 
 ---
 
-name: wav2vec2_asr_base_10h
+name: wav2vec2_asr_base_10m
 model_type: wav2vec2_asr  # compat
 model_family: wav2vec2_asr
 model_arch: base


### PR DESCRIPTION
A nit PR that fixes the wav2vec 2.0 ASR asset name