### PR TITLE
Revise to_ddp and to_fsdp

### DIFF
--- a/src/fairseq2/models/transformer/fsdp.py
+++ b/src/fairseq2/models/transformer/fsdp.py
@@ -17,8 +17,8 @@ from fairseq2.nn.transformer import TransformerDecoder, TransformerEncoder
 
 def get_transformer_wrap_policy(
     model: Module, gang: Gang
-) -> Tuple[Optional[FSDPWrapPolicy], Optional[List[str]]]:
-    """See :class:`~fairseq2.models.fsdp.FSDPWrapPolicyProvider`."""
+) -> Tuple[FSDPWrapPolicy, Optional[List[str]]]:
+    """See :func:`~fairseq2.models.fsdp.to_fsdp`."""
     kls = (TransformerEncoder, TransformerDecoder)
 
     wrap_policy = partial(transformer_auto_wrap_policy, transformer_layer_cls=kls)

--- a/src/fairseq2/nn/ddp.py
+++ b/src/fairseq2/nn/ddp.py
@@ -20,6 +20,7 @@ def to_ddp(
     module: Module,
     gang: Gang,
     *,
+    broadcast_buffers: bool = False,
     find_unused_parameters: bool = False,
     static_graph: bool = False,
     normalize_gradients: bool = True,
@@ -30,6 +31,8 @@ def to_ddp(
         The module to be wrapped with DDP.
     :param gang:
         The gang over which to replicate the module.
+    :param broadcast_buffers:
+        See the corresponding DDP documentation.
     :param find_unused_parameters:
         See the corresponding DDP documentation.
     :param static_graph:
@@ -40,7 +43,7 @@ def to_ddp(
     """
     ddp = DDP(
         module,
-        device_ids=[gang.device],
+        broadcast_buffers=broadcast_buffers,
         process_group=gang.as_process_group(),
         find_unused_parameters=find_unused_parameters,
         static_graph=static_graph,

--- a/src/fairseq2/nn/fsdp.py
+++ b/src/fairseq2/nn/fsdp.py
@@ -36,7 +36,7 @@ from fairseq2.utils.version import _is_pt21_or_greater
 def to_fsdp(
     module: Module,
     gang: Gang,
-    wrap_policy: Optional[FSDPWrapPolicy],
+    wrap_policy: FSDPWrapPolicy,
     *,
     ignored_param_names: Optional[Sequence[str]] = None,
     skip_init: bool = False,
@@ -46,13 +46,11 @@ def to_fsdp(
     """Wrap ``module`` with FSDP.
 
     :param module:
-        The module to be wrapped with FSDP.
+        The module to wrap.
     :param gang:
-        The gang over which to shard the module.
+        The gang over which to shard ``module``.
     :param wrap_policy:
-        The policy to apply FSDP to ``module``.  If ``None``, ``module`` will be
-        wrapped with only a top-level FSDP instance and no sharding will applied
-        (i.e. ``NO_SHARD``).
+        The FSDP wrap policy to apply to ``module``.
     :param ignored_param_names:
         The ignored parameter names. Can contain regular expressions.
     :param skip_init:
@@ -64,11 +62,6 @@ def to_fsdp(
     :param memory_policy:
         The policy to instruct FSDP when and how to allocate memory.
     """
-    if wrap_policy is None:
-        sharding_strategy = ShardingStrategy.NO_SHARD
-    else:
-        sharding_strategy = ShardingStrategy.FULL_SHARD
-
     if memory_policy is None:
         memory_policy = FSDP_STANDARD_MEMORY_POLICY
 
@@ -92,7 +85,7 @@ def to_fsdp(
     fsdp = FSDP(
         module,
         process_group=gang.as_process_group(),
-        sharding_strategy=sharding_strategy,
+        sharding_strategy=ShardingStrategy.FULL_SHARD,
         cpu_offload=CPUOffload() if memory_policy.cpu_offload else None,
         auto_wrap_policy=wrap_policy,
         backward_prefetch=memory_policy.backward_prefetch,

--- a/src/fairseq2/optim/dynamic_loss_scaler.py
+++ b/src/fairseq2/optim/dynamic_loss_scaler.py
@@ -39,6 +39,7 @@ class DynamicLossScaler:
         optimizer: Optimizer,
         gang: Gang,
         *,
+        sharded: bool = True,
         init_scale: float = 2.0**15,
         scale_factor: float = 2.0,
         scale_window: Optional[int] = None,
@@ -51,6 +52,8 @@ class DynamicLossScaler:
             The optimizer that holds the gradients that will be unscaled.
         :param gang:
             The associated gang.
+        :param sharded:
+            If ``True``, assumes that the optimizer state is sharded.
         :param init_scale:
             The initial scale.
         :param scale_factor:
@@ -88,7 +91,7 @@ class DynamicLossScaler:
 
             log.info("The scale window is set to {}.", scale_window)
 
-        if not enabled or gang.size == 1:
+        if not enabled or not sharded or gang.size == 1:
             self._grad_scaler = _InternalGradScaler(
                 init_scale, scale_factor, 1 / scale_factor, scale_window, enabled
             )


### PR DESCRIPTION
This PR includes three changes; (1) `to_ddp()` now accepts a `broadcast_buffers` parameter, but unlike `DDP`, defaults to `False` which is much more common, (2) removes the `NO_SHARD` fallback in `to_fsdp()` since the PyTorch team has decided to deprecate it in favor of DDP, (3) adds a new `sharded` parameter to `DynamicLossScaler` to distinguish between DDP and FSDP uses.