### PR TITLE
Workaround PyTorch 2.3 BC breaking changes

### DIFF
--- a/src/fairseq2/nn/utils/gradient.py
+++ b/src/fairseq2/nn/utils/gradient.py
@@ -103,7 +103,7 @@ def clip_gradient_norm(
 
         return module.clip_grad_norm_(max_norm, norm_type)
 
-    return clip_grad_norm_(
+    return clip_grad_norm_(  # type: ignore[no-any-return]
         module.parameters(), max_norm, norm_type, error_if_nonfinite=False
     )
 


### PR DESCRIPTION
This PR works around the backwards-incompatible changes introduced in PyTorch 2.3