### PR TITLE
Remove WerMetric from __init__

### DIFF
--- a/src/fairseq2/metrics/__init__.py
+++ b/src/fairseq2/metrics/__init__.py
@@ -19,4 +19,3 @@ from fairseq2.metrics.metric_recorder import record_metrics as record_metrics
 from fairseq2.metrics.metric_recorder import (
     register_metric_formatter as register_metric_formatter,
 )
-from fairseq2.metrics.wer_metric import WerMetric as WerMetric

--- a/src/fairseq2/models/wav2vec2/asr/__init__.py
+++ b/src/fairseq2/models/wav2vec2/asr/__init__.py
@@ -15,14 +15,8 @@ from fairseq2.models.wav2vec2.asr.factory import wav2vec2_asr_arch as wav2vec2_a
 from fairseq2.models.wav2vec2.asr.factory import (
     wav2vec2_asr_archs as wav2vec2_asr_archs,
 )
-from fairseq2.models.wav2vec2.asr.model import (
-    Wav2Vec2AsrMetricBag as Wav2Vec2AsrMetricBag,
-)
 from fairseq2.models.wav2vec2.asr.model import Wav2Vec2AsrModel as Wav2Vec2AsrModel
 from fairseq2.models.wav2vec2.asr.model import Wav2Vec2AsrOutput as Wav2Vec2AsrOutput
-from fairseq2.models.wav2vec2.asr.model import (
-    Wav2Vec2AsrValidMetricBag as Wav2Vec2AsrValidMetricBag,
-)
 from fairseq2.models.wav2vec2.asr.setup import (
     load_wav2vec2_asr_config as load_wav2vec2_asr_config,
 )

