### PR TITLE
Add seed parameters to data pipeline APIs

### DIFF
--- a/native/python/src/fairseq2n/bindings/data/data_pipeline.cc
+++ b/native/python/src/fairseq2n/bindings/data/data_pipeline.cc
@@ -217,7 +217,11 @@ def_data_pipeline(py::module_ &data_module)
             },
             py::keep_alive<0, 1>{})
 
-        .def("reset", &data_pipeline::reset, py::call_guard<py::gil_scoped_release>{})
+        .def(
+            "reset",
+            &data_pipeline::reset,
+            py::arg("reset_rng") = false,
+            py::call_guard<py::gil_scoped_release>{})
 
         .def("is_infinite", &data_pipeline::is_infinite)
 
@@ -300,17 +304,17 @@ def_data_pipeline(py::module_ &data_module)
             py::arg("pipelines"))
         .def_static(
             "constant",
-            [](data example, std::optional<std::string> key)
+            [](data example, std::optional<std::string> maybe_key)
             {
-                return data_pipeline::constant(std::move(example), std::move(key));
+                return data_pipeline::constant(std::move(example), std::move(maybe_key));
             },
             py::arg("example"),
             py::arg("key") = std::nullopt)
         .def_static(
             "count",
-            [](std::int64_t start, std::int64_t step, std::optional<std::string> key)
+            [](std::int64_t start, std::int64_t step, std::optional<std::string> maybe_key)
             {
-                return data_pipeline::count(start, step, std::move(key));
+                return data_pipeline::count(start, step, std::move(maybe_key));
             },
             py::arg("start") = 0,
             py::arg("step") = 1,
@@ -337,7 +341,8 @@ def_data_pipeline(py::module_ &data_module)
             "sample",
             [](
                 std::vector<std::reference_wrapper<data_pipeline>> &refs,
-                std::optional<std::vector<float>> weights)
+                std::optional<std::vector<float>> maybe_weights,
+                std::optional<std::uint64_t> maybe_seed)
             {
                 std::vector<data_pipeline> pipelines{};
 
@@ -348,10 +353,12 @@ def_data_pipeline(py::module_ &data_module)
                         return std::move(r.get());
                     });
 
-                return data_pipeline::sample(std::move(pipelines), std::move(weights));
+                return data_pipeline::sample(
+                    std::move(pipelines), std::move(maybe_weights), maybe_seed);
             },
             py::arg("pipelines"),
-            py::arg("weights") = std::nullopt)
+            py::arg("weights") = std::nullopt,
+            py::arg("seed") = std::nullopt)
         .def_static(
             "zip",
             [](
@@ -519,13 +526,15 @@ def_data_pipeline(py::module_ &data_module)
             "repeat",
             [](
                 data_pipeline_builder &self,
-                std::optional<std::size_t> num_repeats) -> data_pipeline_builder &
+                std::optional<std::size_t> num_repeats,
+                bool reset_rng) -> data_pipeline_builder &
             {
-                self = std::move(self).repeat(num_repeats);
+                self = std::move(self).repeat(num_repeats, reset_rng);
 
                 return self;
             },
-            py::arg("num_repeats") = std::nullopt)
+            py::arg("num_repeats") = std::nullopt,
+            py::arg("reset_rng") = false)
         .def(
             "shard",
             [](
@@ -544,14 +553,14 @@ def_data_pipeline(py::module_ &data_module)
             [](
                 data_pipeline_builder &self,
                 std::size_t shuffle_window,
-                bool enabled) -> data_pipeline_builder &
+                std::optional<std::uint64_t> maybe_seed) -> data_pipeline_builder &
             {
-                self = std::move(self).shuffle(shuffle_window, enabled);
+                self = std::move(self).shuffle(shuffle_window, maybe_seed);
 
                 return self;
             },
             py::arg("shuffle_window"),
-            py::arg("enabled") = true)
+            py::arg("seed") = std::nullopt)
         .def(
             "skip",
             [](data_pipeline_builder &self, std::size_t num_examples) -> data_pipeline_builder &

--- a/native/src/fairseq2n/data/bucket_by_length_data_source.cc
+++ b/native/src/fairseq2n/data/bucket_by_length_data_source.cc
@@ -134,12 +134,12 @@ bucket_by_length_data_source::next()
 }
 
 void
-bucket_by_length_data_source::reset()
+bucket_by_length_data_source::reset(bool reset_rng)
 {
     for (data_list &bucket : buckets_)
         bucket.clear();
 
-    inner_->reset();
+    inner_->reset(reset_rng);
 }
 
 void

--- a/native/src/fairseq2n/data/bucket_by_length_data_source.h
+++ b/native/src/fairseq2n/data/bucket_by_length_data_source.h
@@ -33,7 +33,7 @@ public:
     next() override;
 
     void
-    reset() override;
+    reset(bool reset_rng) override;
 
     void
     record_position(tape &t, bool strict) const override;

--- a/native/src/fairseq2n/data/bucket_data_source.cc
+++ b/native/src/fairseq2n/data/bucket_data_source.cc
@@ -40,9 +40,9 @@ bucket_data_source::next()
 }
 
 void
-bucket_data_source::reset()
+bucket_data_source::reset(bool reset_rng)
 {
-    inner_->reset();
+    inner_->reset(reset_rng);
 }
 
 void

--- a/native/src/fairseq2n/data/bucket_data_source.h
+++ b/native/src/fairseq2n/data/bucket_data_source.h
@@ -26,7 +26,7 @@ public:
     next() override;
 
     void
-    reset() override;
+    reset(bool reset_rng) override;
 
     void
     record_position(tape &t, bool strict) const override;

--- a/native/src/fairseq2n/data/concat_data_source.cc
+++ b/native/src/fairseq2n/data/concat_data_source.cc
@@ -31,10 +31,10 @@ concat_data_source::next()
     return std::nullopt;
 }
 
-void concat_data_source::reset()
+void concat_data_source::reset(bool reset_rng)
 {
     for (data_pipeline &pipeline : pipelines_)
-        pipeline.reset();
+        pipeline.reset(reset_rng);
 }
 
 void concat_data_source::record_position(tape &t, bool strict) const

--- a/native/src/fairseq2n/data/concat_data_source.h
+++ b/native/src/fairseq2n/data/concat_data_source.h
@@ -23,7 +23,7 @@ public:
     next() override;
 
     void
-    reset() override;
+    reset(bool reset_rng) override;
 
     void
     record_position(tape &t, bool strict) const override;

