### PR TITLE
Update Wav2Vec2PositionEncoder

### DIFF
--- a/src/fairseq2/checkpoint.py
+++ b/src/fairseq2/checkpoint.py
@@ -463,6 +463,9 @@ class FileCheckpointManager(CheckpointManager):
 
     @override
     def save_consolidated_fsdp_model(self, step_nr: int, model: Module) -> None:
+        if self._model_key in self._replicated_keys or "*" in self._replicated_keys:
+            return
+
         with FSDP.state_dict_type(
             model,
             StateDictType.FULL_STATE_DICT,

--- a/src/fairseq2/models/conformer/block.py
+++ b/src/fairseq2/models/conformer/block.py
@@ -10,7 +10,7 @@ from torch import Tensor
 from torch.nn import Dropout
 
 from fairseq2.models.conformer.convolution import ConformerConvolution
-from fairseq2.nn.normalization import LayerNorm
+from fairseq2.nn import LayerNorm
 from fairseq2.nn.padding import PaddingMask
 from fairseq2.nn.transformer import (
     AttentionMask,

--- a/src/fairseq2/models/conformer/convolution.py
+++ b/src/fairseq2/models/conformer/convolution.py
@@ -10,7 +10,7 @@ from torch import Tensor
 from torch.nn import GLU, BatchNorm1d, Conv1d, Module, SiLU
 from torch.nn.functional import pad
 
-from fairseq2.nn.normalization import LayerNorm, StandardLayerNorm
+from fairseq2.nn import LayerNorm, StandardLayerNorm
 from fairseq2.nn.padding import PaddingMask, apply_padding_mask
 from fairseq2.typing import DataType, Device
 

--- a/src/fairseq2/models/llama/factory.py
+++ b/src/fairseq2/models/llama/factory.py
@@ -15,11 +15,8 @@ from fairseq2.models.transformer import (
     TransformerFrontend,
     init_final_projection,
 )
-from fairseq2.nn.embedding import StandardEmbedding
+from fairseq2.nn import LayerNorm, Linear, RMSNorm, RotaryEncoder, StandardEmbedding
 from fairseq2.nn.lora import LoRAConfig
-from fairseq2.nn.normalization import LayerNorm, RMSNorm
-from fairseq2.nn.position_encoder import RotaryEncoder
-from fairseq2.nn.projection import Linear
 from fairseq2.nn.transformer import (
     FeedForwardNetwork,
     GLUFeedForwardNetwork,

--- a/src/fairseq2/models/mistral/factory.py
+++ b/src/fairseq2/models/mistral/factory.py
@@ -15,10 +15,7 @@ from fairseq2.models.transformer import (
     TransformerFrontend,
     init_final_projection,
 )
-from fairseq2.nn.embedding import StandardEmbedding
-from fairseq2.nn.normalization import LayerNorm, RMSNorm
-from fairseq2.nn.position_encoder import RotaryEncoder
-from fairseq2.nn.projection import Linear
+from fairseq2.nn import LayerNorm, Linear, RMSNorm, RotaryEncoder, StandardEmbedding
 from fairseq2.nn.transformer import (
     CausalAttentionMaskFactory,
     FeedForwardNetwork,

--- a/src/fairseq2/models/nllb/factory.py
+++ b/src/fairseq2/models/nllb/factory.py
@@ -14,9 +14,13 @@ from fairseq2.models.transformer import (
     TransformerFrontend,
     TransformerModel,
 )
-from fairseq2.nn.embedding import Embedding, StandardEmbedding, init_scaled_embedding
-from fairseq2.nn.position_encoder import SinusoidalPositionEncoder
-from fairseq2.nn.projection import TiedProjection
+from fairseq2.nn import (
+    Embedding,
+    SinusoidalPositionEncoder,
+    StandardEmbedding,
+    TiedProjection,
+    init_scaled_embedding,
+)
 from fairseq2.nn.transformer import (
     FeedForwardNetwork,
     MultiheadAttention,

--- a/src/fairseq2/models/s2t_transformer/factory.py
+++ b/src/fairseq2/models/s2t_transformer/factory.py
@@ -20,9 +20,13 @@ from fairseq2.models.transformer import (
     TransformerModel,
     init_final_projection,
 )
-from fairseq2.nn.embedding import StandardEmbedding, init_scaled_embedding
-from fairseq2.nn.position_encoder import PositionEncoder, SinusoidalPositionEncoder
-from fairseq2.nn.projection import Linear
+from fairseq2.nn import (
+    Linear,
+    PositionEncoder,
+    SinusoidalPositionEncoder,
+    StandardEmbedding,
+    init_scaled_embedding,
+)
 from fairseq2.nn.transformer import (
     FeedForwardNetwork,
     MultiheadAttention,

--- a/src/fairseq2/models/s2t_transformer/frontend.py
+++ b/src/fairseq2/models/s2t_transformer/frontend.py
@@ -12,10 +12,9 @@ from torch.nn import Dropout
 
 from fairseq2.models.feature_extractor import SequenceFeatureExtractor
 from fairseq2.models.transformer import TransformerFrontend
+from fairseq2.nn import Linear, PositionEncoder, Projection
 from fairseq2.nn.incremental_state import IncrementalStateBag
 from fairseq2.nn.padding import PaddingMask
-from fairseq2.nn.position_encoder import PositionEncoder
-from fairseq2.nn.projection import Linear, Projection
 from fairseq2.typing import DataType, Device, override
 
 

--- a/src/fairseq2/models/transformer/decoder_model.py
+++ b/src/fairseq2/models/transformer/decoder_model.py
@@ -12,9 +12,9 @@ from fairseq2.data import VocabularyInfo
 from fairseq2.models.decoder import DecoderModel
 from fairseq2.models.sequence import SequenceModelOutput
 from fairseq2.models.transformer.frontend import TransformerFrontend
+from fairseq2.nn import Projection
 from fairseq2.nn.incremental_state import IncrementalStateBag
 from fairseq2.nn.padding import PaddingMask
-from fairseq2.nn.projection import Projection
 from fairseq2.nn.transformer import TransformerDecoder
 from fairseq2.typing import override
 

--- a/src/fairseq2/models/transformer/frontend.py
+++ b/src/fairseq2/models/transformer/frontend.py
@@ -11,15 +11,10 @@ from typing import Optional, Tuple, final
 from torch import Tensor
 from torch.nn import Dropout, Module
 
-from fairseq2.nn.embedding import Embedding
+from fairseq2.nn import Embedding, LayerNorm, PositionEncoder
 from fairseq2.nn.incremental_state import IncrementalStateBag
-from fairseq2.nn.normalization import LayerNorm
 from fairseq2.nn.padding import PaddingMask
-from fairseq2.nn.position_encoder import PositionEncoder
-from fairseq2.nn.transformer.layer_norm import (
-    LayerNormFactory,
-    create_standard_layer_norm,
-)
+from fairseq2.nn.transformer import LayerNormFactory, create_standard_layer_norm
 from fairseq2.typing import DataType, Device, override
 
 

--- a/src/fairseq2/models/transformer/model.py
+++ b/src/fairseq2/models/transformer/model.py
@@ -13,9 +13,9 @@ from fairseq2.data import VocabularyInfo
 from fairseq2.models.encoder_decoder import EncoderDecoderModel
 from fairseq2.models.sequence import SequenceModelOutput
 from fairseq2.models.transformer.frontend import TransformerFrontend
+from fairseq2.nn import Linear, Projection
 from fairseq2.nn.incremental_state import IncrementalStateBag
 from fairseq2.nn.padding import PaddingMask
-from fairseq2.nn.projection import Linear, Projection
 from fairseq2.nn.transformer import TransformerDecoder, TransformerEncoder
 from fairseq2.typing import override
 

--- a/src/fairseq2/models/w2vbert/model.py
+++ b/src/fairseq2/models/w2vbert/model.py
@@ -21,8 +21,8 @@ from fairseq2.models.wav2vec2 import (
     Wav2Vec2Output,
 )
 from fairseq2.models.wav2vec2.masker import extract_masked_elements
+from fairseq2.nn import Linear
 from fairseq2.nn.padding import PaddingMask
-from fairseq2.nn.projection import Linear
 from fairseq2.typing import DataType, Device
 
 

--- a/src/fairseq2/models/wav2vec2/factory.py
+++ b/src/fairseq2/models/wav2vec2/factory.py
@@ -27,7 +27,7 @@ from fairseq2.models.wav2vec2.vector_quantizer import (
     GumbelVectorQuantizer,
     VectorQuantizer,
 )
-from fairseq2.nn.position_encoder import PositionEncoder, RotaryEncoder
+from fairseq2.nn import PositionEncoder, RotaryEncoder
 from fairseq2.nn.transformer import (
     SDPA,
     FeedForwardNetwork,

--- a/src/fairseq2/models/wav2vec2/feature_extractor.py
+++ b/src/fairseq2/models/wav2vec2/feature_extractor.py
@@ -13,7 +13,7 @@ from torch.nn import GELU, Conv1d, Dropout, GroupNorm, Module, Sequential
 from torch.nn.functional import group_norm, layer_norm
 
 from fairseq2.models.feature_extractor import SequenceFeatureExtractor
-from fairseq2.nn.normalization import LayerNorm
+from fairseq2.nn import LayerNorm
 from fairseq2.nn.padding import PaddingMask
 from fairseq2.nn.utils.grad import scale_grad
 from fairseq2.typing import DataType, Device, override

--- a/src/fairseq2/models/wav2vec2/frontend.py
+++ b/src/fairseq2/models/wav2vec2/frontend.py
@@ -12,11 +12,9 @@ from torch.nn import Dropout
 from fairseq2.models.feature_extractor import SequenceFeatureExtractor
 from fairseq2.models.transformer import TransformerFrontend
 from fairseq2.models.wav2vec2.masker import Wav2Vec2Masker
+from fairseq2.nn import LayerNorm, Linear, PositionEncoder, StandardLayerNorm
 from fairseq2.nn.incremental_state import IncrementalStateBag
-from fairseq2.nn.normalization import LayerNorm, StandardLayerNorm
 from fairseq2.nn.padding import PaddingMask
-from fairseq2.nn.position_encoder import PositionEncoder
-from fairseq2.nn.projection import Linear
 from fairseq2.typing import DataType, Device, override
 
 

--- a/src/fairseq2/models/wav2vec2/model.py
+++ b/src/fairseq2/models/wav2vec2/model.py
@@ -21,9 +21,9 @@ from fairseq2.models.wav2vec2.vector_quantizer import (
     VectorQuantizer,
     VectorQuantizerOutput,
 )
+from fairseq2.nn import Linear
 from fairseq2.nn.ops import repeat_interleave
 from fairseq2.nn.padding import PaddingMask
-from fairseq2.nn.projection import Linear
 from fairseq2.nn.transformer import TransformerEncoder
 from fairseq2.typing import DataType, Device
 

--- a/src/fairseq2/models/wav2vec2/vector_quantizer.py
+++ b/src/fairseq2/models/wav2vec2/vector_quantizer.py
@@ -13,7 +13,7 @@ from torch import Tensor
 from torch.nn import Module, Parameter
 from torch.nn.functional import gumbel_softmax
 
-from fairseq2.nn.projection import Linear
+from fairseq2.nn import Linear
 from fairseq2.typing import DataType, Device, override
 
 


### PR DESCRIPTION
This PR improves the implementation of `Wav2Vec2PositionEncoder` to handle frozen weights correctly. Also suppresses the noisy deprecation message and raises a user friendly error if it is used with bfloat16 in < PyTorch 2.2. Beyond that, there are a few nit updates in the PR as well including a `remove_parametrizations()` helper function that is closely related to `weight_norm`.