### PR TITLE
Support additional data types in AudioDecoder

### DIFF
--- a/native/src/fairseq2n/data/audio/audio_decoder.cc
+++ b/native/src/fairseq2n/data/audio/audio_decoder.cc
@@ -11,6 +11,7 @@
 #include <stdexcept>
 
 #include <ATen/Functions.h>
+#include <ATen/ScalarType.h>
 #include <ATen/Tensor.h>
 
 #include "fairseq2n/exception.h"
@@ -30,9 +31,10 @@ audio_decoder::audio_decoder(audio_decoder_options opts)
   : opts_{opts}
 {
     at::ScalarType dtype = opts_.maybe_dtype().value_or(at::kFloat);
-    if (dtype != at::kFloat && dtype != at::kInt && dtype != at::kShort)
+
+    if (!at::isFloatingType(dtype) && !at::isIntegralType(dtype, /*includeBool=*/false))
         throw_<not_supported_error>(
-            "`audio_decoder` supports only `torch.float32`, `torch.int32`, and `torch.int16` data types.");
+            "`audio_decoder` supports only integral and floating-point types.");
 }
 
 data
@@ -60,12 +62,24 @@ audio_decoder::operator()(data &&d) const
 
     at::ScalarType dtype = opts_.maybe_dtype().value_or(at::kFloat);
 
+    at::ScalarType decode_dtype{};
+
+    if (at::isFloatingType(dtype))
+        decode_dtype = at::kFloat;
+    else if (dtype == at::kShort)
+        decode_dtype = at::kShort;
+    else if (at::isIntegralType(dtype, /*includeBool=*/false))
+        decode_dtype = at::kInt;
+    else
+        throw_<internal_error>(
+            "`audio_decoder` uses an unsupported data type. Please file a bug report.");
+
     at::Tensor waveform = at::empty({file.num_frames(), file.num_channels()},
-        at::dtype(dtype).device(at::kCPU).pinned_memory(opts_.pin_memory()));
+        at::dtype(decode_dtype).device(at::kCPU).pinned_memory(opts_.pin_memory()));
 
     writable_memory_span waveform_bits = get_raw_mutable_storage(waveform);
 
-    switch (dtype) {
+    switch (decode_dtype) {
     case at::kFloat: {
         span waveform_data = cast<float32>(waveform_bits);
 
@@ -95,10 +109,11 @@ audio_decoder::operator()(data &&d) const
     if (file.num_channels() == 1 && !opts_.keepdim())
         waveform = waveform.squeeze(-1);
 
+    waveform = waveform.to(dtype);
+
     at::Device device = opts_.maybe_device().value_or(at::kCPU);
     if (device != at::kCPU)
         waveform = waveform.to(device);
-
 
     // Pack audio (i.e. waveform), sample_rate, and format as output.
     data_dict output{

--- a/tests/unit/data/audio/test_audio_decoder.py
+++ b/tests/unit/data/audio/test_audio_decoder.py
@@ -12,22 +12,18 @@ import torch
 
 from fairseq2.data.audio import AudioDecoder
 from fairseq2.memory import MemoryBlock
-from fairseq2.typing import DataType
 from tests.common import assert_close, device
 
 TEST_OGG_PATH: Final = Path(__file__).parent.joinpath("test.ogg")
 
 
 class TestAudioDecoder:
-    @pytest.mark.parametrize("dtype", [torch.float16, torch.int64])
-    def test_init_raises_error_when_data_type_is_not_supported(
-        self, dtype: DataType
-    ) -> None:
+    def test_init_raises_error_when_data_type_is_not_supported(self) -> None:
         with pytest.raises(
             ValueError,
-            match=r"^`audio_decoder` supports only `torch.float32`, `torch.int32`, and `torch.int16` data types\.$",
+            match=r"^`audio_decoder` supports only integral and floating-point types\.$",
         ):
-            AudioDecoder(dtype=dtype)
+            AudioDecoder(dtype=torch.bool)
 
     def test_call_works(self) -> None:
         decoder = AudioDecoder(keepdim=True, device=device)


### PR DESCRIPTION
This PR adds support for additional data types to `AudioDecoder` and also extends the channel handling logic in `Wav2Vec2Frontend`.