### PR TITLE
Revise non-persistent buffer handling

### DIFF
--- a/src/fairseq2/models/nllb/factory.py
+++ b/src/fairseq2/models/nllb/factory.py
@@ -180,7 +180,6 @@ class NllbBuilder:
             self._config.max_seq_len,
             _legacy_pad_idx=1,
             device=self._device,
-            dtype=self._dtype,
         )
 
         return TransformerEmbeddingFrontend(

--- a/src/fairseq2/models/s2t_transformer/factory.py
+++ b/src/fairseq2/models/s2t_transformer/factory.py
@@ -290,7 +290,6 @@ class S2TTransformerBuilder:
             self._config.model_dim,
             self._config.max_source_seq_len,
             device=self._device,
-            dtype=self._dtype,
         )
 
     def build_target_position_encoder(self) -> PositionEncoder:
@@ -300,7 +299,6 @@ class S2TTransformerBuilder:
             self._config.max_target_seq_len,
             _legacy_pad_idx=1,
             device=self._device,
-            dtype=self._dtype,
         )
 
     def build_encoder(self) -> TransformerEncoder:
@@ -410,7 +408,6 @@ class S2TTransformerBuilder:
                     self._config.model_dim,
                     self._config.max_source_seq_len,
                     device=self._device,
-                    dtype=self._dtype,
                 )
 
             sdpa = RelativePositionSDPA(

--- a/src/fairseq2/models/wav2vec2/factory.py
+++ b/src/fairseq2/models/wav2vec2/factory.py
@@ -403,7 +403,6 @@ class Wav2Vec2EncoderBuilder:
                     self._config.model_dim,
                     self._config.max_seq_len,
                     device=self._device,
-                    dtype=self._dtype,
                 )
 
             sdpa = RelativePositionSDPA(

--- a/src/fairseq2/nn/transformer/relative_attention.py
+++ b/src/fairseq2/nn/transformer/relative_attention.py
@@ -204,7 +204,6 @@ class RelativePositionalEncoding(Module):
         max_seq_len: int,
         *,
         device: Optional[Device] = None,
-        dtype: Optional[DataType] = None,
     ) -> None:
         """
         :param encoding_dim:
@@ -223,7 +222,7 @@ class RelativePositionalEncoding(Module):
         self.max_seq_len = max_seq_len
 
         freqs = torch.empty(
-            ((max_seq_len * 2) - 1, encoding_dim), device=device, dtype=dtype
+            ((max_seq_len * 2) - 1, encoding_dim), device=device, dtype=torch.float32
         )
 
         self.register_buffer("freqs", freqs, persistent=False)
@@ -236,12 +235,10 @@ class RelativePositionalEncoding(Module):
 
     def reset_non_persistent_buffers(self) -> None:
         """Reset the non-persistent buffers of the module."""
-        fp32_freqs = self.freqs.float()
+        device, dtype = self.freqs.device, self.freqs.dtype
 
-        device, dtype = fp32_freqs.device, fp32_freqs.dtype
-
-        positive_half = fp32_freqs[: self.max_seq_len]
-        negative_half = fp32_freqs[self.max_seq_len :]
+        positive_half = self.freqs[: self.max_seq_len]
+        negative_half = self.freqs[self.max_seq_len :]
 
         # (S)
         steps = torch.arange(self.max_seq_len, device=device, dtype=dtype)
@@ -266,8 +263,6 @@ class RelativePositionalEncoding(Module):
         torch.sin(-1 * freqs[1:], out=negative_half[:, 0::2])
         torch.cos(-1 * freqs[1:], out=negative_half[:, 1::2])
 
-        self.freqs.copy_(fp32_freqs)
-
     def forward(self, seqs: Tensor) -> Tensor:
         """
         :param seqs:
@@ -284,12 +279,16 @@ class RelativePositionalEncoding(Module):
         """
         seq_len = seqs.size(-2)
 
-        if seq_len > self.max_seq_len:
+        max_seq_len = self.max_seq_len
+
+        if seq_len > max_seq_len:
             raise ValueError(
-                f"The input sequence length must be less than or equal to the maximum sequence length ({self.max_seq_len}), but is {seq_len} instead."
+                f"The input sequence length must be less than or equal to the maximum sequence length ({max_seq_len}), but is {seq_len} instead."
             )
 
-        return self.freqs[self.max_seq_len - seq_len : self.max_seq_len + seq_len - 1]
+        fp32_freqs = self.freqs[max_seq_len - seq_len : max_seq_len + seq_len - 1]
+
+        return fp32_freqs.type_as(seqs)
 
     def extra_repr(self) -> str:
         """:meta private:"""


### PR DESCRIPTION
This PR rolls back the recent change to `SinusoidalPositionEncoder` and instead turns off FSDP mixed precision for buffers. It also works around FSDP's limitation of handling buffer broadcasting by storing the rotary frequencies as float32 instead of complex64. Overall PyTorch and FSDP lack proper handling of module buffers and I believe the solution in this PR (along with the upcoming FSDP PR that turns of mixed precision for buffers) is the best we can get. I also verified that everything works as expected with torch.amp when having single GPU or DDP training.