--- a/src/fairseq2/models/wav2vec2/asr/metrics.py
+++ b/src/fairseq2/models/wav2vec2/asr/metrics.py
@@ -1,0 +1,201 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import math
+from typing import Any, Dict, Optional, Sequence
+
+import torch
+from torch import Tensor
+from torcheval.metrics import Mean, Sum, Throughput
+
+from fairseq2.data.text import TextTokenizer
+from fairseq2.gang import Gang
+from fairseq2.metrics import MetricBag
+from fairseq2.metrics.wer_metric import WerMetric
+from fairseq2.models.seq2seq import Seq2SeqBatch
+from fairseq2.models.wav2vec2.asr.model import Wav2Vec2AsrOutput
+from fairseq2.typing import override
+from fairseq2.utils.profiler import Stopwatch
+
+
+class Wav2Vec2AsrMetricBag(MetricBag):
+    """Holds the common metrics of a wav2vec 2.0 ASR model."""
+
+    ctc_loss: Mean
+    batch_size: Mean
+    elements_per_batch: Mean
+    elements_per_second: Throughput
+    num_examples: Sum
+    num_source_elements: Sum
+    num_target_elements: Sum
+
+    def __init__(self, gang: Gang, *, wall_time: Optional[Stopwatch] = None) -> None:
+        """
+        :param gang:
+            The gang to sync metrics across all processes.
+        :param wall_time:
+            The :class:`Stopwatch` to keep track of process wall time.
+        """
+        super().__init__(gang, wall_time)
+
+        d = gang.device
+
+        self.register_metric("ctc_loss", Mean(device=d), persistent=False)
+
+        self.register_metric("batch_size", Mean(device=d), persistent=False)
+
+        self.register_metric("elements_per_batch", Mean(device=d), persistent=False)
+
+        self.register_metric(
+            "elements_per_second", Throughput(device=d), persistent=False
+        )
+
+        self.num_examples = Sum(device=d)
+
+        self.num_source_elements = Sum(device=d)
+        self.num_target_elements = Sum(device=d)
+
+    @torch.inference_mode()
+    def update_step_metrics(
+        self,
+        batches: Sequence[Seq2SeqBatch],
+        ctc_losses: Sequence[Tensor],
+        time: Stopwatch,
+    ) -> None:
+        """Update the step metrics.
+
+        :param batches:
+            The batches processed by the model.
+        :param ctc_losses:
+            The CTC losses output by the model for ``batches``.
+        :param time:
+            The :class:`Stopwatch` to keep track of elapsed time.
+        """
+        ctc_loss = torch.zeros((), dtype=torch.float64)
+
+        batch_size = torch.zeros((), dtype=torch.float64)
+
+        num_source_elements = torch.zeros((), dtype=torch.float64)
+        num_target_elements = torch.zeros((), dtype=torch.float64)
+
+        for batch, batch_ctc_loss in zip(batches, ctc_losses):
+            ctc_loss += float(batch_ctc_loss)
+
+            batch_size += batch.batch_size
+
+            num_source_elements += batch.num_source_elements()
+            num_target_elements += batch.num_target_elements()
+
+        self.ctc_loss.update(ctc_loss / batch_size / math.log(2), weight=batch_size)
+
+        self.batch_size.update(batch_size * self._gang.size)
+
+        self.num_examples.update(batch_size)
+
+        self.num_source_elements.update(num_source_elements)
+        self.num_target_elements.update(num_target_elements)
+
+        self.elements_per_batch.update(num_source_elements * self._gang.size)
+
+        self.elements_per_second.update(
+            int(num_source_elements), time.get_elapsed_time()
+        )
+
+    def reset_step_metrics(self) -> None:
+        """Reset the step metrics to their initial state."""
+        self.ctc_loss.reset()
+        self.batch_size.reset()
+        self.elements_per_batch.reset()
+        self.elements_per_second.reset()
+
+    @override
+    def process_metric_values(self, values: Dict[str, Any]) -> None:
+        super().process_metric_values(values)
+
+        values["elapsed_time"] = self.elements_per_second.elapsed_time_sec
+
+
+class Wav2Vec2AsrValidMetricBag(Wav2Vec2AsrMetricBag):
+    """Holds the common validation metrics of a wav2vec 2.0 ASR model."""
+
+    wer: WerMetric
+
+    _pad_idx: int
+    _blank_label: int
+
+    def __init__(
+        self,
+        gang: Gang,
+        tokenizer: TextTokenizer,
+        *,
+        blank_label: int = 0,
+        wall_time: Optional[Stopwatch] = None,
+    ) -> None:
+        """
+        :param gang:
+            The gang to sync metrics across all processes.
+        :param tokenizer:
+            The text tokenizer to compute the WER (Word Error Rate).
+        :param blank_label:
+            The blank label in logits.
+        :param wall_time:
+            The :class:`Stopwatch` to keep track of process wall time.
+        """
+        super().__init__(gang, wall_time=wall_time)
+
+        wer = WerMetric(tokenizer=tokenizer, device=gang.device)
+
+        self.register_metric("wer", wer, persistent=False)
+
+        pad_idx = tokenizer.vocab_info.pad_idx
+        if pad_idx is None:
+            raise ValueError(
+                "``vocab_info` of `tokenizer` must have a PAD symbol defined."
+            )
+
+        self._pad_idx = pad_idx
+
+        self._blank_label = blank_label
+
+    @torch.inference_mode()
+    def update_wer_metric(
+        self, batch: Seq2SeqBatch, model_output: Wav2Vec2AsrOutput
+    ) -> None:
+        """Update the WER (Word Error Rate).
+
+        :param batch:
+            The batch processed by the model.
+        :param model_output:
+            The output of the model for ``batch``.
+        """
+        # (N, S), (N, S)
+        hyp_seqs, hyp_padding_mask = model_output.generate_hypotheses(
+            self._pad_idx, self._blank_label
+        )
+
+        self.wer.update(
+            batch.target_seqs,
+            batch.target_padding_mask,
+            hyp_seqs,
+            hyp_padding_mask,
+        )
+
+    @override
+    def reset_step_metrics(self) -> None:
+        super().reset_step_metrics()
+
+        self.wer.reset()
+
+    @override
+    def process_metric_values(self, values: Dict[str, Any]) -> None:
+        super().process_metric_values(values)
+
+        uer, wer = values.pop("wer")
+
+        values["uer"] = uer
+        values["wer"] = wer