--- a/native/src/fairseq2n/data/constant_data_source.cc
+++ b/native/src/fairseq2n/data/constant_data_source.cc
@@ -13,14 +13,14 @@ namespace fairseq2n::detail {
 std::optional<data>
 constant_data_source::next()
 {
-    if (key_)
-        return data_dict{{*key_, example_}};
+    if (maybe_key_)
+        return data_dict{{*maybe_key_, example_}};
 
     return example_;
 }
 
 void
-constant_data_source::reset()
+constant_data_source::reset(bool)
 {}
 
 void

--- a/native/src/fairseq2n/data/constant_data_source.h
+++ b/native/src/fairseq2n/data/constant_data_source.h
@@ -17,15 +17,15 @@ namespace fairseq2n::detail {
 class constant_data_source final : public data_source {
 public:
     explicit
-    constant_data_source(data &&example, std::optional<std::string> &&key) noexcept
-      : example_{std::move(example)}, key_{std::move(key)}
+    constant_data_source(data &&example, std::optional<std::string> &&maybe_key) noexcept
+      : example_{std::move(example)}, maybe_key_{std::move(maybe_key)}
     {}
 
     std::optional<data>
     next() override;
 
     void
-    reset() override;
+    reset(bool reset_rng) override;
 
     void
     record_position(tape &t, bool strict) const override;
@@ -38,7 +38,7 @@ public:
 
 private:
     data example_;
-    std::optional<std::string> key_;
+    std::optional<std::string> maybe_key_;
 };
 
 }  // namespace fairseq2n::detail

--- a/native/src/fairseq2n/data/count_data_source.cc
+++ b/native/src/fairseq2n/data/count_data_source.cc
@@ -17,14 +17,14 @@ count_data_source::next()
 
     counter_ += step_;
 
-    if (key_)
-        return data_dict{{*key_, output}};
+    if (maybe_key_)
+        return data_dict{{*maybe_key_, output}};
 
     return output;
 }
 
 void
-count_data_source::reset()
+count_data_source::reset(bool)
 {
     counter_ = start_;
 }

--- a/native/src/fairseq2n/data/count_data_source.h
+++ b/native/src/fairseq2n/data/count_data_source.h
@@ -16,15 +16,15 @@ class count_data_source final : public data_source {
 public:
     explicit
     count_data_source(
-        std::int64_t start, std::int64_t step, std::optional<std::string> &&key) noexcept
-      : start_{start}, step_{step}, counter_{start}, key_{std::move(key)}
+        std::int64_t start, std::int64_t step, std::optional<std::string> &&maybe_key) noexcept
+      : start_{start}, step_{step}, counter_{start}, maybe_key_{std::move(maybe_key)}
     {}
 
     std::optional<data>
     next() override;
 
     void
-    reset() override;
+    reset(bool reset_rng) override;
 
     void
     record_position(tape &t, bool strict) const override;
@@ -39,7 +39,7 @@ private:
     std::int64_t start_;
     std::int64_t step_;
     std::int64_t counter_;
-    std::optional<std::string> key_;
+    std::optional<std::string> maybe_key_;
 };
 
 }  // namespace fairseq2n::detail

--- a/native/src/fairseq2n/data/data_pipeline.cc
+++ b/native/src/fairseq2n/data/data_pipeline.cc
@@ -79,13 +79,13 @@ data_pipeline::next()
 }
 
 void
