### PR TITLE
Add sharded parameter to DynamicLossScaler

### DIFF
--- a/src/fairseq2/optim/dynamic_loss_scaler.py
+++ b/src/fairseq2/optim/dynamic_loss_scaler.py
@@ -38,6 +38,7 @@ class DynamicLossScaler:
         optimizer: Optimizer,
         gang: Gang,
         *,
+        sharded: bool = True,
         init_scale: float = 2.0**15,
         scale_factor: float = 2.0,
         scale_window: Optional[int] = None,
@@ -50,6 +51,9 @@ class DynamicLossScaler:
             The optimizer that holds the gradients that will be unscaled.
         :param gang:
             The associated gang.
+        :param sharded:
+            If ``True``, indicates that the corresponding optimizer state is
+            sharded (e.g. FSDP).
         :param init_scale:
             The initial scale.
         :param scale_factor:
@@ -87,7 +91,7 @@ class DynamicLossScaler:
 
             logger.info("The scale window is set to %d.", scale_window)
 
-        if gang.size == 1:
+        if gang.size == 1 or not sharded:
             self._grad_scaler = GradScaler(
                 init_scale, scale_factor, 1 / scale_factor, scale_window, enabled
             )


### PR DESCRIPTION
This PR adds a new `sharded` parameter to `DynamicLossScaler` to distinguish between DDP and FSDP.