### PR TITLE
Fix race condition in fairseq2n::map

### DIFF
--- a/native/python/src/fairseq2n/bindings/data/data_pipeline.cc
+++ b/native/python/src/fairseq2n/bindings/data/data_pipeline.cc
@@ -456,7 +456,7 @@ def_data_pipeline(py::module_ &data_module)
 
                 map_fn f = collater(opts, std::move(opt_overrides));
 
-                self = std::move(self).map(std::move(f), num_parallel_calls);
+                self = std::move(self).map(f, num_parallel_calls);
 
                 return self;
             },
@@ -498,7 +498,7 @@ def_data_pipeline(py::module_ &data_module)
 
                 element_mapper mapper{std::move(f), std::move(maybe_selector)};
 
-                self = std::move(self).map(std::move(mapper), num_parallel_calls);
+                self = std::move(self).map(mapper, num_parallel_calls);
 
                 return self;
             },

--- a/native/python/src/fairseq2n/bindings/data/text/text_reader.cc
+++ b/native/python/src/fairseq2n/bindings/data/text/text_reader.cc
@@ -32,6 +32,7 @@ def_text_reader(py::module_ &text_module)
         "read_text",
         [](
             std::filesystem::path path,
+            std::optional<std::string> key,
             std::optional<std::string> maybe_encoding,
             line_ending le,
             bool ltrim,
@@ -49,9 +50,10 @@ def_text_reader(py::module_ &text_module)
                 .memory_map(memory_map)
                 .maybe_block_size(maybe_block_size);
 
-            return read_text(std::move(path), std::move(opts));
+            return read_text(std::move(path), std::move(key), std::move(opts));
         },
         py::arg("path"),
+        py::arg("key")         = std::nullopt,
         py::arg("encoding")    = std::nullopt,
         py::arg("line_ending") = line_ending::infer,
         py::arg("ltrim")       = false,