-data_pipeline::reset()
+data_pipeline::reset(bool reset_rng)
 {
     if (is_broken_ || !source_)
         return;
 
     try {
-        source_->reset();
+        source_->reset(reset_rng);
     } catch (const std::exception &) {
         is_broken_ = true;
 
@@ -209,22 +209,22 @@ data_pipeline::concat(std::vector<data_pipeline> pipelines)
 }
 
 data_pipeline_builder
-data_pipeline::constant(data example, std::optional<std::string> key)
+data_pipeline::constant(data example, std::optional<std::string> maybe_key)
 {
-    auto factory = [example = std::move(example), key = std::move(key)]() mutable
+    auto factory = [example = std::move(example), maybe_key = std::move(maybe_key)]() mutable
     {
-        return std::make_unique<constant_data_source>(std::move(example), std::move(key));
+        return std::make_unique<constant_data_source>(std::move(example), std::move(maybe_key));
     };
 
     return data_pipeline_builder{std::move(factory)};
 }
 
 data_pipeline_builder
-data_pipeline::count(std::int64_t start, std::int64_t step, std::optional<std::string> key)
+data_pipeline::count(std::int64_t start, std::int64_t step, std::optional<std::string> maybe_key)
 {
-    auto factory = [start, step, key = std::move(key)]() mutable
+    auto factory = [start, step, maybe_key = std::move(maybe_key)]() mutable
     {
-        return std::make_unique<count_data_source>(start, step, std::move(key));
+        return std::make_unique<count_data_source>(start, step, std::move(maybe_key));
     };
 
     return data_pipeline_builder{std::move(factory)};
@@ -255,7 +255,9 @@ data_pipeline::round_robin(std::vector<data_pipeline> pipelines, bool stop_at_sh
 
 data_pipeline_builder
 data_pipeline::sample(
-    std::vector<data_pipeline> pipelines, std::optional<std::vector<float32>> maybe_weights)
+    std::vector<data_pipeline> pipelines,
+    std::optional<std::vector<float32>> maybe_weights,
+    std::optional<std::uint64_t> maybe_seed)
 {
     bool is_broken = std::any_of(
         pipelines.begin(), pipelines.end(), [](const data_pipeline &pipeline)
@@ -293,8 +295,8 @@ data_pipeline::sample(
 
     auto tmp = std::make_shared<std::vector<data_pipeline>>(std::move(pipelines));
 
-    auto factory = [tmp, weights=std::move(weights)]() mutable {
-        return std::make_unique<sample_data_source>(std::move(*tmp), std::move(weights));
+    auto factory = [tmp, weights=std::move(weights), maybe_seed]() mutable {
+        return std::make_unique<sample_data_source>(std::move(*tmp), std::move(weights), maybe_seed);
     };
 
     return data_pipeline_builder{std::move(factory)};
@@ -420,23 +422,21 @@ data_pipeline_builder::map(const map_fn &fn, std::size_t num_parallel_calls) &&
 data_pipeline_builder
 data_pipeline_builder::prefetch(std::size_t num_examples) &&
 {
-    if (num_examples > 0)
-        factory_ = [=, inner = std::move(factory_)]
-        {
-            return std::make_unique<prefetch_data_source>(inner(), num_examples);
-        };
+    factory_ = [=, inner = std::move(factory_)]
+    {
+        return std::make_unique<prefetch_data_source>(inner(), num_examples);
+    };
 
     return std::move(*this);
 }
 
 data_pipeline_builder
-data_pipeline_builder::repeat(std::optional<std::size_t> num_repeats) &&
+data_pipeline_builder::repeat(std::optional<std::size_t> num_repeats, bool reset_rng) &&
 {
-    if (!num_repeats || *num_repeats != 1)
-        factory_ = [=, inner = std::move(factory_)]
-        {
-            return std::make_unique<repeat_data_source>(inner(), num_repeats);
-        };
+    factory_ = [=, inner = std::move(factory_)]
+    {
+        return std::make_unique<repeat_data_source>(inner(), num_repeats, reset_rng);
+    };
 
     return std::move(*this);
 }
@@ -444,27 +444,29 @@ data_pipeline_builder::repeat(std::optional<std::size_t> num_repeats) &&
 data_pipeline_builder
 data_pipeline_builder::shard(std::size_t shard_idx, std::size_t num_shards) &&
 {
+    if (num_shards == 0)
+        throw_<std::invalid_argument>(
+            "`num_shards` must be greater than zero.");
+
     if (shard_idx >= num_shards)
         throw_<std::invalid_argument>(
             "`shard_idx` must be less than `num_shards` ({}), but is {} instead.", num_shards, shard_idx);
 
-    if (num_shards > 1)
-        factory_ = [=, inner = std::move(factory_)]
-        {
-            return std::make_unique<shard_data_source>(inner(), shard_idx, num_shards);
-        };
+    factory_ = [=, inner = std::move(factory_)]
+    {
+        return std::make_unique<shard_data_source>(inner(), shard_idx, num_shards);
+    };
 
     return std::move(*this);
 }
 
 data_pipeline_builder
-data_pipeline_builder::shuffle(std::size_t shuffle_window, bool enabled) &&
+data_pipeline_builder::shuffle(std::size_t shuffle_window, std::optional<std::uint64_t> maybe_seed) &&
 {
-    if (enabled)
-        factory_ = [=, inner = std::move(factory_)]
-        {
-            return std::make_unique<shuffle_data_source>(inner(), shuffle_window);
-        };
+    factory_ = [=, inner = std::move(factory_)]
+    {
+        return std::make_unique<shuffle_data_source>(inner(), shuffle_window, maybe_seed);
+    };
 
     return std::move(*this);
 }
@@ -472,11 +474,10 @@ data_pipeline_builder::shuffle(std::size_t shuffle_window, bool enabled) &&
 data_pipeline_builder
 data_pipeline_builder::skip(std::size_t num_examples) &&
 {
-    if (num_examples > 0)
-        factory_ = [=, inner = std::move(factory_)]
-        {
-            return std::make_unique<skip_data_source>(inner(), num_examples);
-        };
+    factory_ = [=, inner = std::move(factory_)]
+    {
+        return std::make_unique<skip_data_source>(inner(), num_examples);
+    };
 
     return std::move(*this);
 }

--- a/native/src/fairseq2n/data/data_pipeline.h
+++ b/native/src/fairseq2n/data/data_pipeline.h
@@ -44,10 +44,10 @@ public:
     next();
 
     void
-    reset();
+    reset(bool reset_rng = false);
 
     void
-    record_position(tape &t, bool strict) const;
+    record_position(tape &t, bool strict = true) const;
 
     void
     reload_position(tape &t);
@@ -85,7 +85,10 @@ public:
     round_robin(std::vector<data_pipeline> pipelines, bool stop_at_shortest = false);
 
     static data_pipeline_builder
-    sample(std::vector<data_pipeline> pipelines, std::optional<std::vector<float>> weights = {});
+    sample(
+        std::vector<data_pipeline> pipelines,
+        std::optional<std::vector<float>> maybe_weights = {},
+        std::optional<std::uint64_t> maybe_seed = {});
 
     static data_pipeline_builder
     zip(
@@ -148,13 +151,13 @@ public:
     prefetch(std::size_t num_examples) &&;
 
     data_pipeline_builder
-    repeat(std::optional<std::size_t> num_repeats = std::nullopt) &&;
+    repeat(std::optional<std::size_t> num_repeats = std::nullopt, bool reset_rng = false) &&;
 
     data_pipeline_builder
     shard(std::size_t shard_idx, std::size_t num_shards) &&;
 
     data_pipeline_builder
-    shuffle(std::size_t shuffle_window, bool enabled = true) &&;
+    shuffle(std::size_t shuffle_window, std::optional<std::uint64_t> maybe_seed = {}) &&;
 
     data_pipeline_builder
     skip(std::size_t num_examples) &&;

--- a/native/src/fairseq2n/data/data_source.h
+++ b/native/src/fairseq2n/data/data_source.h
@@ -32,7 +32,7 @@ public:
     next() = 0;
 
     virtual void
-    reset() = 0;
+    reset(bool reset_rng) = 0;
 
     virtual void
     record_position(tape &t, bool strict) const = 0;

--- a/native/src/fairseq2n/data/detail/rng.h
+++ b/native/src/fairseq2n/data/detail/rng.h
@@ -1,0 +1,22 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <cstddef>
+#include <random>
+
+namespace fairseq2n::detail {
+
+inline std::uint64_t
+pseudo_random()
+{
+    std::random_device rd{};
+
+    return ((static_cast<std::uint64_t>(rd()) << 32) + rd()) & 0x1FFFFFFFFFFFFF;
+}
+
+}  // namespace fairseq2n::detail

--- a/native/src/fairseq2n/data/filter_data_source.cc
+++ b/native/src/fairseq2n/data/filter_data_source.cc
@@ -23,9 +23,9 @@ filter_data_source::next()
 }
 
 void
-filter_data_source::reset()
+filter_data_source::reset(bool reset_rng)
 {
-    inner_->reset();
+    inner_->reset(reset_rng);
 }
 
 void

--- a/native/src/fairseq2n/data/filter_data_source.h
+++ b/native/src/fairseq2n/data/filter_data_source.h
@@ -25,7 +25,7 @@ public :
     next() override;
 
     void
-    reset() override;
+    reset(bool reset_rng) override;
 
     void
     record_position(tape &t, bool strict) const override;

--- a/native/src/fairseq2n/data/list_data_source.cc
+++ b/native/src/fairseq2n/data/list_data_source.cc
@@ -20,7 +20,7 @@ list_data_source::next()
 }
 
 void
-list_data_source::reset()
+list_data_source::reset(bool)
 {
     pos_ = list_.begin();
 }

--- a/native/src/fairseq2n/data/list_data_source.h
+++ b/native/src/fairseq2n/data/list_data_source.h
@@ -24,7 +24,7 @@ public:
     next() override;
 
     void
-    reset() override;
+    reset(bool reset_rng) override;
 
     void
     record_position(tape &t, bool strict) const override;

--- a/native/src/fairseq2n/data/map_data_source.cc
+++ b/native/src/fairseq2n/data/map_data_source.cc
@@ -51,13 +51,13 @@ map_data_source::next()
 }
 
 void
-map_data_source::reset()
+map_data_source::reset(bool reset_rng)
 {
     buffer_.clear();
 
     buffer_pos_ = buffer_.begin();
 
-    inner_->reset();
+    inner_->reset(reset_rng);
 }
 
 void

--- a/native/src/fairseq2n/data/map_data_source.h
+++ b/native/src/fairseq2n/data/map_data_source.h
@@ -29,7 +29,7 @@ public:
     next() override;
 
     void
-    reset() override;
+    reset(bool reset_rng) override;
 
     void
     record_position(tape &t, bool strict) const override;

--- a/native/src/fairseq2n/data/prefetch_data_source.cc
+++ b/native/src/fairseq2n/data/prefetch_data_source.cc
@@ -20,6 +20,9 @@ prefetch_data_source::~prefetch_data_source()
 std::optional<data>
 prefetch_data_source::next()
 {
+    if (num_examples_ == 0)
+        return inner_->next();
+
     // We pop and return examples from the read queue until we drain it and
     // then swap it with the fill queue. In parallel, the background thread
     // continuously pushes examples read from inner data source to the fill
@@ -55,7 +58,7 @@ prefetch_data_source::next()
 }
 
 void
-prefetch_data_source::reset()
+prefetch_data_source::reset(bool reset_rng)
 {
     stop_prefetch_thread();
 
@@ -67,7 +70,7 @@ prefetch_data_source::reset()
     fill_queue_.clear();
     next_queue_.clear();
 
-    inner_->reset();
+    inner_->reset(reset_rng);
 }
 
 void

--- a/native/src/fairseq2n/data/prefetch_data_source.h
+++ b/native/src/fairseq2n/data/prefetch_data_source.h
@@ -40,7 +40,7 @@ public:
     next() override;
 
     void
-    reset() override;
+    reset(bool reset_rng) override;
 
     void
     record_position(tape &t, bool strict) const override;

--- a/native/src/fairseq2n/data/repeat_data_source.cc
+++ b/native/src/fairseq2n/data/repeat_data_source.cc
@@ -32,18 +32,18 @@ repeat_data_source::next()
 
         repeat_nr_++;
 
-        inner_->reset();
+        inner_->reset(reset_rng_);
     }
 }
 
 void
-repeat_data_source::reset()
+repeat_data_source::reset(bool reset_rng)
 {
     has_data_ = false;
 
     repeat_nr_ = 0;
 
-    inner_->reset();
+    inner_->reset(reset_rng);
 }
 
 void

--- a/native/src/fairseq2n/data/repeat_data_source.h
+++ b/native/src/fairseq2n/data/repeat_data_source.h
@@ -19,15 +19,17 @@ class repeat_data_source final : public data_source {
 public:
     explicit
     repeat_data_source(
-        std::unique_ptr<data_source> &&inner, std::optional<std::size_t> num_repeats) noexcept
-      : inner_{std::move(inner)}, num_repeats_{num_repeats}
+        std::unique_ptr<data_source> &&inner,
+        std::optional<std::size_t> num_repeats,
+        bool reset_rng) noexcept
+      : inner_{std::move(inner)}, num_repeats_{num_repeats}, reset_rng_{reset_rng}
     {}
 
     std::optional<data>
     next() override;
 
     void
-    reset() override;
+    reset(bool reset_rng) override;
 
     void
     record_position(tape &t, bool strict) const override;
@@ -42,6 +44,7 @@ private:
     std::unique_ptr<data_source> inner_;
     bool has_data_ = false;
     std::optional<std::size_t> num_repeats_;
+    bool reset_rng_;
     std::size_t repeat_nr_ = 0;
 };
 

--- a/native/src/fairseq2n/data/round_robin_data_source.cc
+++ b/native/src/fairseq2n/data/round_robin_data_source.cc
@@ -63,7 +63,7 @@ round_robin_data_source::next()
 }
 
 void
