### PR TITLE
Add strict parameter to DataPipeline.state_dict()

### DIFF
--- a/native/python/src/fairseq2n/bindings/data/data_pipeline.cc
+++ b/native/python/src/fairseq2n/bindings/data/data_pipeline.cc
@@ -226,18 +226,19 @@ def_data_pipeline(py::module_ &data_module)
         // state_dict
         .def(
             "state_dict",
-            [](const data_pipeline &self)
+            [](const data_pipeline &self, bool strict)
             {
                 tape t{};
 
                 {
                     py::gil_scoped_release no_gil{};
 
-                    self.record_position(t);
+                    self.record_position(t, strict);
                 }
 
                 return py::dict{py::arg("position") = py::cast(t.storage())};
-            })
+            },
+            py::arg("strict") = true)
         .def(
             "load_state_dict",
             [](data_pipeline &self, const py::dict &state_dict)
@@ -543,15 +544,13 @@ def_data_pipeline(py::module_ &data_module)
             [](
                 data_pipeline_builder &self,
                 std::size_t shuffle_window,
-                bool strict,
                 bool enabled) -> data_pipeline_builder &
             {
-                self = std::move(self).shuffle(shuffle_window, strict, enabled);
+                self = std::move(self).shuffle(shuffle_window, enabled);
 
                 return self;
             },
             py::arg("shuffle_window"),
-            py::arg("strict") = true,
             py::arg("enabled") = true)
         .def(
             "skip",

--- a/native/src/fairseq2n/data/bucket_by_length_data_source.cc
+++ b/native/src/fairseq2n/data/bucket_by_length_data_source.cc
@@ -143,19 +143,19 @@ bucket_by_length_data_source::reset()
 }
 
 void
-bucket_by_length_data_source::record_position(tape &t) const
+bucket_by_length_data_source::record_position(tape &t, bool strict) const
 {
     t.record(buckets_);
 
-    inner_->record_position(t);
+    inner_->record_position(t, strict);
 }
 
 void
-bucket_by_length_data_source::reload_position(tape &t)
+bucket_by_length_data_source::reload_position(tape &t, bool strict)
 {
     buckets_ = t.read<std::vector<data_list>>();
 
-    inner_->reload_position(t);
+    inner_->reload_position(t, strict);
 }
 
 bool

--- a/native/src/fairseq2n/data/bucket_by_length_data_source.h
+++ b/native/src/fairseq2n/data/bucket_by_length_data_source.h
@@ -36,10 +36,10 @@ public:
     reset() override;
 
     void
-    record_position(tape &t) const override;
+    record_position(tape &t, bool strict) const override;
 
     void
-    reload_position(tape &t) override;
+    reload_position(tape &t, bool strict) override;
 
     bool
     is_infinite() const noexcept override;

--- a/native/src/fairseq2n/data/bucket_data_source.cc
+++ b/native/src/fairseq2n/data/bucket_data_source.cc
@@ -46,15 +46,15 @@ bucket_data_source::reset()
 }
 
 void
-bucket_data_source::record_position(tape &t) const
+bucket_data_source::record_position(tape &t, bool strict) const
 {
-    inner_->record_position(t);
+    inner_->record_position(t, strict);
 }
 
 void
-bucket_data_source::reload_position(tape &t)
+bucket_data_source::reload_position(tape &t, bool strict)
 {
-    inner_->reload_position(t);
+    inner_->reload_position(t, strict);
 }
 
 bool

--- a/native/src/fairseq2n/data/bucket_data_source.h
+++ b/native/src/fairseq2n/data/bucket_data_source.h
@@ -29,10 +29,10 @@ public:
     reset() override;
 
     void
-    record_position(tape &t) const override;
+    record_position(tape &t, bool strict) const override;
 
     void
-    reload_position(tape &t) override;
+    reload_position(tape &t, bool strict) override;
 
     bool
     is_infinite() const noexcept override;

--- a/native/src/fairseq2n/data/concat_data_source.cc
+++ b/native/src/fairseq2n/data/concat_data_source.cc
@@ -37,13 +37,13 @@ void concat_data_source::reset()
         pipeline.reset();
 }
 
