### PR TITLE
Add CI support for PyTorch 2.2.2

### DIFF
--- a/.github/workflows/_build_doc.yaml
+++ b/.github/workflows/_build_doc.yaml
@@ -9,7 +9,7 @@ on:
     inputs:
       torch:
         type: string
-        default: '2.2.1'
+        default: '2.2.2'
       py:
         type: string
         default: '3.11'

--- a/.github/workflows/_build_wheel-macos.yaml
+++ b/.github/workflows/_build_wheel-macos.yaml
@@ -83,7 +83,7 @@ jobs:
       - name: Upload wheels and native tests to staging
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ inputs.artifacts_name }}-pt${{ inputs.torch }}-py${{ inputs.py }}-macos_${{ inputs.arch }}-cpu
+          name: ${{ inputs.artifacts_name }}-pt${{ inputs.torch }}-py${{ inputs.py }}-macos_${{ inputs.arch }}-cpu-nosan
           path: |
             build/wheelhouse/*.whl
             native/build/tests/run-tests
@@ -104,7 +104,7 @@ jobs:
       - name: Download wheels and native tests from staging
         uses: actions/download-artifact@v3
         with:
-          name: ${{ inputs.artifacts_name }}-pt${{ inputs.torch }}-py${{ inputs.py }}-macos_${{ inputs.arch }}-cpu
+          name: ${{ inputs.artifacts_name }}-pt${{ inputs.torch }}-py${{ inputs.py }}-macos_${{ inputs.arch }}-cpu-nosan
           path: ~/artifacts/
       - name: Check-out the repository
         uses: actions/checkout@v3

--- a/.github/workflows/_build_wheels.yaml
+++ b/.github/workflows/_build_wheels.yaml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        torch: ['2.0.1']
+        torch: ['2.0.0', '2.0.1']
         py: ['3.8', '3.9', '3.10', '3.11']
         variant: ['cpu', 'cu117', 'cu118']
         sanitizers: ['nosan']
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        torch: ['2.1.2']
+        torch: ['2.1.0', '2.1.1', '2.1.2']
         py: ['3.8', '3.9', '3.10', '3.11']
         variant: ['cpu', 'cu118', 'cu121']
         sanitizers: ['nosan']
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        torch: ['2.2.0', '2.2.1']
+        torch: ['2.2.0', '2.2.1', '2.2.2']
         py: ['3.8', '3.9', '3.10', '3.11']
         variant: ['cpu', 'cu118', 'cu121']
         sanitizers: ['nosan']
@@ -63,14 +63,14 @@ jobs:
           - run_integration_tests: false
 
           # Integration Tests
-          - torch: '2.2.1'
+          - torch: '2.2.2'
             py: '3.11'
             variant: 'cpu'
             sanitizers: 'nosan'
             run_integration_tests: true
 
           # ASAN/UBSAN
-          - torch: '2.2.1'
+          - torch: '2.2.2'
             py: '3.11'
             variant: 'cpu'
             sanitizers: 'asan_ubsan'
@@ -83,6 +83,19 @@ jobs:
       version_override: ${{ inputs.version_override }}
       run_integration_tests: ${{ matrix.run_integration_tests }}
 
+  build_pt22_wheel-macos:
+    name: Build wheels (pt${{ matrix.torch }}, py${{ matrix.py }}, macos-arm64)
+    uses: ./.github/workflows/_build_wheel-macos.yaml
+    strategy:
+      fail-fast: false
+      matrix:
+        torch: ['2.2.0', '2.2.1', '2.2.2']
+        py: ['3.8', '3.9', '3.10', '3.11']
+    with:
+      torch: ${{ matrix.torch }}
+      py: ${{ matrix.py }}
+      version_override: ${{ inputs.version_override }}
+
   build_pypi_wheel-linux:
     name: Build wheels for PyPI (pt${{ matrix.torch }}, py${{ matrix.py }}, linux-x86_64, ${{ matrix.variant }})
     uses: ./.github/workflows/_build_wheel-linux.yaml
@@ -90,7 +103,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        torch: ['2.2.1']
+        torch: ['2.2.2']
         py: ['3.8', '3.9', '3.10', '3.11']
         variant: ['cu121']
     with:
@@ -108,7 +121,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        torch: ['2.2.1']
+        torch: ['2.2.2']
         py: ['3.8', '3.9', '3.10', '3.11']
     with:
       torch: ${{ matrix.torch }}

--- a/.github/workflows/_lint_cc.yaml
+++ b/.github/workflows/_lint_cc.yaml
@@ -9,7 +9,7 @@ on:
     inputs:
       torch:
         type: string
-        default: '2.2.1'
+        default: '2.2.2'
       py:
         type: string
         default: '3.11'

--- a/.github/workflows/_lint_py.yaml
+++ b/.github/workflows/_lint_py.yaml
@@ -9,7 +9,7 @@ on:
     inputs:
       torch:
         type: string
-        default: '2.2.1'
+        default: '2.2.2'
       py:
         type: string
         default: '3.11'

--- a/.github/workflows/_publish.yaml
+++ b/.github/workflows/_publish.yaml
@@ -16,7 +16,7 @@ jobs:
     name: Publish to S3 (pt${{ matrix.torch }}, py${{ matrix.py }}, linux-x86_64, ${{ matrix.variant }})
     strategy:
       matrix:
-        torch: ['2.0.1']
+        torch: ['2.0.0', '2.0.1']
         py: ['3.8', '3.9', '3.10', '3.11']
         variant: ['cpu', 'cu117', 'cu118']
       max-parallel: 1
@@ -32,7 +32,7 @@ jobs:
     name: Publish to S3 (pt${{ matrix.torch }}, py${{ matrix.py }}, linux-x86_64, ${{ matrix.variant }})
     strategy:
       matrix:
-        torch: ['2.1.2']
+        torch: ['2.1.0', '2.1.1', '2.1.2']
         py: ['3.8', '3.9', '3.10', '3.11']
         variant: ['cpu', 'cu118', 'cu121']
       max-parallel: 1
@@ -48,7 +48,7 @@ jobs:
     name: Publish to S3 (pt${{ matrix.torch }}, py${{ matrix.py }}, linux-x86_64, ${{ matrix.variant }})
     strategy:
       matrix:
-        torch: ['2.2.0', '2.2.1']
+        torch: ['2.2.0', '2.2.1', '2.2.2']
         py: ['3.8', '3.9', '3.10', '3.11']
         variant: ['cpu', 'cu118', 'cu121']
       max-parallel: 1
@@ -60,17 +60,33 @@ jobs:
       variant: ${{ matrix.variant }}
       release_type: ${{ inputs.release_type }}
 
+  publish_pt22_s3-macos:
+    name: Publish to S3 (pt${{ matrix.torch }}, py${{ matrix.py }}, macos-arm64)
+    strategy:
+      matrix:
+        torch: ['2.2.0', '2.2.1', '2.2.2']
+        py: ['3.8', '3.9', '3.10', '3.11']
+      max-parallel: 1
+    uses: ./.github/workflows/_publish_s3.yaml
+    with:
+      os: 'macos'
+      torch: ${{ matrix.torch }}
+      py: ${{ matrix.py }}
+      release_type: ${{ inputs.release_type }}
+      arch: 'arm64'
+
   publish_pypi-linux:
     name: Publish to PyPI (pt${{ matrix.torch }}, py${{ matrix.py }}, linux-x86_64, ${{ matrix.variant }})
     needs:
       - publish_pt20_s3-linux
       - publish_pt21_s3-linux
       - publish_pt22_s3-linux
+      - publish_pt22_s3-macos
     if: inputs.release_type == 'stable'
     uses: ./.github/workflows/_publish_pypi.yaml
     strategy:
       matrix:
-        torch: ['2.2.1']
+        torch: ['2.2.2']
         py: ['3.8', '3.9', '3.10', '3.11']
         variant: ['cu121']
       max-parallel: 1
@@ -88,7 +104,7 @@ jobs:
     uses: ./.github/workflows/_publish_pypi.yaml
     strategy:
       matrix:
-        torch: ['2.2.1']
+        torch: ['2.2.2']
         py: ['3.8', '3.9', '3.10', '3.11']
       max-parallel: 1
     with:

--- a/.github/workflows/ci_build_wheels.yaml
+++ b/.github/workflows/ci_build_wheels.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        torch: ['2.2.1']
+        torch: ['2.2.2']
         py: ['3.11']
         variant: ['cpu', 'cu118', 'cu121']
         sanitizers: ['nosan']
@@ -28,21 +28,21 @@ jobs:
           - run_integration_tests: false
 
           # Integration Tests
-          - torch: '2.2.1'
+          - torch: '2.2.2'
             py: '3.11'
             variant: 'cpu'
             sanitizers: 'nosan'
             run_integration_tests: true
 
           # ASAN/UBSAN
-          - torch: '2.2.1'
+          - torch: '2.2.2'
             py: '3.11'
             variant: 'cpu'
             sanitizers: 'asan_ubsan'
             run_integration_tests: false
 
           # Lowest Supported Version
-          - torch: '2.0.1'
+          - torch: '2.0.0'
             py: '3.8'
             variant: 'cpu'
             sanitizers: 'nosan'
@@ -61,11 +61,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - torch: '2.2.1'
+          - torch: '2.2.2'
             py: '3.11'
 
           # Lowest Supported Version
-          - torch: '2.0.1'
+          - torch: '2.0.0'
             py: '3.8'
     with:
       torch: ${{ matrix.torch }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,11 +14,11 @@ fairseq2n is not available as a pre-built package for your system, please follow
 the installation instructions [here](INSTALL_FROM_SOURCE.md).
 
 For an editable installation, first, install a nightly build of fairseq2n (shown
-for PyTorch `2.2.1` and variant `cu118`):
+for PyTorch `2.2.2` and variant `cu118`):
 
 ```sh
 pip install fairseq2n\
-  --pre --upgrade --extra-index-url https://fair.pkg.atmeta.com/fairseq2/whl/nightly/pt2.2.1/cu118
+  --pre --upgrade --extra-index-url https://fair.pkg.atmeta.com/fairseq2/whl/nightly/pt2.2.2/cu118
 ```
 
 > [!WARNING]

--- a/README.md
+++ b/README.md
@@ -107,19 +107,19 @@ matrix shows the supported combinations.
   <tbody>
     <tr>
       <td rowspan=3><code>HEAD</code></td>
-      <td><code>2.2.0</code>, <code>2.2.1</code></td>
+      <td><code>2.2.0</code>, <code>2.2.1</code>, <code>2.2.2</code></td>
       <td><code>&gt;=3.8</code>, <code>&lt;=3.11</code></td>
       <td><code>cpu</code>, <code>cu118</code>, <code>cu121</code></td>
       <td><code>x86_64</code></td>
     </tr>
     <tr>
-      <td><code>2.1.2</code></td>
+      <td><code>2.1.0</code>, <code>2.1.1</code>, <code>2.1.2</code></td>
       <td><code>&gt;=3.8</code>, <code>&lt;=3.11</code></td>
       <td><code>cpu</code>, <code>cu118</code>, <code>cu121</code></td>
       <td><code>x86_64</code></td>
     </tr>
     <tr>
-      <td><code>2.0.1</code></td>
+      <td><code>2.0.0</code>, <code>2.0.1</code></td>
       <td><code>&gt;=3.8</code>, <code>&lt;=3.11</code></td>
       <td><code>cpu</code>, <code>cu117</code>, <code>cu118</code></td>
       <td><code>x86_64</code></td>
@@ -150,12 +150,12 @@ matrix shows the supported combinations.
 
 To install a specific combination, first follow the installation instructions on
 [pytorch.org](https://pytorch.org/get-started/locally) for the desired PyTorch
-version, and then use the following command (shown for PyTorch `2.2.1` and
+version, and then use the following command (shown for PyTorch `2.2.2` and
 variant `cu118`):
 
 ```sh
 pip install fairseq2\
-  --extra-index-url https://fair.pkg.atmeta.com/fairseq2/whl/pt2.2.1/cu118
+  --extra-index-url https://fair.pkg.atmeta.com/fairseq2/whl/pt2.2.2/cu118
 ```
 
 
@@ -171,12 +171,12 @@ pip install fairseq2\
 For Linux, we also host nightly builds on FAIR's package repository. The
 supported variants are identical to the ones listed in *Variants* above. Once
 you have installed the desired PyTorch version, you can use the following
-command to install the corresponding nightly package  (shown for PyTorch `2.2.1`
+command to install the corresponding nightly package  (shown for PyTorch `2.2.2`
 and variant `cu118`):
 
 ```sh
 pip install fairseq2\
-  --pre --extra-index-url https://fair.pkg.atmeta.com/fairseq2/whl/nightly/pt2.2.1/cu118
+  --pre --extra-index-url https://fair.pkg.atmeta.com/fairseq2/whl/nightly/pt2.2.2/cu118
 ```
 
 


### PR DESCRIPTION
This PR adds support for PyTorch 2.2.2 in GitHub Actions and also starts building nightlies for macOS.