### PR TITLE
Introduce sharded projection and embedding modules

### DIFF
--- a/src/fairseq2/nn/__init__.py
+++ b/src/fairseq2/nn/__init__.py
@@ -5,7 +5,9 @@
 # LICENSE file in the root directory of this source tree.
 
 from fairseq2.nn.embedding import Embedding as Embedding
+from fairseq2.nn.embedding import ShardedEmbedding as ShardedEmbedding
 from fairseq2.nn.embedding import StandardEmbedding as StandardEmbedding
+from fairseq2.nn.embedding import VocabShardedEmbedding as VocabShardedEmbedding
 from fairseq2.nn.embedding import init_scaled_embedding as init_scaled_embedding
 from fairseq2.nn.incremental_state import IncrementalState as IncrementalState
 from fairseq2.nn.incremental_state import IncrementalStateBag as IncrementalStateBag
@@ -21,6 +23,8 @@ from fairseq2.nn.position_encoder import RotaryEncoder as RotaryEncoder
 from fairseq2.nn.position_encoder import (
     SinusoidalPositionEncoder as SinusoidalPositionEncoder,
 )
+from fairseq2.nn.projection import ColumnShardedLinear as ColumnShardedLinear
 from fairseq2.nn.projection import Linear as Linear
 from fairseq2.nn.projection import Projection as Projection
+from fairseq2.nn.projection import RowShardedLinear as RowShardedLinear
 from fairseq2.nn.projection import TiedProjection as TiedProjection

--- a/src/fairseq2/nn/embedding.py
+++ b/src/fairseq2/nn/embedding.py
@@ -16,7 +16,10 @@ from torch.nn import Module
 from torch.nn.functional import embedding
 from torch.nn.parameter import Parameter
 
-from fairseq2.typing import DataType, Device, override
+from fairseq2.collective import gather, reduce, reduce_on_backward
+from fairseq2.gang import Gang
+from fairseq2.nn.utils.module import to_empty
+from fairseq2.typing import META, DataType, Device, override
 
 
 class Embedding(Module, ABC):
@@ -130,6 +133,335 @@ class StandardEmbedding(Embedding):
     def extra_repr(self) -> str:
         """:meta private:"""
         s = super().extra_repr()