-void concat_data_source::record_position(tape &t) const
+void concat_data_source::record_position(tape &t, bool strict) const
 {
     for (const data_pipeline &pipeline : pipelines_)
-        pipeline.record_position(t);
+        pipeline.record_position(t, strict);
 }
 
-void concat_data_source::reload_position(tape &t)
+void concat_data_source::reload_position(tape &t, bool)
 {
     for (data_pipeline &pipeline : pipelines_)
         pipeline.reload_position(t);

--- a/native/src/fairseq2n/data/concat_data_source.h
+++ b/native/src/fairseq2n/data/concat_data_source.h
@@ -26,10 +26,10 @@ public:
     reset() override;
 
     void
-    record_position(tape &t) const override;
+    record_position(tape &t, bool strict) const override;
 
     void
-    reload_position(tape &t) override;
+    reload_position(tape &t, bool strict) override;
 
     bool
     is_infinite() const noexcept override;

--- a/native/src/fairseq2n/data/constant_data_source.cc
+++ b/native/src/fairseq2n/data/constant_data_source.cc
@@ -24,11 +24,11 @@ constant_data_source::reset()
 {}
 
 void
-constant_data_source::record_position(tape &) const
+constant_data_source::record_position(tape &, bool) const
 {}
 
 void
-constant_data_source::reload_position(tape &)
+constant_data_source::reload_position(tape &, bool)
 {}
 
 bool

--- a/native/src/fairseq2n/data/constant_data_source.h
+++ b/native/src/fairseq2n/data/constant_data_source.h
@@ -28,10 +28,10 @@ public:
     reset() override;
 
     void
-    record_position(tape &t) const override;
+    record_position(tape &t, bool strict) const override;
 
     void
-    reload_position(tape &t) override;
+    reload_position(tape &t, bool strict) override;
 
     bool
     is_infinite() const noexcept override;

--- a/native/src/fairseq2n/data/count_data_source.cc
+++ b/native/src/fairseq2n/data/count_data_source.cc
@@ -30,13 +30,13 @@ count_data_source::reset()
 }
 
 void
-count_data_source::record_position(tape &t) const
+count_data_source::record_position(tape &t, bool) const
 {
     t.record(counter_);
 }
 
 void
-count_data_source::reload_position(tape &t)
+count_data_source::reload_position(tape &t, bool)
 {
     counter_ = t.read<std::int64_t>();
 }

--- a/native/src/fairseq2n/data/count_data_source.h
+++ b/native/src/fairseq2n/data/count_data_source.h
@@ -27,10 +27,10 @@ public:
     reset() override;
 
     void
-    record_position(tape &t) const override;
+    record_position(tape &t, bool strict) const override;
 
     void
-    reload_position(tape &t) override;
+    reload_position(tape &t, bool strict) override;
 
     bool
     is_infinite() const noexcept override;

--- a/native/src/fairseq2n/data/data_pipeline.cc
+++ b/native/src/fairseq2n/data/data_pipeline.cc
@@ -94,7 +94,7 @@ data_pipeline::reset()
 }
 
 void