-round_robin_data_source::reset()
+round_robin_data_source::reset(bool reset_rng)
 {
     buffer_.clear();
 
@@ -74,7 +74,7 @@ round_robin_data_source::reset()
     is_eod_ = false;
 
     for (data_pipeline &pipeline : pipelines_)
-        pipeline.reset();
+        pipeline.reset(reset_rng);
 }
 
 void

--- a/native/src/fairseq2n/data/round_robin_data_source.h
+++ b/native/src/fairseq2n/data/round_robin_data_source.h
@@ -24,7 +24,7 @@ public:
     next() override;
 
     void
-    reset() override;
+    reset(bool reset_rng) override;
 
     void
     record_position(tape &t, bool strict) const override;

--- a/native/src/fairseq2n/data/sample_data_source.cc
+++ b/native/src/fairseq2n/data/sample_data_source.cc
@@ -7,8 +7,6 @@
 #include "fairseq2n/data/sample_data_source.h"
 
 #include <algorithm>
-#include <cstddef>
-#include <mutex>
 #include <stdexcept>
 #include <utility>
 
@@ -17,15 +15,20 @@
 #include <ATen/core/TransformationHelper.h>
 
 #include "fairseq2n/data/detail/exception.h"
+#include "fairseq2n/data/detail/rng.h"
 #include "fairseq2n/detail/exception.h"
 
 namespace fairseq2n::detail {
 
 sample_data_source::sample_data_source(
-    std::vector<data_pipeline> &&pipelines, std::vector<float32> &&weights)
+    std::vector<data_pipeline> &&pipelines,
+    std::vector<float32> &&weights,
+    std::optional<std::uint64_t> maybe_seed)
   : pipelines_(std::move(pipelines)), is_epoch_done_(pipelines_.size())
 {
-    generator_ = at::globalContext().defaultGenerator(at::kCPU);
+    seed_ = maybe_seed ? *maybe_seed : pseudo_random();
+
+    generator_ = at::make_generator<at::CPUGeneratorImpl>(seed_);
 
     weight_cumsums_.reserve(weights.size());
 
@@ -70,7 +73,7 @@ sample_data_source::next()
 }
 
 void
