### PR TITLE
Fix nn/transformer/encoder.py

### DIFF
--- a/src/fairseq2/nn/transformer/encoder.py
+++ b/src/fairseq2/nn/transformer/encoder.py
@@ -188,7 +188,7 @@ class StandardTransformerEncoder(TransformerEncoder):
     def forward(
         self, seqs: Tensor, padding_mask: Optional[PaddingMask]
     ) -> Tuple[Tensor, Optional[PaddingMask]]:
-        if self._layer_output_hooks and self.layers.drop_p > 0.0 and self.training:
+        if self._layer_output_hooks and self.layer_drop_p > 0.0 and self.training:
             raise RuntimeError(
                 "The layer output hooks cannot be run when LayerDrop is enabled."
             )


### PR DESCRIPTION
Fix error
```
... site-packages/fairseq2/nn/transformer/encoder.py", line 191, in forward
    if self._layer_output_hooks and self.layers.drop_p > 0.0 and self.training:

... site-packages/torch/nn/modules/module.py", line 1695, in __getattr__
    raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
AttributeError: 'ModuleList' object has no attribute 'drop_p'
```