--- a/src/fairseq2/models/wav2vec2/asr/model.py
+++ b/src/fairseq2/models/wav2vec2/asr/model.py
@@ -19,7 +19,8 @@ from torcheval.metrics import Mean, Sum, Throughput
 
 from fairseq2.data.text import TextTokenizer
 from fairseq2.gang import Gang
-from fairseq2.metrics import MetricBag, WerMetric
+from fairseq2.metrics import MetricBag
+from fairseq2.metrics.wer_metric import WerMetric
 from fairseq2.models.model import Model
 from fairseq2.models.seq2seq import Seq2SeqBatch
 from fairseq2.models.wav2vec2.frontend import Wav2Vec2Frontend

--- a/src/fairseq2/models/wav2vec2/asr/model.py
+++ b/src/fairseq2/models/wav2vec2/asr/model.py
@@ -6,21 +6,15 @@
 
 from __future__ import annotations
 
-import math
 from dataclasses import dataclass
-from typing import Any, Dict, Optional, Sequence, Tuple, final
+from typing import Optional, Tuple, final
 
 import torch
 import torch.nn as nn
 from torch import Tensor
 from torch.nn import Dropout
 from torch.nn.functional import ctc_loss, log_softmax
-from torcheval.metrics import Mean, Sum, Throughput
 
-from fairseq2.data.text import TextTokenizer
-from fairseq2.gang import Gang
-from fairseq2.metrics import MetricBag
-from fairseq2.metrics.wer_metric import WerMetric
 from fairseq2.models.model import Model
 from fairseq2.models.seq2seq import Seq2SeqBatch
 from fairseq2.models.wav2vec2.frontend import Wav2Vec2Frontend
@@ -28,8 +22,7 @@ from fairseq2.models.wav2vec2.masker import Wav2Vec2Masker
 from fairseq2.nn import Linear
 from fairseq2.nn.padding import PaddingMask, get_seq_lens, pad_seqs
 from fairseq2.nn.transformer import TransformerEncoder
-from fairseq2.typing import DataType, Device, override
-from fairseq2.utils.profiler import Stopwatch
+from fairseq2.typing import DataType, Device
 
 
 @final
@@ -204,181 +197,3 @@ class Wav2Vec2AsrOutput:
 
         # (N, S), (N, S)
         return pad_seqs(hyp_seq_list, pad_value=pad_idx)
