### PR TITLE
Introduce Batch interface

### DIFF
--- a/src/fairseq2/datasets/nllb.py
+++ b/src/fairseq2/datasets/nllb.py
@@ -138,10 +138,10 @@ class NllbDataset(ParallelTextDataset):
         # each process. So, it is important to ensure that all processes
         # are in sync about the end of the data. If this is not the case,
         # the training can hang.
-        sync_eod = repeat is not None and (sample or bucket_by_length)
+        sync_batches = repeat is not None and (sample or bucket_by_length)
 
         return DataPipelineReader[Seq2SeqBatch](
-            pipeline, gang, num_accumulate=num_accumulate, sync_eod=sync_eod
+            pipeline, gang, num_accumulate=num_accumulate, sync_batches=sync_batches
         )
 
     @override

--- a/src/fairseq2/models/__init__.py
+++ b/src/fairseq2/models/__init__.py
@@ -24,4 +24,6 @@ from fairseq2.models.loader import ModelFactory as ModelFactory
 from fairseq2.models.loader import ModelLoader as ModelLoader
 from fairseq2.models.loader import StandardModelLoader as StandardModelLoader
 from fairseq2.models.loader import load_model as load_model
+from fairseq2.models.model import Batch as Batch
+from fairseq2.models.model import Model as Model
 from fairseq2.models.setup import setup_model as setup_model

--- a/src/fairseq2/models/model.py
+++ b/src/fairseq2/models/model.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from abc import ABC, abstractmethod
 from typing import Optional
 
 from torch.nn import Module
@@ -35,3 +36,12 @@ class Model(Module):
     def family(self) -> Optional[str]:
         """The family of the model."""
         return self._family
+
+
+class Batch(ABC):
+    """Represents a batch of inputs to be processed by a machine learning model."""
+
+    @property
+    @abstractmethod
+    def batch_size(self) -> int:
+        """The number of inputs in the batch (i.e. number of rows)."""

--- a/src/fairseq2/models/seq2seq.py
+++ b/src/fairseq2/models/seq2seq.py
@@ -17,7 +17,7 @@ from torcheval.metrics import Mean, Sum, Throughput
 from fairseq2.data import VocabularyInfo
 from fairseq2.gang import Gang
 from fairseq2.metrics import MetricBag
-from fairseq2.models.model import Model
+from fairseq2.models.model import Batch, Model
 from fairseq2.models.sequence import SequenceModelOutput
 from fairseq2.nn.padding import PaddingMask
 from fairseq2.typing import override
@@ -56,7 +56,7 @@ class Seq2SeqModel(Model, ABC):
 
 @final
 @dataclass(frozen=True)
-class Seq2SeqBatch:
+class Seq2SeqBatch(Batch):
     """Represents a sequence-to-sequence batch."""
 
     source_seqs: Tensor
@@ -110,6 +110,7 @@ class Seq2SeqBatch:
         return batch, self.target_seqs[:, 1:]
 
     @property
+    @override
     def batch_size(self) -> int:
         """The size of the batch dimension."""
         return self.target_seqs.size(0)

--- a/src/fairseq2/models/sequence.py
+++ b/src/fairseq2/models/sequence.py
@@ -18,7 +18,7 @@ from torcheval.metrics import Mean, Sum, Throughput
 from fairseq2.data import VocabularyInfo
 from fairseq2.gang import Gang
 from fairseq2.metrics import MetricBag
-from fairseq2.models.model import Model
+from fairseq2.models.model import Batch, Model
 from fairseq2.nn.functional import nll_loss
 from fairseq2.nn.padding import PaddingMask
 from fairseq2.typing import override
@@ -53,7 +53,7 @@ class SequenceModel(Model, ABC):
 
 @final
 @dataclass(frozen=True)
-class SequenceBatch:
+class SequenceBatch(Batch):
     """Represents a sequence batch."""
 
     seqs: Tensor
@@ -69,6 +69,7 @@ class SequenceBatch:
     """The data example from which this batch was constructed."""
 
     @property
+    @override
     def batch_size(self) -> int:
         """The size of the batch."""
         return self.seqs.size(0)
@@ -93,7 +94,7 @@ class SequenceModelOutput:
     """Holds the output of a sequence model."""
 
     logits: Tensor
-    """The logits for next-step prediction. *Shape:* :math:`(N,S,T)`, where
+    """The logits for the next-step predictions. *Shape:* :math:`(N,S,T)`, where
     :math:`N` is the batch size, :math:`S` is the sequence length, and :math:`T`
     is the size of the vocabulary."""
 


### PR DESCRIPTION
This PR introduces a new `Batch` interface and revises the `DataReader` API by renaming `sync_eods` to `sync_batches` in preperation of #415.