### PR TITLE
Introduce torch_greater_or_equal

### DIFF
--- a/native/python/src/fairseq2n/__init__.py
+++ b/native/python/src/fairseq2n/__init__.py
@@ -171,8 +171,10 @@ _load_shared_libraries()
 def _check_torch_version() -> None:
     import torch
 
-    # Trim the local version label.
-    source_version = torch.__version__.split("+", 1)[0]
+    def mmp(version: str) -> str:
+        return version.split("+", 1)[0]  # Trim the local label.
+
+    source_version, target_version = mmp(torch.__version__), mmp(_TORCH_VERSION)
 
     if source_var := torch.version.cuda:
         # Use only the major and minor version segments.
@@ -180,9 +182,11 @@ def _check_torch_version() -> None:
     else:
         source_variant = "CPU-only"
 
-    if source_version != _TORCH_VERSION or source_variant != _TORCH_VARIANT:
+    target_variant = _TORCH_VARIANT
+
+    if source_version != target_version or source_variant != target_variant:
         raise RuntimeError(
-            f"fairseq2 requires a {_TORCH_VARIANT} build of PyTorch {_TORCH_VERSION}, but the installed version is a {source_variant} build of PyTorch {source_version}. Either follow the instructions at https://pytorch.org/get-started/locally to update PyTorch, or the instructions at https://github.com/facebookresearch/fairseq2#variants to update fairseq2."
+            f"fairseq2 requires a {target_variant} build of PyTorch {target_version}, but the installed version is a {source_variant} build of PyTorch {source_version}. Either follow the instructions at https://pytorch.org/get-started/locally to update PyTorch, or the instructions at https://github.com/facebookresearch/fairseq2#variants to update fairseq2."
         )
 
 

--- a/native/python/src/fairseq2n/config.py.in
+++ b/native/python/src/fairseq2n/config.py.in
@@ -6,7 +6,7 @@
 
 from typing import Final
 
-_TORCH_VERSION: Final = "@TORCH_VERSION@"
+_TORCH_VERSION: Final = "@TORCH_PEP440_VERSION@"
 _TORCH_VARIANT: Final = "@TORCH_VARIANT@"
 
 _SUPPORTS_IMAGE: Final = @SUPPORTS_IMAGE@

--- a/src/fairseq2/gang.py
+++ b/src/fairseq2/gang.py
@@ -17,7 +17,7 @@ from torch.distributed import ProcessGroup, ReduceOp
 
 from fairseq2.typing import CPU, Device, override
 from fairseq2.utils.logging import get_log_writer
-from fairseq2.utils.version import _is_pt22_or_greater
+from fairseq2.utils.version import torch_greater_or_equal
 
 log = get_log_writer(__name__)
 
@@ -239,7 +239,7 @@ class ProcessGroupGang(AbstractGang):
                 if env_name in os.environ:
                     return
 
-                if _is_pt22_or_greater():
+                if torch_greater_or_equal(2, 2):
                     env_name = "TORCH_NCCL_ASYNC_ERROR_HANDLING"
                     if env_name in os.environ:
                         return

--- a/src/fairseq2/models/utils/checkpoint.py
+++ b/src/fairseq2/models/utils/checkpoint.py
@@ -15,7 +15,7 @@ from torch import Tensor
 from typing_extensions import TypeAlias
 
 from fairseq2.typing import Device
