### PR TITLE
Make sequence metric bags non-final

### DIFF
--- a/src/fairseq2/models/seq2seq.py
+++ b/src/fairseq2/models/seq2seq.py
@@ -129,7 +129,6 @@ class Seq2SeqBatch:
         return int(self.target_padding_mask.seq_lens.sum())
 
 
-@final
 class Seq2SeqModelMetricBag(MetricBag):
     """Holds the common metrics of a sequence-to-sequence model."""
 

--- a/src/fairseq2/models/sequence.py
+++ b/src/fairseq2/models/sequence.py
@@ -144,7 +144,6 @@ class SequenceModelOutput:
         return nll_loss(lprobs, targets, self.pad_idx, label_smoothing=label_smoothing)
 
 
-@final
 class SequenceModelMetricBag(MetricBag):
     """Holds the common metrics of a sequence model."""
 


### PR DESCRIPTION
A nit PR that makes sequence metric bags non-final for easier authoring.