### PR TITLE
Do not sync NLLB dataset if repeat is true

### DIFF
--- a/src/fairseq2/datasets/nllb.py
+++ b/src/fairseq2/datasets/nllb.py
@@ -138,7 +138,7 @@ class NllbDataset(ParallelTextDataset):
         # each process. So, it is important to ensure that all processes
         # are in sync about the end of the data. If this is not the case,
         # the training can hang.
-        sync_eod = sample or bucket_by_length
+        sync_eod = repeat is not None and (sample or bucket_by_length)
 
         return DataPipelineReader[Seq2SeqBatch](
             pipeline, gang, num_accumulate=num_accumulate, sync_eod=sync_eod


### PR DESCRIPTION
A nit PR that avoids syncing ranks while reading the NLLB dataset if `repeat` is set to `True`.