### PR TITLE
Strip DDP module prefix while loading model

### DIFF
--- a/src/fairseq2/checkpoint.py
+++ b/src/fairseq2/checkpoint.py
@@ -26,6 +26,7 @@ import torch
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.distributed.fsdp.api import FullStateDictConfig, StateDictType
 from torch.nn import Module
+from torch.nn.modules.utils import consume_prefix_in_state_dict_if_present
 
 from fairseq2.gang import Gang
 from fairseq2.models.utils.checkpoint import load_checkpoint
@@ -525,6 +526,9 @@ class FileCheckpointManager(CheckpointManager):
             state_dict = checkpoint["model"]
         except KeyError as ex:
             raise_error(ex)
+
+        # Remove DP/DDP 'module' prefix.
+        consume_prefix_in_state_dict_if_present(state_dict, prefix="module.")
 
         try:
             load_state_dict(out, state_dict)

--- a/src/fairseq2/models/llama/setup.py
+++ b/src/fairseq2/models/llama/setup.py
@@ -21,6 +21,10 @@ def convert_llama_checkpoint(
     checkpoint: Dict[str, Any], config: LLaMAConfig
 ) -> Dict[str, Any]:
     """Convert a reference LLaMA checkpoint to fairseq2 format."""
+    # Check if we have a fairseq2 checkpoint.
+    if "model" in checkpoint:
+        return checkpoint
+
     key_map = {
         # fmt: off
         r"^layers\.([0-9]+)\.attention\.wq\.":    r"decoder.layers.\1.self_attn.q_proj.",

--- a/src/fairseq2/models/loader.py
+++ b/src/fairseq2/models/loader.py
@@ -10,6 +10,7 @@ from pickle import PickleError
 from typing import Any, Dict, Generic, Optional, Protocol, TypeVar, Union, final
 
 from torch.nn import Module
+from torch.nn.modules.utils import consume_prefix_in_state_dict_if_present
 
 from fairseq2.assets import (
     AssetCard,
@@ -246,6 +247,9 @@ class StandardModelLoader(ModelLoader[ModelT], Generic[ModelT, ModelConfigT]):
             raise AssetError(
                 f"The checkpoint of {card.name} does not contain a 'model' entry."
             )
+
+        # Remove DDP 'module' prefix.
+        consume_prefix_in_state_dict_if_present(state_dict, prefix="module.")
 
         try:
             load_state_dict(model, state_dict)

--- a/src/fairseq2/models/mistral/setup.py
+++ b/src/fairseq2/models/mistral/setup.py
@@ -21,6 +21,10 @@ def convert_mistral_checkpoint(
     checkpoint: Dict[str, Any], config: MistralConfig
 ) -> Dict[str, Any]:
     """Convert a reference Mistral checkpoint to fairseq2 format."""
+    # Check if we have a fairseq2 checkpoint.
+    if "model" in checkpoint:
+        return checkpoint
+
     key_map = {
         # fmt: off
         r"^layers\.([0-9]+)\.attention\.wq\.":    r"decoder.layers.\1.self_attn.q_proj.",

--- a/src/fairseq2/models/nllb/setup.py
+++ b/src/fairseq2/models/nllb/setup.py
@@ -29,7 +29,11 @@ def convert_nllb_checkpoint(
     state_dict = checkpoint["model"]
 
     # Check if we have a fairseq2 checkpoint.
-    if "decoder_frontend.embed_weight" in state_dict:
+    if "decoder_frontend.embed.weight" in state_dict:
+        return checkpoint
+
+    # Check if we have a DDP wrapped fairseq2 checkpoint.
+    if "module.decoder_frontend.embed.weight" in state_dict:
         return checkpoint
 
     key_map = {

--- a/src/fairseq2/models/s2t_transformer/setup.py
+++ b/src/fairseq2/models/s2t_transformer/setup.py
@@ -24,6 +24,16 @@ def convert_s2t_transformer_checkpoint(
     checkpoint: Dict[str, Any], config: S2TTransformerConfig
 ) -> Dict[str, Any]:
     """Convert a fairseq S2T Transformer checkpoint to fairseq2 format."""
+    state_dict = checkpoint["model"]
+
+    # Check if we have a fairseq2 checkpoint.
+    if "decoder_frontend.embed.weight" in state_dict:
+        return checkpoint
+
+    # Check if we have a DDP wrapped fairseq2 checkpoint.
+    if "module.decoder_frontend.embed.weight" in state_dict:
+        return checkpoint
+
     key_map = {
         # fmt: off
         r"^encoder\.subsample\.conv_layers\.([0-9]+)\.":                   r"encoder_frontend.feature_extractor.layers.\1.conv.",

--- a/src/fairseq2/models/w2vbert/setup.py
+++ b/src/fairseq2/models/w2vbert/setup.py
@@ -28,6 +28,10 @@ def convert_w2vbert_checkpoint(
     if "w2v2_model.final_target_proj.weight" in state_dict:
         return checkpoint
 
+    # Check if we have a DDP wrapped fairseq2 checkpoint.
+    if "module.w2v2_model.final_target_proj.weight" in state_dict:
+        return checkpoint
+
     state_dict["w2v2_model.quantizer.num_updates"] = torch.zeros((), device="cpu")
 
     key_map = {

--- a/src/fairseq2/models/wav2vec2/setup.py
+++ b/src/fairseq2/models/wav2vec2/setup.py
@@ -29,6 +29,10 @@ def convert_wav2vec2_checkpoint(
     if "final_target_proj.weight" in state_dict:
         return checkpoint
 
+    # Check if we have a DDP wrapped fairseq2 checkpoint.
+    if "module.final_target_proj.weight" in state_dict:
+        return checkpoint
+
     if config.encoder_config.norm_order == TransformerNormOrder.POST:
         # fmt: off
         state_dict["encoder_frontend.layer_norm.weight"] = state_dict["encoder.layer_norm.weight"]


### PR DESCRIPTION
This PR extends the model loading implementation to handle models saved as part of DDP. It automatically removes the "module." prefix if necessary.