### PR TITLE
Improve bucket_by_length

### DIFF
--- a/native/python/src/fairseq2n/bindings/data/data_pipeline.cc
+++ b/native/python/src/fairseq2n/bindings/data/data_pipeline.cc
@@ -417,20 +417,26 @@ def_data_pipeline(py::module_ &data_module)
                 data_pipeline_builder &self,
                 std::vector<std::pair<std::size_t, std::size_t>> bucket_sizes,
                 std::optional<std::string> maybe_selector,
-                bool bucket_long_examples,
+                std::size_t min_data_len,
+                bool skip_below_min_examples,
+                bool skip_above_max_examples,
                 bool drop_remainder) -> data_pipeline_builder &
             {
                 self = std::move(self).bucket_by_length(
                     std::move(bucket_sizes),
                     data_length_extractor{std::move(maybe_selector)},
-                    bucket_long_examples,
+                    min_data_len,
+                    skip_below_min_examples,
+                    skip_above_max_examples,
                     drop_remainder);
 
                 return self;
             },
             py::arg("bucket_sizes"),
             py::arg("selector") = std::nullopt,
-            py::arg("bucket_long_examples") = false,
+            py::arg("min_data_len") = 1,
+            py::arg("skip_below_min_examples") = false,
+            py::arg("skip_above_max_examples") = false,
             py::arg("drop_remainder") = false)
         .def(
             "collate",

--- a/native/src/fairseq2n/data/bucket_by_length_data_source.cc
+++ b/native/src/fairseq2n/data/bucket_by_length_data_source.cc
@@ -14,13 +14,17 @@ bucket_by_length_data_source::bucket_by_length_data_source(
     std::unique_ptr<data_source> &&inner,
     std::vector<std::pair<std::size_t, std::size_t>> &&bucket_sizes,
     data_length_fn &&fn,
-    bool bucket_long_examples,
+    std::size_t min_data_len,
+    bool skip_below_min_examples,
+    bool skip_above_max_examples,
     bool drop_remainder)
   : inner_{std::move(inner)},
     bucket_sizes_(std::move(bucket_sizes)),
-    max_data_len_{bucket_sizes_.back().second},
     data_length_fn_{std::move(fn)},
-    bucket_long_examples_{bucket_long_examples},
+    min_data_len_{min_data_len},
+    max_data_len_{bucket_sizes_.back().second},
+    skip_below_min_examples_{skip_below_min_examples},
+    skip_above_max_examples_{skip_above_max_examples},
     drop_remainder_{drop_remainder}
 {
     buckets_.reserve(bucket_sizes_.size());
@@ -43,25 +47,40 @@ bucket_by_length_data_source::next()
                 "The length of the input data cannot be determined.");
         }
 
