### PR TITLE
add truncation in text translator

### DIFF
--- a/src/fairseq2/generation/text.py
+++ b/src/fairseq2/generation/text.py
@@ -153,7 +153,7 @@ class TextTranslator:
     _converter: SequenceToTextConverter
     _pad_idx: int
     _source_text_encoder: TextTokenEncoder
-    max_src_len: Optional[int]
+    _max_source_len: Optional[int]
 
     def __init__(
         self,
@@ -161,7 +161,7 @@ class TextTranslator:
         tokenizer: TextTokenizer,
         source_lang: Optional[str] = None,
         target_lang: Optional[str] = None,
-        max_src_len: Optional[int] = None,
+        max_source_len: Optional[int] = None,
     ) -> None:
         """
         :param generator:
@@ -172,8 +172,8 @@ class TextTranslator:
             The source language.
         :param target_lang:
             The target language.
-        :param max_src_len:
-            The number of tokens above which the source sequence gets truncated (None for no truncation)
+        :param max_source_len:
+            The number of tokens above which the source sequence gets truncated (None or 0 for no truncation)
         """
         self._converter = SequenceToTextConverter(
             generator, tokenizer, "translation", target_lang
@@ -192,7 +192,7 @@ class TextTranslator:
         self._source_text_encoder = tokenizer.create_encoder(
             task="translation", lang=source_lang, mode="source", device=device
         )
-        self.max_src_len = max_src_len
+        self._max_source_len = max_source_len
 
     def __call__(self, source_text: str) -> Tuple[str, Seq2SeqGeneratorOutput]:
         """
@@ -205,8 +205,8 @@ class TextTranslator:
         """
         source_seq = self._source_text_encoder(source_text)
 
-        if self.max_src_len and source_seq.shape[0] > self.max_src_len:
-            source_seq = source_seq[: self.max_src_len]
+        if self._max_source_len and source_seq.shape[0] > self._max_source_len:
+            source_seq = source_seq[: self._max_source_len]
 
         return self._converter(source_seq)
 
@@ -228,8 +228,8 @@ class TextTranslator:
 
         source_seq_list = [self._source_text_encoder(t) for t in source_texts]
 
-        if self.max_src_len:
-            source_seq_list = [seq[: self.max_src_len] for seq in source_seq_list]
+        if self._max_source_len:
+            source_seq_list = [seq[: self._max_source_len] for seq in source_seq_list]
 
         source_seqs, source_padding_mask = pad_seqs(source_seq_list, self._pad_idx)
 

--- a/tests/integration/models/test_nllb.py
+++ b/tests/integration/models/test_nllb.py
@@ -6,6 +6,7 @@
 
 from typing import Final
 
+import pytest
 import torch
 
 from fairseq2.generation import BeamSearchSeq2SeqGenerator, TextTranslator
@@ -25,7 +26,7 @@ def test_load_dense_distill_600m() -> None:
 
     tokenizer = load_nllb_tokenizer(model_name, progress=False)
 
-    generator = BeamSearchSeq2SeqGenerator(model, echo_prompt=True)
+    generator = BeamSearchSeq2SeqGenerator(model, echo_prompt=True, max_seq_len=128)
 
     translator = TextTranslator(
         generator, tokenizer, source_lang="eng_Latn", target_lang="deu_Latn"
@@ -34,3 +35,18 @@ def test_load_dense_distill_600m() -> None:
     text, _ = translator(ENG_SENTENCE)
 
     assert text == DEU_SENTENCE
+
+    # testing that truncation prevents length-related errors
+    with pytest.raises(
+        ValueError, match="The input sequence length must be less than or equal"
+    ):
+        text, _ = translator(ENG_SENTENCE * 20)
+
+    translator = TextTranslator(
+        generator,
+        tokenizer,
+        source_lang="eng_Latn",
+        target_lang="deu_Latn",
+        max_src_len=1024,
+    )
+    text, _ = translator(ENG_SENTENCE * 20)

--- a/tests/integration/models/test_nllb.py
+++ b/tests/integration/models/test_nllb.py
@@ -47,6 +47,6 @@ def test_load_dense_distill_600m() -> None:
         tokenizer,
         source_lang="eng_Latn",
         target_lang="deu_Latn",
-        max_src_len=1024,
+        max_source_len=1024,
     )
     text, _ = translator(ENG_SENTENCE * 20)


### PR DESCRIPTION
**What does this PR do? Please describe:**
This PR allows bypassing the problem of `TextTranslator` failure when the number of source tokens exceeds the maximal length supported by the translation model. As tokenization happens within the `TextTranslator`, truncation, if implemented, should also happen there. The PR therefore adds a `max_src_len` argument to it, and enables truncation if this argument is not empty. 

**Does your PR introduce any breaking changes? If yes, please list them:**
None

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**?
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
