### PR TITLE
Improvements to to_fsdp

### DIFF
--- a/src/fairseq2/models/fsdp.py
+++ b/src/fairseq2/models/fsdp.py
@@ -21,8 +21,8 @@ from fairseq2.nn.transformer import (
 
 def get_fsdp_wrap_policy(
     model: Module, wrap_granularity: Literal["layer", "stack", "model"] = "layer"
-) -> Tuple[Optional[FSDPWrapPolicy], Optional[List[str]]]:
-    """Return the FSDP wrap policy for ``model``.
+) -> Tuple[Optional[FSDPWrapPolicy], Optional[List[Module]]]:
+    """Return the FSDP wrap policy for ``model`` along with ignored modules.
 
     :param model:
         The model to be wrapped.


### PR DESCRIPTION
This PR updates `to_fsdp()` with two changes:

(1) Simplifies the ignored module parameter and expects module instances instead of names.
(2) Disables mixed precision handling for buffers which is flawed and does not work correctly. A more sophisticated approach similar to torch.amp is needed to control precision for certain blocks/buffers/params. Till then, this is mostly sufficient (at least with the models we work with)