### PR TITLE
Add ffn_inner_dim_scale to LLama's factory

### DIFF
--- a/src/fairseq2/models/llama/factory.py
+++ b/src/fairseq2/models/llama/factory.py
@@ -72,6 +72,9 @@ class LLaMAConfig:
     dropout_p: float = 0.1
     """The dropout probability on outputs of Transformer layers."""
 
+    ffn_inner_dim_scale: float = 2 / 3
+    """The scale factor for the dimensionality of the FFN's inner projection"""
+
 
 llama_archs = ModelArchitectureRegistry[LLaMAConfig]()
 
@@ -290,6 +293,7 @@ class LLaMABuilder:
             self._config.model_dim,
             self._config.ffn_inner_dim,
             bias=False,
+            inner_dim_scale=self._config.ffn_inner_dim_scale,
             inner_dim_to_multiple=self._config.ffn_inner_dim_to_multiple,
             device=self._device,
             dtype=self._dtype,

--- a/src/fairseq2/models/llama/factory.py
+++ b/src/fairseq2/models/llama/factory.py
@@ -65,15 +65,15 @@ class LLaMAConfig:
     ffn_inner_dim: int = 4096 * 4
     """The dimensionality of inner projection layers in feed-forward networks."""
 
+    ffn_inner_dim_scale: float = 2 / 3
+    """The scale factor for the dimensionality of the FFN's inner projection"""
+
     ffn_inner_dim_to_multiple: int = 256
     """The dimensionality of inner projection layers in feed-forward networks is
     rounded up to the nearest multiple of this value."""
 
     dropout_p: float = 0.1
     """The dropout probability on outputs of Transformer layers."""
-
-    ffn_inner_dim_scale: float = 2 / 3
-    """The scale factor for the dimensionality of the FFN's inner projection"""
 
 
 llama_archs = ModelArchitectureRegistry[LLaMAConfig]()


### PR DESCRIPTION
Adding `ffn_inner_dim_scale` to LLama's config to allow for creating/loading LLama models with
 `ffn_inner_dim_scale ! = 2/3`