+
+        if self.init_fn is not None:
+            init_fn = getattr(self.init_fn, "__name__", self.init_fn)
+
+            s = f"{s}, init_fn={init_fn}"
+
+        return s
+
+
+@final
+class VocabShardedEmbedding(Embedding):
+    """Represents a :class:`StandardEmbedding` that is sharded across its
+    vocabulary dimension."""
+
+    gang: Gang
+    sharded_num_embeddings: int
+    weight: Parameter
+    init_fn: Optional[Callable[[StandardEmbedding], None]]
+
+    @staticmethod
+    def from_embedding(embed: StandardEmbedding, gang: Gang) -> VocabShardedEmbedding:
+        """Construct a :class:`VocabShardedEmbedding` by sharding ``embed``.
+
+        :param embed:
+            The embedding to shard.
+        :param gang:
+            The gang over which to shard ``embed``.
+        """
+        sharded = VocabShardedEmbedding(
+            gang,
+            embed.num_embeddings,
+            embed.embedding_dim,
+            embed.pad_idx,
+            init_fn=embed.init_fn,
+            device=META,
+            dtype=embed.weight.dtype,
+        )
+
+        to_empty(sharded, gang.device)
+
+        sharded._copy_table(embed)
+
+        return sharded
+
+    def __init__(
+        self,
+        gang: Gang,
+        num_embeddings: int,
+        embedding_dim: int,
+        pad_idx: Optional[int] = None,
+        *,
+        init_fn: Optional[Callable[[StandardEmbedding], None]] = None,
+        device: Optional[Device] = None,
+        dtype: Optional[DataType] = None,
+    ) -> None:
+        """
+        :param gang:
+            The gang over which to shard the embedding table.
+        :param num_embeddings:
+            The size of the embedding table.
+        :param embedding_dim:
+            The dimensionality of returned embeddings.
+        :param pad_idx:
+            If not ``None``, entries at ``pad_idx`` do not contribute to the
+            gradient; therefore, the embedding at ``pad_idx`` is not updated
+            during training.
+        :param init_fn:
+            The callable to use for parameter initialization.
+        """
+        super().__init__(num_embeddings, embedding_dim, pad_idx)
+
+        if num_embeddings % gang.size != 0:
+            raise ValueError(
+                f"`num_embeddings` must be divisible by `gang.size` ({gang.size}), but is {num_embeddings} instead."
+            )
+
+        self.gang = gang
+
+        self.sharded_num_embeddings = num_embeddings // gang.size
+
+        if device is None:
+            device = gang.device
+        elif device != gang.device and device != META:
+            raise ValueError(
+                "`device` must either match `gang.device` or must be of type `meta`."
+            )
+
+        weight = torch.empty(
+            (self.sharded_num_embeddings, embedding_dim), device=device, dtype=dtype
+        )
+
+        self.weight = Parameter(weight)
+
+        self.init_fn = init_fn
+
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        """Reset the parameters and buffers of the module."""
+        embed = self._embed_like(self.gang.device)
+
+        self._copy_table(embed)
+
+    def _copy_table(self, embed: StandardEmbedding) -> None:
+        with torch.no_grad():
+            weight_shards = embed.weight.split(self.sharded_num_embeddings, dim=0)
+
+            self.weight.copy_(weight_shards[self.gang.rank])
+
+    @override
+    def forward(self, x: Tensor) -> Tensor:
+        num_embeds = self.sharded_num_embeddings
+
+        vocab_begin_idx, vocab_end_idx = (
+            self.gang.rank * num_embeds, (self.gang.rank + 1) * num_embeds  # fmt: skip
+        )
+
+        if self.pad_idx is None:
+            pad_idx = None
+        elif self.pad_idx >= vocab_begin_idx and self.pad_idx < vocab_end_idx:
+            pad_idx = self.pad_idx - vocab_begin_idx
+        else:
+            pad_idx = None
+
+        # (N, S)
+        mask = (x < vocab_begin_idx) | (x >= vocab_end_idx)
+
+        x = x - vocab_begin_idx
+
+        x = torch.where(mask, 0, x)
+
+        # (N, S, E)
+        x = embedding(x, self.weight, pad_idx)
+
+        # (N, S, 1)
+        mask = mask.unsqueeze(-1)
+
+        x = torch.where(mask, 0.0, x)
+
+        # (N, S, E)
+        x = reduce(x, self.gang)
+
+        return x
+
+    def to_embedding(self, device: Optional[Device] = None) -> StandardEmbedding:
+        """Convert this instance to a :class:`StandardEmbedding`."""
+        embed = self._embed_like(META)
+
+        to_empty(embed, device or self.gang.device)
+
+        with torch.no_grad():
+            weight = gather(self.weight, self.gang, dim=0)
+
+            embed.weight.copy_(weight)
+
+        return embed
+
+    def _embed_like(self, device: Device) -> StandardEmbedding:
+        return StandardEmbedding(
+            self.num_embeddings,
+            self.embedding_dim,
+            self.pad_idx,
+            init_fn=self.init_fn,
+            device=device,
+            dtype=self.weight.dtype,
+        )
+
+    def extra_repr(self) -> str:
+        """:meta private:"""
+        s = super().extra_repr()
+
+        s = (
+            f"{s}, "
+            f"sharded_num_embeddings={self.sharded_num_embeddings}, "
+            f"rank={self.gang.rank}, "
+            f"world_size={self.gang.size}"
+        )
+
+        if self.init_fn is not None:
+            init_fn = getattr(self.init_fn, "__name__", self.init_fn)
+
+            s = f"{s}, init_fn={init_fn}"
+
+        return s
+
+
+@final
+class ShardedEmbedding(Embedding):
+    """Represents a :class:`StandardEmbedding` that is sharded across its
+    embedding dimension."""
+
+    gang: Gang
+    sharded_embedding_dim: int
+    weight: Parameter
+    init_fn: Optional[Callable[[StandardEmbedding], None]]
+
+    @staticmethod
+    def from_embedding(embed: StandardEmbedding, gang: Gang) -> ShardedEmbedding:
+        """Construct a :class:`ShardedEmbedding` by sharding ``embed``.
+
+        :param embed:
+            The embedding to shard.
+        :param gang:
+            The gang over which to shard ``embed``.
+        """
+        sharded = ShardedEmbedding(
+            gang,
+            embed.num_embeddings,
+            embed.embedding_dim,
+            embed.pad_idx,
+            init_fn=embed.init_fn,
+            device=META,
+            dtype=embed.weight.dtype,
+        )
+
+        to_empty(sharded, gang.device)
+
+        sharded._copy_table(embed)
+
+        return sharded
+
+    def __init__(
+        self,
+        gang: Gang,
+        num_embeddings: int,
+        embedding_dim: int,
+        pad_idx: Optional[int] = None,
+        *,
+        init_fn: Optional[Callable[[StandardEmbedding], None]] = None,
+        device: Optional[Device] = None,
+        dtype: Optional[DataType] = None,
+    ) -> None:
+        """
+        :param gang:
+            The gang over which to shard the embedding table.
+        :param num_embeddings:
+            The size of the embedding table.
+        :param embedding_dim:
+            The dimensionality of returned embeddings.
+        :param pad_idx:
+            If not ``None``, entries at ``pad_idx`` do not contribute to the
+            gradient; therefore, the embedding at ``pad_idx`` is not updated
+            during training.
+        :param init_fn:
+            The callable to use for parameter initialization.
+        """
+        super().__init__(num_embeddings, embedding_dim, pad_idx)
+
+        if embedding_dim % gang.size != 0:
+            raise ValueError(
+                f"`embedding_dim` must be divisible by `gang.size` ({gang.size}), but is {embedding_dim} instead."
+            )
+
+        self.gang = gang
+
+        self.sharded_embedding_dim = embedding_dim // gang.size
+
+        if device is None:
+            device = gang.device
+        elif device != gang.device and device != META:
+            raise ValueError(
+                "`device` must either match `gang.device` or must be of type `meta`."
+            )
+
+        weight = torch.empty(
+            (num_embeddings, self.sharded_embedding_dim), device=device, dtype=dtype
+        )
+
+        self.weight = Parameter(weight)
+
+        self.init_fn = init_fn
+
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        """Reset the parameters and buffers of the module."""
+        embed = self._embed_like(self.gang.device)
+
+        self._copy_table(embed)
+
+    def _copy_table(self, embed: StandardEmbedding) -> None:
+        with torch.no_grad():
+            weight_shards = embed.weight.split(self.sharded_embedding_dim, dim=1)
+
+            self.weight.copy_(weight_shards[self.gang.rank])
+
+    @override
+    def forward(self, x: Tensor) -> Tensor:
+        x = reduce_on_backward(x, self.gang)
+
+        x = embedding(x, self.weight, self.pad_idx)
+
+        x = gather(x, self.gang)
+
+        return x
+
+    def to_embedding(self, device: Optional[Device] = None) -> StandardEmbedding:
+        """Convert this instance to a :class:`StandardEmbedding`."""
+        embed = self._embed_like(META)
+
+        to_empty(embed, device or self.gang.device)
+
+        with torch.no_grad():
+            weight = gather(self.weight, self.gang, dim=1)
+
+            embed.weight.copy_(weight)
+
+        return embed
+
+    def _embed_like(self, device: Device) -> StandardEmbedding:
+        return StandardEmbedding(
+            self.num_embeddings,
+            self.embedding_dim,
+            self.pad_idx,
+            init_fn=self.init_fn,
+            device=device,
+            dtype=self.weight.dtype,
+        )
+
+    def extra_repr(self) -> str:
+        """:meta private:"""
+        s = super().extra_repr()
+
+        s = (
+            f"{s}, "
+            f"sharded_embedding_dim={self.sharded_embedding_dim}, "
+            f"rank={self.gang.rank}, "
+            f"world_size={self.gang.size}"
+        )
 
         if self.init_fn is not None:
             init_fn = getattr(self.init_fn, "__name__", self.init_fn)

