### PR TITLE
Fix state restore bug in sample and round_robin ops

### DIFF
--- a/native/src/fairseq2n/data/round_robin_data_source.cc
+++ b/native/src/fairseq2n/data/round_robin_data_source.cc
@@ -106,7 +106,7 @@ round_robin_data_source::reload_position(tape &t, bool strict)
 
         buffer_idx_ = 0;
 
-        is_epoch_done_.clear();
+        is_epoch_done_.assign(pipelines_.size(), false);
     }
 
     is_eod_ = false;

--- a/native/src/fairseq2n/data/sample_data_source.cc
+++ b/native/src/fairseq2n/data/sample_data_source.cc
@@ -105,7 +105,7 @@ sample_data_source::reload_position(tape &t, bool strict)
     } else {
         buffer_.clear();
 
-        is_epoch_done_.clear();
+        is_epoch_done_.assign(pipelines_.size(), false);
     }
 
     is_eod_ = false;


### PR DESCRIPTION
This PR fixes the state restore bug in `sample()` and `round_robin()` ops.