-data_pipeline::record_position(tape &t) const
+data_pipeline::record_position(tape &t, bool strict) const
 {
     check_if_broken();
 
@@ -104,8 +104,10 @@ data_pipeline::record_position(tape &t) const
         if (!source_)
             return;
 
+        t.record(strict);
+
         try {
-            source_->record_position(t);
+            source_->record_position(t, strict);
         } catch (const std::exception &) {
             is_broken_ = true;
 
@@ -126,8 +128,10 @@ data_pipeline::reload_position(tape &t)
         if (!source_)
             return;
 
+        bool strict = t.read<bool>();
+
         try {
-            source_->reload_position(t);
+            source_->reload_position(t, strict);
         } catch (const std::exception &) {
             is_broken_ = true;
 
@@ -454,12 +458,12 @@ data_pipeline_builder::shard(std::size_t shard_idx, std::size_t num_shards) &&
 }
 
 data_pipeline_builder
-data_pipeline_builder::shuffle(std::size_t shuffle_window, bool strict, bool enabled) &&
+data_pipeline_builder::shuffle(std::size_t shuffle_window, bool enabled) &&
 {
     if (enabled)
         factory_ = [=, inner = std::move(factory_)]
         {
-            return std::make_unique<shuffle_data_source>(inner(), shuffle_window, strict);
+            return std::make_unique<shuffle_data_source>(inner(), shuffle_window);
         };
 
     return std::move(*this);

--- a/native/src/fairseq2n/data/data_pipeline.h
+++ b/native/src/fairseq2n/data/data_pipeline.h
@@ -47,7 +47,7 @@ public:
     reset();
 
     void
-    record_position(tape &t) const;
+    record_position(tape &t, bool strict) const;
 
     void
     reload_position(tape &t);
@@ -154,7 +154,7 @@ public:
     shard(std::size_t shard_idx, std::size_t num_shards) &&;
 
     data_pipeline_builder
-    shuffle(std::size_t shuffle_window, bool strict, bool enabled = true) &&;
+    shuffle(std::size_t shuffle_window, bool enabled = true) &&;
 
     data_pipeline_builder
     skip(std::size_t num_examples) &&;

--- a/native/src/fairseq2n/data/data_source.h
+++ b/native/src/fairseq2n/data/data_source.h
@@ -35,10 +35,10 @@ public:
     reset() = 0;
 
     virtual void
-    record_position(tape &t) const = 0;
+    record_position(tape &t, bool strict) const = 0;
 
     virtual void
-    reload_position(tape &t) = 0;
+    reload_position(tape &t, bool strict) = 0;
 
     virtual bool
     is_infinite() const noexcept = 0;

--- a/native/src/fairseq2n/data/filter_data_source.cc
+++ b/native/src/fairseq2n/data/filter_data_source.cc
@@ -29,15 +29,15 @@ filter_data_source::reset()
 }
 
 void
-filter_data_source::record_position(tape &t) const
+filter_data_source::record_position(tape &t, bool strict) const
 {
-    inner_->record_position(t);
+    inner_->record_position(t, strict);
 }
 
 void
-filter_data_source::reload_position(tape &t)
+filter_data_source::reload_position(tape &t, bool strict)
 {
-    inner_->reload_position(t);
+    inner_->reload_position(t, strict);
 }
 
 bool

--- a/native/src/fairseq2n/data/filter_data_source.h
+++ b/native/src/fairseq2n/data/filter_data_source.h
@@ -28,10 +28,10 @@ public :
     reset() override;
 
     void
-    record_position(tape &t) const override;
+    record_position(tape &t, bool strict) const override;
 
     void
-    reload_position(tape &t) override;
+    reload_position(tape &t, bool strict) override;
 
     bool
     is_infinite() const noexcept override;

--- a/native/src/fairseq2n/data/list_data_source.cc
+++ b/native/src/fairseq2n/data/list_data_source.cc
@@ -26,13 +26,13 @@ list_data_source::reset()
 }
 
 void
-list_data_source::record_position(tape &t) const
+list_data_source::record_position(tape &t, bool) const
 {
     t.record(pos_ - list_.begin());
 }
 
 void
-list_data_source::reload_position(tape &t)
+list_data_source::reload_position(tape &t, bool)
 {
     pos_ = list_.begin() + t.read<std::ptrdiff_t>();
 }

--- a/native/src/fairseq2n/data/list_data_source.h
+++ b/native/src/fairseq2n/data/list_data_source.h
@@ -27,10 +27,10 @@ public:
     reset() override;
 
     void
-    record_position(tape &t) const override;
+    record_position(tape &t, bool strict) const override;
 
     void
-    reload_position(tape &t) override;
+    reload_position(tape &t, bool strict) override;
 
     bool
     is_infinite() const noexcept override;

--- a/native/src/fairseq2n/data/map_data_source.cc
+++ b/native/src/fairseq2n/data/map_data_source.cc
@@ -61,23 +61,31 @@ map_data_source::reset()
 }
 
 void
