### PR TITLE
Introduce PackageAssetMetadataProvider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build/
 
 # Core Dumps
 core
+core.*
 
 # Byte-Compiled Modules
 __pycache__/

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from setuptools import find_packages, setup
+from setuptools import find_namespace_packages, setup
 
 version = "0.3.0.dev0"
 
@@ -38,14 +38,18 @@ setup(
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
     ],
     package_dir={"": "src"},
-    packages=find_packages(where="src"),
-    package_data={"fairseq2": ["py.typed", "assets/cards/*.yaml"]},
+    packages=find_namespace_packages(where="src"),
+    package_data={
+        "fairseq2": ["py.typed"],
+        "fairseq2.assets.cards": ["*.yaml"],
+    },
     zip_safe=False,
     python_requires=">=3.8",
     install_requires=[
         "editdistance~=0.8.1",
         "fairseq2n" + fairseq2n_version_spec,
         "importlib_metadata~=7.0",
+        "importlib_resources~=6.4",
         "numpy~=1.23",
         "packaging~=23.1",
         "psutil~=5.9",

--- a/src/fairseq2/assets/__init__.py
+++ b/src/fairseq2/assets/__init__.py
@@ -31,6 +31,9 @@ from fairseq2.assets.metadata_provider import (
 from fairseq2.assets.metadata_provider import (
     InProcAssetMetadataProvider as InProcAssetMetadataProvider,
 )
+from fairseq2.assets.metadata_provider import (
+    PackageAssetMetadataProvider as PackageAssetMetadataProvider,
+)
 from fairseq2.assets.store import AssetStore as AssetStore
 from fairseq2.assets.store import EnvironmentResolver as EnvironmentResolver
 from fairseq2.assets.store import StandardAssetStore as StandardAssetStore

--- a/src/fairseq2/assets/metadata_provider.py
+++ b/src/fairseq2/assets/metadata_provider.py
@@ -8,9 +8,11 @@ import os
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Dict, Optional, Sequence, final
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union, final
 
 import yaml
+from importlib_resources import files
+from importlib_resources.readers import MultiplexedPath
 from typing_extensions import NoReturn
 from yaml import YAMLError
 
@@ -54,10 +56,8 @@ class FileAssetMetadataProvider(AssetMetadataProvider):
     def get_metadata(self, name: str) -> Dict[str, Any]:
         self._ensure_cache_loaded()
 
-        assert self._cache is not None
-
         try:
-            return deepcopy(self._cache[name])
+            return deepcopy(self._cache[name])  # type: ignore[index]
         except KeyError:
             raise AssetNotFoundError(
                 f"An asset with the name '{name}' cannot be found."
@@ -83,54 +83,130 @@ class FileAssetMetadataProvider(AssetMetadataProvider):
                 if file.suffix != ".yaml" and file.suffix != ".yml":
                     continue
 
-                self._load_file(file)
+                for name, metadata in _load_metadata_file(file):
+                    if name in self._cache:
+                        raise AssetMetadataError(
+                            f"Two assets under the directory '{self._base_dir}' have the same name '{name}'."
+                        )
 
-    def _load_file(self, file: Path) -> None:
-        assert self._cache is not None
-
-        try:
-            fp = file.open()
-        except OSError as ex:
-            raise AssetMetadataError(
-                f"The asset metadata file '{file}' cannot be opened. See nested exception for details."
-            ) from ex
-
-        with fp:
-            try:
-                all_metadata = yaml.safe_load_all(fp)
-            except YAMLError as ex:
-                raise AssetMetadataError(
-                    f"The asset metadata file '{file}' cannot be loaded. See nested exception for details."
-                ) from ex
-
-            for idx, metadata in enumerate(all_metadata):
-                if not isinstance(metadata, dict):
-                    raise AssetMetadataError(
-                        f"The asset metadata at index {idx} in the file '{file}' is invalid."
-                    )
-
-                try:
-                    name = metadata["name"]
-                except KeyError:
-                    raise AssetMetadataError(
-                        f"The asset metadata at index {idx} in the file '{file}' does not have a name entry."
-                    )
-
-                if not isinstance(name, str):
-                    raise AssetMetadataError(
-                        f"The asset metadata at index {idx} in the file '{file}' has an invalid name."
-                    )
-
-                if name in self._cache:
-                    raise AssetMetadataError(
-                        f"Two assets under the directory {self._base_dir} have the same name '{name}'."
-                    )
-
-                self._cache[name] = metadata
+                    self._cache[name] = metadata
 
     @override
     def clear_cache(self) -> None:
         self._cache = None
+
+
+@final
+class PackageAssetMetadataProvider(AssetMetadataProvider):
+    """Provides asset metadata stored in a Python namespace package."""
+
+    _package_name: str
+    _package_path: MultiplexedPath
+    _cache: Optional[Dict[str, Dict[str, Any]]]
+
+    def __init__(self, package_name: str) -> None:
+        """
+        :param package_name:
+            The name of the package in which asset metadata is stored.
+        """
+        self._package_name = package_name
+
+        self._package_path = files(package_name)
+
+        self._cache = None
+
+    @override
+    def get_metadata(self, name: str) -> Dict[str, Any]:
+        self._ensure_cache_loaded()
+
+        try:
+            return deepcopy(self._cache[name])  # type: ignore[index]
+        except KeyError:
+            raise AssetNotFoundError(
+                f"An asset with the name '{name}' cannot be found."
+            )
+
+    def _ensure_cache_loaded(self) -> None:
+        if self._cache is not None:
+            return
+
+        self._cache = {}
+
+        for file in self._list_files():
+            if file.suffix != ".yaml" and file.suffix != ".yml":
+                continue
+
+            for name, metadata in _load_metadata_file(file):
+                if name in self._cache:
+                    raise AssetMetadataError(
+                        f"Two assets under the namespace package '{self._package_name}' have the same name '{name}'."
+                    )
+
+                self._cache[name] = metadata
+
+    def _list_files(self) -> List[Path]:
+        files = []
+
+        def collect_files(p: Union[MultiplexedPath, Path]) -> None:
+            if p.is_file():
+                if not isinstance(p, Path):
+                    raise RuntimeError(
+                        "`importlib.resources` returned a file path that is not of type `pathlib.Path`. Please file a bug report."
+                    )
+
+                files.append(p)
+            elif p.is_dir():
+                for e in p.iterdir():
+                    collect_files(e)
+
+        collect_files(self._package_path)
+
+        return files
+
+    @override
+    def clear_cache(self) -> None:
+        self._cache = None
+
+
+def _load_metadata_file(file: Path) -> List[Tuple[str, Dict[str, Any]]]:
+    output = []
+
+    try:
+        fp = file.open()
+    except OSError as ex:
+        raise AssetMetadataError(
+            f"The asset metadata file '{file}' cannot be opened. See nested exception for details."
+        ) from ex
+
+    with fp:
+        try:
+            all_metadata = yaml.safe_load_all(fp)
+        except YAMLError as ex:
+            raise AssetMetadataError(
+                f"The asset metadata file '{file}' cannot be loaded. See nested exception for details."
+            ) from ex
+
+        for idx, metadata in enumerate(all_metadata):
+            if not isinstance(metadata, dict):
+                raise AssetMetadataError(
+                    f"The asset metadata at index {idx} in the file '{file}' has an invalid format."
+                )
+
+            try:
+                name = metadata["name"]
+            except KeyError:
+                raise AssetMetadataError(
+                    f"The asset metadata at index {idx} in the file '{file}' does not have a name entry."
+                )
+
+            if not isinstance(name, str):
+                raise AssetMetadataError(
+                    f"The asset metadata at index {idx} in the file '{file}' has an invalid name."
+                )
+
+            output.append((name, metadata))
+
+    return output
 
 
 @final

--- a/src/fairseq2/assets/store.py
+++ b/src/fairseq2/assets/store.py
@@ -16,6 +16,7 @@ from fairseq2.assets.metadata_provider import (
     AssetMetadataProvider,
     AssetNotFoundError,
     FileAssetMetadataProvider,
+    PackageAssetMetadataProvider,
 )
 from fairseq2.assets.utils import _get_path_from_env
 from fairseq2.typing import override
@@ -133,9 +134,25 @@ class StandardAssetStore(AssetStore):
         for provider in self.user_metadata_providers:
             provider.clear_cache()
 
-    def add_file_metadata_provider(self, path: Path) -> None:
-        """Add a new :class:`FileAssetMetadataProvider` pointing to ``path``."""
-        self.metadata_providers.append(FileAssetMetadataProvider(path))
+    def add_file_metadata_provider(self, path: Path, user: bool = False) -> None:
+        """Add a new :class:`FileAssetMetadataProvider` pointing to ``path``.
+
+        :param path:
+            The directory under which asset metadata is stored.
+        :param user:
+            If ``True``, adds the metadata provider to the user scope.
+        """
+        providers = self.user_metadata_providers if user else self.metadata_providers
+
+        providers.append(FileAssetMetadataProvider(path))
+
+    def add_package_metadata_provider(self, package_name: str) -> None:
+        """Add a new :class:`PackageAssetMetadataProvider` for ``package_name``.
+
+        :param package_name:
+            The name of the package in which asset metadata is stored.
+        """
+        self.metadata_providers.append(PackageAssetMetadataProvider(package_name))
 
 
 class EnvironmentResolver(Protocol):
@@ -150,9 +167,7 @@ class EnvironmentResolver(Protocol):
 
 
 def _create_default_asset_store() -> StandardAssetStore:
-    cards_dir = Path(__file__).parent.joinpath("cards")
-
-    metadata_provider = FileAssetMetadataProvider(cards_dir)
+    metadata_provider = PackageAssetMetadataProvider("fairseq2.assets.cards")
 
     return StandardAssetStore(metadata_provider)
 
@@ -167,7 +182,7 @@ def _load_asset_directory() -> None:
         if not asset_dir.exists():
             return
 
-    default_asset_store.metadata_providers.append(FileAssetMetadataProvider(asset_dir))
+    default_asset_store.add_file_metadata_provider(asset_dir)
 
 
 _load_asset_directory()
@@ -184,9 +199,7 @@ def _load_user_asset_directory() -> None:
         if not asset_dir.exists():
             return
 
-    default_asset_store.user_metadata_providers.append(
-        FileAssetMetadataProvider(asset_dir)
-    )
+    default_asset_store.add_file_metadata_provider(asset_dir, user=True)
 
 
 _load_user_asset_directory()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ from argparse import ArgumentTypeError
 from pathlib import Path
 from typing import cast
 
-import pytest
+from pytest import Config, Parser, Session
 
 import tests.common
 from fairseq2.typing import Device
@@ -21,7 +21,7 @@ def parse_device_arg(value: str) -> Device:
         raise ArgumentTypeError(f"'{value}' is not a valid device name.")
 
 
-def pytest_addoption(parser: pytest.Parser) -> None:
+def pytest_addoption(parser: Parser) -> None:
     # fmt: off
     parser.addoption(
         "--device", default="cpu", type=parse_device_arg,
@@ -34,15 +34,13 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     # fmt: on
 
 
-def pytest_sessionstart(session: pytest.Session) -> None:
+def pytest_sessionstart(session: Session) -> None:
     tests.common.device = cast(Device, session.config.getoption("device"))
 
 
-def pytest_ignore_collect(
-    collection_path: Path, path: None, config: pytest.Config
-) -> bool:
+def pytest_ignore_collect(collection_path: Path, path: None, config: Config) -> bool:
+    # Ignore integration tests unless we run `pytest --integration`.
     if "integration" in collection_path.parts:
-        # Ignore integration tests unless we run `pytest --integration`.
         return not cast(bool, config.getoption("integration"))
 
     return False


### PR DESCRIPTION
This PR introduces a new `PackageMetadataProvider` that follows the PEP standards for accessing yaml files under package directories.