--- a/native/src/fairseq2n/data/constant_data_source.h
+++ b/native/src/fairseq2n/data/constant_data_source.h
@@ -17,7 +17,7 @@ namespace fairseq2n::detail {
 class constant_data_source final : public data_source {
 public:
     explicit
-    constant_data_source(data &&example, std::optional<std::string> key) noexcept
+    constant_data_source(data &&example, std::optional<std::string> &&key) noexcept
       : example_{std::move(example)}, key_{std::move(key)}
     {}
 

--- a/native/src/fairseq2n/data/count_data_source.h
+++ b/native/src/fairseq2n/data/count_data_source.h
@@ -15,7 +15,8 @@ namespace fairseq2n::detail {
 class count_data_source final : public data_source {
 public:
     explicit
-    count_data_source(std::int64_t start, std::int64_t step, std::optional<std::string> key) noexcept
+    count_data_source(
+        std::int64_t start, std::int64_t step, std::optional<std::string> &&key) noexcept
       : start_{start}, step_{step}, counter_{start}, key_{std::move(key)}
     {}
 

--- a/native/src/fairseq2n/data/data_pipeline.h
+++ b/native/src/fairseq2n/data/data_pipeline.h
@@ -142,7 +142,7 @@ public:
     filter(predicate_fn fn) &&;
 
     data_pipeline_builder
-    map(map_fn fn, std::size_t num_parallel_calls = 1) &&;
+    map(const map_fn &fn, std::size_t num_parallel_calls = 1) &&;
 
     data_pipeline_builder
     prefetch(std::size_t num_examples) &&;

--- a/native/src/fairseq2n/data/map_data_source.cc
+++ b/native/src/fairseq2n/data/map_data_source.cc
@@ -15,8 +15,10 @@
 namespace fairseq2n::detail {
 
 map_data_source::map_data_source(
-    std::unique_ptr<data_source> &&inner, map_fn &&fn, std::size_t num_parallel_calls)
-  : inner_{std::move(inner)}, map_fn_{std::move(fn)}, num_parallel_calls_{num_parallel_calls}
+    std::unique_ptr<data_source> &&inner, std::vector<map_fn> &&fns, std::size_t num_parallel_calls)
+  : inner_{std::move(inner)},
+    map_fns_{std::move(fns)},
+    num_parallel_calls_{num_parallel_calls}
 {
     buffer_.reserve(num_parallel_calls);
 
@@ -28,7 +30,7 @@ map_data_source::next()
 {
     if (num_parallel_calls_ <= 1) {
         while (std::optional<data> maybe_example = inner_->next()) {
-            maybe_example = invoke_function(*std::move(maybe_example));
+            maybe_example = invoke_function(*std::move(maybe_example), 0);
             if (maybe_example)
                 return maybe_example;
         }
@@ -104,7 +106,7 @@ map_data_source::fill_buffer()
     auto apply_function = [this](std::size_t begin, std::size_t end)
     {
         for (auto i = begin; i < end; ++i)
-            buffer_[i] = invoke_function(*std::move(buffer_[i]));
+            buffer_[i] = invoke_function(*std::move(buffer_[i]), i);
     };
 
     // Avoid threading overhead if we have just one example.
@@ -119,10 +121,10 @@ map_data_source::fill_buffer()
 }
 
 std::optional<data>
-map_data_source::invoke_function(data &&example)
+map_data_source::invoke_function(data &&example, std::size_t fn_idx)
 {
     try {
-        return map_fn_(std::move(example));
+        return map_fns_[fn_idx](std::move(example));
     } catch (const data_pipeline_error &) {
         throw;
     } catch (const std::exception &) {

--- a/native/src/fairseq2n/data/map_data_source.h
+++ b/native/src/fairseq2n/data/map_data_source.h
@@ -21,7 +21,9 @@ class map_data_source final : public data_source {
 public:
     explicit
     map_data_source(
-        std::unique_ptr<data_source> &&inner, map_fn &&fn, std::size_t num_parallel_calls);
+        std::unique_ptr<data_source> &&inner,
+        std::vector<map_fn> &&fns,
+        std::size_t num_parallel_calls);
 
     std::optional<data>
     next() override;
@@ -43,11 +45,11 @@ private:
     fill_buffer();
 
     std::optional<data>
-    invoke_function(data &&example);
+    invoke_function(data &&example, std::size_t fn_idx);
 
 private:
     std::unique_ptr<data_source> inner_;
-    map_fn map_fn_;
+    std::vector<map_fn> map_fns_;
     std::size_t num_parallel_calls_;
     std::vector<std::optional<data>> buffer_{};
     std::vector<std::optional<data>>::iterator buffer_pos_{};

--- a/native/src/fairseq2n/data/text/text_data_source.cc
+++ b/native/src/fairseq2n/data/text/text_data_source.cc
@@ -22,8 +22,9 @@
 
 namespace fairseq2n::detail {
 
-text_data_source::text_data_source(std::filesystem::path &&path, text_options &&opts)
-  : path_{std::move(path)}, opts_{std::move(opts)}
+text_data_source::text_data_source(
+    std::filesystem::path &&path, std::optional<std::string> &&key, text_options &&opts)
+  : path_{std::move(path)}, key_{std::move(key)}, opts_{std::move(opts)}
 {
     try {
         line_reader_ = make_text_line_reader();
@@ -53,6 +54,9 @@ text_data_source::next()
 
     if (opts_.rtrim())
         output = rtrim(output);
+
+    if (key_)
+        return data_dict{{*key_, std::move(output)}};
 
     return output;
 }

--- a/native/src/fairseq2n/data/text/text_data_source.h
+++ b/native/src/fairseq2n/data/text/text_data_source.h
@@ -9,6 +9,7 @@
 #include <cstddef>
 #include <filesystem>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 
@@ -23,7 +24,8 @@ namespace fairseq2n::detail {
 class text_data_source final : public data_source {
 public:
     explicit
-    text_data_source(std::filesystem::path &&path, text_options &&opts);
+    text_data_source(
+        std::filesystem::path &&path, std::optional<std::string> &&key, text_options &&opts);
 
     std::optional<data>
     next() override;
@@ -58,6 +60,7 @@ private:
 
 private:
     std::filesystem::path path_;
+    std::optional<std::string> key_;
     text_options opts_;
     std::unique_ptr<text_line_reader> line_reader_;
     std::size_t num_lines_read_ = 0;

--- a/native/src/fairseq2n/data/text/text_reader.cc
+++ b/native/src/fairseq2n/data/text/text_reader.cc
@@ -16,11 +16,11 @@ using namespace fairseq2n::detail;
 namespace fairseq2n {
 
 data_pipeline_builder
-read_text(std::filesystem::path path, text_options opts)
+read_text(std::filesystem::path path, std::optional<std::string> key, text_options opts)
 {
-    auto factory = [path = std::move(path), opts = std::move(opts)]() mutable
+    auto factory = [path = std::move(path), key = std::move(key), opts = std::move(opts)]() mutable
     {
-        return std::make_unique<text_data_source>(std::move(path), std::move(opts));
+        return std::make_unique<text_data_source>(std::move(path), std::move(key), std::move(opts));
     };
 
     return data_pipeline_builder{std::move(factory)};

--- a/native/src/fairseq2n/data/text/text_reader.h
+++ b/native/src/fairseq2n/data/text/text_reader.h
@@ -135,6 +135,6 @@ private:
 class data_pipeline_builder;
 
 FAIRSEQ2_API data_pipeline_builder
-read_text(std::filesystem::path path, text_options opts = {});
+read_text(std::filesystem::path path, std::optional<std::string> key = {}, text_options opts = {});
 
 }  // namespace fairseq2n

--- a/native/src/fairseq2n/data/zip_data_source.cc
+++ b/native/src/fairseq2n/data/zip_data_source.cc
@@ -135,7 +135,7 @@ zip_data_source::flatten_to_dict(data_list &zip)
             }
         else
             throw_data_pipeline_error(std::nullopt, /*recoverable=*/true,
-                "The zipped data pipelines must all return only dicts, or only non-dicts when `flatten` is set.");
+                "The zipped data pipelines must all return only dicts or only non-dicts when `flatten` is set.");
     }
 
     return output;
@@ -151,7 +151,7 @@ zip_data_source::flatten_to_list(data_list &zip)
         // expect all other pipelines to return non-dicts as well.
         if (example.is_dict())
             throw_data_pipeline_error(std::nullopt, /*recoverable=*/true,
-                "The zipped data pipelines must all return only dicts, or only non-dicts when `flatten` is set.");
+                "The zipped data pipelines must all return only dicts or only non-dicts when `flatten` is set.");
 
         if (example.is_list())
             for (data &element : example.as_list())

--- a/src/fairseq2/data/text/text_reader.py
+++ b/src/fairseq2/data/text/text_reader.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING or DOC_MODE:
 
     def read_text(
         path: Path,
+        key: Optional[str] = None,
         encoding: Optional[str] = None,
         line_ending: LineEnding = LineEnding.INFER,
         ltrim: bool = False,

--- a/tests/unit/data/data_pipeline/test_map.py
+++ b/tests/unit/data/data_pipeline/test_map.py
@@ -15,7 +15,7 @@ from fairseq2.data.text.converters import StrToIntConverter
 
 
 class TestMapOp:
-    @pytest.mark.parametrize("num_parallel_calls", [0, 1, 4, 10, 20])
+    @pytest.mark.parametrize("num_parallel_calls", [1, 4, 10, 20])
     def test_op_works(self, num_parallel_calls: int) -> None:
         def fn(d: int) -> int:
             return d**2
@@ -282,7 +282,7 @@ class TestMapOp:
 
         assert str(cause) == "The input data does not have an element at path '[1].foo1'."  # fmt: skip
 
-    @pytest.mark.parametrize("num_parallel_calls", [0, 1, 4, 20])
+    @pytest.mark.parametrize("num_parallel_calls", [1, 4, 20])
     def test_op_raises_nested_error_when_callable_fails(
         self, num_parallel_calls: int
     ) -> None:
@@ -304,7 +304,7 @@ class TestMapOp:
 
         assert str(cause) == "map error"
 
-    @pytest.mark.parametrize("num_parallel_calls", [0, 1, 4, 20])
+    @pytest.mark.parametrize("num_parallel_calls", [1, 4, 20])
     def test_op_saves_and_restores_its_state(self, num_parallel_calls: int) -> None:
         def fn(d: int) -> int:
             return d

--- a/tests/unit/data/data_pipeline/test_zip.py
+++ b/tests/unit/data/data_pipeline/test_zip.py
@@ -185,7 +185,7 @@ class TestZipOp:
 
         with pytest.raises(
             DataPipelineError,
-            match=r"^The zipped data pipelines must all return only dicts, or only non-dicts when `flatten` is set\.$",
+            match=r"^The zipped data pipelines must all return only dicts or only non-dicts when `flatten` is set\.$",
         ):
             next(iter(pipeline))
 
@@ -196,7 +196,7 @@ class TestZipOp:
 
         with pytest.raises(
             DataPipelineError,
-            match=r"^The zipped data pipelines must all return only dicts, or only non-dicts when `flatten` is set\.$",
+            match=r"^The zipped data pipelines must all return only dicts or only non-dicts when `flatten` is set\.$",
         ):
             next(iter(pipeline))
 


### PR DESCRIPTION
This PR fixes a race condition in `map` function that is introduced with the introduction of multithreaded `element_mapper`. Also adds a new `key` parameter the `read_text` function.