-        if (data_len > max_data_len_ && !bucket_long_examples_) {
-            throw_data_pipeline_error(std::move(maybe_example), /*recoverable=*/true,
-                "The length of the input data must be less than or equal to the maximum bucket data length ({}), but is {} instead.", max_data_len_, data_len);
+        if (data_len < min_data_len_) {
+            if (!skip_below_min_examples_)
+                throw_data_pipeline_error(std::move(maybe_example), /*recoverable=*/true,
+                    "The length of the input data must be greater than or equal to the minimum bucket data length ({}), but is {} instead.", min_data_len_, data_len);
+
+            // TODO(balioglu): log
+
+            continue;
         }
 
-        // Find the smallest bucket that would fit `example`, and return that bucket
-        // if it is full.
-        for (std::size_t i = 0; i < buckets_.size(); i++) {
-            auto [bucket_batch_size, bucket_data_len] = bucket_sizes_[i];
+        if (data_len > max_data_len_) {
+            if (!skip_above_max_examples_)
+                throw_data_pipeline_error(std::move(maybe_example), /*recoverable=*/true,
+                    "The length of the input data must be less than or equal to the maximum bucket data length ({}), but is {} instead.", max_data_len_, data_len);
 
-            if (data_len <= bucket_data_len || i == buckets_.size() - 1) {
+            // TODO(balioglu): log
+
+            continue;
+        }
+
+        // Find the smallest bucket that would fit `example`, and return that
+        // bucket if it is full.
+        for (std::size_t i = 0; i < buckets_.size(); i++) {
+            auto [bucket_num_examples, bucket_data_len] = bucket_sizes_[i];
+
+            if (data_len <= bucket_data_len) {
                 data_list &bucket = buckets_[i];
 
                 bucket.push_back(std::move(example));
 
-                if (bucket.size() >= bucket_batch_size) {
+                if (bucket.size() >= bucket_num_examples) {
                     data output = data{std::exchange(bucket, {})};
 
-                    bucket.reserve(bucket_batch_size);
+                    bucket.reserve(bucket_num_examples);
 
                     return output;
                 }
@@ -71,14 +90,44 @@ bucket_by_length_data_source::next()
         }
     }
 
-    if (!drop_remainder_) {
-        // Return the smallest partially filled bucket.
-        for (data_list &bucket : buckets_) {
-            if (bucket.empty())
-                continue;
+    // If we are here, it means we exhausted the inner data source. For the
+    // remaining examples in the buckets, return them by chunking them together
+    // starting from the last bucket. Going in reverse bucket order is important
+    // to ensure that we never exceed the maximum number of elements.
+    for (std::size_t i = buckets_.size(); i > 0; i--) {
+        data_list &bucket = buckets_[i - 1];
+        if (bucket.empty())
+            continue;
 
-            return std::exchange(bucket, {});
+        auto [bucket_num_examples, bucket_data_len] = bucket_sizes_[i - 1];
+
+        if (i - 1 > 0) {
+            std::size_t remaining = bucket_num_examples - bucket.size();
+
+            for (std::size_t j = i - 1; j > 0; j--) {
+                data_list &other_bucket = buckets_[j - 1];
+
+                while (remaining > 0 && !other_bucket.empty()) {
+                    bucket.push_back(std::move(other_bucket.back()));
+
+                    other_bucket.pop_back();
+
+                    remaining--;
+                }
+
+                if (remaining == 0)
+                    break;
+            }
         }
+
+        // This can only be true for the very last chunked bucket.
+        if (drop_remainder_ && bucket.size() != bucket_num_examples) {
+            bucket.clear();
+
+            return std::nullopt;
+        }
+
+        return std::exchange(bucket, {});
     }
 
     return std::nullopt;

--- a/native/src/fairseq2n/data/bucket_by_length_data_source.h
+++ b/native/src/fairseq2n/data/bucket_by_length_data_source.h
@@ -24,7 +24,9 @@ public:
         std::unique_ptr<data_source> &&inner,
         std::vector<std::pair<std::size_t, std::size_t>> &&bucket_sizes,
         data_length_fn &&fn,
-        bool bucket_long_examples,
+        std::size_t min_data_len,
+        bool skip_below_min_examples,
+        bool skip_above_max_examples,
         bool drop_remainder);
 
     std::optional<data>
@@ -45,9 +47,11 @@ public:
 private:
     std::unique_ptr<data_source> inner_;
     std::vector<std::pair<std::size_t, std::size_t>> bucket_sizes_;
-    std::size_t max_data_len_;
     data_length_fn data_length_fn_;
-    bool bucket_long_examples_;
+    std::size_t min_data_len_;
+    std::size_t max_data_len_;
+    bool skip_below_min_examples_;
+    bool skip_above_max_examples_;
     bool drop_remainder_;
     std::vector<data_list> buckets_{};
 };

--- a/native/src/fairseq2n/data/data_pipeline.cc
+++ b/native/src/fairseq2n/data/data_pipeline.cc
@@ -352,7 +352,9 @@ data_pipeline_builder
 data_pipeline_builder::bucket_by_length(
     std::vector<std::pair<std::size_t, std::size_t>> bucket_sizes,
     data_length_fn fn,
-    bool bucket_long_examples,
+    std::size_t min_data_len,
+    bool skip_below_min_examples,
+    bool skip_above_max_examples,
     bool drop_remainder) &&
 {
     if (bucket_sizes.empty())
@@ -371,7 +373,13 @@ data_pipeline_builder::bucket_by_length(
         inner = std::move(factory_)]() mutable
     {
         return std::make_unique<bucket_by_length_data_source>(
-            inner(), std::move(bucket_sizes), std::move(fn), bucket_long_examples, drop_remainder);
+            inner(),
+            std::move(bucket_sizes),
+            std::move(fn),
+            min_data_len,
+            skip_below_min_examples,
+            skip_above_max_examples,
+            drop_remainder);
     };
 
     return std::move(*this);

--- a/native/src/fairseq2n/data/data_pipeline.h
+++ b/native/src/fairseq2n/data/data_pipeline.h
@@ -133,7 +133,9 @@ public:
     bucket_by_length(
         std::vector<std::pair<std::size_t, std::size_t>> bucket_sizes,
         data_length_fn fn,
-        bool bucket_long_examples = false,
+        std::size_t min_data_len = 1,
+        bool skip_below_min_examples = false,
+        bool skip_above_max_examples = false,
         bool drop_remainder = false) &&;
 
     data_pipeline_builder

--- a/src/fairseq2/data/data_pipeline.py
+++ b/src/fairseq2/data/data_pipeline.py
@@ -159,7 +159,9 @@ if TYPE_CHECKING or DOC_MODE:
             self,
             bucket_sizes: Sequence[Tuple[int, int]],
             selector: Optional[str] = None,
-            bucket_long_examples: bool = False,
+            min_data_len: int = 1,
+            skip_below_min_examples: bool = False,
+            skip_above_max_examples: bool = False,
             drop_remainder: bool = False,
         ) -> Self:
             """Combine examples of similar shape into batches."""
@@ -479,16 +481,32 @@ class FileMapperOutput(TypedDict):
 
 
 def create_bucket_sizes(
-    max_num_elements: int, max_seq_len: int, min_seq_len: int = 1
+    *,
+    max_num_elements: int,
+    max_seq_len: int,
+    min_seq_len: int = 1,
+    num_seqs_multiple_of: int = 1,
 ) -> List[Tuple[int, int]]:
-    """Create optimal bucket sizes for ``max_num_elements`` with ``max_seq_len``.
+    """Create optimal bucket sizes for :meth:`DataPipeline.bucket_by_length`.
 
-    This is a convenience function that can be used with the
-    :meth:`DataPipeline.bucket_by_length` operator.
+    :param max_num_elements:
+        The maximum number of elements that each bucket can contain.
+    :param max_seq_len:
+        The maximum allowed sequence length.
+    :param min_seq_len:
+        The minimum allowed sequence length.
+    :param num_seqs_multiple_of:
+        The number of sequences contained in each bucket must be a multiple of
+        this value.
     """
-    if max_num_elements < max_seq_len:
+    if max_seq_len > max_num_elements:
         raise ValueError(
             f"`max_seq_len` must be less than or equal to `max_num_elements` ({max_num_elements}), but is {max_seq_len} instead."
+        )
+
+    if min_seq_len < 1:
+        raise ValueError(
+            f"`min_seq_len` must be greater than zero, but is {min_seq_len} instead."
         )
 
     if min_seq_len > max_seq_len:
@@ -496,17 +514,38 @@ def create_bucket_sizes(
             f"`min_seq_len` must be less than or equal to `max_seq_len` ({max_seq_len}), but is {min_seq_len} instead."
         )
 
+    if num_seqs_multiple_of < 1:
+        raise ValueError(
+            f"`num_seqs_multiple_of` must be greater than or equal to 1, but is {num_seqs_multiple_of} instead."
+        )
+
+    if max_num_elements % (max_seq_len * num_seqs_multiple_of) != 0:
+        raise ValueError(
+            f"`max_num_elements` must be equal to a multiple of `max_seq_len` ({max_seq_len}) times `num_seqs_multiple_of` ({num_seqs_multiple_of}), but is {max_num_elements} instead."
+        )
+
     bucket_sizes = []
 
-    seq_len = min_seq_len
+    seq_len = 1
 
-    batch_size = max_num_elements // seq_len
+    bucket_size = max_num_elements // seq_len
 
     while seq_len <= max_seq_len:
-        bucket_sizes.append((batch_size, seq_len))
+        if seq_len >= min_seq_len:
+            bucket_sizes.append((bucket_size, seq_len))
 
-        batch_size = max_num_elements // (seq_len + 1)
+        bucket_size = max_num_elements // (seq_len + 1)
 
-        seq_len = max_num_elements // batch_size
+        seq_len = max_num_elements // bucket_size
 
-    return bucket_sizes
+    if num_seqs_multiple_of == 1:
+        return bucket_sizes
+
+    cropped_bucket_sizes = []
+
+    for bucket_size, seq_len in bucket_sizes:
+        cropped_bucket_sizes.append(
+            (bucket_size - (bucket_size % num_seqs_multiple_of), seq_len)
+        )
+
+    return cropped_bucket_sizes

--- a/src/fairseq2/datasets/asr_dataset.py
+++ b/src/fairseq2/datasets/asr_dataset.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from abc import ABC, abstractmethod
-from typing import List, Literal, Optional, TypeVar, Union
+from typing import List, Optional, TypeVar
 
 from fairseq2.assets import default_asset_store, default_download_manager
 from fairseq2.data.text import TextTokenizer
@@ -35,9 +35,8 @@ class AsrDataset(ABC):
         *,
         dtype: Optional[DataType] = None,
         min_audio_len: int = 1,
-        bucket_by_length: bool = False,
         shuffle_window_size: int = 0,
-        repeat: Union[int, Literal["forever"]] = 1,
+        num_repeats: Optional[int] = 1,
         num_prefetch: int = 0,
         num_accumulate: int = 1,
     ) -> DataReader[Seq2SeqBatch]:
@@ -59,13 +58,11 @@ class AsrDataset(ABC):
         :param min_audio_len:
             The minimum audio length of each example. Examples shorter than
             this value will be dropped.
-        :param bucket_by_length:
-            If ``True``, examples will be bucketed by their length.
         :param shuffle_window_size:
             The size of the streaming shuffle window.
-        :param repeat:
-            The dataset will be repeatedly read this many times. If ``forever``,
-            it will be read indefinitely.
+        :param num_repeats:
+            The dataset will be repeatedly read this many times. If ``None``, it
+            will be read indefinitely.
         :param num_prefetch:
             The number of batches to prefetch in background.
         :param num_accumulate:

--- a/src/fairseq2/datasets/parallel_text_dataset.py
+++ b/src/fairseq2/datasets/parallel_text_dataset.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import List, Literal, NamedTuple, Optional, Sequence, TypeVar, Union
+from typing import List, NamedTuple, Optional, Sequence, TypeVar
 
 from fairseq2.assets import default_asset_store, default_download_manager
 from fairseq2.data.text import TextTokenizer
@@ -47,10 +47,9 @@ class ParallelTextDataset(ABC):
         max_seq_len: int,
         max_num_tokens: int,
         *,
-        bucket_by_length: bool = False,
         sample: bool = False,
         shuffle_window_size: int = 0,
-        repeat: Union[int, Literal["forever"]] = 1,
+        num_repeats: Optional[int] = 1,
         num_prefetch: int = 0,
         num_accumulate: int = 1,
         lang_pairs: Optional[Sequence[LangPair]] = None,
@@ -68,16 +67,14 @@ class ParallelTextDataset(ABC):
             this value will be dropped.
         :param max_num_tokens:
             The maximum number of tokens in each batch.
-        :param bucket_by_length:
-            If ``True``, examples will be bucketed by their length.
         :param sample:
             If ``True``, language pair corpora will be sampled in proportion to
             their size.
         :param shuffle_window_size:
             The size of the streaming shuffle window.
-        :param repeat:
-            The dataset will be repeatedly read this many times. If ``forever``,
-            it will be read indefinitely.
+        :param num_repeats:
+            The dataset will be repeatedly read this many times. If ``None``, it
+            will be read indefinitely.
         :param num_prefetch:
             The number of batches to prefetch in background.
         :param num_accumulate:

--- a/tests/unit/data/data_pipeline/test_bucket_by_length.py
+++ b/tests/unit/data/data_pipeline/test_bucket_by_length.py
@@ -13,3 +13,11 @@ def test_create_bucket_sizes() -> None:
     )
 
     assert bucket_sizes == [(8, 2), (5, 3), (4, 4), (3, 5), (2, 8)]
+
+
+def test_create_bucket_sizes_with_num_seqs_multiple_of() -> None:
+    bucket_sizes = create_bucket_sizes(
+        max_num_elements=16, max_seq_len=8, min_seq_len=2, num_seqs_multiple_of=2
+    )
+
+    assert bucket_sizes == [(8, 2), (4, 3), (4, 4), (2, 5), (2, 8)]


### PR DESCRIPTION
This PR improves the implementation of `bucket_by_length()` op to handle the remainder examples more efficiently by chunking them together. It also adds two new parameters to drop/skip examples that have below the minimum or above the maximum length.