--- a/src/fairseq2/nn/projection.py
+++ b/src/fairseq2/nn/projection.py
@@ -17,7 +17,10 @@ from torch.nn import Module
 from torch.nn.functional import linear
 from torch.nn.parameter import Parameter
 
-from fairseq2.typing import DataType, Device, override
+from fairseq2.collective import gather, reduce, reduce_on_backward, scatter
+from fairseq2.gang import Gang
+from fairseq2.nn.utils.module import to_empty
+from fairseq2.typing import META, DataType, Device, override
 
 
 class Projection(Module, ABC):
@@ -113,7 +116,7 @@ class Linear(Projection):
         if self.init_fn is not None:
             self.init_fn(self)
         else:
-            _init_uniform_weight_bias(self.weight, self.bias)
+            _init_uniform_weight_and_bias(self.weight, self.bias)
 
     @override
     def forward(self, x: Tensor) -> Tensor:
@@ -124,6 +127,353 @@ class Linear(Projection):
         s = super().extra_repr()
 
         s = f"{s}, bias={self.bias is not None}"
+
+        if self.init_fn is not None:
+            init_fn = getattr(self.init_fn, "__name__", self.init_fn)
+
+            s = f"{s}, init_fn={init_fn}"
+
+        return s
+
+
+@final
+class ColumnShardedLinear(Projection):
+    """Represents a :class:`Linear` that is sharded across its output dimension."""
+
+    gang: Gang
+    sharded_output_dim: int
+    weight: Parameter
+    bias: Optional[Parameter]
+    init_fn: Optional[Callable[[Linear], None]]
+
+    @staticmethod
+    def from_linear(linear: Linear, gang: Gang) -> ColumnShardedLinear:
+        """Construct a :class:`ColumnShardedLinear` by sharding ``linear``.
+
+        :param linear:
+            The projection to shard.
+        :param gang:
+            The gang over which to shard ``linear``.
+        """
+        sharded = ColumnShardedLinear(
+            gang,
+            linear.input_dim,
+            linear.output_dim,
+            bias=linear.bias is not None,
+            init_fn=linear.init_fn,
+            device=META,
+            dtype=linear.weight.dtype,
+        )
+
+        to_empty(sharded, gang.device)
+
+        sharded._copy_weight_and_bias(linear)
+
+        return sharded
+
+    def __init__(
+        self,
+        gang: Gang,
+        input_dim: int,
+        output_dim: int,
+        bias: bool,
+        *,
+        init_fn: Optional[Callable[[Linear], None]] = None,
+        device: Optional[Device] = None,
+        dtype: Optional[DataType] = None,
+    ) -> None:
+        """
+        :param gang:
+            The gang over which to shard the weight tensor.
+        :param input_dim:
+            The dimensionality of inputs.
+        :param output_dim:
+            The dimensionality of projected outputs.
+        :param bias:
+            If ``True``, learns an additive bias.
+        :param init_fn:
+            The callable to use for parameter initialization.
+        """
+        super().__init__(input_dim, output_dim)
+
+        if output_dim % gang.size != 0:
+            raise ValueError(
+                f"`output_dim` must be divisible by `gang.size` ({gang.size}), but is {output_dim} instead."
+            )
+
+        self.gang = gang
+
+        self.sharded_output_dim = output_dim // gang.size
+
+        if device is None:
+            device = gang.device
+        elif device != gang.device and device != META:
+            raise ValueError(
+                "`device` must either match `gang.device` or must be of type `meta`."
+            )
+
+        weight = torch.empty(
+            (self.sharded_output_dim, input_dim), device=device, dtype=dtype
+        )
+
+        self.weight = Parameter(weight)
+
+        if bias:
+            self.bias = Parameter(
+                torch.empty((self.sharded_output_dim,), device=device, dtype=dtype)
+            )
+        else:
+            self.register_parameter("bias", None)
+
+        self.init_fn = init_fn
+
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        """Reset the parameters and buffers of the module."""
+        linear = self._linear_like(self.gang.device)
+
+        self._copy_weight_and_bias(linear)
+
+    def _copy_weight_and_bias(self, linear: Linear) -> None:
+        with torch.no_grad():
+            weight_shards = linear.weight.split(self.sharded_output_dim)
+
+            self.weight.copy_(weight_shards[self.gang.rank])
+
+        if self.bias is not None:
+            assert linear.bias is not None
+
+            with torch.no_grad():
+                bias_shards = linear.bias.split(self.sharded_output_dim)
+
+                self.bias.copy_(bias_shards[self.gang.rank])
+
+    @override
+    def forward(self, x: Tensor) -> Tensor:
+        x = reduce_on_backward(x, self.gang)
+
+        x = linear(x, self.weight, self.bias)
+
+        x = gather(x, self.gang, dim=-1)
+
+        return x
+
+    def to_linear(self, device: Optional[Device] = None) -> Linear:
+        """Convert this instance to a :class:`Linear`."""
+        linear = self._linear_like(META)
+
+        to_empty(linear, device or self.gang.device)
+
+        with torch.no_grad():
+            weight = gather(self.weight, self.gang, dim=0)
+
+            linear.weight.copy_(weight)
+
+        if self.bias is not None:
+            assert linear.bias is not None
+
+            with torch.no_grad():
+                bias = gather(self.bias, self.gang, dim=0)
+
+                linear.bias.copy_(bias)
+
+        return linear
+
+    def _linear_like(self, device: Device) -> Linear:
+        return Linear(
+            self.input_dim,
+            self.output_dim,
+            bias=self.bias is not None,
+            init_fn=self.init_fn,
+            device=device,
+            dtype=self.weight.dtype,
+        )
+
+    def extra_repr(self) -> str:
+        """:meta private:"""
+        s = super().extra_repr()
+
+        s = (
+            f"{s}, "
+            f"bias={self.bias is not None}, "
+            f"sharded_output_dim={self.sharded_output_dim}, "
+            f"rank={self.gang.rank}, "
+            f"world_size={self.gang.size}"
+        )
+
+        if self.init_fn is not None:
+            init_fn = getattr(self.init_fn, "__name__", self.init_fn)
+
+            s = f"{s}, init_fn={init_fn}"
+
+        return s
+
+
+@final
+class RowShardedLinear(Projection):
+    """Represents a :class:`Linear` that is sharded across its input dimension."""
+
+    gang: Gang
+    sharded_input_dim: int
+    weight: Parameter
+    bias: Optional[Parameter]
+    init_fn: Optional[Callable[[Linear], None]]
+
+    @staticmethod
+    def from_linear(linear: Linear, gang: Gang) -> RowShardedLinear:
+        """Construct a :class:`RowShardedLinear` by sharding ``linear``.
+
+        :param linear:
+            The projection to shard.
+        :param gang:
+            The gang over which to shard ``linear``.
+        """
+        sharded = RowShardedLinear(
+            gang,
+            linear.input_dim,
+            linear.output_dim,
+            bias=linear.bias is not None,
+            init_fn=linear.init_fn,
+            device=META,
+            dtype=linear.weight.dtype,
+        )
+
+        to_empty(sharded, gang.device)
+
+        sharded._copy_weight_and_bias(linear)
+
+        return sharded
+
+    def __init__(
+        self,
+        gang: Gang,
+        input_dim: int,
+        output_dim: int,
+        bias: bool,
+        *,
+        init_fn: Optional[Callable[[Linear], None]] = None,
+        device: Optional[Device] = None,
+        dtype: Optional[DataType] = None,
+    ) -> None:
+        """
+        :param gang:
+            The gang over which to shard the weight tensor.
+        :param input_dim:
+            The dimensionality of inputs.
+        :param output_dim:
+            The dimensionality of projected outputs.
+        :param bias:
+            If ``True``, learns an additive bias.
+        :param init_fn:
+            The callable to use for parameter initialization.
+        """
+        super().__init__(input_dim, output_dim)
+
+        if input_dim % gang.size != 0:
+            raise ValueError(
+                f"`input_dim` must be divisible by `gang.size` ({gang.size}), but is {input_dim} instead."
+            )
+
+        self.gang = gang
+
+        self.sharded_input_dim = input_dim // gang.size
+
+        if device is None:
+            device = gang.device
+        elif device != gang.device and device != META:
+            raise ValueError(
+                "`device` must either match `gang.device` or must be of type `meta`."
+            )
+
+        weight = torch.empty(
+            (output_dim, self.sharded_input_dim), device=device, dtype=dtype
+        )
+
+        self.weight = Parameter(weight)
+
+        if bias:
+            self.bias = Parameter(
+                torch.empty((output_dim,), device=device, dtype=dtype)
+            )
+        else:
+            self.register_parameter("bias", None)
+
+        self.init_fn = init_fn
+
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        """Reset the parameters and buffers of the module."""
+        linear = self._linear_like(self.gang.device)
+
+        self._copy_weight_and_bias(linear)
+
+    def _copy_weight_and_bias(self, linear: Linear) -> None:
+        with torch.no_grad():
+            weight_shards = linear.weight.split(self.sharded_input_dim, dim=1)
+
+            self.weight.copy_(weight_shards[self.gang.rank])
+
+        if self.bias is not None:
+            assert linear.bias is not None
+
+            with torch.no_grad():
+                self.bias.copy_(linear.bias)
+
+    @override
+    def forward(self, x: Tensor) -> Tensor:
+        x = scatter(x, self.gang, dim=-1)
+
+        x = linear(x, self.weight)
+
+        x = reduce(x, self.gang)
+
+        if self.bias is not None:
+            x = x + self.bias
+
+        return x
+
+    def to_linear(self, device: Optional[Device] = None) -> Linear:
+        """Convert this instance to a :class:`Linear`."""
+        linear = self._linear_like(META)
+
+        to_empty(linear, device or self.gang.device)
+
+        with torch.no_grad():
+            weight = gather(self.weight, self.gang, dim=1)
+
+            linear.weight.copy_(weight)
+
+        if self.bias is not None:
+            assert linear.bias is not None
+
+            with torch.no_grad():
+                linear.bias.copy_(self.bias)
+
+        return linear
+
+    def _linear_like(self, device: Device) -> Linear:
+        return Linear(
+            self.input_dim,
+            self.output_dim,
+            bias=self.bias is not None,
+            init_fn=self.init_fn,
+            device=device,
+            dtype=self.weight.dtype,
+        )
+
+    def extra_repr(self) -> str:
+        """:meta private:"""
+        s = super().extra_repr()
+
+        s = (
+            f"{s}, "
+            f"bias={self.bias is not None}, "
+            f"sharded_input_dim={self.sharded_input_dim}, "
+            f"rank={self.gang.rank}, "
+            f"world_size={self.gang.size}"
+        )
 
         if self.init_fn is not None:
             init_fn = getattr(self.init_fn, "__name__", self.init_fn)