-from fairseq2.utils.version import _is_pt21_or_greater
+from fairseq2.utils.version import torch_greater_or_equal
 
 MapLocation: TypeAlias = Optional[
     Union[Callable[[Tensor, str], Tensor], Device, str, Dict[str, str]]
@@ -63,7 +63,7 @@ def load_checkpoint(
 
         kwargs = {}
 
-        if mmap and _is_pt21_or_greater():
+        if mmap and torch_greater_or_equal(2, 1):
             kwargs["mmap"] = True
 
         checkpoint: Dict[str, Any] = torch.load(

--- a/src/fairseq2/models/wav2vec2/position_encoder.py
+++ b/src/fairseq2/models/wav2vec2/position_encoder.py
@@ -20,7 +20,7 @@ from fairseq2.nn import LayerNorm, PositionEncoder, StandardLayerNorm
 from fairseq2.nn.incremental_state import IncrementalStateBag
 from fairseq2.nn.padding import PaddingMask, apply_padding_mask
 from fairseq2.typing import DataType, Device, override
-from fairseq2.utils.version import _is_pt22_or_greater
+from fairseq2.utils.version import torch_greater_or_equal
 
 
 @final
@@ -116,7 +116,7 @@ class Wav2Vec2PositionalConv1d(Conv1d):
         except AttributeError:
             weight = self.weight
 
-            if weight.dtype == torch.bfloat16 and not _is_pt22_or_greater():
+            if weight.dtype == torch.bfloat16 and not torch_greater_or_equal(2, 2):
                 raise RuntimeError(
                     "`torch.nn.utils.weight_norm()` supports `torch.bfloat16` only in PyTorch 2.2 and later versions."
                 )

--- a/src/fairseq2/nn/fsdp.py
+++ b/src/fairseq2/nn/fsdp.py
@@ -30,7 +30,7 @@ from fairseq2.nn.utils.module import (
     to_empty,
 )
 from fairseq2.typing import META, Device
-from fairseq2.utils.version import _is_pt21_or_greater
+from fairseq2.utils.version import torch_greater_or_equal
 
 
 def to_fsdp(
@@ -66,7 +66,7 @@ def to_fsdp(
         memory_policy = FSDP_STANDARD_MEMORY_POLICY
 
     if infer_device(module) == META:
-        if not _is_pt21_or_greater():
+        if not torch_greater_or_equal(2, 1):
             raise RuntimeError(
                 "FSDP meta initialization is only supported by PyTorch 2.1.0 or greater."
             )

--- a/src/fairseq2/utils/logging.py
+++ b/src/fairseq2/utils/logging.py
@@ -17,7 +17,7 @@ from logging import (
     getLogger,
 )
 from pathlib import Path
-from typing import Any, List, Optional, final
+from typing import Any, List, Optional, Set, final
 
 
 def setup_logging(
@@ -85,6 +85,7 @@ class LogWriter:
     """Writes log messages using ``format()`` strings."""
 
     _logger: Logger
+    _once_messages: Set[str]
 
     def __init__(self, logger: Logger) -> None:
         """
@@ -93,21 +94,59 @@ class LogWriter:
         """
         self._logger = logger
 
+        self._once_messages = set()
+
     def debug(self, msg: Any, *args: Any, **kwargs: Any) -> None:
         """Log a message with level ``DEBUG``."""
         self._write(logging.DEBUG, msg, args, kwargs)
+
+    def debug_once(self, msg: Any, *args: Any, **kwargs: Any) -> None:
+        """Log a message only once with level ``DEBUG``."""
+        if msg in self._once_messages:
+            return
+
+        self._write(logging.DEBUG, msg, args, kwargs)
+
+        self._once_messages.add(msg)
 
     def info(self, msg: Any, *args: Any, **kwargs: Any) -> None:
         """Log a message with level ``INFO``."""
         self._write(logging.INFO, msg, args, kwargs)
 
+    def info_once(self, msg: Any, *args: Any, **kwargs: Any) -> None:
+        """Log a message only once with level ``INFO``."""
+        if msg in self._once_messages:
+            return
+
+        self._write(logging.INFO, msg, args, kwargs)
+
+        self._once_messages.add(msg)
+
     def warning(self, msg: Any, *args: Any, **kwargs: Any) -> None:
         """Log a message with level ``WARNING``."""
         self._write(logging.WARNING, msg, args, kwargs)
 
+    def warning_once(self, msg: Any, *args: Any, **kwargs: Any) -> None:
+        """Log a message only once with level ``WARNING``."""
+        if msg in self._once_messages:
+            return
+
+        self._write(logging.WARNING, msg, args, kwargs)
+
+        self._once_messages.add(msg)
+
     def error(self, msg: Any, *args: Any, **kwargs: Any) -> None:
         """Log a message with level ``ERROR``."""
         self._write(logging.ERROR, msg, args, kwargs)
+
+    def error_once(self, msg: Any, *args: Any, **kwargs: Any) -> None:
+        """Log a message only once with level ``ERROR``."""
+        if msg in self._once_messages:
+            return
+
+        self._write(logging.ERROR, msg, args, kwargs)
+
+        self._once_messages.add(msg)
 
     def exception(self, msg: Any, *args: Any, **kwargs: Any) -> None:
         """Log a message with level ``ERROR``."""

--- a/src/fairseq2/utils/version.py
+++ b/src/fairseq2/utils/version.py
@@ -21,21 +21,13 @@ def _get_torch_version() -> Version:
 TORCH_VERSION: Final = _get_torch_version()
 
 
-def _is_pt21_or_greater() -> bool:
-    if TORCH_VERSION.major <= 1:
+def torch_greater_or_equal(major: int, minor: int) -> bool:
+    """Return ``True`` if the installed version of PyTorch is greater than or
+    equal to the specified major-minor version."""
+    if TORCH_VERSION.major <= major - 1:
         return False
 
-    if TORCH_VERSION.major == 2 and TORCH_VERSION.minor == 0:
-        return False
-
-    return True
-
-
-def _is_pt22_or_greater() -> bool:
-    if TORCH_VERSION.major <= 1:
-        return False
-
-    if TORCH_VERSION.major == 2 and TORCH_VERSION.minor <= 1:
+    if TORCH_VERSION.major == major and TORCH_VERSION.minor <= minor - 1:
         return False
 
     return True


### PR DESCRIPTION
This PR includes three nit fixes/improvements:

(1) Introduces a new `torch_greater_or_equal` utility function to check PyTorch versions
(2) Fixes fairseq2n __init__.py so that it can be used with locally-built PyTorch versions.
(3) Introduces "once" variants of logging functions that log a specified message only once to reduce noise in log outputs.