### PR TITLE
Support dinosr inference (pseudo w2v2 approach)

### DIFF
--- a/src/fairseq2/assets/cards/wav2vec2.yaml
+++ b/src/fairseq2/assets/cards/wav2vec2.yaml
@@ -16,7 +16,7 @@ name: dinosr_base
 model_type: wav2vec2  # compat
 model_family: wav2vec2
 model_arch: pseudo_dinosr_base
-checkpoint: "https://dl.fbaipublicfiles.com/fairseq/wav2vec/wav2vec2_fs2_small.pt"
+checkpoint: "/fsx-ust/andyyuan/pt_models/xlsr_ckpts/pseudo_dinosr_spin_ft_use7_frz5_cl4096.pt"
 
 ---
 

--- a/src/fairseq2/assets/cards/wav2vec2.yaml
+++ b/src/fairseq2/assets/cards/wav2vec2.yaml
@@ -16,7 +16,7 @@ name: dinosr_base
 model_type: wav2vec2  # compat
 model_family: wav2vec2
 model_arch: pseudo_dinosr_base
-checkpoint: "/fsx-ust/andyyuan/pt_models/xlsr_ckpts/pseudo_dinosr_spin_ft_use7_frz5_cl4096.pt"
+checkpoint: "https://ai.meta.com/pseudo_dinosr_base/;gated=true"
 
 ---
 

--- a/src/fairseq2/assets/cards/wav2vec2.yaml
+++ b/src/fairseq2/assets/cards/wav2vec2.yaml
@@ -12,6 +12,14 @@ checkpoint: "https://dl.fbaipublicfiles.com/fairseq/wav2vec/wav2vec2_fs2_small.p
 
 ---
 
+name: dinosr_base
+model_type: wav2vec2  # compat
+model_family: wav2vec2
+model_arch: pseudo_dinosr_base
+checkpoint: "https://dl.fbaipublicfiles.com/fairseq/wav2vec/wav2vec2_fs2_small.pt"
+
+---
+
 name: wav2vec2_asr_base_10m
 model_type: wav2vec2_asr  # compat
 model_family: wav2vec2_asr

--- a/src/fairseq2/models/wav2vec2/factory.py
+++ b/src/fairseq2/models/wav2vec2/factory.py
@@ -222,6 +222,11 @@ def _base() -> Wav2Vec2Config:
     return Wav2Vec2Config()
 
 
+@wav2vec2_arch("pseudo_dinosr_base")
+def _pseudo_dinosr_base() -> Wav2Vec2Config:
+    return Wav2Vec2Config()
+
+
 class Wav2Vec2EncoderBuilder:
     """Builds modules of a wav2vec 2.0 encoder as described in
     :cite:t:`https://doi.org/10.48550/arxiv.2006.11477`.

--- a/src/fairseq2/models/wav2vec2/setup.py
+++ b/src/fairseq2/models/wav2vec2/setup.py
@@ -57,7 +57,7 @@ def convert_wav2vec2_checkpoint(
         r"^encoder\.layers\.([0-9]+)\.fc2\.":                 r"encoder.layers.\1.ffn.output_proj.",
         r"^encoder\.layers\.([0-9]+)\.final_layer_norm\.":    r"encoder.layers.\1.ffn_layer_norm.",
         r"^encoder\.embed_tokens\.":                          r"encoder_frontend.embed.",
-        r"^encoder\.pos_conv\.0\.":                           r"encoder_frontend.pos_encoder.conv.",
+        r"^encoder\.pos_conv\.([0-4])\.":                     r"encoder_frontend.pos_encoder.conv.",
         r"^feature_extractor\.conv_layers\.([0-9]+)\.0\.":    r"encoder_frontend.feature_extractor.layers.\1.conv.",
         r"^feature_extractor\.conv_layers\.([0-9]+)\.2\.1\.": r"encoder_frontend.feature_extractor.layers.\1.layer_norm.",
         r"^feature_extractor\.conv_layers\.0\.2\.":           r"encoder_frontend.feature_extractor.layers.0.group_norm.",


### PR DESCRIPTION
**What does this PR do? Please describe:**

The PR provides an adhoc way to support inference of the DinoSR tokenizer pre-trained in fairseq.  The idea is to reuse the existing wav2vec2 architecture in fairseq2 but load it with dinosr weights.  This approach is feasible because besides the pretraining-specific modules in wav2vec2 (inclduing mask_emb, quantizer, final_proj, and project_q) and dinosr (mask_emb, codebook_* and ema), which will not be used in fine-tuning or inference, both models are essentially identical as a stack of Transformer layers.