-map_data_source::record_position(tape &t) const
+map_data_source::record_position(tape &t, bool strict) const
 {
-    t.record(buffer_);
+    if (strict) {
+        t.record(buffer_);
 
-    t.record(buffer_pos_ - buffer_.begin());
+        t.record(buffer_pos_ - buffer_.begin());
+    }
 
-    inner_->record_position(t);
+    inner_->record_position(t, strict);
 }
 
 void
-map_data_source::reload_position(tape &t)
+map_data_source::reload_position(tape &t, bool strict)
 {
-    buffer_ = t.read<std::vector<std::optional<data>>>();
+    if (strict) {
+        buffer_ = t.read<std::vector<std::optional<data>>>();
 
-    buffer_pos_ = buffer_.begin() + t.read<std::ptrdiff_t>();
+        buffer_pos_ = buffer_.begin() + t.read<std::ptrdiff_t>();
+    } else {
+        buffer_.clear();
 
-    inner_->reload_position(t);
+        buffer_pos_ = buffer_.begin();
+    }
+
+    inner_->reload_position(t, strict);
 }
 
 bool

--- a/native/src/fairseq2n/data/map_data_source.h
+++ b/native/src/fairseq2n/data/map_data_source.h
@@ -32,10 +32,10 @@ public:
     reset() override;
 
     void
-    record_position(tape &t) const override;
+    record_position(tape &t, bool strict) const override;
 
     void
-    reload_position(tape &t) override;
+    reload_position(tape &t, bool strict) override;
 
     bool
     is_infinite() const noexcept override;

--- a/native/src/fairseq2n/data/prefetch_data_source.h
+++ b/native/src/fairseq2n/data/prefetch_data_source.h
@@ -43,10 +43,10 @@ public:
     reset() override;
 
     void
-    record_position(tape &t) const override;
+    record_position(tape &t, bool strict) const override;
 
     void
-    reload_position(tape &t) override;
+    reload_position(tape &t, bool strict) override;
 
     bool
     is_infinite() const noexcept override;

--- a/native/src/fairseq2n/data/repeat_data_source.cc
+++ b/native/src/fairseq2n/data/repeat_data_source.cc
@@ -47,19 +47,19 @@ repeat_data_source::reset()
 }
 
 void
-repeat_data_source::record_position(tape &t) const
+repeat_data_source::record_position(tape &t, bool strict) const
 {
     t.record(repeat_nr_);
 
-    inner_->record_position(t);
+    inner_->record_position(t, strict);
 }
 
 void
-repeat_data_source::reload_position(tape &t)
+repeat_data_source::reload_position(tape &t, bool strict)
 {
     repeat_nr_ = t.read<std::size_t>();
 
-    inner_->reload_position(t);
+    inner_->reload_position(t, strict);
 }
 
 bool

--- a/native/src/fairseq2n/data/repeat_data_source.h
+++ b/native/src/fairseq2n/data/repeat_data_source.h
@@ -30,10 +30,10 @@ public:
     reset() override;
 
     void
-    record_position(tape &t) const override;
+    record_position(tape &t, bool strict) const override;
 
     void
-    reload_position(tape &t) override;
+    reload_position(tape &t, bool strict) override;
 
     bool
     is_infinite() const noexcept override;

--- a/native/src/fairseq2n/data/round_robin_data_source.cc
+++ b/native/src/fairseq2n/data/round_robin_data_source.cc
@@ -78,26 +78,36 @@ round_robin_data_source::reset()
 }
 
 void
-round_robin_data_source::record_position(tape &t) const
+round_robin_data_source::record_position(tape &t, bool strict) const
 {
-    t.record(buffer_);
+    if (strict) {
+        t.record(buffer_);
 
-    t.record(buffer_idx_);
+        t.record(buffer_idx_);
 
-    t.record(is_epoch_done_);
+        t.record(is_epoch_done_);
+    }
 
     for (const data_pipeline &pipeline : pipelines_)
-        pipeline.record_position(t);
+        pipeline.record_position(t, strict);
 }
 
 void
