### PR TITLE
Nit updates to wav2vec2 and w2v-Bert

### DIFF
--- a/src/fairseq2/models/decoder.py
+++ b/src/fairseq2/models/decoder.py
@@ -66,11 +66,11 @@ class DecoderModel(SequenceModel):
 
         :returns:
             - The decoder output. *Shape:* :math:`(N,S,M)`, where :math:`N` is
-              the batch size, :math:`S` is the target sequence length, and
-              :math:`M` is the dimensionality of the model.
+              the batch size, :math:`S` is the sequence length, and :math:`M` is
+              the dimensionality of the model.
             - The padding mask of the decoder output. *Shape:* :math:`(N,S)`,
-              where :math:`N` is the batch size and :math:`S` is the target
-              sequence length.
+              where :math:`N` is the batch size and :math:`S` is the sequence
+              length.
         """
 
     @abstractmethod

--- a/src/fairseq2/models/encoder_decoder.py
+++ b/src/fairseq2/models/encoder_decoder.py
@@ -64,16 +64,17 @@ class EncoderDecoderModel(Seq2SeqModel):
             sequence length, and :math:`*` is any number of sequence-specific
             dimensions including none.
         :param padding_mask:
-            The padding mask of ``seqs``. *Shape:* :math:`(N,S)`, where :math:`N`
-            is the batch size and :math:`S` is the sequence length.
+            The padding mask of ``seqs``. *Shape:* :math:`(N,S_{src})`, where
+            :math:`N` is the batch size and :math:`S_{src}` is the source
+            sequence length.
 
         :returns:
-            - The encoder output. *Shape:* :math:`(N,S_{out},M)`, where
-              :math:`N` is the batch size, :math:`S_{out}` is the output
+            - The encoder output. *Shape:* :math:`(N,S_{enc},M)`, where
+              :math:`N` is the batch size, :math:`S_{enc}` is the encoder output
               sequence length, and :math:`M` is the dimensionality of the model.
             - The padding mask of the encoder output. *Shape:*
-              :math:`(N,S_{out})`, where :math:`N` is the batch size and
-              :math:`S_{out}` is the output sequence length.
+              :math:`(N,S_{enc})`, where :math:`N` is the batch size and
+              :math:`S_{enc}` is the encoder output sequence length.
         """
 
     @abstractmethod
@@ -94,8 +95,9 @@ class EncoderDecoderModel(Seq2SeqModel):
             sequence length, and :math:`*` is any number of sequence-specific
             dimensions including none.
         :param padding_mask:
-            The padding mask of ``seqs``. *Shape:* :math:`(N,S)`, where :math:`N`
-            is the batch size and :math:`S` is the sequence length.
+            The padding mask of ``seqs``. *Shape:* :math:`(N,S_{tgt})`, where
+            :math:`N` is the batch size and :math:`S_{tgt}` is the target
+            sequence length.
         :param encoder_output:
             The encoder output to use in encoder-decoder attention. *Shape:*
             :math:`(N,S_{enc},M)`, where :math:`N` is the batch size,

--- a/src/fairseq2/models/sequence.py
+++ b/src/fairseq2/models/sequence.py
@@ -94,7 +94,7 @@ class SequenceModelOutput:
     """Holds the output of a sequence model."""
 
     logits: Tensor
-    """The logits for the next-step predictions. *Shape:* :math:`(N,S,T)`, where
+    """The logits for next-step prediction. *Shape:* :math:`(N,S,T)`, where
     :math:`N` is the batch size, :math:`S` is the sequence length, and :math:`T`
     is the size of the vocabulary."""
 

--- a/src/fairseq2/models/wav2vec2/asr/model.py
+++ b/src/fairseq2/models/wav2vec2/asr/model.py
@@ -133,9 +133,9 @@ class Wav2Vec2AsrLoss:
 @dataclass
 class Wav2Vec2AsrOutput:
     logits: Tensor
-    """The logits for next-step prediction. *Shape:* :math:`(N,S,T)`, where
-    :math:`N` is the batch size, :math:`S` is the source sequence length, and
-    :math:`T` is the size of the vocabulary."""
+    """The logits for next-step prediction. *Shape:* :math:`(N,S_{enc},T)`,
+    where :math:`N` is the batch size, :math:`S_{enc}` is the encoder output
+    sequence length, and :math:`T` is the size of the vocabulary."""
 
     encoder_output: Tensor
     """The encoder output. *Shape:* :math:`(N,S_{enc},M)`, where :math:`N` is
