### PR TITLE
Add allow_uneven parameter to shard

### DIFF
--- a/native/python/src/fairseq2n/bindings/data/data_pipeline.cc
+++ b/native/python/src/fairseq2n/bindings/data/data_pipeline.cc
@@ -540,14 +540,16 @@ def_data_pipeline(py::module_ &data_module)
             [](
                 data_pipeline_builder &self,
                 std::size_t shard_idx,
-                std::size_t num_shards) -> data_pipeline_builder &
+                std::size_t num_shards,
+                bool allow_uneven) -> data_pipeline_builder &
             {
-                self = std::move(self).shard(shard_idx, num_shards);
+                self = std::move(self).shard(shard_idx, num_shards, allow_uneven);
 
                 return self;
             },
             py::arg("shard_idx"),
-            py::arg("num_shards"))
+            py::arg("num_shards"),
+            py::arg("allow_uneven") = false)
         .def(
             "shuffle",
             [](

--- a/native/src/fairseq2n/data/data_pipeline.cc
+++ b/native/src/fairseq2n/data/data_pipeline.cc
@@ -442,7 +442,7 @@ data_pipeline_builder::repeat(std::optional<std::size_t> num_repeats, bool reset
 }
 
 data_pipeline_builder
-data_pipeline_builder::shard(std::size_t shard_idx, std::size_t num_shards) &&
+data_pipeline_builder::shard(std::size_t shard_idx, std::size_t num_shards, bool allow_uneven) &&
 {
     if (num_shards == 0)
         throw_<std::invalid_argument>(
@@ -454,7 +454,7 @@ data_pipeline_builder::shard(std::size_t shard_idx, std::size_t num_shards) &&
 
     factory_ = [=, inner = std::move(factory_)]
     {
-        return std::make_unique<shard_data_source>(inner(), shard_idx, num_shards);
+        return std::make_unique<shard_data_source>(inner(), shard_idx, num_shards, allow_uneven);
     };
 
     return std::move(*this);

--- a/native/src/fairseq2n/data/data_pipeline.h
+++ b/native/src/fairseq2n/data/data_pipeline.h
@@ -154,7 +154,7 @@ public:
     repeat(std::optional<std::size_t> num_repeats = std::nullopt, bool reset_rng = false) &&;
 
     data_pipeline_builder
-    shard(std::size_t shard_idx, std::size_t num_shards) &&;
+    shard(std::size_t shard_idx, std::size_t num_shards, bool allow_uneven = false) &&;
 
     data_pipeline_builder
     shuffle(std::size_t shuffle_window, std::optional<std::uint64_t> maybe_seed = {}) &&;

--- a/native/src/fairseq2n/data/shard_data_source.cc
+++ b/native/src/fairseq2n/data/shard_data_source.cc
@@ -8,6 +8,17 @@
 
 namespace fairseq2n::detail {
 
+shard_data_source::shard_data_source(
+    std::unique_ptr<data_source> &&inner,
+    std::size_t shard_idx,
+    std::size_t num_shards,
+    bool allow_uneven) noexcept
+  : inner_{std::move(inner)},
+    shard_idx_{shard_idx},
+    num_shards_{num_shards},
+    allow_uneven_{allow_uneven}
+{}
+
 std::optional<data>
 shard_data_source::next()
 {
@@ -23,8 +34,12 @@ shard_data_source::next()
         return std::nullopt;
 
     for (std::size_t i = 0; i < num_shards_ - shard_idx_ - 1; i++)
-        if (!inner_->next())
+        if (!inner_->next()) {
+            if (allow_uneven_)
+                break;
+
             return std::nullopt;
+        }
 
     return maybe_example;
 }

--- a/native/src/fairseq2n/data/shard_data_source.h
+++ b/native/src/fairseq2n/data/shard_data_source.h
@@ -20,9 +20,8 @@ public:
     shard_data_source(
         std::unique_ptr<data_source> &&inner,
         std::size_t shard_idx,
-        std::size_t num_shards) noexcept
-      : inner_{std::move(inner)}, shard_idx_{shard_idx}, num_shards_{num_shards}
-    {}
+        std::size_t num_shards,
+        bool allow_uneven) noexcept;
 
     std::optional<data>
     next() override;
@@ -43,6 +42,7 @@ private:
     std::unique_ptr<data_source> inner_;
     std::size_t shard_idx_;
     std::size_t num_shards_;
+    bool allow_uneven_;
 };
 
 }  // namespace fairseq2n::detail

--- a/src/fairseq2/data/data_pipeline.py
+++ b/src/fairseq2/data/data_pipeline.py
@@ -239,7 +239,9 @@ if TYPE_CHECKING or DOC_MODE:
         ) -> Self:
             ...
 
-        def shard(self, shard_idx: int, num_shards: int) -> Self:
+        def shard(
+            self, shard_idx: int, num_shards: int, allow_uneven: bool = False
+        ) -> Self:
             """Read only 1/``num_shards`` of the examples in the data pipeline.
 
             :param shard_idx:

--- a/src/fairseq2/datasets/nllb.py
+++ b/src/fairseq2/datasets/nllb.py
@@ -246,8 +246,8 @@ class _NllbDataPipelineBuilder:
         source_builder = read_text(source_file, rtrim=True, memory_map=True)
         target_builder = read_text(target_file, rtrim=True, memory_map=True)
 
-        source_builder.shard(self._gang.rank, self._gang.size)
-        target_builder.shard(self._gang.rank, self._gang.size)
+        source_builder.shard(self._gang.rank, self._gang.size, allow_uneven=True)
+        target_builder.shard(self._gang.rank, self._gang.size, allow_uneven=True)
 
         # Initialize the token encoders for the source and target languages.
         source_encoder_mode = "source"

--- a/src/fairseq2/nn/module_list.py
+++ b/src/fairseq2/nn/module_list.py
@@ -12,9 +12,6 @@ from torch.nn import Module
 from torch.nn import ModuleList as TorchModuleList
 
 from fairseq2.typing import CPU
-from fairseq2.utils.logging import get_log_writer
-
-log = get_log_writer(__name__)
 
 
 @final

--- a/tests/unit/data/data_pipeline/test_shard.py
+++ b/tests/unit/data/data_pipeline/test_shard.py
@@ -36,6 +36,32 @@ class TestShardOp:
 
             pipeline.reset()
 
+    def test_op_works_when_allow_uneven_is_true(self) -> None:
+        seq = list(range(1, 23))
+
+        pipeline = read_sequence(seq).shard(1, 5, allow_uneven=True).and_return()
+
+        for _ in range(2):
+            assert list(pipeline) == [2, 7, 12, 17, 22]
+
+            pipeline.reset()
+
+        pipeline = read_sequence(seq).shard(4, 5, allow_uneven=True).and_return()
+
+        for _ in range(2):
+            assert list(pipeline) == [5, 10, 15, 20]
+
+            pipeline.reset()
+
+        seq = list(range(1, 4))
+
+        pipeline = read_sequence(seq).shard(0, 5, allow_uneven=True).and_return()
+
+        for _ in range(2):
+            assert list(pipeline) == [1]
+
+            pipeline.reset()
+
     @pytest.mark.parametrize("idx", [4, 5])
     def test_op_raises_error_when_shard_idx_is_invalid(self, idx: int) -> None:
         with pytest.raises(


### PR DESCRIPTION
This PR introduces a new `allow_uneven` parameter to the `shard()` pipeline operator.