@@ -158,7 +508,7 @@ class TiedProjection(Projection):
         return linear(x, self.weight, self.bias)
 
 
-def _init_uniform_weight_bias(weight: Tensor, bias: Optional[Tensor]) -> None:
+def _init_uniform_weight_and_bias(weight: Tensor, bias: Optional[Tensor]) -> None:
     nn.init.kaiming_uniform_(weight, a=math.sqrt(5))
 
     if bias is not None:

--- a/src/fairseq2/nn/utils/gradient.py
+++ b/src/fairseq2/nn/utils/gradient.py
@@ -24,7 +24,7 @@ def scale_gradients(module: Module, value: float) -> None:
     """Scale gradients of ``module`` by ``value``.
 
     :param module:
-        The module whose gradients to clip.
+        The module whose gradients to scale.
     :param value:
         The value to scale by.
     """

--- a/src/fairseq2/nn/utils/module.py
+++ b/src/fairseq2/nn/utils/module.py
@@ -292,8 +292,7 @@ def freeze_parameters(module: Optional[Module], value: bool = True) -> None:
     if module is None:
         return
 
-    for param in module.parameters():
-        param.requires_grad_(not value)
+    module.requires_grad_(not value)
 
 
 def select_parameters(


### PR DESCRIPTION
This PR introduces the types `RowShardedLinear`, `ColumnShardedLinear`, `ShardedEmbedding`, and `VocabShardedEmbedding` that are mostly rewrites of fairscale's similarly named (i.e. `ParallelXX`) types with the improvements and abstractions available in fairseq2 and modern versions of PyTorch.