-round_robin_data_source::reload_position(tape &t)
+round_robin_data_source::reload_position(tape &t, bool strict)
 {
-    buffer_ = t.read<std::vector<std::optional<data>>>();
+    if (strict) {
+        buffer_ = t.read<std::vector<std::optional<data>>>();
 
-    buffer_idx_ = t.read<std::size_t>();
+        buffer_idx_ = t.read<std::size_t>();
 
-    is_epoch_done_ = t.read<std::vector<bool>>();
+        is_epoch_done_ = t.read<std::vector<bool>>();
+    } else {
+        buffer_.clear();
+
+        buffer_idx_ = 0;
+
+        is_epoch_done_.clear();
+    }
 
     is_eod_ = false;
 

--- a/native/src/fairseq2n/data/round_robin_data_source.h
+++ b/native/src/fairseq2n/data/round_robin_data_source.h
@@ -27,10 +27,10 @@ public:
     reset() override;
 
     void
-    record_position(tape &t) const override;
+    record_position(tape &t, bool strict) const override;
 
     void
-    reload_position(tape &t) override;
+    reload_position(tape &t, bool strict) override;
 
     bool
     is_infinite() const noexcept override;

--- a/native/src/fairseq2n/data/sample_data_source.cc
+++ b/native/src/fairseq2n/data/sample_data_source.cc
@@ -83,22 +83,30 @@ sample_data_source::reset()
 }
 
 void
-sample_data_source::record_position(tape &t) const
+sample_data_source::record_position(tape &t, bool strict) const
 {
-    t.record(buffer_);
+    if (strict) {
+        t.record(buffer_);
 
-    t.record(is_epoch_done_);
+        t.record(is_epoch_done_);
+    }
 
     for (const data_pipeline &pipeline : pipelines_)
-        pipeline.record_position(t);
+        pipeline.record_position(t, strict);
 }
 
 void
-sample_data_source::reload_position(tape &t)
+sample_data_source::reload_position(tape &t, bool strict)
 {
-    buffer_ = t.read<std::vector<data>>();
+    if (strict) {
+        buffer_ = t.read<std::vector<data>>();
 
-    is_epoch_done_ = t.read<std::vector<bool>>();
+        is_epoch_done_ = t.read<std::vector<bool>>();
+    } else {
+        buffer_.clear();
+
+        is_epoch_done_.clear();
+    }
 
     is_eod_ = false;
 

--- a/native/src/fairseq2n/data/sample_data_source.h
+++ b/native/src/fairseq2n/data/sample_data_source.h
@@ -28,10 +28,10 @@ public:
     reset() override;
 
     void
-    record_position(tape &t) const override;
+    record_position(tape &t, bool strict) const override;
 
     void
-    reload_position(tape &t) override;
+    reload_position(tape &t, bool strict) override;
 
     bool
     is_infinite() const noexcept override;

--- a/native/src/fairseq2n/data/shard_data_source.cc
+++ b/native/src/fairseq2n/data/shard_data_source.cc
@@ -33,15 +33,15 @@ shard_data_source::reset()
 }
 
 void
-shard_data_source::record_position(tape &t) const
+shard_data_source::record_position(tape &t, bool strict) const
 {
-    inner_->record_position(t);
+    inner_->record_position(t, strict);
 }
 
 void
-shard_data_source::reload_position(tape &t)
+shard_data_source::reload_position(tape &t, bool strict)
 {
-    inner_->reload_position(t);
+    inner_->reload_position(t, strict);
 }
 
 bool

--- a/native/src/fairseq2n/data/shard_data_source.h
+++ b/native/src/fairseq2n/data/shard_data_source.h
@@ -31,10 +31,10 @@ public:
     reset() override;
 
     void
-    record_position(tape &t) const override;
+    record_position(tape &t, bool strict) const override;
 
     void
-    reload_position(tape &t) override;
+    reload_position(tape &t, bool strict) override;
 
     bool
     is_infinite() const noexcept override;

