### PR TITLE
Set default CUDA device in _determine_default_device

### DIFF
--- a/src/fairseq2/gang.py
+++ b/src/fairseq2/gang.py
@@ -379,6 +379,9 @@ def _determine_default_device() -> Device:
     if _default_device is None:
         _default_device = CPU
 
+    if _default_device.type == "cuda":
+        torch.cuda.set_device(_default_device)
+
     log.info("Setting '{}' as the default device of the process.", _default_device)
 
     return _default_device
@@ -404,9 +407,6 @@ def _determine_default_cuda_device() -> Device:
         idx = _get_device_index(num_devices, device_type="cuda")
 
         device = Device("cuda", index=idx)
-
-    # As of PyTorch 2.0, FSDP fails to work if the default device is not set.
-    torch.cuda.set_device(device)
 
     return device
 

--- a/src/fairseq2/nn/utils/module.py
+++ b/src/fairseq2/nn/utils/module.py
@@ -519,4 +519,4 @@ def log_module(module: Module, log: Union[LogWriter, Logger]) -> None:
 
     s = " | ".join(info)
 
-    log.info("Module - {}\n{}", s, module)
+    log.info("Module Info - {} | Layout:\n{}", s, module)


### PR DESCRIPTION
This PR fixes the `torch.cuda.set_device` call by moving it to `_determine_default_device` since the user can now explicitly specify a device via `FAIRSEQ2_DEVICE` environment variable.