### PR TITLE
Fix fairseq2n::data payload move bug

### DIFF
--- a/native/src/fairseq2n/data/data.h
+++ b/native/src/fairseq2n/data/data.h
@@ -57,8 +57,19 @@ public:
     data(const data &) = default;
     data &operator=(const data &) = default;
 
-    data(data &&other) noexcept = default;
-    data &operator=(data &&other) noexcept = default;
+    data(data &&other) noexcept
+      : payload_{std::move(other.payload_)}
+    {
+        other.payload_ = {};
+    }
+
+    data &
+    operator=(data &&other) noexcept
+    {
+        payload_ = std::exchange(other.payload_, {});
+
+        return *this;
+    }
 
    ~data() = default;
 

--- a/tests/unit/data/data_pipeline/test_shuffle.py
+++ b/tests/unit/data/data_pipeline/test_shuffle.py
@@ -49,6 +49,23 @@ class TestShuffleOp:
 
                 pipeline.reset()
 
+    def test_op_saves_its_state_after_internal_buffer_is_emptied(self) -> None:
+        class Foo:
+            pass
+
+        # Deliberately use an opaque Python object to ensure that it cannot be
+        # saved in case the buffer is not emptied correctly.
+        seq = [Foo()] * 10
+
+        pipeline = read_sequence(seq).shuffle(40).and_return()
+
+        # Exhaust the whole pipeline so that the internal shuffle buffer is
+        # emptied.
+        _ = list(pipeline)
+
+        # Must not fail.
+        pipeline.state_dict()
+
     @pytest.mark.parametrize("window", [10, 100, 1000])
     def test_op_saves_and_restores_its_state(self, window: int) -> None:
         seq = list(range(5000))


### PR DESCRIPTION
This PR fixes a pesky bug where the index bit of an `std::variant` is not cleared by its move operation. This causes moved `fairseq2n::data` objects to point to invalid values (e.g. Python objects) which causes errors when they are accidentally used in operations such as moving them to Python.