### PR TITLE
Revise repeat parameter

### DIFF
--- a/native/src/fairseq2n/data/data_pipeline.cc
+++ b/native/src/fairseq2n/data/data_pipeline.cc
@@ -414,7 +414,7 @@ data_pipeline_builder::prefetch(std::size_t num_examples) &&
 data_pipeline_builder
 data_pipeline_builder::repeat(std::optional<std::size_t> num_repeats) &&
 {
-    if (!num_repeats || *num_repeats > 1)
+    if (!num_repeats || *num_repeats != 1)
         factory_ = [=, inner = std::move(factory_)]
         {
             return std::make_unique<repeat_data_source>(inner(), num_repeats);

--- a/native/src/fairseq2n/data/repeat_data_source.cc
+++ b/native/src/fairseq2n/data/repeat_data_source.cc
@@ -13,6 +13,9 @@ namespace fairseq2n::detail {
 std::optional<data>
 repeat_data_source::next()
 {
+    if (num_repeats_ && *num_repeats_ == 0)
+        return std::nullopt;
+
     while (true) {
         std::optional<data> maybe_example = inner_->next();
         if (maybe_example) {

--- a/src/fairseq2/datasets/asr_dataset.py
+++ b/src/fairseq2/datasets/asr_dataset.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from abc import ABC, abstractmethod
-from typing import List, Optional, TypeVar
+from typing import List, Literal, Optional, TypeVar, Union
 
 from fairseq2.assets import default_asset_store, default_download_manager
 from fairseq2.data.text import TextTokenizer
@@ -37,7 +37,7 @@ class AsrDataset(ABC):
         min_audio_len: int = 1,
         bucket_by_length: bool = False,
         shuffle_window_size: int = 0,
-        repeat: Optional[int] = 1,
+        repeat: Union[int, Literal["forever"]] = 1,
         num_prefetch: int = 0,
         num_accumulate: int = 1,
     ) -> DataReader[Seq2SeqBatch]:
@@ -64,8 +64,8 @@ class AsrDataset(ABC):
         :param shuffle_window_size:
             The size of the streaming shuffle window.
         :param repeat:
-            The dataset will be repeatedly read this many times. If ``None``, it
-            will be read infinitely.
+            The dataset will be repeatedly read this many times. If ``forever``,
+            it will be read indefinitely.
         :param num_prefetch:
             The number of batches to prefetch in background.
         :param num_accumulate:

--- a/src/fairseq2/datasets/parallel_text_dataset.py
+++ b/src/fairseq2/datasets/parallel_text_dataset.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import List, NamedTuple, Optional, Sequence, TypeVar
+from typing import List, Literal, NamedTuple, Optional, Sequence, TypeVar, Union
 
 from fairseq2.assets import default_asset_store, default_download_manager
 from fairseq2.data.text import TextTokenizer
@@ -50,7 +50,7 @@ class ParallelTextDataset(ABC):
         bucket_by_length: bool = False,
         sample: bool = False,
         shuffle_window_size: int = 0,
-        repeat: Optional[int] = 1,
+        repeat: Union[int, Literal["forever"]] = 1,
         num_prefetch: int = 0,
         num_accumulate: int = 1,
         lang_pairs: Optional[Sequence[LangPair]] = None,
@@ -76,8 +76,8 @@ class ParallelTextDataset(ABC):
         :param shuffle_window_size:
             The size of the streaming shuffle window.
         :param repeat:
-            The dataset will be repeatedly read this many times. If ``None``, it
-            will be read infinitely.
+            The dataset will be repeatedly read this many times. If ``forever``,
+            it will be read indefinitely.
         :param num_prefetch:
             The number of batches to prefetch in background.
         :param num_accumulate:

--- a/tests/unit/data/data_pipeline/test_repeat.py
+++ b/tests/unit/data/data_pipeline/test_repeat.py
@@ -30,6 +30,16 @@ class TestRepeatOp:
 
             pipeline.reset()
 
+    def test_op_works_when_num_repeats_is_zero(self) -> None:
+        seq = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+        pipeline = read_sequence(seq).repeat(0).and_return()
+
+        for _ in range(2):
+            assert list(pipeline) == []
+
+            pipeline.reset()
+
     def test_op_saves_and_restores_its_state(self) -> None:
         seq = [1, 2, 3, 4, 5, 6, 7, 8, 9]
 


### PR DESCRIPTION
This PR revises the `repeat` parameter of `AsrDataset` and `ParallelTextDataset` to use the literal "forever" to indicate indefinite repeating.