-
-
-class Wav2Vec2AsrMetricBag(MetricBag):
-    """Holds the common metrics of a wav2vec 2.0 ASR model."""
-
-    ctc_loss: Mean
-    batch_size: Mean
-    elements_per_batch: Mean
-    elements_per_second: Throughput
-    num_examples: Sum
-    num_source_elements: Sum
-    num_target_elements: Sum
-
-    def __init__(self, gang: Gang, *, wall_time: Optional[Stopwatch] = None) -> None:
-        """
-        :param gang:
-            The gang to sync metrics across all processes.
-        :param wall_time:
-            The :class:`Stopwatch` to keep track of process wall time.
-        """
-        super().__init__(gang, wall_time)
-
-        d = gang.device
-
-        self.register_metric("ctc_loss", Mean(device=d), persistent=False)
-
-        self.register_metric("batch_size", Mean(device=d), persistent=False)
-
-        self.register_metric("elements_per_batch", Mean(device=d), persistent=False)
-
-        self.register_metric(
-            "elements_per_second", Throughput(device=d), persistent=False
-        )
-
-        self.num_examples = Sum(device=d)
-
-        self.num_source_elements = Sum(device=d)
-        self.num_target_elements = Sum(device=d)
-
-    @torch.inference_mode()
-    def update_step_metrics(
-        self,
-        batches: Sequence[Seq2SeqBatch],
-        ctc_losses: Sequence[Tensor],
-        time: Stopwatch,
-    ) -> None:
-        """Update the step metrics.
-
-        :param batches:
-            The batches processed by the model.
-        :param ctc_losses:
-            The CTC losses output by the model for ``batches``.
-        :param time:
-            The :class:`Stopwatch` to keep track of elapsed time.
-        """
-        ctc_loss = torch.zeros((), dtype=torch.float64)
-
-        batch_size = torch.zeros((), dtype=torch.float64)
-
-        num_source_elements = torch.zeros((), dtype=torch.float64)
-        num_target_elements = torch.zeros((), dtype=torch.float64)
-
-        for batch, batch_ctc_loss in zip(batches, ctc_losses):
-            ctc_loss += float(batch_ctc_loss)
-
-            batch_size += batch.batch_size
-
-            num_source_elements += batch.num_source_elements()
-            num_target_elements += batch.num_target_elements()
-
-        self.ctc_loss.update(ctc_loss / batch_size / math.log(2), weight=batch_size)
-
-        self.batch_size.update(batch_size * self._gang.size)
-
-        self.num_examples.update(batch_size)
-
-        self.num_source_elements.update(num_source_elements)
-        self.num_target_elements.update(num_target_elements)
-
-        self.elements_per_batch.update(num_source_elements * self._gang.size)
-
-        self.elements_per_second.update(
-            int(num_source_elements), time.get_elapsed_time()
-        )
-
-    def reset_step_metrics(self) -> None:
-        """Reset the step metrics to their initial state."""
-        self.ctc_loss.reset()
-        self.batch_size.reset()
-        self.elements_per_batch.reset()
-        self.elements_per_second.reset()
-
-    @override
-    def process_metric_values(self, values: Dict[str, Any]) -> None:
-        super().process_metric_values(values)
-
-        values["elapsed_time"] = self.elements_per_second.elapsed_time_sec
-
-
-class Wav2Vec2AsrValidMetricBag(Wav2Vec2AsrMetricBag):
-    """Holds the common validation metrics of a wav2vec 2.0 ASR model."""
-
-    wer: WerMetric
-
-    _pad_idx: int
-    _blank_label: int
-
-    def __init__(
-        self,
-        gang: Gang,
-        tokenizer: TextTokenizer,
-        *,
-        blank_label: int = 0,
-        wall_time: Optional[Stopwatch] = None,
-    ) -> None:
-        """
-        :param gang:
-            The gang to sync metrics across all processes.
-        :param tokenizer:
-            The text tokenizer to compute the WER (Word Error Rate).
-        :param blank_label:
-            The blank label in logits.
-        :param wall_time:
-            The :class:`Stopwatch` to keep track of process wall time.
-        """
-        super().__init__(gang, wall_time=wall_time)
-
-        wer = WerMetric(tokenizer=tokenizer, device=gang.device)
-
-        self.register_metric("wer", wer, persistent=False)
-
-        pad_idx = tokenizer.vocab_info.pad_idx
-        if pad_idx is None:
-            raise ValueError(
-                "``vocab_info` of `tokenizer` must have a PAD symbol defined."
-            )
-
-        self._pad_idx = pad_idx
-
-        self._blank_label = blank_label
-
-    @torch.inference_mode()
-    def update_wer_metric(
-        self, batch: Seq2SeqBatch, model_output: Wav2Vec2AsrOutput
-    ) -> None:
-        """Update the WER (Word Error Rate).
-
-        :param batch:
-            The batch processed by the model.
-        :param model_output:
-            The output of the model for ``batch``.
-        """
-        # (N, S), (N, S)
-        hyp_seqs, hyp_padding_mask = model_output.generate_hypotheses(
-            self._pad_idx, self._blank_label
-        )
-
-        self.wer.update(
-            batch.target_seqs,
-            batch.target_padding_mask,
-            hyp_seqs,
-            hyp_padding_mask,
-        )
-
-    @override
-    def reset_step_metrics(self) -> None:
-        super().reset_step_metrics()
-
-        self.wer.reset()
-
-    @override
-    def process_metric_values(self, values: Dict[str, Any]) -> None:
-        super().process_metric_values(values)
-
-        uer, wer = values.pop("wer")
-
-        values["uer"] = uer
-        values["wer"] = wer


### PR DESCRIPTION
This PR removes `WerMetric` from `__init__.py` of `fairseq2.metrics` since it transitively causes a dependency on the editdistance package. It also moves wav2vec 2.0 ASR metric bags to their own module for similar reason.