### PR TITLE
Improve memory efficiency of SinusoidalPositionEncoder

### DIFF
--- a/src/fairseq2/models/nllb/factory.py
+++ b/src/fairseq2/models/nllb/factory.py
@@ -180,6 +180,7 @@ class NllbBuilder:
             self._config.max_seq_len,
             _legacy_pad_idx=1,
             device=self._device,
+            dtype=self._dtype,
         )
 
         return TransformerEmbeddingFrontend(

--- a/src/fairseq2/models/s2t_transformer/factory.py
+++ b/src/fairseq2/models/s2t_transformer/factory.py
@@ -287,7 +287,10 @@ class S2TTransformerBuilder:
             return None
 
         return SinusoidalPositionEncoder(
-            self._config.model_dim, self._config.max_source_seq_len, device=self._device
+            self._config.model_dim,
+            self._config.max_source_seq_len,
+            device=self._device,
+            dtype=self._dtype,
         )
 
     def build_target_position_encoder(self) -> PositionEncoder:
@@ -297,6 +300,7 @@ class S2TTransformerBuilder:
             self._config.max_target_seq_len,
             _legacy_pad_idx=1,
             device=self._device,
+            dtype=self._dtype,
         )
 
     def build_encoder(self) -> TransformerEncoder:

--- a/src/fairseq2/nn/functional.py
+++ b/src/fairseq2/nn/functional.py
@@ -38,6 +38,7 @@ def nll_loss(
     :param reduction:
         The reduction to apply to the output.
     """
+    # (N, S) -> (N, S, 1)
     targets = targets.unsqueeze(-1)
 
     loss = -lprobs.gather(dim=-1, index=targets)

--- a/src/fairseq2/nn/module_list.py
+++ b/src/fairseq2/nn/module_list.py
@@ -83,6 +83,6 @@ class ModuleList(TorchModuleList):
         s = super().extra_repr()
 
         if self.drop_p > 0.0:
-            s = f"{s}, drop_p={self.drop_p}"
+            s = f"{s}, drop_p={self.drop_p:G}"
 
         return s

--- a/src/fairseq2/nn/transformer/attention.py
+++ b/src/fairseq2/nn/transformer/attention.py
@@ -159,7 +159,7 @@ class TorchSDPA(SDPA):
 
     def extra_repr(self) -> str:
         """:meta private:"""
-        return f"attn_dropout_p={self.attn_dropout_p}"
+        return f"attn_dropout_p={self.attn_dropout_p:G}"
 
 
 @final
@@ -201,7 +201,7 @@ class NaiveSDPA(SDPA):
 
     def extra_repr(self) -> str:
         """:meta private:"""
-        return f"attn_dropout_p={self.attn_dropout_p}"
+        return f"attn_dropout_p={self.attn_dropout_p:G}"
 
 
 def _naive_scaled_dot_product_attention(

--- a/src/fairseq2/nn/transformer/ffn.py
+++ b/src/fairseq2/nn/transformer/ffn.py
@@ -238,6 +238,6 @@ class GLUFeedForwardNetwork(FeedForwardNetwork):
 
         return (
             f"{s}, "
-            f"inner_dim_scale={self.inner_dim_scale}, "
+            f"inner_dim_scale={self.inner_dim_scale:G}, "
             f"inner_dim_to_multiple={self.inner_dim_to_multiple}"
         )


### PR DESCRIPTION
This PR updates `SinusoidalPositionEncoder` to make it play nicely with mixed precision training and also reduces the memory overhead when used with lower-precision data types. Instead of storing the buffer in fp32, we cast it to fp16/bf16 at initialization time instead of casting inputs to fp32 in forward pass. I haven't observed any numerical instabilities due to frequency summation in low precision. Also a nit update in `extra_repr()` functions where floating point attributes are "pretty printed" now.