### PR TITLE
Include git commit hash as local label in nighlies

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,14 +46,16 @@ jobs:
               exit 1
             fi
           fi
-      - name: Stamp version with current date if nightly
+      - name: Stamp version with current date and commit hash if nightly
         id: stamp_version
         if: inputs.release_type == 'nightly'
         run: |
           version=$(cat VERSION)
 
+          commit_hash=$(git rev-parse --short HEAD)
+
           # Append datetime-stamped dev segment.
-          echo version_override=${version%.dev*}.dev$(date --utc +%Y%m%d%H%M) >> "$GITHUB_OUTPUT"
+          echo version_override=${version%.dev*}.dev$(date --utc +%Y%m%d%H%M)+g$commit_hash >> "$GITHUB_OUTPUT"
 
   lint:
     name: Lint


### PR DESCRIPTION
This PR extends the nighly package versions with an additional git commit hash to identify the exact commit matching the nightly build.

Note that GitHub Actions lacks any tooling to test changes in CI workflow files. Once this PR gets merged, we will kick off a nightly and see if it produces the indented label.