--- a/native/src/fairseq2n/data/shuffle_data_source.cc
+++ b/native/src/fairseq2n/data/shuffle_data_source.cc
@@ -19,8 +19,8 @@
 namespace fairseq2n::detail {
 
 shuffle_data_source::shuffle_data_source(
-    std::unique_ptr<data_source> &&inner, std::size_t shuffle_window, bool strict) noexcept
-  : inner_{std::move(inner)}, strict_{strict}
+    std::unique_ptr<data_source> &&inner, std::size_t shuffle_window) noexcept
+  : inner_{std::move(inner)}
 {
     if (shuffle_window == 0)
         shuffle_window_ = std::numeric_limits<std::size_t>::max();
@@ -101,9 +101,9 @@ shuffle_data_source::reset()
 }
 
 void
-shuffle_data_source::record_position(tape &t) const
+shuffle_data_source::record_position(tape &t, bool strict) const
 {
-    if (strict_) {
+    if (strict) {
         t.record(buffer_);
 
         t.record(buffer_pos_ - buffer_.begin());
@@ -112,13 +112,13 @@ shuffle_data_source::record_position(tape &t) const
         t.record(fill_buffer_);
     }
 
-    inner_->record_position(t);
+    inner_->record_position(t, strict);
 }
 
 void
-shuffle_data_source::reload_position(tape &t)
+shuffle_data_source::reload_position(tape &t, bool strict)
 {
-    if (strict_) {
+    if (strict) {
         buffer_ = t.read<data_list>();
 
         buffer_pos_ = buffer_.begin() + t.read<std::ptrdiff_t>();
@@ -134,7 +134,7 @@ shuffle_data_source::reload_position(tape &t)
         fill_buffer_ = true;
     }
 
-    inner_->reload_position(t);
+    inner_->reload_position(t, strict);
 }
 
 bool

--- a/native/src/fairseq2n/data/shuffle_data_source.h
+++ b/native/src/fairseq2n/data/shuffle_data_source.h
@@ -21,8 +21,7 @@ class shuffle_data_source final : public data_source {
 
 public:
     explicit
-    shuffle_data_source(
-        std::unique_ptr<data_source> &&inner, std::size_t shuffle_window, bool strict) noexcept;
+    shuffle_data_source(std::unique_ptr<data_source> &&inner, std::size_t shuffle_window) noexcept;
 
     std::optional<data>
     next() override;
@@ -31,10 +30,10 @@ public:
     reset() override;
 
     void
-    record_position(tape &t) const override;
+    record_position(tape &t, bool strict) const override;
 
     void
-    reload_position(tape &t) override;
+    reload_position(tape &t, bool strict) override;
 
     bool
     is_infinite() const noexcept override;
@@ -50,7 +49,6 @@ private:
     data_list::iterator buffer_end_ = buffer_.end();
     std::size_t shuffle_window_;
     at::Generator generator_;
-    bool strict_;
     bool fill_buffer_ = true;
 };
 

--- a/native/src/fairseq2n/data/skip_data_source.cc
+++ b/native/src/fairseq2n/data/skip_data_source.cc
@@ -31,19 +31,19 @@ skip_data_source::reset()
 }
 
 void
-skip_data_source::record_position(tape &t) const
+skip_data_source::record_position(tape &t, bool strict) const
 {
     t.record(skip_);
 
-    inner_->record_position(t);
+    inner_->record_position(t, strict);
 }
 
 void
-skip_data_source::reload_position(tape &t)
+skip_data_source::reload_position(tape &t, bool strict)
 {
     skip_ = t.read<bool>();
 
-    inner_->reload_position(t);
+    inner_->reload_position(t, strict);
 }
 
 bool

--- a/native/src/fairseq2n/data/skip_data_source.h
+++ b/native/src/fairseq2n/data/skip_data_source.h
@@ -28,10 +28,10 @@ public:
     reset() override;
 
     void
-    record_position(tape &t) const override;
+    record_position(tape &t, bool strict) const override;
 
     void
-    reload_position(tape &t) override;
+    reload_position(tape &t, bool strict) override;
 
     bool
     is_infinite() const noexcept override;

--- a/native/src/fairseq2n/data/take_data_source.cc
+++ b/native/src/fairseq2n/data/take_data_source.cc
@@ -30,19 +30,19 @@ take_data_source::reset()
 }
 
 void