@@ -153,8 +153,8 @@ class Wav2Vec2AsrOutput:
         """Compute the CTC (Connectionist Temporal Classification) loss.
 
         :param targets:
-            The target indices. *Shape:* :math:`(N,S)`, where :math:`N` is the
-            batch size and :math:`S` is the target sequence length.
+            The target indices. *Shape:* :math:`(N,S_{tgt})`, where :math:`N` is
+            the batch size and :math:`S_{tgt}` is the target sequence length.
         :param target_padding_mask:
             The padding mask of the targets. *Shape:* Same as ``targets``.
 

--- a/src/fairseq2/models/wav2vec2/factory.py
+++ b/src/fairseq2/models/wav2vec2/factory.py
@@ -131,14 +131,14 @@ class Wav2Vec2EncoderConfig:
     ffn_inner_dim: int = 3072
     """The inner dimensionality of feed-forward networks."""
 
-    ffn_inner_dropout_p: float = 0.0
-    """The dropout probability on inner activations of feed-forward networks."""
-
     dropout_p: float = 0.1
     """The dropout probability on outputs of Transformer layers."""
 
     attn_dropout_p: float = 0.1
     """The dropout probability on attention weights."""
+
+    ffn_inner_dropout_p: float = 0.0
+    """The dropout probability on inner activations of feed-forward networks."""
 
     layer_drop_p: float = 0.05
     """If greater than zero, applies LayerDrop to encoder layers as described in

--- a/src/fairseq2/models/wav2vec2/feature_extractor.py
+++ b/src/fairseq2/models/wav2vec2/feature_extractor.py
@@ -234,6 +234,9 @@ class Wav2Vec2FeatureExtractionLayer(Module):
             seqs = self.dropout(seqs)
 
         if self.group_norm is not None:
+            # The padding ratio of `seqs` must be as low as possible since the
+            # Group Normalization implementation in PyTorch has no support for
+            # padding and a large ratio can skew normalization.
             seqs = self.group_norm(seqs)
 
         if self.layer_norm is not None:

--- a/src/fairseq2/models/wav2vec2/frontend.py
+++ b/src/fairseq2/models/wav2vec2/frontend.py
@@ -184,17 +184,17 @@ class Wav2Vec2Frontend(TransformerFrontend):
             is the batch size and :math:`S` is the sequence length.
         :param masker:
             If not ``None``, the features will be masked and the applied
-            temporal mask will be returned as the third tuple element.
+            temporal mask will be returned as the third element of the tuple.
 
         :returns:
-            - The processed sequences to pass to a Transformer encoder. *Shape:*
+            - The processed features to pass to the context network. *Shape:*
               :math:`(N,S,M)`, where :math:`N` is the batch size, :math:`S` is
               the sequence length, and :math:`M` is the dimensionality of the
               model.
-            - The padding mask of the processed sequences. *Shape:* :math:`(N,S)`,
+            - The padding mask of the processed features. *Shape:* :math:`(N,S)`,
               where :math:`N` is the batch size and :math:`S` is the output
               sequence length.
-            - The temporal mask that has been applied to the processed sequences.
+            - The temporal mask that has been applied to the processed features.
               *Shape:* :math:`(N,S)`, where :math:`N` is the batch size and
               :math`S` is the sequence length.
         """

--- a/src/fairseq2/models/wav2vec2/masker.py
+++ b/src/fairseq2/models/wav2vec2/masker.py
@@ -111,7 +111,7 @@ class Wav2Vec2Masker(Module):
 
         assert temporal_mask is not None
 
-        seqs[temporal_mask] = self.temporal_mask_embed
+        seqs[temporal_mask] = self.temporal_mask_embed.type_as(seqs)
 
         if self.max_spatial_mask_prob > 0.0:
             # Spatial mask over features.

--- a/src/fairseq2/nn/padding.py
+++ b/src/fairseq2/nn/padding.py
@@ -43,7 +43,7 @@ class PaddingMask:
 
         return self._materialized
 
-    def trim(self, size: int) -> "PaddingMask":
+    def trim(self, size: int) -> PaddingMask:
         """Return a new trimmed padding mask.
 
         :param size:


### PR DESCRIPTION
This PR mostly fixes/updates docstrs of wav2vec2 and w2v-BERT models. Also adds `encoder_padding_mask` to `Wav2Vec2Features` and `Wav2Vec2Output`  for completeness.