-sample_data_source::reset()
+sample_data_source::reset(bool reset_rng)
 {
     buffer_.clear();
 
@@ -78,8 +81,11 @@ sample_data_source::reset()
 
     is_eod_ = false;
 
+    if (reset_rng)
+        generator_.set_current_seed(seed_);
+
     for (data_pipeline &pipeline : pipelines_)
-        pipeline.reset();
+        pipeline.reset(reset_rng);
 }
 
 void
@@ -90,6 +96,10 @@ sample_data_source::record_position(tape &t, bool strict) const
 
         t.record(is_epoch_done_);
     }
+
+    t.record(seed_);
+
+    t.record(generator_.get_state());
 
     for (const data_pipeline &pipeline : pipelines_)
         pipeline.record_position(t, strict);
@@ -110,6 +120,10 @@ sample_data_source::reload_position(tape &t, bool strict)
 
     is_eod_ = false;
 
+    seed_ = t.read<std::uint64_t>();
+
+    generator_.set_state(t.read<at::Tensor>());
+
     for (data_pipeline &pipeline : pipelines_)
         pipeline.reload_position(t);
 }
@@ -123,9 +137,7 @@ sample_data_source::is_infinite() const noexcept
 std::size_t
 sample_data_source::random_pipeline_index()
 {
-    std::lock_guard<std::mutex> guard{generator_.mutex()};
-
-    auto *gen = at::check_generator<at::CPUGeneratorImpl>(generator_);
+    auto *gen = generator_.get<at::CPUGeneratorImpl>();
 
     float32 sample = at::transformation::uniform_real(gen->random(), 0.0F, 1.0F);
 

--- a/native/src/fairseq2n/data/sample_data_source.h
+++ b/native/src/fairseq2n/data/sample_data_source.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <cstddef>
+#include <optional>
 #include <vector>
 
 #include <ATen/Generator.h>
@@ -19,13 +21,16 @@ namespace fairseq2n::detail {
 class sample_data_source final : public data_source {
 public:
     explicit
-    sample_data_source(std::vector<data_pipeline> &&pipelines, std::vector<float32> &&weights);
+    sample_data_source(
+        std::vector<data_pipeline> &&pipelines,
+        std::vector<float32> &&weights,
+        std::optional<std::uint64_t> maybe_seed);
 
     std::optional<data>
     next() override;
 
     void
-    reset() override;
+    reset(bool reset_rng) override;
 
     void
     record_position(tape &t, bool strict) const override;
@@ -48,12 +53,13 @@ private:
 
 private:
     std::vector<data_pipeline> pipelines_;
-    at::Generator generator_;
     std::vector<float32> weight_cumsums_;
     std::vector<data> buffer_{};
     std::vector<bool> is_epoch_done_;
     bool is_eod_ = false;
     bool is_infinite_;
+    std::uint64_t seed_;
+    at::Generator generator_;
 };
 
 }  // namespace fairseq2n::detail

--- a/native/src/fairseq2n/data/shard_data_source.cc
+++ b/native/src/fairseq2n/data/shard_data_source.cc
@@ -11,6 +11,9 @@ namespace fairseq2n::detail {
 std::optional<data>
 shard_data_source::next()
 {
+    if (num_shards_ == 1)
+        return inner_->next();
+
     for (std::size_t i = 0; i < shard_idx_; i++)
         if (!inner_->next())
             return std::nullopt;
@@ -27,9 +30,9 @@ shard_data_source::next()
 }
 
 void
-shard_data_source::reset()
+shard_data_source::reset(bool reset_rng)
 {
-    inner_->reset();
+    inner_->reset(reset_rng);
 }
 
 void

--- a/native/src/fairseq2n/data/shard_data_source.h
+++ b/native/src/fairseq2n/data/shard_data_source.h
@@ -28,7 +28,7 @@ public:
     next() override;
 
     void
-    reset() override;
+    reset(bool reset_rng) override;
 
     void
     record_position(tape &t, bool strict) const override;

--- a/native/src/fairseq2n/data/shuffle_data_source.h
+++ b/native/src/fairseq2n/data/shuffle_data_source.h
@@ -8,6 +8,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <optional>
 #include <utility>
 
 #include <ATen/Generator.h>
@@ -21,13 +22,16 @@ class shuffle_data_source final : public data_source {
 
 public:
     explicit
-    shuffle_data_source(std::unique_ptr<data_source> &&inner, std::size_t shuffle_window) noexcept;
+    shuffle_data_source(
+        std::unique_ptr<data_source> &&inner,
+        std::size_t shuffle_window,
+        std::optional<std::uint64_t> maybe_seed);
 
     std::optional<data>
     next() override;
 
     void
-    reset() override;
+    reset(bool reset_rng) override;
 
     void
     record_position(tape &t, bool strict) const override;
@@ -48,8 +52,9 @@ private:
     data_list::iterator buffer_pos_ = buffer_.begin();
     data_list::iterator buffer_end_ = buffer_.end();
     std::size_t shuffle_window_;
-    at::Generator generator_;
     bool fill_buffer_ = true;
+    std::uint64_t seed_;
+    at::Generator generator_;
 };
 
 }  // namespace fairseq2n::detail

--- a/native/src/fairseq2n/data/skip_data_source.cc
+++ b/native/src/fairseq2n/data/skip_data_source.cc
@@ -11,6 +11,9 @@ namespace fairseq2n::detail {
 std::optional<data>
 skip_data_source::next()
 {
+    if (num_examples_ == 0)
+        return inner_->next();
+
     if (!skip_) {
         for (std::size_t i = 0; i < num_examples_; i++)
             if (!inner_->next())
@@ -23,11 +26,11 @@ skip_data_source::next()
 }
 
 void
-skip_data_source::reset()
+skip_data_source::reset(bool reset_rng)
 {
     skip_ = false;
 
-    inner_->reset();
+    inner_->reset(reset_rng);
 }
 
 void

--- a/native/src/fairseq2n/data/skip_data_source.h
+++ b/native/src/fairseq2n/data/skip_data_source.h
@@ -25,7 +25,7 @@ public:
     next() override;
 
     void
-    reset() override;
+    reset(bool reset_rng) override;
 
     void
     record_position(tape &t, bool strict) const override;

--- a/native/src/fairseq2n/data/take_data_source.cc
+++ b/native/src/fairseq2n/data/take_data_source.cc
@@ -22,11 +22,11 @@ take_data_source::next()
 }
 
 void
-take_data_source::reset()
+take_data_source::reset(bool reset_rng)
 {
     num_examples_read_ = 0;
 
-    inner_->reset();
+    inner_->reset(reset_rng);
 }
 
 void

--- a/native/src/fairseq2n/data/take_data_source.h
+++ b/native/src/fairseq2n/data/take_data_source.h
@@ -25,7 +25,7 @@ public:
     next() override;
 
     void
-    reset() override;
+    reset(bool reset_rng) override;
 
     void
     record_position(tape &t, bool strict) const override;

--- a/native/src/fairseq2n/data/text/text_data_source.cc
+++ b/native/src/fairseq2n/data/text/text_data_source.cc
@@ -23,8 +23,8 @@
 namespace fairseq2n::detail {
 
 text_data_source::text_data_source(
-    std::filesystem::path &&path, std::optional<std::string> &&key, text_options &&opts)
-  : path_{std::move(path)}, key_{std::move(key)}, opts_{std::move(opts)}
+    std::filesystem::path &&path, std::optional<std::string> &&maybe_key, text_options &&opts)
+  : path_{std::move(path)}, maybe_key_{std::move(maybe_key)}, opts_{std::move(opts)}
 {
     try {
         line_reader_ = make_text_line_reader();
@@ -55,14 +55,14 @@ text_data_source::next()
     if (opts_.rtrim())
         output = rtrim(output);
 
-    if (key_)
-        return data_dict{{*key_, std::move(output)}};
+    if (maybe_key_)
+        return data_dict{{*maybe_key_, std::move(output)}};
 
     return output;
 }
 
 void
-text_data_source::reset()
+text_data_source::reset(bool)
 {
     try {
         line_reader_->reset();
@@ -84,7 +84,7 @@ text_data_source::reload_position(tape &t, bool)
 {
     auto num_lines_read = t.read<std::size_t>();
 
-    reset();
+    reset(false);
 
     for (std::size_t i = 0; i < num_lines_read; ++i)
         read_next_line();

--- a/native/src/fairseq2n/data/text/text_data_source.h
+++ b/native/src/fairseq2n/data/text/text_data_source.h
@@ -25,13 +25,13 @@ class text_data_source final : public data_source {
 public:
     explicit
     text_data_source(
-        std::filesystem::path &&path, std::optional<std::string> &&key, text_options &&opts);
+        std::filesystem::path &&path, std::optional<std::string> &&maybe_key, text_options &&opts);
 
     std::optional<data>
     next() override;
 
     void
-    reset() override;
+    reset(bool reset_rng) override;
 
     void
     record_position(tape &t, bool strict) const override;
@@ -60,7 +60,7 @@ private:
 
 private:
     std::filesystem::path path_;
-    std::optional<std::string> key_;
+    std::optional<std::string> maybe_key_;
     text_options opts_;
     std::unique_ptr<text_line_reader> line_reader_;
     std::size_t num_lines_read_ = 0;

--- a/native/src/fairseq2n/data/text/text_reader.cc
+++ b/native/src/fairseq2n/data/text/text_reader.cc
@@ -16,11 +16,15 @@ using namespace fairseq2n::detail;
 namespace fairseq2n {
 
 data_pipeline_builder
-read_text(std::filesystem::path path, std::optional<std::string> key, text_options opts)
+read_text(std::filesystem::path path, std::optional<std::string> maybe_key, text_options opts)
 {
-    auto factory = [path = std::move(path), key = std::move(key), opts = std::move(opts)]() mutable
+    auto factory = [
+        path = std::move(path),
+        maybe_key = std::move(maybe_key),
+        opts = std::move(opts)]() mutable
     {
-        return std::make_unique<text_data_source>(std::move(path), std::move(key), std::move(opts));
+        return std::make_unique<text_data_source>(
+            std::move(path), std::move(maybe_key), std::move(opts));
     };
 
     return data_pipeline_builder{std::move(factory)};

--- a/native/src/fairseq2n/data/text/text_reader.h
+++ b/native/src/fairseq2n/data/text/text_reader.h
@@ -135,6 +135,7 @@ private:
 class data_pipeline_builder;
 
 FAIRSEQ2_API data_pipeline_builder
-read_text(std::filesystem::path path, std::optional<std::string> key = {}, text_options opts = {});
+read_text(
+    std::filesystem::path path, std::optional<std::string> maybe_key = {}, text_options opts = {});
 
 }  // namespace fairseq2n

--- a/native/src/fairseq2n/data/yield_from_data_source.cc
+++ b/native/src/fairseq2n/data/yield_from_data_source.cc
@@ -25,13 +25,13 @@ yield_from_data_source::next()
 }
 
 void
-yield_from_data_source::reset()
+yield_from_data_source::reset(bool reset_rng)
 {
     maybe_current_example_ = {};
 
     data_pipeline_ = {};
 
-    inner_->reset();
+    inner_->reset(reset_rng);
 }
 
 void

--- a/native/src/fairseq2n/data/yield_from_data_source.h
+++ b/native/src/fairseq2n/data/yield_from_data_source.h
@@ -25,7 +25,7 @@ public:
     next() override;
 
     void
-    reset() override;
+    reset(bool reset_rng) override;
 
     void
     record_position(tape &t, bool strict) const override;

--- a/native/src/fairseq2n/data/zip_data_source.cc
+++ b/native/src/fairseq2n/data/zip_data_source.cc
@@ -164,10 +164,10 @@ zip_data_source::flatten_to_list(data_list &zip)
 }
 
 void
-zip_data_source::reset()
+zip_data_source::reset(bool reset_rng)
 {
     for (data_pipeline &pipeline : pipelines_)
-        pipeline.reset();
+        pipeline.reset(reset_rng);
 }
 
 void

--- a/native/src/fairseq2n/data/zip_data_source.h
+++ b/native/src/fairseq2n/data/zip_data_source.h
@@ -29,7 +29,7 @@ public:
     next() override;
 
     void
-    reset() override;
+    reset(bool reset_rng) override;
 
     void
     record_position(tape &t, bool strict) const override;

--- a/native/src/fairseq2n/data/zip_file_data_source.cc
+++ b/native/src/fairseq2n/data/zip_file_data_source.cc
@@ -55,7 +55,7 @@ zip_file_data_source::next()
 }
 
 void
-zip_file_data_source::reset()
+zip_file_data_source::reset(bool)
 {
     num_files_read_ = 0;
 }
@@ -71,7 +71,7 @@ zip_file_data_source::reload_position(tape &t, bool)
 {
     auto num_files_read = t.read<std::size_t>();
 
-    reset();
+    num_files_read_ = 0;
 
     // TODO: use random access
     for (std::size_t i = 0; i < num_files_read; i++)

--- a/native/src/fairseq2n/data/zip_file_data_source.h
+++ b/native/src/fairseq2n/data/zip_file_data_source.h
@@ -29,7 +29,7 @@ public:
     next() override;
 
     void
-    reset() override;
+    reset(bool reset_rng) override;
 
     void
     record_position(tape &t, bool strict) const override;

--- a/recipes/parquet/parquet_dataloader.py
+++ b/recipes/parquet/parquet_dataloader.py
@@ -87,7 +87,7 @@ class ParquetBasicDataloaderConfig:
     drop_null: bool = True
     """If ``True``, drops rows containing any null value."""
 
-    seed: Optional[int] = None
+    seed: int = 2
     """The RNG seed value for deterministic behavior."""
 
     min_batch_size: int = 1

--- a/src/fairseq2/checkpoint.py
+++ b/src/fairseq2/checkpoint.py
@@ -463,9 +463,6 @@ class FileCheckpointManager(CheckpointManager):
 
     @override
     def save_consolidated_fsdp_model(self, step_nr: int, model: Module) -> None:
-        if self._model_key in self._replicated_keys or "*" in self._replicated_keys:
-            return
-
         with FSDP.state_dict_type(
             model,
             StateDictType.FULL_STATE_DICT,

--- a/src/fairseq2/data/data_pipeline.py
+++ b/src/fairseq2/data/data_pipeline.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING or DOC_MODE:
             so it's not safe to have several iterators over the same DataPipeline.
             """
 
-        def reset(self) -> None:
+        def reset(self, reset_rng: bool = False) -> None:
             """Move back to the first example in the data pipeline."""
 
         def is_infinite(self) -> bool:
@@ -119,6 +119,7 @@ if TYPE_CHECKING or DOC_MODE:
         def sample(
             pipelines: Sequence[DataPipeline],
             weights: Optional[Sequence[float]] = None,
+            seed: Optional[int] = None,
         ) -> DataPipelineBuilder:
             """Extract examples from ``pipelines`` by sampling based on ``weights``.
 
@@ -233,7 +234,9 @@ if TYPE_CHECKING or DOC_MODE:
                 The number of examples to prefetch.
             """
 
-        def repeat(self, num_repeats: Optional[int] = None) -> Self:
+        def repeat(
+            self, num_repeats: Optional[int] = None, reset_rng: bool = False
+        ) -> Self:
             ...
 
         def shard(self, shard_idx: int, num_shards: int) -> Self:
@@ -245,7 +248,7 @@ if TYPE_CHECKING or DOC_MODE:
                 The number of shards.
             """
 
-        def shuffle(self, shuffle_window: int, enabled: bool = True) -> Self:
+        def shuffle(self, shuffle_window: int, seed: Optional[int] = None) -> Self:
             """Shuffle examples using a fixed sized buffer.
 
             :param shuffle_window:
@@ -253,8 +256,6 @@ if TYPE_CHECKING or DOC_MODE:
                 will be randomly sampled from this buffer, and selected examples
                 will be replaced with new examples. If ``0``, all examples will
                 be loaded into memory for full shuffling.
-            :param enabled:
-                If ``False``, disables shuffling.
             """
 
         def skip(self, num_examples: int) -> Self:

--- a/src/fairseq2/datasets/asr_dataset.py
+++ b/src/fairseq2/datasets/asr_dataset.py
@@ -35,10 +35,11 @@ class AsrDataset(ABC):
         *,
         dtype: Optional[DataType] = None,
         min_audio_len: int = 1,
-        shuffle_window_size: int = 0,
+        shuffle_window_size: int = 1,
         num_repeats: Optional[int] = 1,
         num_prefetch: int = 0,
         num_accumulate: int = 1,
+        seed: int = 2,
     ) -> DataReader[Seq2SeqBatch]:
         """Create a dataset reader.
 
@@ -59,7 +60,8 @@ class AsrDataset(ABC):
             The minimum audio length of each example. Examples shorter than
             this value will be dropped.
         :param shuffle_window_size:
-            The size of the streaming shuffle window.
+            The size of the shuffle window. If ``1``, no shuffling is performed;
+            if ``0``, performs true shuffling by loading the entire dataset.
         :param num_repeats:
             The dataset will be repeatedly read this many times. If ``None``, it
             will be read indefinitely.
@@ -68,6 +70,8 @@ class AsrDataset(ABC):
         :param num_accumulate:
             The number of batches to accumulate in each iteration. Typically
             used with gradient accumulation during training.
+        :param seed:
+            The seed to initialize the random number generators.
         """
 
     @abstractmethod

--- a/src/fairseq2/datasets/nllb.py
+++ b/src/fairseq2/datasets/nllb.py
@@ -71,11 +71,12 @@ class NllbDataset(ParallelTextDataset):
         max_num_tokens: int,
         *,
         sample: bool = False,
-        shuffle_window_size: int = 0,
+        shuffle_window_size: int = 1,
         num_repeats: Optional[int] = 1,
         num_prefetch: int = 0,
         num_accumulate: int = 1,
         lang_pairs: Optional[Sequence[LangPair]] = None,
+        seed: int = 2,
     ) -> DataPipelineReader[Seq2SeqBatch]:
         splits = []
 
@@ -127,6 +128,7 @@ class NllbDataset(ParallelTextDataset):
             shuffle_window_size,
             num_repeats,
             num_prefetch,
+            seed,
         )
 
         pipeline = builder.build()
@@ -161,6 +163,7 @@ class _NllbDataPipelineBuilder:
     _shuffle_window_size: int
     _num_repeats: Optional[int]
     _num_prefetch: int
+    _seed: int
 
     def __init__(
         self,
@@ -175,6 +178,7 @@ class _NllbDataPipelineBuilder:
         shuffle_window_size: int,
         num_repeats: Optional[int],
         num_prefetch: int,
+        seed: int,
     ) -> None:
         self._dataset_name = dataset_name
         self._data_dir = data_dir
@@ -187,6 +191,7 @@ class _NllbDataPipelineBuilder:
         self._shuffle_window_size = shuffle_window_size
         self._num_repeats = num_repeats
         self._num_prefetch = num_prefetch
+        self._seed = seed
 
     def build(self) -> DataPipeline:
         lang_pair_pipelines: List[DataPipeline] = []
@@ -218,9 +223,11 @@ class _NllbDataPipelineBuilder:
                 total_size += size
 
         if self._sample:
+            weights = [s / total_size for s in lang_pair_sizes]
+
             # Sample the language pairs in proportion to their corpus size.
             builder = DataPipeline.sample(
-                lang_pair_pipelines, weights=[s / total_size for s in lang_pair_sizes]
+                lang_pair_pipelines, weights=weights, seed=self._seed
             )
         else:
             builder = DataPipeline.concat(lang_pair_pipelines)
@@ -239,9 +246,8 @@ class _NllbDataPipelineBuilder:
         source_builder = read_text(source_file, rtrim=True, memory_map=True)
         target_builder = read_text(target_file, rtrim=True, memory_map=True)
 
-        if self._gang.size > 1:
-            source_builder.shard(self._gang.rank, self._gang.size)
-            target_builder.shard(self._gang.rank, self._gang.size)
+        source_builder.shard(self._gang.rank, self._gang.size)
+        target_builder.shard(self._gang.rank, self._gang.size)
 
         # Initialize the token encoders for the source and target languages.
         source_encoder_mode = "source"
@@ -276,10 +282,10 @@ class _NllbDataPipelineBuilder:
 
         # Zip the source and target pipelines along with the pseudo pipelines
         # into one.
-        names = ["split", "lang_pair", "line_nr", "source_indices", "target_indices"]
+        keys = ["split", "lang_pair", "line_nr", "source_indices", "target_indices"]
 
         builder = DataPipeline.zip(
-            [split_, lang_pair_, line_nr, source_pipeline, target_pipeline], names
+            [split_, lang_pair_, line_nr, source_pipeline, target_pipeline], keys
         )
 
         return builder.and_return()
@@ -306,12 +312,10 @@ class _NllbDataPipelineBuilder:
         return source_file, target_file
 
     def _build_pipeline(self, builder: DataPipelineBuilder) -> DataPipeline:
-        if self._num_repeats != 1:
-            builder.repeat(self._num_repeats)
+        builder.repeat(self._num_repeats)
 
         # Shuffle examples.
-        if self._shuffle_window_size > 0:
-            builder.shuffle(self._shuffle_window_size)
+        builder.shuffle(self._shuffle_window_size, self._seed + 1)
 
         # Bucket by the length of the source or target sequence. The longer one
         # will be considered the length of the example.
@@ -333,8 +337,7 @@ class _NllbDataPipelineBuilder:
         builder.map(collater, num_parallel_calls=num_parallel_calls)
 
         # Prefetch examples in a background thread.
-        if self._num_prefetch > 0:
-            builder.prefetch(self._num_prefetch)
+        builder.prefetch(self._num_prefetch)
 
         # Convert to `Seq2SeqBatch`.
         builder.map(lambda b: self._example_to_batch(b, self._gang.device))

--- a/src/fairseq2/datasets/parallel_text_dataset.py
+++ b/src/fairseq2/datasets/parallel_text_dataset.py
@@ -48,11 +48,12 @@ class ParallelTextDataset(ABC):
         max_num_tokens: int,
         *,
         sample: bool = False,
-        shuffle_window_size: int = 0,
+        shuffle_window_size: int = 1,
         num_repeats: Optional[int] = 1,
         num_prefetch: int = 0,
         num_accumulate: int = 1,
         lang_pairs: Optional[Sequence[LangPair]] = None,
+        seed: int = 2,
     ) -> DataReader[Seq2SeqBatch]:
         """Create a dataset reader.
 
@@ -71,7 +72,8 @@ class ParallelTextDataset(ABC):
             If ``True``, language pair corpora will be sampled in proportion to
             their size.
         :param shuffle_window_size:
-            The size of the streaming shuffle window.
+            The size of the shuffle window. If ``1``, no shuffling is performed;
+            if ``0``, performs true shuffling by loading the entire dataset.
         :param num_repeats:
             The dataset will be repeatedly read this many times. If ``None``, it
             will be read indefinitely.
@@ -82,6 +84,8 @@ class ParallelTextDataset(ABC):
             used with gradient accumulation during training.
         :param lang_pairs:
             The language pairs to read. If ``None``, all pairs will be read.
+        :param seed:
+            The seed to initialize the random number generators.
         """
 
     @abstractmethod

--- a/src/fairseq2/utils/log.py
+++ b/src/fairseq2/utils/log.py
@@ -29,11 +29,11 @@ def exception_logger(log: LogWriter) -> Generator[None, None, None]:
     except OutOfMemoryError:
         s = torch.cuda.memory_summary()
 
-        log.exception("CUDA run out of memory. See the memory stats and the exception details below.\n{}", s)  # fmt: skip
+        log.exception("CUDA run out of memory. See memory stats and exception details below.\n{}", s)  # fmt: skip
 
         raise
     except Exception:
-        log.exception("Job has failed. See the exception details below.")
+        log.exception("Job has failed. See exception details below.")
 
         raise
 

--- a/src/fairseq2/utils/rng.py
+++ b/src/fairseq2/utils/rng.py
@@ -73,6 +73,10 @@ class RngBag:
 
         return RngBag(*generators)
 
+    def add_generator(self, generator: Generator) -> None:
+        """Add ``generator`` to the bag."""
+        self._generators.append(generator)
+
     def seed(self) -> None:
         """Set the seed of the random number generators to a random number."""
         if not self._generators:

--- a/tests/integration/parquet/test_parquet_dataloader.py
+++ b/tests/integration/parquet/test_parquet_dataloader.py
@@ -166,7 +166,7 @@ class TestParquetDataloader:
 
         assert list(res[0].columns) == ["string_col2", "list_int_col", "float_col"]
 
-        assert Counter(map(len, res)) == Counter({3: 340, 1: 2})
+        assert Counter(map(len, res)) == Counter({3: 340, 2: 1})
 
     def test_filtered_with_columns_dataload_min_batch_size(
         self, multi_partition_file: str


### PR DESCRIPTION
This PR adds `seed` parameters to `shuffle()` and `sample()` data pipeline ops. It also extends `repeat()` op, and `reset()` function with a new `reset_rng` parameter (defaults to `False`) to reset RNGs back to their original seed for repeatable epoch iterations.