### PR TITLE
Remove debug parameter from activation checkpointing

### DIFF
--- a/src/fairseq2/metrics/recorder.py
+++ b/src/fairseq2/metrics/recorder.py
@@ -59,10 +59,10 @@ _metric_formatters: Dict[str, Tuple[str, int, Callable[[Any], str]]] = {
     "elements_per_batch":  ("Elements per Batch",        900, format_as_int),
     "elements_per_second": ("Elements per Second",       900, format_as_int),
     "num_examples":        ("Number of Examples",        900, format_as_int),
-    "num_elements":        ("Number of Elements",        900, format_as_int),
-    "num_source_elements": ("Number of Source Elements", 900, format_as_int),
-    "num_target_elements": ("Number of Target Elements", 900, format_as_int),
-    "num_loss_targets":    ("Number of Loss Targets:",   900, format_as_int),
+    "num_elements":        ("Number of Elements",        910, format_as_int),
+    "num_source_elements": ("Number of Source Elements", 910, format_as_int),
+    "num_target_elements": ("Number of Target Elements", 910, format_as_int),
+    "num_loss_targets":    ("Number of Loss Targets:",   920, format_as_int),
     # fmt: on
 }
 

--- a/src/fairseq2/nn/checkpointing.py
+++ b/src/fairseq2/nn/checkpointing.py
@@ -11,13 +11,12 @@ from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
     checkpoint_wrapper,
 )
 from torch.nn import Module
-from torch.utils.checkpoint import checkpoint
 
 from fairseq2.nn.transformer import TransformerDecoderLayer, TransformerEncoderLayer
 
 
 def use_layerwise_activation_checkpointing(
-    module: Module, preserve_rng_state: bool = False, debug: bool = False
+    module: Module, preserve_rng_state: bool = False
 ) -> None:
     """Use layer-wise activation checkpointing in ``module``.
 
@@ -27,17 +26,8 @@ def use_layerwise_activation_checkpointing(
         If ``True``, stashes the states of the default random number generators
         for the CPU and the device of ``module`` during the original forward
         pass and restores them during the recomputation.
-    :param debug:
-        If ``True``, error messages will include a trace of the operators ran
-        during the original forward pass.
     """
-    wrap = partial(
-        checkpoint_wrapper,
-        checkpoint_fn=checkpoint,
-        preserve_rng_state=preserve_rng_state,
-        use_reentrant=False,
-        debug=debug,
-    )
+    wrap = partial(checkpoint_wrapper, preserve_rng_state=preserve_rng_state)
 
     def check_module_type(m: Module) -> bool:
         return isinstance(m, (TransformerEncoderLayer, TransformerDecoderLayer))

--- a/src/fairseq2/utils/log.py
+++ b/src/fairseq2/utils/log.py
@@ -152,14 +152,14 @@ def log_hardware_info(
     )
 
     if device is not None:
-        s = f"{s} | Device Name: {device}"
+        s = f"{s} | Device: {device}"
 
     if device is not None and device.type == "cuda":
         pr = torch.cuda.get_device_properties(device)
 
         s = (
             f"{s} | "
-            f"Device Display Name: {pr.name} | "
+            f"Device Name: {pr.name} | "
             f"Device Memory: {pr.total_memory // (1024 * 1024):,}MiB | "
             f"Number of SMs: {pr.multi_processor_count} | "
             f"Compute Capability: {pr.major}.{pr.minor}"


### PR DESCRIPTION
It turns out that `torch.utils.checkpoint.checkpoint` leaks memory when `debug` is set to `True`. This PR removes it till it gets fixed in PyTorch and also does two very nit updates in logging.