### PR TITLE
Introduce autograd-aware collective ops

### DIFF
--- a/src/fairseq2/collective.py
+++ b/src/fairseq2/collective.py
@@ -1,0 +1,128 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, Tuple
+
+import torch
+from torch import Tensor
+from torch.autograd import Function
+
+from fairseq2.gang import Gang, ReduceOperation
+
+# mypy: disable-error-code="no-any-return,override"
+
+
+def reduce(x: Tensor, gang: Gang) -> Tensor:
+    """Reduce ``x`` across all processes in ``gang``.
+
+    This is an autograd-aware operation and the backward pass will return the
+    all-reduced gradient of ``x``.
+    """
+    return _ReduceFunction.apply(x, gang)
+
+
+class _ReduceFunction(Function):
+    @staticmethod
+    def forward(ctx: Any, x: Tensor, gang: Gang) -> Tensor:
+        x = x.clone().detach()
+
+        gang.all_reduce(x, ReduceOperation.SUM)
+
+        x.requires_grad_(True)
+
+        return x
+
+    @staticmethod
+    def backward(ctx: Any, grad_output: Tensor) -> Tuple[Tensor, None]:
+        return grad_output, None
+
+
+def scatter(x: Tensor, gang: Gang, dim: int = -1) -> Tensor:
+    """Scatter ``x`` across all processes in ``gang`` over ``dim``.
+
+    This is an autograd-aware operation and the backward pass will return the
+    all-gathered gradient of ``x``.
+    """
+    return _ScatterFunction.apply(x, gang, dim)
+
+
+class _ScatterFunction(Function):
+    @staticmethod
+    def forward(ctx: Any, x: Tensor, gang: Gang, dim: int) -> Tensor:
+        ctx.dim = dim
+        ctx.data = gang
+
+        return _do_scatter(x, gang, dim)
+
+    @staticmethod
+    def backward(ctx: Any, grad_output: Tensor) -> Tuple[Tensor, None, None]:
+        return _do_gather(grad_output, ctx.gang, ctx.dim), None, None
+
+
+def gather(x: Tensor, gang: Gang, dim: int = -1) -> Tensor:
+    """Gather ``x`` across all processes in ``gang`` over ``dim``.
+
+    This is an autograd-aware operation and the backward pass will return the
+    scattered gradient of ``x``.
+    """
+    return _GatherFunction.apply(x, gang, dim)
+
+
+class _GatherFunction(Function):
+    @staticmethod
+    def forward(ctx: Any, x: Tensor, gang: Gang, dim: int) -> Tensor:
+        ctx.dim = dim
+        ctx.gang = gang
+
+        return _do_gather(x, gang, dim)
+
+    @staticmethod
+    def backward(ctx: Any, grad_output: Tensor) -> Tuple[Tensor, None, None]:
+        return _do_scatter(grad_output, ctx.gang, ctx.dim), None, None
+
+
+def reduce_on_backward(x: Tensor, gang: Gang) -> Tensor:
+    """Reduce the gradient of ``x`` across all processes in ``gang``."""
+    return _ReduceOnBackwardFunction.apply(x, gang)
+
+
+class _ReduceOnBackwardFunction(Function):
+    @staticmethod
+    def forward(ctx: Any, x: Tensor, gang: Gang) -> Tensor:
+        ctx.gang = Gang
+
+        return x
+
+    @staticmethod
+    def backward(ctx: Any, grad_output: Tensor) -> Tuple[Tensor, None]:
+        return ctx.gang.all_reduce(grad_output), None
+
+
+def _do_scatter(x: Tensor, gang: Gang, dim: int) -> Tensor:
+    if gang.size == 1:
+        return x
+
+    dim_size = x.size(dim)
+
+    if dim_size % gang.size != 0:
+        raise ValueError(
+            f"The size of the dimension {dim} of `x` must be divisible by `gang.size` ({gang.size}), but is {dim_size} instead."
+        )
+
+    splits = x.split(dim_size // gang.size, dim=-1)
+
+    return splits[gang.rank]
+
+
+def _do_gather(x: Tensor, gang: Gang, dim: int) -> Tensor:
+    if gang.size == 1:
+        return x
+
+    splits = [torch.empty_like(x) for _ in range(gang.size)]
+
+    gang.all_gather_to_list(splits, x)
+
+    return torch.cat(splits, dim=dim)

--- a/src/fairseq2/nn/utils/gradient.py
+++ b/src/fairseq2/nn/utils/gradient.py
@@ -44,10 +44,10 @@ def scale_gradient(x: Tensor, scale: float) -> Tensor:
     :param scale:
         The scale factor of the gradient.
     """
-    return _GradientScaler.apply(x, scale)  # type: ignore[no-any-return]
+    return _GradientScaleFunction.apply(x, scale)  # type: ignore[no-any-return]
 
 
-class _GradientScaler(Function):
+class _GradientScaleFunction(Function):
     @staticmethod
     def forward(ctx: Any, x: Tensor, scale: float) -> Tensor:  # type: ignore[override]
         if not x.dtype.is_floating_point:
@@ -60,8 +60,8 @@ class _GradientScaler(Function):
         return x.clone().detach().requires_grad_(True)
 
     @staticmethod
-    def backward(ctx: Any, output: Tensor) -> Tuple[Tensor, None]:  # type: ignore[override]
-        return output * ctx.scale, None
+    def backward(ctx: Any, grad_output: Tensor) -> Tuple[Tensor, None]:  # type: ignore[override]
+        return grad_output * ctx.scale, None
 
 
 def clip_gradient_norm(


### PR DESCRIPTION
This PR introduces autograd-aware collection ops `scatter`, `gather`, `reduce`, and `reduce_on_backward` that can be used in different parallelism techniques.