-take_data_source::record_position(tape &t) const
+take_data_source::record_position(tape &t, bool strict) const
 {
     t.record(num_examples_read_);
 
-    inner_->record_position(t);
+    inner_->record_position(t, strict);
 }
 
 void
-take_data_source::reload_position(tape &t)
+take_data_source::reload_position(tape &t, bool strict)
 {
     num_examples_read_ = t.read<std::size_t>();
 
-    inner_->reload_position(t);
+    inner_->reload_position(t, strict);
 }
 
 bool

--- a/native/src/fairseq2n/data/take_data_source.h
+++ b/native/src/fairseq2n/data/take_data_source.h
@@ -28,10 +28,10 @@ public:
     reset() override;
 
     void
-    record_position(tape &t) const override;
+    record_position(tape &t, bool strict) const override;
 
     void
-    reload_position(tape &t) override;
+    reload_position(tape &t, bool strict) override;
 
     bool
     is_infinite() const noexcept override;

--- a/native/src/fairseq2n/data/text/text_data_source.cc
+++ b/native/src/fairseq2n/data/text/text_data_source.cc
@@ -74,13 +74,13 @@ text_data_source::reset()
 }
 
 void
-text_data_source::record_position(tape &t) const
+text_data_source::record_position(tape &t, bool) const
 {
     t.record(num_lines_read_);
 }
 
 void
-text_data_source::reload_position(tape &t)
+text_data_source::reload_position(tape &t, bool)
 {
     auto num_lines_read = t.read<std::size_t>();
 

--- a/native/src/fairseq2n/data/text/text_data_source.h
+++ b/native/src/fairseq2n/data/text/text_data_source.h
@@ -34,10 +34,10 @@ public:
     reset() override;
 
     void
-    record_position(tape &t) const override;
+    record_position(tape &t, bool strict) const override;
 
     void
-    reload_position(tape &t) override;
+    reload_position(tape &t, bool strict) override;
 
     bool
     is_infinite() const noexcept override;

--- a/native/src/fairseq2n/data/yield_from_data_source.h
+++ b/native/src/fairseq2n/data/yield_from_data_source.h
@@ -28,10 +28,10 @@ public:
     reset() override;
 
     void
-    record_position(tape &t) const override;
+    record_position(tape &t, bool strict) const override;
 
     void
-    reload_position(tape &t) override;
+    reload_position(tape &t, bool strict) override;
 
     bool
     is_infinite() const noexcept override;

--- a/native/src/fairseq2n/data/zip_data_source.cc
+++ b/native/src/fairseq2n/data/zip_data_source.cc
@@ -171,14 +171,14 @@ zip_data_source::reset()
 }
 
 void
-zip_data_source::record_position(tape &t) const
+zip_data_source::record_position(tape &t, bool strict) const
 {
     for (const data_pipeline &pipeline : pipelines_)
-        pipeline.record_position(t);
+        pipeline.record_position(t, strict);
 }
 
 void
-zip_data_source::reload_position(tape &t)
+zip_data_source::reload_position(tape &t, bool)
 {
     for (data_pipeline &pipeline : pipelines_)
         pipeline.reload_position(t);

--- a/native/src/fairseq2n/data/zip_data_source.h
+++ b/native/src/fairseq2n/data/zip_data_source.h
@@ -32,10 +32,10 @@ public:
     reset() override;
 
     void
-    record_position(tape &t) const override;
+    record_position(tape &t, bool strict) const override;
 
     void
-    reload_position(tape &t) override;
+    reload_position(tape &t, bool strict) override;
 
     bool
     is_infinite() const noexcept override;

--- a/native/src/fairseq2n/data/zip_file_data_source.cc
+++ b/native/src/fairseq2n/data/zip_file_data_source.cc
@@ -61,13 +61,13 @@ zip_file_data_source::reset()
 }
 
 void
