### PR TITLE
Remove cache_only parameter from download manager

### DIFF
--- a/src/fairseq2/assets/store.py
+++ b/src/fairseq2/assets/store.py
@@ -19,6 +19,9 @@ from fairseq2.assets.metadata_provider import (
 )
 from fairseq2.assets.utils import _get_path_from_env
 from fairseq2.typing import override
+from fairseq2.utils.logging import get_log_writer
+
+log = get_log_writer(__name__)
 
 
 class AssetStore(ABC):
@@ -158,7 +161,7 @@ default_asset_store = _create_default_asset_store()
 
 
 def _load_asset_directory() -> None:
-    asset_dir = _get_path_from_env("FAIRSEQ2_ASSET_DIR")
+    asset_dir = _get_path_from_env("FAIRSEQ2_ASSET_DIR", log)
     if asset_dir is None:
         asset_dir = Path("/etc/fairseq2/assets").resolve()
         if not asset_dir.exists():
@@ -171,9 +174,9 @@ _load_asset_directory()
 
 
 def _load_user_asset_directory() -> None:
-    asset_dir = _get_path_from_env("FAIRSEQ2_USER_ASSET_DIR")
+    asset_dir = _get_path_from_env("FAIRSEQ2_USER_ASSET_DIR", log)
     if asset_dir is None:
-        asset_dir = _get_path_from_env("XDG_CONFIG_HOME")
+        asset_dir = _get_path_from_env("XDG_CONFIG_HOME", log)
         if asset_dir is None:
             asset_dir = Path("~/.config").expanduser()
 

--- a/src/fairseq2/assets/utils.py
+++ b/src/fairseq2/assets/utils.py
@@ -9,7 +9,7 @@ import re
 from pathlib import Path
 from typing import Final, Optional
 
-from fairseq2.utils.logging import get_log_writer
+from fairseq2.utils.logging import LogWriter
 
 _SCHEME_REGEX: Final = re.compile("^[a-zA-Z0-9]+://")
 
@@ -18,7 +18,9 @@ def _starts_with_scheme(s: str) -> bool:
     return re.match(_SCHEME_REGEX, s) is not None
 
 
-def _get_path_from_env(var_name: str, missing_ok: bool = False) -> Optional[Path]:
+def _get_path_from_env(
+    var_name: str, log: LogWriter, missing_ok: bool = False
+) -> Optional[Path]:
     pathname = os.getenv(var_name)
     if not pathname:
         return None
@@ -35,8 +37,6 @@ def _get_path_from_env(var_name: str, missing_ok: bool = False) -> Optional[Path
     if not resolved_path.exists():
         if missing_ok:
             return resolved_path
-
-        log = get_log_writer("fairseq2.assets")
 
         log.warning("The path '{}' pointed to by the `{}` environment variable does not exist.", path, var_name)  # fmt: skip
 

--- a/src/fairseq2/models/config_loader.py
+++ b/src/fairseq2/models/config_loader.py
@@ -108,12 +108,7 @@ class StandardModelConfigLoader(ModelConfigLoader[ModelConfigT]):
 
         # Check if we should override anything in the default model
         # configuration.
-        try:
-            config_overrides = card.field("model_config").as_(dict)
-        except AssetCardFieldNotFoundError:
-            config_overrides = None
-
-        if config_overrides:
+        if config_overrides := card.field("model_config").get_as_(dict):
             try:
                 update_dataclass(config, deepcopy(config_overrides))
             except (TypeError, ValueError) as ex:

--- a/src/fairseq2/models/loader.py
+++ b/src/fairseq2/models/loader.py
@@ -72,7 +72,6 @@ class ModelLoader(Protocol[ModelT_co]):
         device: Optional[Device] = None,
         dtype: Optional[DataType] = None,
         force: bool = False,
-        cache_only: bool = False,
         progress: bool = True,
     ) -> ModelT_co:
         """
@@ -85,8 +84,6 @@ class ModelLoader(Protocol[ModelT_co]):
         :param force:
             If ``True``, downloads the model checkpoint even if it is already in
             cache.
-        :param cache_only:
-            If ``True``, skips the download and uses the cached model checkpoint.
         :param progress:
             If ``True``, displays a progress bar to stderr.
 
@@ -173,7 +170,6 @@ class DenseModelLoader(ModelLoader[ModelT], Generic[ModelT, ModelConfigT]):
         device: Optional[Device] = None,
         dtype: Optional[DataType] = None,
         force: bool = False,
-        cache_only: bool = False,
         progress: bool = True,
     ) -> ModelT:
         if isinstance(model_name_or_card, AssetCard):
@@ -191,7 +187,7 @@ class DenseModelLoader(ModelLoader[ModelT], Generic[ModelT, ModelConfigT]):
 
         try:
             path = self._download_manager.download_checkpoint(
-                uri, card.name, force=force, cache_only=cache_only, progress=progress
+                uri, card.name, force=force, progress=progress
             )
         except ValueError as ex:
             raise AssetCardError(
@@ -289,7 +285,6 @@ class DelegatingModelLoader(ModelLoader[ModelT]):
         device: Optional[Device] = None,
         dtype: Optional[DataType] = None,
         force: bool = False,
-        cache_only: bool = False,
         progress: bool = True,
     ) -> ModelT:
         if isinstance(model_name_or_card, AssetCard):
@@ -311,7 +306,6 @@ class DelegatingModelLoader(ModelLoader[ModelT]):
             device=device,
             dtype=dtype,
             force=force,
-            cache_only=cache_only,
             progress=progress,
         )
 


### PR DESCRIPTION
This PR mainly removes the `cache_only` parameter from `AssetDownloadManager` that was a first attempt to workaround the race condition issue mentioned in #302. We need a more sophisticated approach that we will reevaluate later. Beyond that change, the PR also includes two additional nit updates: (1) The progress messages in `InProcDownloadManager` now use the logger instead of printing to stdout directly (2) `AssetCard` has a new `get_as_()` method similar to `dict.get()` that accepts an optional default value and does not raise `AssetCardFieldNotFoundError`.