### PR TITLE
Rollback recent DataReader changes

### DIFF
--- a/src/fairseq2/datasets/loader.py
+++ b/src/fairseq2/datasets/loader.py
@@ -135,7 +135,7 @@ class DelegatingDatasetLoader(DatasetLoader[DatasetT]):
             loader = self._loaders[family]
         except KeyError:
             raise AssetError(
-                f"The value of the field 'dataset_family' of the asset card '{card.name}' must be a supported dataset type, but '{family}' has no registered loader."
+                f"The value of the field 'dataset_family' of the asset card '{card.name}' must be a supported dataset family, but '{family}' has no registered loader."
             )
 
         return loader(card, force=force, progress=progress)

--- a/src/fairseq2/datasets/nllb.py
+++ b/src/fairseq2/datasets/nllb.py
@@ -76,12 +76,12 @@ class NllbDataset(ParallelTextDataset):
         max_seq_len: int,
         max_num_tokens: int,
         *,
+        lang_pairs: Optional[Sequence[LangPair]] = None,
         sample: bool = False,
         shuffle_window_size: int = 1,
         num_repeats: Optional[int] = 1,
-        num_prefetch: int = 0,
         num_accumulate: int = 1,
-        lang_pairs: Optional[Sequence[LangPair]] = None,
+        num_prefetch: int = 0,
         seed: int = 2,
     ) -> DataPipelineReader[Seq2SeqBatch]:
         splits = []
@@ -144,7 +144,7 @@ class NllbDataset(ParallelTextDataset):
             gang,
             num_accumulate=num_accumulate,
             drop_remainder=False,
-            sync_batches=True,
+            sync_batches=num_repeats is not None,
         )
 
     @override

--- a/src/fairseq2/datasets/parallel_text.py
+++ b/src/fairseq2/datasets/parallel_text.py
@@ -42,12 +42,12 @@ class ParallelTextDataset(ABC):
         max_seq_len: int,
         max_num_tokens: int,
         *,
+        lang_pairs: Optional[Sequence[LangPair]] = None,
         sample: bool = False,
         shuffle_window_size: int = 1,
         num_repeats: Optional[int] = 1,
-        num_prefetch: int = 0,
         num_accumulate: int = 1,
-        lang_pairs: Optional[Sequence[LangPair]] = None,
+        num_prefetch: int = 0,
         seed: int = 2,
     ) -> DataReader[Seq2SeqBatch]:
         """Create a dataset reader.
@@ -63,6 +63,8 @@ class ParallelTextDataset(ABC):
             this value will be dropped.
         :param max_num_tokens:
             The maximum number of tokens in each batch.
+        :param lang_pairs:
+            The language pairs to read. If ``None``, all pairs will be read.
         :param sample:
             If ``True``, language pair corpora will be sampled in proportion to
             their size.
@@ -72,13 +74,11 @@ class ParallelTextDataset(ABC):
         :param num_repeats:
             The dataset will be repeatedly read this many times. If ``None``, it
             will be read indefinitely.
-        :param num_prefetch:
-            The number of batches to prefetch in background.
         :param num_accumulate:
             The number of batches to accumulate in each iteration. Typically
             used with gradient accumulation during training.
-        :param lang_pairs:
-            The language pairs to read. If ``None``, all pairs will be read.
+        :param num_prefetch:
+            The number of batches to prefetch in background.
         :param seed:
             The seed to initialize the random number generators.
         """

--- a/src/fairseq2/datasets/utils.py
+++ b/src/fairseq2/datasets/utils.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 import logging
-from typing import List, Tuple
 
 import torch
 
@@ -13,44 +12,22 @@ from fairseq2.gang import Gang
 from fairseq2.utils.logging import LogWriter
 
 
-def _reduce_batch_stats(
-    stats: List[Tuple[int, int]], gang: Gang, log: LogWriter
-) -> Tuple[int, int, int]:
-    # (G, N, 2)
-    all_stats = torch.zeros(
-        (gang.size, len(stats), 2), device=gang.device, dtype=torch.int64
-    )
+def _reduce_num_batches(num_batches: int, gang: Gang, log: LogWriter) -> int:
+    all_num_batches = torch.zeros((gang.size,), device=gang.device, dtype=torch.int64)
 
-    # (N, 2)
-    this_stats = torch.tensor(stats, device=gang.device)
+    gang.all_gather(all_num_batches, torch.tensor(num_batches, device=gang.device))
 
-    gang.all_gather(all_stats, this_stats)
+    min_num_batches = int(all_num_batches.min())
+    if min_num_batches != 0:
+        return min_num_batches
 
-    # (G, N)
-    batch_sizes = all_stats[:, :, 0::2].squeeze(-1)
+    # If not all processes have reached end of data, report the ones that have
+    # reached for debugging purposes.
+    if log.is_enabled_for(logging.DEBUG) and all_num_batches.sum() > 0:
+        ranks = all_num_batches.bool().logical_not_().nonzero().squeeze(-1).tolist()
 
-    # (G, N)
-    num_target_elements = all_stats[:, :, 1::2].squeeze(-1)
+        s = ", ".join(str(r) for r in ranks)
 
-    # Determine the number of batches read by each process.
-    # (G)
-    num_batches = batch_sizes.count_nonzero(dim=-1)
+        log.debug("End of data reached at rank(s) {}.", s)
 
-    min_num_batches = int(num_batches.min())
-    if min_num_batches == 0:
-        # If not all processes reached end of data, report the ones that have
-        # reached for debugging purposes.
-        if log.is_enabled_for(logging.DEBUG) and num_batches.sum() > 0:
-            ranks = num_batches.bool().logical_not_().nonzero().squeeze(-1).tolist()
-
-            s = ", ".join(str(r) for r in ranks)
-
-            log.debug("End of data reached at rank(s) {}.", s)
-
-        return 0, 0, 0
-
-    batch_sizes = batch_sizes[:, :min_num_batches]
-
-    num_target_elements = num_target_elements[:, :min_num_batches]
-
-    return min_num_batches, int(batch_sizes.sum()), int(num_target_elements.sum())
+    return 0


### PR DESCRIPTION
This PR reverts the recent changes introduced to DataReader API in #464. We instead use a standalone `normalize_gradients()` function in training recipes instead of asking `DataReader` to handle it.