### PR TITLE
Wav2vec2 `codebook_sampling_temparature` typefix (int->float)

### DIFF
--- a/src/fairseq2/models/wav2vec2/factory.py
+++ b/src/fairseq2/models/wav2vec2/factory.py
@@ -200,7 +200,7 @@ class Wav2Vec2Config:
     num_codebook_entries: int = 320
     """The number of entries per codebook."""
 
-    codebook_sampling_temperature: Tuple[float, float, float] = (2, 0.5, 0.999995)
+    codebook_sampling_temperature: Tuple[float, float, float] = (2.0, 0.5, 0.999995)
     """A tuple of start temperature, end temperature, and decay factor for
     codebook entry sampling."""
 


### PR DESCRIPTION
**What does this PR do? Please describe:**
This fixes the default value of a field which should be a float, but is set to be an int. This causes problems in our configuration downstream.

**Does your PR introduce any breaking changes? If yes, please list them:**
List of all backwards-incompatible changes.

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [ ] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
