### PR TITLE
Has wildcard support in element_selector::matches

### DIFF
--- a/native/src/fairseq2n/data/element_selector.cc
+++ b/native/src/fairseq2n/data/element_selector.cc
@@ -164,9 +164,22 @@ element_selector::matches(element_path_ref path) const
         if (p.size() != path.size())
             return false;
 
-        for (std::size_t i = 0; i < p.size(); ++i)
-            if (p[i] != path[i])
+        for (std::size_t i = 0; i < p.size(); i++) {
+            const element_path_segment &segment1 = p[i];
+            const element_path_segment &segment2 = path[i];
+
+            if (segment1 != segment2) {
+                bool holds_index1 = std::holds_alternative<std::size_t>(segment1);
+                bool holds_index2 = std::holds_alternative<std::size_t>(segment2);
+
+                if (holds_index1 && holds_index2) {
+                    if (std::get<std::size_t>(segment1) == wildcard_index)
+                        continue;
+                }
+
                 return false;
+            }
+        }
 
         return true;
     };

--- a/tests/unit/data/test_collater.py
+++ b/tests/unit/data/test_collater.py
@@ -157,7 +157,9 @@ class TestCollater:
 
         collater = Collater(
             pad_value=1,
-            overrides=[CollateOptionsOverride("foo1[*]", pad_value=3, pad_to_multiple=3)],
+            overrides=[
+                CollateOptionsOverride("foo1[*]", pad_value=3, pad_to_multiple=3)
+            ],
         )
 
         output = collater(bucket)

--- a/tests/unit/data/test_collater.py
+++ b/tests/unit/data/test_collater.py
@@ -140,15 +140,24 @@ class TestCollater:
     def test_call_works_when_options_are_overriden(self) -> None:
         # fmt: off
         bucket = [
-            {"foo1": torch.full((4,2), 0, device=device, dtype=torch.int32), "foo2": torch.full((4,2), 0, device=device, dtype=torch.int64)},
-            {"foo1": torch.full((2,2), 1, device=device, dtype=torch.int32), "foo2": torch.full((2,2), 1, device=device, dtype=torch.int64)},
-            {"foo1": torch.full((3,2), 2, device=device, dtype=torch.int32), "foo2": torch.full((3,2), 2, device=device, dtype=torch.int64)},
+            {
+                "foo1": [torch.full((4,2), 0, device=device, dtype=torch.int32)],
+                "foo2": [torch.full((4,2), 0, device=device, dtype=torch.int64)],
+            },
+            {
+                "foo1": [torch.full((2,2), 1, device=device, dtype=torch.int32)],
+                "foo2": [torch.full((2,2), 1, device=device, dtype=torch.int64)],
+            },
+            {
+                "foo1": [torch.full((3,2), 2, device=device, dtype=torch.int32)],
+                "foo2": [torch.full((3,2), 2, device=device, dtype=torch.int64)],
+            },
         ]
         # fmt: on
 
         collater = Collater(
             pad_value=1,
-            overrides=[CollateOptionsOverride("foo1", pad_value=3, pad_to_multiple=3)],
+            overrides=[CollateOptionsOverride("foo1[*]", pad_value=3, pad_to_multiple=3)],
         )
 
         output = collater(bucket)
@@ -175,14 +184,14 @@ class TestCollater:
 
         expected_seq_lens = torch.tensor([4, 2, 3], device=device, dtype=torch.int64)
 
-        assert_close(output["foo1"]["seqs"], expected_seqs1)
-        assert_close(output["foo2"]["seqs"], expected_seqs2)
+        assert_close(output["foo1"][0]["seqs"], expected_seqs1)
+        assert_close(output["foo2"][0]["seqs"], expected_seqs2)
 
-        assert_equal(output["foo1"]["seq_lens"], expected_seq_lens)
-        assert_equal(output["foo2"]["seq_lens"], expected_seq_lens)
+        assert_equal(output["foo1"][0]["seq_lens"], expected_seq_lens)
+        assert_equal(output["foo2"][0]["seq_lens"], expected_seq_lens)
 
-        assert output["foo1"]["is_ragged"] == True
-        assert output["foo2"]["is_ragged"] == True
+        assert output["foo1"][0]["is_ragged"] == True
+        assert output["foo2"][0]["is_ragged"] == True
 
     def test_call_works_when_input_has_composite_elements(self) -> None:
         # fmt: off


### PR DESCRIPTION
This PR adds support for wildcards in `element_selector::matches`, which is mainly used in `Collater`.