-zip_file_data_source::record_position(tape &t) const
+zip_file_data_source::record_position(tape &t, bool) const
 {
     t.record(num_files_read_);
 }
 
 void
-zip_file_data_source::reload_position(tape &t)
+zip_file_data_source::reload_position(tape &t, bool)
 {
     auto num_files_read = t.read<std::size_t>();
 

--- a/native/src/fairseq2n/data/zip_file_data_source.h
+++ b/native/src/fairseq2n/data/zip_file_data_source.h
@@ -32,10 +32,10 @@ public:
     reset() override;
 
     void
-    record_position(tape &t) const override;
+    record_position(tape &t, bool strict) const override;
 
     void
-    reload_position(tape &t) override;
+    reload_position(tape &t, bool strict) override;
 
     bool
     is_infinite() const noexcept override;

--- a/src/fairseq2/data/data_pipeline.py
+++ b/src/fairseq2/data/data_pipeline.py
@@ -63,11 +63,17 @@ if TYPE_CHECKING or DOC_MODE:
             :class:`DataPipelineError`.
             """
 
-        def state_dict(self) -> Dict[str, Any]:
+        def state_dict(self, strict: bool = True) -> Dict[str, Any]:
             """Return a dictionary containing the state of the data pipeline.
 
             The current position of the data pipeline can be restored by passing
             the returned state dictionary to :meth:`load_state_dict`.
+
+            :param strict:
+                If ``True``, the internal buffers will be saved as part of
+                ``state_dict``. This ensures that on preemption no example will
+                be lost, but for large buffers this can significantly increase
+                the state size and the time to restore the data pipeline.
             """
 
         def load_state_dict(self, state_dict: Mapping[str, Any]) -> None:
@@ -239,9 +245,7 @@ if TYPE_CHECKING or DOC_MODE:
                 The number of shards.
             """
 
-        def shuffle(
-            self, shuffle_window: int, strict: bool = True, enabled: bool = True
-        ) -> Self:
+        def shuffle(self, shuffle_window: int, enabled: bool = True) -> Self:
             """Shuffle examples using a fixed sized buffer.
 
             :param shuffle_window:
@@ -249,12 +253,6 @@ if TYPE_CHECKING or DOC_MODE:
                 will be randomly sampled from this buffer, and selected examples
                 will be replaced with new examples. If ``0``, all examples will
                 be loaded into memory for full shuffling.
-            :param strict:
-                If ``True``, the intermediate shuffle buffer will be saved as
-                part of ``state_dict``. This ensures that on preemption no
-                example will be lost, but for large buffers this can
-                significantly increase the state size and the time to restore
-                the data pipeline.
             :param enabled:
                 If ``False``, disables shuffling.
             """

--- a/tests/unit/data/data_pipeline/test_shuffle.py
+++ b/tests/unit/data/data_pipeline/test_shuffle.py
@@ -114,12 +114,12 @@ class TestShuffleOp:
     def test_record_reload_position_works_as_expected_with_no_strict(self) -> None:
         seq = list(range(100))
 
-        pipeline = read_sequence(seq).shuffle(80, strict=False).and_return()
+        pipeline = read_sequence(seq).shuffle(80).and_return()
 
         # Do one dummy iteration to force to fill the buffer.
         next(iter(pipeline))
 
-        state_dict = pipeline.state_dict()
+        state_dict = pipeline.state_dict(strict=False)
 
         pipeline.load_state_dict(state_dict)
 


### PR DESCRIPTION
This PR generalizes the `strict` parameter of the `shuffle()` pipeline op to all ops. `DataPipeline.state_dict()` now offers a `strict` parameter that, when set to `False`, discards any internal buffers held by its ops. This can significantly reduce the amount of data stored in the returned `state_dict`. The tradeoff is that when restored, the pipeline will resume from the last position in its source op (e.g. `read_sequence()`) and all "not-yet returned" items before the `state_dict()` call (e.g. shuffle buffers, prefetch buffer) will be lost. Depending on the use case, this can be an acceptable tradeoff.