### PR TITLE
Allow overwriting when recording formatters

### DIFF
--- a/src/fairseq2/metrics/recorder.py
+++ b/src/fairseq2/metrics/recorder.py
@@ -72,7 +72,7 @@ def register_metric_formatter(
     display_name: str,
     priority: int,
     format_fn: Callable[[Any], str],
-    overwrite: Optional[bool] = False,
+    overwrite: bool = False,
 ) -> None:
     """Register a string formatter for the specified metric.
 
@@ -84,6 +84,8 @@ def register_metric_formatter(
         The display priority of the metric.
     :param format_fn:
         The callable to convert a metric value to its string representation.
+    :param overwrite:
+        If ``True``, overwrites any existing metric formatter with the same name.
     """
     if name in _metric_formatters and not overwrite:
         raise ValueError(

--- a/src/fairseq2/metrics/recorder.py
+++ b/src/fairseq2/metrics/recorder.py
@@ -68,7 +68,11 @@ _metric_formatters: Dict[str, Tuple[str, int, Callable[[Any], str]]] = {
 
 
 def register_metric_formatter(
-    name: str, display_name: str, priority: int, format_fn: Callable[[Any], str]
+    name: str,
+    display_name: str,
+    priority: int,
+    format_fn: Callable[[Any], str],
+    overwrite: Optional[bool] = False,
 ) -> None:
     """Register a string formatter for the specified metric.
 
@@ -81,7 +85,7 @@ def register_metric_formatter(
     :param format_fn:
         The callable to convert a metric value to its string representation.
     """
-    if name in _metric_formatters:
+    if name in _metric_formatters and not overwrite:
         raise ValueError(
             f"`name` must be a unique metric name, but '{name}' is already registered."
         )


### PR DESCRIPTION
**What does this PR do? Please describe:**
Allow for overwriting metric formatters when calling `register_metric_formatter`
