### PR TITLE
Introduce layerwise checkpointing API

### DIFF
--- a/src/fairseq2/nn/checkpointing.py
+++ b/src/fairseq2/nn/checkpointing.py
@@ -1,0 +1,47 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from functools import partial
+
+from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
+    apply_activation_checkpointing,
+    checkpoint_wrapper,
+)
+from torch.nn import Module
+from torch.utils.checkpoint import checkpoint
+
+from fairseq2.nn.transformer import TransformerDecoderLayer, TransformerEncoderLayer
+
+
+def use_layerwise_activation_checkpointing(
+    module: Module, preserve_rng_state: bool = False, debug: bool = False
+) -> None:
+    """Use layer-wise activation checkpointing in ``module``.
+
+    :param module:
+        The module to apply checkpointing.
+    :param preserve_rng_state:
+        If ``True``, stashes the states of the default random number generators
+        for the CPU and the device of ``module`` during the original forward
+        pass and restores them during the recomputation.
+    :param debug:
+        If ``True``, error messages will include a trace of the operators ran
+        during the original forward pass.
+    """
+    wrap = partial(
+        checkpoint_wrapper,
+        checkpoint_fn=checkpoint,
+        preserve_rng_state=preserve_rng_state,
+        use_reentrant=False,
+        debug=debug,
+    )
+
+    def check_module_type(m: Module) -> bool:
+        return isinstance(m, (TransformerEncoderLayer, TransformerDecoderLayer))
+
+    apply_activation_checkpointing(
+        module, checkpoint_wrapper_fn=wrap, check_fn=check_module_type
+    )


### PR DESCRIPTION
This PR introduces a convenience function for activation checkpointing that also exposes some additional parameters that are not straightforward to set with the official PyTorch API.