### PR TITLE
Introduce LogWriter

### DIFF
--- a/src/fairseq2/assets/utils.py
+++ b/src/fairseq2/assets/utils.py
@@ -4,11 +4,12 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import logging
 import os
 import re
 from pathlib import Path
 from typing import Final, Optional
+
+from fairseq2.utils.logging import get_log_writer
 
 _SCHEME_REGEX: Final = re.compile("^[a-zA-Z0-9]+://")
 
@@ -35,9 +36,9 @@ def _get_path_from_env(var_name: str, missing_ok: bool = False) -> Optional[Path
         if missing_ok:
             return resolved_path
 
-        logger = logging.getLogger("fairseq2.assets")
+        log = get_log_writer("fairseq2.assets")
 
-        logger.warning(f"The path '{path}' pointed to by the `{var_name}` environment variable does not exist.")  # fmt: skip
+        log.warning("The path '{}' pointed to by the `{}` environment variable does not exist.", path, var_name)  # fmt: skip
 
         return None
 

--- a/src/fairseq2/datasets/data_reader.py
+++ b/src/fairseq2/datasets/data_reader.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import logging
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Iterator, List, Mapping, Tuple, TypeVar, final
 
@@ -15,8 +14,9 @@ from fairseq2.datasets.utils import _reduce_batch_size
 from fairseq2.gang import Gang
 from fairseq2.models import Batch
 from fairseq2.typing import override
+from fairseq2.utils.logging import get_log_writer
 
-logger = logging.getLogger(__name__)
+log = get_log_writer(__name__)
 
 
 BatchT = TypeVar("BatchT", bound=Batch)
@@ -119,7 +119,7 @@ class DataPipelineReader(DataReader[BatchT]):
             batch_size = sum(b.batch_size for b in batches)
 
         if self._sync_batches:
-            batch_size = _reduce_batch_size(batch_size, self._gang, logger)
+            batch_size = _reduce_batch_size(batch_size, self._gang, log)
         else:
             # If we don't sync, we assume all processes read equal amount of
             # data at each iteration.

--- a/src/fairseq2/datasets/utils.py
+++ b/src/fairseq2/datasets/utils.py
@@ -5,14 +5,14 @@
 # LICENSE file in the root directory of this source tree.
 
 import logging
-from logging import Logger
 
 import torch
 
 from fairseq2.gang import Gang
+from fairseq2.utils.logging import LogWriter
 
 
-def _reduce_batch_size(batch_size: int, gang: Gang, logger: Logger) -> int:
+def _reduce_batch_size(batch_size: int, gang: Gang, log: LogWriter) -> int:
     if gang.size == 1:
         return batch_size
 
@@ -23,10 +23,10 @@ def _reduce_batch_size(batch_size: int, gang: Gang, logger: Logger) -> int:
     # Check if any process has reached end of data. If so, return 0 to indicate
     # that we should stop the iterator.
     if (eods := batch_sizes == 0).any():
-        if logger.isEnabledFor(logging.DEBUG) and not eods.all():
+        if log.is_enabled_for(logging.DEBUG) and not eods.all():
             ranks = ", ".join(str(r) for r in eods.nonzero().squeeze(1).tolist())
 
-            logger.debug(f"End of data reached at rank(s) {ranks}.")
+            log.debug("End of data reached at rank(s) {}.", ranks)
 
         return 0
 

--- a/src/fairseq2/gang.py
+++ b/src/fairseq2/gang.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import logging
 import os
 from abc import ABC, abstractmethod
 from datetime import timedelta
@@ -17,9 +16,10 @@ from torch import Tensor
 from torch.distributed import ProcessGroup, ReduceOp
 
 from fairseq2.typing import CPU, Device, override
+from fairseq2.utils.logging import get_log_writer
 from fairseq2.utils.version import _is_pt22_or_greater
 
-logger = logging.getLogger(__name__)
+log = get_log_writer(__name__)
 
 
 class ReduceOperation(Enum):
@@ -216,7 +216,7 @@ class ProcessGroupGang(AbstractGang):
         if num_threads is not None:
             torch.set_num_threads(num_threads)
 
-            logger.info("Setting the number of threads used for intraop parallelism to %d.", num_threads)  # fmt: skip
+            log.info("Setting the number of threads used for intraop parallelism to {}.", num_threads)  # fmt: skip
 
         if device is None:
             device = _determine_default_device()
@@ -245,7 +245,7 @@ class ProcessGroupGang(AbstractGang):
                         return
 
                 if warn_only:
-                    logger.warning("The default process group uses the `nccl` backend, but the `%s` environment variable is not set. Your collective communication calls can hang indefinitely. Learn more at https://github.com/pytorch/pytorch/issues/46874.", env_name)  # fmt: skip
+                    log.warning("The default process group uses the `nccl` backend, but the `{}` environment variable is not set. Your collective communication calls can hang indefinitely. Learn more at https://github.com/pytorch/pytorch/issues/46874.", env_name)  # fmt: skip
                 else:
                     raise RuntimeError(
                         f"The default process group uses the `nccl` backend, but the `{env_name}` environment variable is not set. Learn more at https://github.com/pytorch/pytorch/issues/46874."
@@ -344,7 +344,7 @@ class ProcessGroupGang(AbstractGang):
 def _get_num_cpus(num_procs: int) -> int:
     num_cpus = os.cpu_count()
     if num_cpus is None:
-        logger.warning("The number of CPU cores cannot be determined.")
+        log.warning("The number of CPU cores cannot be determined.")
 
         return 1
 
@@ -379,7 +379,7 @@ def _determine_default_device() -> Device:
     if _default_device is None:
         _default_device = CPU
 
-    logger.info("Setting '%s' as the default device of the process.", _default_device)
+    log.info("Setting '{}' as the default device of the process.", _default_device)
 
     return _default_device
 

--- a/src/fairseq2/models/config_loader.py
+++ b/src/fairseq2/models/config_loader.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import logging
 from copy import deepcopy
 from typing import Optional, Protocol, Type, TypeVar, Union, final
 
@@ -17,9 +16,6 @@ from fairseq2.assets import (
 )
 from fairseq2.models.architecture_registry import ModelArchitectureRegistry
 from fairseq2.utils.dataclass import update_dataclass
-
-logger = logging.getLogger("fairseq2.models")
-
 
 ModelConfigT = TypeVar("ModelConfigT")
 

--- a/src/fairseq2/models/loader.py
+++ b/src/fairseq2/models/loader.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import logging
 from functools import partial
 from pickle import PickleError
 from typing import Any, Dict, Generic, Optional, Protocol, TypeVar, Union, final
@@ -29,8 +28,9 @@ from fairseq2.nn.utils.module import (
     to_empty,
 )
 from fairseq2.typing import CPU, META, DataType, Device
+from fairseq2.utils.logging import get_log_writer
 
-logger = logging.getLogger("fairseq2.models")
+log = get_log_writer("fairseq2.models")
 
 
 ModelT = TypeVar("ModelT", bound=Module)
@@ -223,7 +223,7 @@ class StandardModelLoader(ModelLoader[ModelT], Generic[ModelT, ModelConfigT]):
                 # Try to construct the model on the meta device.
                 model = self._factory(config, device=META, dtype=dtype)
             except NotImplementedError:
-                logger.warning("One or more operators in %s constructor do not support the meta device. Skipping meta device initialization.", card.name)  # fmt: skip
+                log.warning("One or more operators in {} constructor do not support the meta device. Skipping meta device initialization.", card.name)  # fmt: skip
 
         if model is None:
             model = self._factory(config, device=device, dtype=dtype)

--- a/src/fairseq2/nn/transformer/attention.py
+++ b/src/fairseq2/nn/transformer/attention.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import logging
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from typing import Generator, Optional, Protocol, Tuple, final
@@ -18,8 +17,9 @@ from torch.nn.functional import dropout, softmax
 from fairseq2.nn.padding import PaddingMask
 from fairseq2.nn.transformer.attention_mask import AttentionMask, CausalAttentionMask
 from fairseq2.typing import override
+from fairseq2.utils.logging import get_log_writer
 
-logger = logging.getLogger(__name__)
+log = get_log_writer(__name__)
 
 
 class SDPA(Module, ABC):
@@ -103,7 +103,7 @@ class TorchSDPA(SDPA):
     ) -> Tuple[Tensor, Optional[Tensor]]:
         if needs_weights:
             if not self._has_warned:
-                logger.warning("`TorchSDPA` has to fall back to the naive SDPA implementation because of `needs_weights` set to `True`.")  # fmt: skip
+                log.warning("`TorchSDPA` has to fall back to the naive SDPA implementation because of `needs_weights` set to `True`.")  # fmt: skip
 
                 self._has_warned = True
 

--- a/src/fairseq2/nn/utils/module.py
+++ b/src/fairseq2/nn/utils/module.py
@@ -22,6 +22,7 @@ from typing import (
     Sequence,
     Set,
     Tuple,
+    Union,
     final,
     runtime_checkable,
 )
@@ -31,6 +32,7 @@ from torch import Tensor
 from torch.nn import Module, Parameter
 
 from fairseq2.typing import CPU, META, Device
+from fairseq2.utils.logging import LogWriter
 
 
 @runtime_checkable
@@ -494,9 +496,12 @@ def get_module_size(module: Module) -> ModuleSizeInfo:
     return info
 
 
-def log_module(module: Module, logger: Logger) -> None:
+def log_module(module: Module, log: Union[LogWriter, Logger]) -> None:
     """Log information about ``module`` and its descendants."""
-    if not logger.isEnabledFor(logging.INFO):
+    if isinstance(log, Logger):
+        log = LogWriter(log)
+
+    if not log.is_enabled_for(logging.INFO):
         return
 
     info = []
@@ -514,4 +519,4 @@ def log_module(module: Module, logger: Logger) -> None:
 
     s = " | ".join(info)
 
-    logger.info(f"Module - {s}\n{module}")
+    log.info("Module - {}\n{}", s, module)

--- a/src/fairseq2/utils/logging.py
+++ b/src/fairseq2/utils/logging.py
@@ -6,11 +6,18 @@
 
 import logging
 import time
-from logging import DEBUG, INFO, FileHandler, Formatter, Handler, StreamHandler
+from logging import (
+    DEBUG,
+    INFO,
+    FileHandler,
+    Formatter,
+    Handler,
+    Logger,
+    StreamHandler,
+    getLogger,
+)
 from pathlib import Path
-from typing import List, Optional
-
-from fairseq2.gang import get_rank
+from typing import Any, List, Optional, final
 
 
 def setup_logging(
@@ -32,6 +39,8 @@ def setup_logging(
     :param force:
         If ``True``, overwrites existing log configuration.
     """
+    from fairseq2.gang import get_rank  # Avoid circular import.
+
     rank = get_rank()
 
     handlers: List[Handler] = [StreamHandler()]  # Log to stderr.
@@ -69,3 +78,58 @@ def setup_logging(
 
     if utc_time:
         Formatter.converter = time.gmtime
+
+
+@final
+class LogWriter:
+    """Writes log messages using ``format()`` strings."""
+
+    _logger: Logger
+
+    def __init__(self, logger: Logger) -> None:
+        """
+        :param logger:
+            The logger to write to.
+        """
+        self._logger = logger
+
+    def debug(self, msg: Any, *args: Any, **kwargs: Any) -> None:
+        """Log a message with level ``DEBUG``."""
+        self._write(logging.DEBUG, msg, args, kwargs)
+
+    def info(self, msg: Any, *args: Any, **kwargs: Any) -> None:
+        """Log a message with level ``INFO``."""
+        self._write(logging.INFO, msg, args, kwargs)
+
+    def warning(self, msg: Any, *args: Any, **kwargs: Any) -> None:
+        """Log a message with level ``WARNING``."""
+        self._write(logging.WARNING, msg, args, kwargs)
+
+    def error(self, msg: Any, *args: Any, **kwargs: Any) -> None:
+        """Log a message with level ``ERROR``."""
+        self._write(logging.ERROR, msg, args, kwargs)
+
+    def exception(self, msg: Any, *args: Any, **kwargs: Any) -> None:
+        """Log a message with level ``ERROR``."""
+        self._write(logging.ERROR, msg, args, kwargs, exc_info=True)
+
+    def _write(
+        self, level: int, msg: Any, args: Any, kwargs: Any, exc_info: bool = False
+    ) -> None:
+        if args or kwargs:
+            if not self._logger.isEnabledFor(level):
+                return
+
+            msg = str(msg).format(*args, **kwargs)
+
+        self._logger.log(level, msg, exc_info=exc_info)
+
+    def is_enabled_for(self, level: int) -> bool:
+        """Return ``True`` if a message of severity ``level`` would be processed
+        by this writer."""
+        return self._logger.isEnabledFor(level)
+
+
+def get_log_writer(name: Optional[str] = None) -> LogWriter:
+    """Return a :class:`LogWriter` for the logger with the specified name."""
+    return LogWriter(getLogger(name))


### PR DESCRIPTION
This PR introduces the helper `LogWriter` class that uses modern `format()` strings instead of old format string style of `logging.Logger`.