### PR TITLE
Introduce CLI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,4 +62,5 @@ setup(
     extras_require={
         "arrow": ["pyarrow>=13.0.0", "pandas~=2.0.0"],
     },
+    entry_points={"console_scripts": ["fairseq2=fairseq2.recipes:main"]},
 )

--- a/src/fairseq2/assets/download_manager.py
+++ b/src/fairseq2/assets/download_manager.py
@@ -22,8 +22,8 @@ from tqdm import tqdm  # type: ignore[import]
 
 from fairseq2.assets.error import AssetError
 from fairseq2.assets.utils import _get_path_from_env, _starts_with_scheme
+from fairseq2.logging import get_log_writer
 from fairseq2.typing import override
-from fairseq2.utils.logging import get_log_writer
 
 log = get_log_writer(__name__)
 

--- a/src/fairseq2/assets/metadata_provider.py
+++ b/src/fairseq2/assets/metadata_provider.py
@@ -181,7 +181,7 @@ def _load_metadata_file(file: Path) -> List[Tuple[str, Dict[str, Any]]]:
     with fp:
         try:
             all_metadata = yaml.safe_load_all(fp)
-        except YAMLError as ex:
+        except (OSError, YAMLError) as ex:
             raise AssetMetadataError(
                 f"The asset metadata file '{file}' cannot be loaded. See nested exception for details."
             ) from ex

--- a/src/fairseq2/assets/store.py
+++ b/src/fairseq2/assets/store.py
@@ -19,8 +19,8 @@ from fairseq2.assets.metadata_provider import (
     PackageAssetMetadataProvider,
 )
 from fairseq2.assets.utils import _get_path_from_env
+from fairseq2.logging import get_log_writer
 from fairseq2.typing import override
-from fairseq2.utils.logging import get_log_writer
 
 log = get_log_writer(__name__)
 

--- a/src/fairseq2/assets/utils.py
+++ b/src/fairseq2/assets/utils.py
@@ -9,7 +9,7 @@ import re
 from pathlib import Path
 from typing import Final, Optional
 
-from fairseq2.utils.logging import LogWriter
+from fairseq2.logging import LogWriter
 
 _SCHEME_REGEX: Final = re.compile("^[a-zA-Z0-9]+://")
 

--- a/src/fairseq2/config_registry.py
+++ b/src/fairseq2/config_registry.py
@@ -4,17 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import (
-    AbstractSet,
-    Callable,
-    Dict,
-    Generic,
-    Iterator,
-    Protocol,
-    Tuple,
-    TypeVar,
-    final,
-)
+from typing import AbstractSet, Callable, Dict, Generic, Protocol, TypeVar, final
 
 from fairseq2.typing import DataClass
 
@@ -58,7 +48,7 @@ class ConfigRegistry(Generic[ConfigT]):
         """
         if name in self._configs:
             raise ValueError(
-                f"`name` must be a unique configuration name, but '{name}' is already registered."
+                f"`name` must be a unique configuration name, but '{name}' has already a registered configuration factory."
             )
 
         self._configs[name] = config_factory
@@ -74,11 +64,6 @@ class ConfigRegistry(Generic[ConfigT]):
             return config_factory
 
         return register
-
-    def all(self) -> Iterator[Tuple[str, ConfigT]]:
-        """Return all configurations."""
-        for name, factory in self._configs.items():
-            yield name, factory()
 
     def names(self) -> AbstractSet[str]:
         """Return the names of all configurations."""

--- a/src/fairseq2/data/text/sentencepiece.py
+++ b/src/fairseq2/data/text/sentencepiece.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, List, Optional, Sequence, final
 from fairseq2n import DOC_MODE
 from torch import Tensor
 
-from fairseq2.assets import AssetCard, default_asset_store, default_download_manager
+from fairseq2.assets import AssetCard
 from fairseq2.data.text.text_tokenizer import (
     AbstractTextTokenizer,
     AbstractTextTokenizerLoader,
@@ -237,9 +237,7 @@ class BasicSentencePieceTokenizerLoader(
         return BasicSentencePieceTokenizer(path)
 
 
-default_basic_sentencepiece_tokenizer_loader = BasicSentencePieceTokenizerLoader(
-    default_asset_store, default_download_manager
-)
+default_basic_sentencepiece_tokenizer_loader = BasicSentencePieceTokenizerLoader()
 
 
 def vocab_info_from_sentencepiece(model: SentencePieceModel) -> VocabularyInfo:

--- a/src/fairseq2/data/text/text_tokenizer.py
+++ b/src/fairseq2/data/text/text_tokenizer.py
@@ -20,6 +20,7 @@ from fairseq2.assets import (
     AssetError,
     AssetStore,
     default_asset_store,
+    default_download_manager,
 )
 from fairseq2.data.vocabulary_info import VocabularyInfo
 from fairseq2.typing import Device, override
@@ -184,7 +185,10 @@ class AbstractTextTokenizerLoader(ABC, TextTokenizerLoader[TextTokenizerT]):
     _download_manager: AssetDownloadManager
 
     def __init__(
-        self, asset_store: AssetStore, download_manager: AssetDownloadManager
+        self,
+        *,
+        asset_store: Optional[AssetStore] = None,
+        download_manager: Optional[AssetDownloadManager] = None,
     ) -> None:
         """
         :param asset_store:
@@ -192,8 +196,8 @@ class AbstractTextTokenizerLoader(ABC, TextTokenizerLoader[TextTokenizerT]):
         :param download_manager:
             The download manager.
         """
-        self._asset_store = asset_store
-        self._download_manager = download_manager
+        self._asset_store = asset_store or default_asset_store
+        self._download_manager = download_manager or default_download_manager
 
     def __call__(
         self,
@@ -215,7 +219,7 @@ class AbstractTextTokenizerLoader(ABC, TextTokenizerLoader[TextTokenizerT]):
             )
         except ValueError as ex:
             raise AssetCardError(
-                f"The value of the field 'tokenizer' of the asset card '{card.name}' is not valid. See nested exception for details."
+                f"The value of the field 'tokenizer' of the asset card '{card.name}' must be a URI. See nested exception for details."
             ) from ex
 
         try:
@@ -242,12 +246,12 @@ class DelegatingTextTokenizerLoader(TextTokenizerLoader[TextTokenizerT]):
     _asset_store: AssetStore
     _loaders: Dict[str, TextTokenizerLoader[TextTokenizerT]]
 
-    def __init__(self, asset_store: AssetStore) -> None:
+    def __init__(self, *, asset_store: Optional[AssetStore] = None) -> None:
         """
         :param asset_store:
             The asset store where to check for available tokenizers.
         """
-        self._asset_store = asset_store
+        self._asset_store = asset_store or default_asset_store
 
         self._loaders = {}
 
@@ -305,4 +309,4 @@ class DelegatingTextTokenizerLoader(TextTokenizerLoader[TextTokenizerT]):
         self._loaders[family] = loader
 
 
-load_text_tokenizer = DelegatingTextTokenizerLoader[TextTokenizer](default_asset_store)
+load_text_tokenizer = DelegatingTextTokenizerLoader[TextTokenizer]()

--- a/src/fairseq2/datasets/asr/base.py
+++ b/src/fairseq2/datasets/asr/base.py
@@ -7,7 +7,6 @@
 from abc import ABC, abstractmethod
 from typing import List, Optional
 
-from fairseq2.assets import default_asset_store
 from fairseq2.data.text import TextTokenizer
 from fairseq2.datasets.data_reader import DataReader
 from fairseq2.datasets.loader import DelegatingDatasetLoader
@@ -74,4 +73,4 @@ class AsrDataset(ABC):
         """Return the list of splits."""
 
 
-load_asr_dataset = DelegatingDatasetLoader[AsrDataset](default_asset_store)
+load_asr_dataset = DelegatingDatasetLoader[AsrDataset]()

--- a/src/fairseq2/datasets/data_reader.py
+++ b/src/fairseq2/datasets/data_reader.py
@@ -12,8 +12,8 @@ from typing_extensions import Self
 from fairseq2.data import DataPipeline
 from fairseq2.datasets.utils import _reduce_num_batches
 from fairseq2.gang import Gang
+from fairseq2.logging import get_log_writer
 from fairseq2.typing import override
-from fairseq2.utils.logging import get_log_writer
 
 log = get_log_writer(__name__)
 

--- a/src/fairseq2/datasets/instruction/base.py
+++ b/src/fairseq2/datasets/instruction/base.py
@@ -7,7 +7,6 @@
 from abc import ABC, abstractmethod
 from typing import List, Optional
 
-from fairseq2.assets import default_asset_store
 from fairseq2.data.text import TextTokenizer
 from fairseq2.datasets.data_reader import DataPipelineReader
 from fairseq2.datasets.loader import DelegatingDatasetLoader
@@ -66,6 +65,4 @@ class InstructionDataset(ABC):
         """Return the list of splits."""
 
 
-load_instruction_dataset = DelegatingDatasetLoader[InstructionDataset](
-    default_asset_store
-)
+load_instruction_dataset = DelegatingDatasetLoader[InstructionDataset]()

--- a/src/fairseq2/datasets/parallel_text/base.py
+++ b/src/fairseq2/datasets/parallel_text/base.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import List, NamedTuple, Optional, Sequence
 
-from fairseq2.assets import default_asset_store
 from fairseq2.data.text import TextTokenizer
 from fairseq2.datasets.data_reader import DataReader
 from fairseq2.datasets.loader import DelegatingDatasetLoader
@@ -92,6 +91,4 @@ class ParallelTextDataset(ABC):
         """Return the list of language pairs of ``split``."""
 
 
-load_parallel_text_dataset = DelegatingDatasetLoader[ParallelTextDataset](
-    default_asset_store
-)
+load_parallel_text_dataset = DelegatingDatasetLoader[ParallelTextDataset]()

--- a/src/fairseq2/datasets/parallel_text/nllb.py
+++ b/src/fairseq2/datasets/parallel_text/nllb.py
@@ -10,12 +10,7 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Tuple, cast, final
 
-from fairseq2.assets import (
-    AssetCard,
-    AssetCardError,
-    default_asset_store,
-    default_download_manager,
-)
+from fairseq2.assets import AssetCard, AssetCardError
 from fairseq2.data import (
     Collater,
     DataPipeline,
@@ -401,7 +396,7 @@ class NllbDatasetLoader(AbstractDatasetLoader[NllbDataset]):
         return NllbDataset(card.name, path, split_lang_pairs)
 
 
-load_nllb_dataset = NllbDatasetLoader(default_asset_store, default_download_manager)
+load_nllb_dataset = NllbDatasetLoader()
 
 
 def _register_nllb() -> None:

--- a/src/fairseq2/datasets/utils.py
+++ b/src/fairseq2/datasets/utils.py
@@ -9,7 +9,7 @@ import logging
 import torch
 
 from fairseq2.gang import Gang
-from fairseq2.utils.logging import LogWriter
+from fairseq2.logging import LogWriter
 
 
 def _reduce_num_batches(num_batches: int, gang: Gang, log: LogWriter) -> int:

--- a/src/fairseq2/logging.py
+++ b/src/fairseq2/logging.py
@@ -5,131 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 import logging
-import os
-import time
-from logging import DEBUG, INFO, FileHandler, Formatter, Handler, Logger, getLogger
-from pathlib import Path
-from typing import TYPE_CHECKING, Any, Final, List, Optional, Set, final
-
-from fairseq2n import DOC_MODE
-from rich.logging import RichHandler
-
-
-def setup_logging(
-    log_file: Path,
-    *,
-    debug: bool = False,
-    utc_time: bool = False,
-    force: bool = False,
-) -> None:
-    """Set up logging for a training or evaluation job.
-
-    :param log_file:
-        The file to which logs will be written. Must have a 'rank' replacement
-        field; for example '/path/to/train_{rank}.log'.
-    :param debug:
-        If ``True``, sets the log level to ``DEBUG``; otherwise, to ``INFO``.
-    :param utc_time:
-        If ``True``, logs dates and times in UTC.
-    :param force:
-        If ``True``, overwrites existing log configuration.
-    """
-    from fairseq2.gang import get_rank  # Avoid circular import.
-
-    rank = get_rank()
-
-    filename = log_file.name.format(rank=rank)
-
-    if filename == log_file.name:
-        raise ValueError(
-            f"`log_file` must contain a 'rank' replacement field (i.e. {{rank}}) in its filename, but is '{log_file}' instead."
-        )
-
-    log_file = log_file.with_name(filename)
-
-    try:
-        log_file.parent.mkdir(parents=True, exist_ok=True)
-    except OSError as ex:
-        raise RuntimeError(
-            f"The log directory ({log_file.parent}) cannot be created. See nested exception for details."
-        ) from ex
-
-    if utc_time:
-        Formatter.converter = time.gmtime
-
-    file_handler = FileHandler(log_file)
-
-    formatter = Formatter(
-        f"[Rank {rank}] %(asctime)s %(levelname)s %(name)s - %(message)s"
-    )
-
-    file_handler.setFormatter(formatter)
-
-    handlers: List[Handler] = [file_handler]
-
-    if rank == 0:
-        rich_handler = RichHandler(show_path=False, keywords=[])
-
-        formatter = Formatter("%(name)s - %(message)s")
-
-        rich_handler.setFormatter(formatter)
-
-        handlers.append(rich_handler)
-
-    datefmt = "%Y-%m-%d %H:%M:%S"
-
-    logging.basicConfig(
-        level=DEBUG if debug else INFO, handlers=handlers, datefmt=datefmt, force=force
-    )
-
-    _setup_aten_logging(log_file, force)
-
-    _setup_nccl_logging(log_file, force)
-
-
-def _setup_aten_logging(log_file: Path, force: bool) -> None:
-    if "TORCH_CPP_LOG_LEVEL" in os.environ and not force:
-        return
-
-    aten_log_file = log_file.parent.joinpath("aten", log_file.name)
-
-    try:
-        aten_log_file.parent.mkdir(parents=True, exist_ok=True)
-    except OSError as ex:
-        raise RuntimeError(
-            f"The ATen log directory ({aten_log_file.parent}) cannot be created. See nested exception for details."
-        ) from ex
-
-    _enable_aten_logging(aten_log_file)
-
-    # This variable has no effect at this point. We set it for completeness.
-    os.environ["TORCH_CPP_LOG_LEVEL"] = "INFO"
-
-
-if TYPE_CHECKING or DOC_MODE:
-
-    def _enable_aten_logging(log_file: Path) -> Path:
-        ...
-
-else:
-    from fairseq2n.bindings import _enable_aten_logging
-
-
-def _setup_nccl_logging(log_file: Path, force: bool) -> None:
-    if "NCCL_DEBUG" in os.environ and not force:
-        return
-
-    nccl_log_file = log_file.parent.joinpath("nccl", log_file.name)
-
-    try:
-        nccl_log_file.parent.mkdir(parents=True, exist_ok=True)
-    except OSError as ex:
-        raise RuntimeError(
-            f"The NCCL log directory ({nccl_log_file.parent}) cannot be created. See nested exception for details."
-        ) from ex
-
-    os.environ["NCCL_DEBUG"] = "INFO"
-    os.environ["NCCL_DEBUG_FILE"] = str(nccl_log_file)
+from logging import Logger, getLogger
+from typing import Any, Final, Optional, Set, final
 
 
 @final
@@ -247,6 +124,11 @@ class LogWriter:
         """Return ``True`` if a message of severity ``level`` would be processed
         by this writer."""
         return self._logger.isEnabledFor(level)
+
+    def is_debug_enabled(self) -> bool:
+        """Return ``True`` if a message of severity ``DEBUG`` would be processed
+        by this writer."""
+        return self._logger.isEnabledFor(logging.DEBUG)
 
 
 def get_log_writer(name: Optional[str] = None) -> LogWriter:

--- a/src/fairseq2/metrics/recorder.py
+++ b/src/fairseq2/metrics/recorder.py
@@ -12,10 +12,10 @@ from functools import partial
 from logging import Logger
 from pathlib import Path
 from string import capwords
-from typing import Any, Callable, Dict, Optional, Sequence, Tuple, Union, final
+from typing import Any, Callable, Dict, Mapping, Optional, Sequence, Tuple, Union, final
 
+from fairseq2.logging import LogWriter, get_log_writer
 from fairseq2.typing import override
-from fairseq2.utils.logging import LogWriter, get_log_writer
 
 
 def format_as_int(value: Any, *, postfix: Optional[str] = None) -> str:
@@ -102,7 +102,7 @@ class MetricRecorder(ABC):
     def record_metrics(
         self,
         run: str,
-        values: Dict[str, Any],
+        values: Mapping[str, Any],
         step_nr: int,
         *,
         flush: bool = False,
@@ -127,7 +127,7 @@ class MetricRecorder(ABC):
 def record_metrics(
     recorders: Sequence[MetricRecorder],
     run: str,
-    values: Dict[str, Any],
+    values: Mapping[str, Any],
     step_nr: int,
     *,
     flush: bool = False,
@@ -169,7 +169,7 @@ class LogMetricRecorder(MetricRecorder):
     def record_metrics(
         self,
         run: str,
-        values: Dict[str, Any],
+        values: Mapping[str, Any],
         step_nr: int,
         *,
         flush: bool = False,
@@ -236,7 +236,7 @@ class TensorBoardRecorder(MetricRecorder):
     def record_metrics(
         self,
         run: str,
-        values: Dict[str, Any],
+        values: Mapping[str, Any],
         step_nr: int,
         *,
         flush: bool = False,

--- a/src/fairseq2/models/config_loader.py
+++ b/src/fairseq2/models/config_loader.py
@@ -13,10 +13,12 @@ from fairseq2.assets import (
     AssetCardFieldNotFoundError,
     AssetError,
     AssetStore,
+    default_asset_store,
 )
 from fairseq2.config_registry import ConfigRegistry
 from fairseq2.typing import DataClass
-from fairseq2.utils.dataclass import update_dataclass
+from fairseq2.utils.dataclass import FieldError, update_dataclass
+from fairseq2.utils.value_converter import ValueConverter, default_value_converter
 
 ModelConfigT = TypeVar("ModelConfigT", bound=DataClass)
 
@@ -40,29 +42,36 @@ class StandardModelConfigLoader(ModelConfigLoader[ModelConfigT]):
     _asset_store: AssetStore
     _family: str
     _config_kls: Type[ModelConfigT]
-    _archs: Optional[ConfigRegistry[ModelConfigT]]
+    _arch_configs: Optional[ConfigRegistry[ModelConfigT]]
+    _value_converter: ValueConverter
 
     def __init__(
         self,
-        asset_store: AssetStore,
+        *,
         family: str,
         config_kls: Type[ModelConfigT],
-        archs: Optional[ConfigRegistry[ModelConfigT]],
+        arch_configs: Optional[ConfigRegistry[ModelConfigT]],
+        asset_store: Optional[AssetStore] = None,
+        value_converter: Optional[ValueConverter] = None,
     ) -> None:
         """
-        :param asset_store:
-            The asset store where to check for available models.
         :param family:
             The model family.
         :param config_kls:
             The type of the model configuration.
-        :param archs:
+        :param arch_configs:
             The registry containing all supported model architectures.
+        :param asset_store:
+            The asset store where to check for available models.
+        :param value_converter:
+            The :class:`ValueConverter` instance to use. If ``None``, the
+            default instance will be used.
         """
-        self._asset_store = asset_store
+        self._asset_store = asset_store or default_asset_store
         self._family = family
         self._config_kls = config_kls
-        self._archs = archs
+        self._arch_configs = arch_configs
+        self._value_converter = value_converter or default_value_converter
 
     def __call__(self, model_name_or_card: Union[str, AssetCard]) -> ModelConfigT:
         if isinstance(model_name_or_card, AssetCard):
@@ -82,10 +91,10 @@ class StandardModelConfigLoader(ModelConfigLoader[ModelConfigT]):
 
         arch = None
 
-        if self._archs is not None:
+        if self._arch_configs is not None:
             try:
                 # Ensure that the card has a valid model architecture.
-                arch = card.field("model_arch").as_one_of(self._archs.names())
+                arch = card.field("model_arch").as_one_of(self._arch_configs.names())
             except AssetCardFieldNotFoundError:
                 pass
 
@@ -98,23 +107,29 @@ class StandardModelConfigLoader(ModelConfigLoader[ModelConfigT]):
                     f"The {self._family} model family has no default configuration."
                 ) from ex
         else:
-            assert self._archs is not None
+            assert self._arch_configs is not None
 
             try:
-                config = self._archs.get(arch)
+                config = self._arch_configs.get(arch)
             except ValueError as ex:
                 raise AssetError(
                     f"The {self._family} model family has no architecture named '{arch}'."
                 ) from ex
 
-        # Check if we should override anything in the default model
-        # configuration.
+        # Check whether to override anything in the default model configuration.
         if config_overrides := card.field("model_config").get_as_(dict):
             try:
-                update_dataclass(config, deepcopy(config_overrides))
-            except (TypeError, ValueError) as ex:
-                raise AssetError(
-                    f"The value of the field `model_config` of the asset card '{card.name}' contains one or more invalid keys. See nested exception for details."
+                unknown_fields = update_dataclass(
+                    config, config_overrides, value_converter=self._value_converter
+                )
+            except FieldError as ex:
+                raise AssetCardError(
+                    f"The value of the field `model_config` of the asset card '{card.name}' must be a valid model configuration, but the value of the configuration field '{ex.field_name}' is invalid. See nested exception for details."
                 ) from ex
+
+            if unknown_fields:
+                raise AssetCardError(
+                    f"The value of the field `model_config` of the asset card '{card.name}' must be a valid model configuration, but the following configuration fields are unknown: {', '.join(unknown_fields)}"
+                )
 
         return config

--- a/src/fairseq2/models/llama/setup.py
+++ b/src/fairseq2/models/llama/setup.py
@@ -6,7 +6,7 @@
 
 from typing import Any, Dict, final
 
-from fairseq2.assets import AssetCard, default_asset_store, default_download_manager
+from fairseq2.assets import AssetCard
 from fairseq2.data.text import default_basic_sentencepiece_tokenizer_loader
 from fairseq2.gang import Gang
 from fairseq2.models.config_loader import StandardModelConfigLoader
@@ -25,7 +25,7 @@ from fairseq2.models.utils.checkpoint import convert_model_state_dict
 from fairseq2.typing import override
 
 load_llama_config = StandardModelConfigLoader(
-    default_asset_store, LLAMA_FAMILY, LLaMAConfig, llama_archs
+    family=LLAMA_FAMILY, config_kls=LLaMAConfig, arch_configs=llama_archs
 )
 
 
@@ -78,11 +78,9 @@ def convert_llama_checkpoint(
 
 
 load_llama_model = LLaMAModelLoader(
-    default_asset_store,
-    default_download_manager,
-    load_llama_config,
-    create_llama_model,
-    convert_llama_checkpoint,
+    config_loader=load_llama_config,
+    factory=create_llama_model,
+    checkpoint_converter=convert_llama_checkpoint,
     mmap=True,
 )
 

--- a/src/fairseq2/models/mistral/setup.py
+++ b/src/fairseq2/models/mistral/setup.py
@@ -6,7 +6,6 @@
 
 from typing import Any, Dict
 
-from fairseq2.assets import default_asset_store, default_download_manager
 from fairseq2.data.text import default_basic_sentencepiece_tokenizer_loader
 from fairseq2.models.config_loader import StandardModelConfigLoader
 from fairseq2.models.loader import DenseModelLoader
@@ -19,7 +18,7 @@ from fairseq2.models.mistral.factory import (
 from fairseq2.models.utils.checkpoint import convert_model_state_dict
 
 load_mistral_config = StandardModelConfigLoader(
-    default_asset_store, MISTRAL_FAMILY, MistralConfig, mistral_archs
+    family=MISTRAL_FAMILY, config_kls=MistralConfig, arch_configs=mistral_archs
 )
 
 
@@ -54,11 +53,9 @@ def convert_mistral_checkpoint(
 
 
 load_mistral_model = DenseModelLoader(
-    default_asset_store,
-    default_download_manager,
-    load_mistral_config,
-    create_mistral_model,
-    convert_mistral_checkpoint,
+    config_loader=load_mistral_config,
+    factory=create_mistral_model,
+    checkpoint_converter=convert_mistral_checkpoint,
     mmap=True,
 )
 

--- a/src/fairseq2/models/nllb/setup.py
+++ b/src/fairseq2/models/nllb/setup.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, final
 
 import torch
 
-from fairseq2.assets import AssetCard, default_asset_store, default_download_manager
+from fairseq2.assets import AssetCard
 from fairseq2.data.text import AbstractTextTokenizerLoader
 from fairseq2.models.config_loader import StandardModelConfigLoader
 from fairseq2.models.loader import DenseModelLoader
@@ -24,7 +24,7 @@ from fairseq2.models.utils.checkpoint import convert_fairseq_checkpoint
 from fairseq2.typing import override
 
 load_nllb_config = StandardModelConfigLoader(
-    default_asset_store, NLLB_FAMILY, NllbConfig, nllb_archs
+    family=NLLB_FAMILY, config_kls=NllbConfig, arch_configs=nllb_archs
 )
 
 
@@ -92,11 +92,9 @@ def convert_nllb_checkpoint(
 
 
 load_nllb_model = DenseModelLoader(
-    default_asset_store,
-    default_download_manager,
-    load_nllb_config,
-    create_nllb_model,
-    convert_nllb_checkpoint,
+    config_loader=load_nllb_config,
+    factory=create_nllb_model,
+    checkpoint_converter=convert_nllb_checkpoint,
     mmap=True,
     restrict_checkpoints=False,
 )
@@ -115,4 +113,4 @@ class NllbTokenizerLoader(AbstractTextTokenizerLoader[NllbTokenizer]):
         return NllbTokenizer(path, langs, default_lang)
 
 
-load_nllb_tokenizer = NllbTokenizerLoader(default_asset_store, default_download_manager)
+load_nllb_tokenizer = NllbTokenizerLoader()

--- a/src/fairseq2/models/s2t_transformer/setup.py
+++ b/src/fairseq2/models/s2t_transformer/setup.py
@@ -7,7 +7,7 @@
 from pathlib import Path
 from typing import Any, Dict, Final, final
 
-from fairseq2.assets import AssetCard, default_asset_store, default_download_manager
+from fairseq2.assets import AssetCard
 from fairseq2.data.text import AbstractTextTokenizerLoader
 from fairseq2.models.config_loader import StandardModelConfigLoader
 from fairseq2.models.loader import DenseModelLoader
@@ -22,10 +22,9 @@ from fairseq2.models.utils.checkpoint import convert_fairseq_checkpoint
 from fairseq2.typing import override
 
 load_s2t_transformer_config = StandardModelConfigLoader(
-    default_asset_store,
-    S2T_TRANSFORMER_FAMILY,
-    S2TTransformerConfig,
-    s2t_transformer_archs,
+    family=S2T_TRANSFORMER_FAMILY,
+    config_kls=S2TTransformerConfig,
+    arch_configs=s2t_transformer_archs,
 )
 
 
@@ -91,11 +90,9 @@ def convert_s2t_transformer_checkpoint(
 
 
 load_s2t_transformer_model = DenseModelLoader(
-    default_asset_store,
-    default_download_manager,
-    load_s2t_transformer_config,
-    create_s2t_transformer_model,
-    convert_s2t_transformer_checkpoint,
+    config_loader=load_s2t_transformer_config,
+    factory=create_s2t_transformer_model,
+    checkpoint_converter=convert_s2t_transformer_checkpoint,
     mmap=True,
     restrict_checkpoints=False,
 )
@@ -120,6 +117,4 @@ class S2TTransformerTokenizerLoader(
         )
 
 
-load_s2t_transformer_tokenizer = S2TTransformerTokenizerLoader(
-    default_asset_store, default_download_manager
-)
+load_s2t_transformer_tokenizer = S2TTransformerTokenizerLoader()

--- a/src/fairseq2/models/w2vbert/setup.py
+++ b/src/fairseq2/models/w2vbert/setup.py
@@ -8,7 +8,6 @@ from typing import Any, Dict
 
 import torch
 
-from fairseq2.assets import default_asset_store, default_download_manager
 from fairseq2.models.config_loader import StandardModelConfigLoader
 from fairseq2.models.loader import DenseModelLoader
 from fairseq2.models.utils.checkpoint import convert_fairseq_checkpoint
@@ -20,7 +19,7 @@ from fairseq2.models.w2vbert.factory import (
 )
 
 load_w2vbert_config = StandardModelConfigLoader(
-    default_asset_store, W2VBERT_FAMILY, W2VBertConfig, w2vbert_archs
+    family=W2VBERT_FAMILY, config_kls=W2VBertConfig, arch_configs=w2vbert_archs
 )
 
 
@@ -76,10 +75,8 @@ def convert_w2vbert_checkpoint(
 
 
 load_w2vbert_model = DenseModelLoader(
-    default_asset_store,
-    default_download_manager,
-    load_w2vbert_config,
-    create_w2vbert_model,
-    convert_w2vbert_checkpoint,
+    config_loader=load_w2vbert_config,
+    factory=create_w2vbert_model,
+    checkpoint_converter=convert_w2vbert_checkpoint,
     mmap=True,
 )

--- a/src/fairseq2/models/wav2vec2/asr/setup.py
+++ b/src/fairseq2/models/wav2vec2/asr/setup.py
@@ -6,7 +6,6 @@
 
 from typing import Any, Dict
 
-from fairseq2.assets import default_asset_store, default_download_manager
 from fairseq2.models.config_loader import StandardModelConfigLoader
 from fairseq2.models.loader import DenseModelLoader
 from fairseq2.models.utils.checkpoint import convert_fairseq_checkpoint
@@ -19,7 +18,9 @@ from fairseq2.models.wav2vec2.asr.factory import (
 from fairseq2.nn.transformer import TransformerNormOrder
 
 load_wav2vec2_asr_config = StandardModelConfigLoader(
-    default_asset_store, WAV2VEC2_ASR_FAMILY, Wav2Vec2AsrConfig, wav2vec2_asr_archs
+    family=WAV2VEC2_ASR_FAMILY,
+    config_kls=Wav2Vec2AsrConfig,
+    arch_configs=wav2vec2_asr_archs,
 )
 
 
@@ -72,11 +73,9 @@ def convert_wav2vec2_asr_checkpoint(
 
 
 load_wav2vec2_asr_model = DenseModelLoader(
-    default_asset_store,
-    default_download_manager,
-    load_wav2vec2_asr_config,
-    create_wav2vec2_asr_model,
-    convert_wav2vec2_asr_checkpoint,
+    config_loader=load_wav2vec2_asr_config,
+    factory=create_wav2vec2_asr_model,
+    checkpoint_converter=convert_wav2vec2_asr_checkpoint,
     mmap=False,
     restrict_checkpoints=False,
 )

--- a/src/fairseq2/models/wav2vec2/setup.py
+++ b/src/fairseq2/models/wav2vec2/setup.py
@@ -8,7 +8,6 @@ from typing import Any, Dict
 
 import torch
 
-from fairseq2.assets import default_asset_store, default_download_manager
 from fairseq2.models.config_loader import StandardModelConfigLoader
 from fairseq2.models.loader import DenseModelLoader
 from fairseq2.models.utils.checkpoint import convert_fairseq_checkpoint
@@ -21,7 +20,7 @@ from fairseq2.models.wav2vec2.factory import (
 from fairseq2.nn.transformer import TransformerNormOrder
 
 load_wav2vec2_config = StandardModelConfigLoader(
-    default_asset_store, WAV2VEC2_FAMILY, Wav2Vec2Config, wav2vec2_archs
+    family=WAV2VEC2_FAMILY, config_kls=Wav2Vec2Config, arch_configs=wav2vec2_archs
 )
 
 
@@ -74,11 +73,9 @@ def convert_wav2vec2_checkpoint(
 
 
 load_wav2vec2_model = DenseModelLoader(
-    default_asset_store,
-    default_download_manager,
-    load_wav2vec2_config,
-    create_wav2vec2_model,
-    convert_wav2vec2_checkpoint,
+    config_loader=load_wav2vec2_config,
+    factory=create_wav2vec2_model,
+    checkpoint_converter=convert_wav2vec2_checkpoint,
     mmap=False,
     restrict_checkpoints=False,
 )

--- a/src/fairseq2/nn/transformer/attention.py
+++ b/src/fairseq2/nn/transformer/attention.py
@@ -13,10 +13,10 @@ from torch import Tensor
 from torch.nn import Module
 from torch.nn.functional import dropout, scaled_dot_product_attention, softmax
 
+from fairseq2.logging import get_log_writer
 from fairseq2.nn.padding import PaddingMask
 from fairseq2.nn.transformer.attention_mask import AttentionMask, CausalAttentionMask
 from fairseq2.typing import override
-from fairseq2.utils.logging import get_log_writer
 
 log = get_log_writer(__name__)
 

--- a/src/fairseq2/nn/transformer/decoder.py
+++ b/src/fairseq2/nn/transformer/decoder.py
@@ -224,7 +224,7 @@ class StandardTransformerDecoder(TransformerDecoder):
         *,
         state_bag: Optional[IncrementalStateBag] = None,
     ) -> Tuple[Tensor, Optional[PaddingMask]]:
-        if self._layer_output_hooks and self.layers.drop_p > 0.0 and self.training:
+        if self._layer_output_hooks and self.layer_drop_p > 0.0 and self.training:
             raise RuntimeError(
                 "The layer output hooks cannot be run when LayerDrop is enabled."
             )

--- a/src/fairseq2/nn/utils/gradient.py
+++ b/src/fairseq2/nn/utils/gradient.py
@@ -15,7 +15,7 @@ from torch.nn import Module
 from torch.nn.utils import clip_grad_norm_  # type: ignore[attr-defined]
 
 from fairseq2.gang import Gang, ReduceOperation
-from fairseq2.utils.logging import get_log_writer
+from fairseq2.logging import get_log_writer
 
 log = get_log_writer(__name__)
 

--- a/src/fairseq2/nn/utils/module.py
+++ b/src/fairseq2/nn/utils/module.py
@@ -30,8 +30,8 @@ from torch import Tensor
 from torch.nn import Module, Parameter
 from torch.nn.utils import remove_weight_norm  # type: ignore[attr-defined]
 
+from fairseq2.logging import LogWriter
 from fairseq2.typing import CPU, META, Device
-from fairseq2.utils.logging import LogWriter
 
 
 # compat

--- a/src/fairseq2/optim/dynamic_loss_scaler.py
+++ b/src/fairseq2/optim/dynamic_loss_scaler.py
@@ -17,8 +17,8 @@ from torch.distributed.fsdp.sharded_grad_scaler import ShardedGradScaler
 from torch.optim import Optimizer
 
 from fairseq2.gang import Gang
+from fairseq2.logging import get_log_writer
 from fairseq2.typing import Device, override
-from fairseq2.utils.logging import get_log_writer
 
 log = get_log_writer(__name__)
 

--- a/src/fairseq2/recipes/__init__.py
+++ b/src/fairseq2/recipes/__init__.py
@@ -1,0 +1,40 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from importlib_metadata import entry_points
+
+from fairseq2.recipes.cli import Cli
+from fairseq2.recipes.llama import _setup_llama_cli
+from fairseq2.recipes.lm import _setup_lm_cli
+
+
+def main() -> None:
+    """Run the command line fairseq2 program."""
+    from fairseq2 import __version__, setup_extensions
+
+    setup_extensions()
+
+    cli = Cli("fairseq2", __version__, description="command line interface of fairseq2")
+
+    _setup_cli(cli)
+
+    cli()
+
+
+def _setup_cli(cli: Cli) -> None:
+    _setup_lm_cli(cli)
+    _setup_llama_cli(cli)
+
+    # Set up 3rd party CLI extensions.
+    for entry_point in entry_points(group="fairseq2.cli"):
+        setup_cli_extension = entry_point.load()
+
+        try:
+            setup_cli_extension(cli)
+        except TypeError:
+            raise RuntimeError(
+                f"The entry point '{entry_point.value}' is not a valid fairseq2 CLI setup function."
+            )

--- a/src/fairseq2/recipes/cli.py
+++ b/src/fairseq2/recipes/cli.py
@@ -1,0 +1,516 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import sys
+from abc import ABC, abstractmethod
+from argparse import OPTIONAL, ArgumentParser, Namespace
+from copy import deepcopy
+from pathlib import Path
+from typing import Callable, Dict, Generic, Optional, Protocol, TypeVar, final
+
+import yaml
+from yaml import YAMLError
+
+from fairseq2.config_registry import ConfigRegistry
+from fairseq2.logging import get_log_writer
+from fairseq2.recipes.logging import setup_basic_logging, setup_logging
+from fairseq2.recipes.utils.argparse import BooleanOptionalAction, ConfigAction
+from fairseq2.recipes.utils.environment import (
+    EnvironmentSetterRegistry,
+    default_env_setters,
+)
+from fairseq2.recipes.utils.log import exception_logger
+from fairseq2.recipes.utils.sweep import generate_sweep_tag
+from fairseq2.typing import DataClass, override
+from fairseq2.utils.dataclass import FieldError, dump_dataclass, update_dataclass
+from fairseq2.utils.value_converter import ValueConverter, default_value_converter
+
+log = get_log_writer(__name__)
+
+
+class Cli:
+    """Represents the entry point of a command line program."""
+
+    _name: str
+    _version: str
+    _description: Optional[str]
+    _groups: Dict[str, CliGroup]
+
+    def __init__(
+        self, name: str, version: str, *, description: Optional[str] = None
+    ) -> None:
+        """
+        :param name:
+            The name of the program.
+        :param version:
+            The version of the program.
+        :param help:
+            The description of the program.
+        """
+        self._name = name
+        self._version = version
+        self._description = description
+        self._groups = {}
+
+    def register_group(self, group: CliGroup) -> None:
+        """Register a command group."""
+        if group.name in self._groups:
+            raise ValueError(
+                f"`name` must be a unique group name, but '{group.name}' is already registered."
+            )
+
+        self._groups[group.name] = group
+
+    def get_group(self, name: str) -> CliGroup:
+        """Return the command group of ``name``."""
+        try:
+            return self._groups[name]
+        except KeyError:
+            raise ValueError(
+                f"`name` must be a registered group name, but is '{name}' instead."
+            )
+
+    def init_parser(self, parser: ArgumentParser) -> None:
+        """Initialize ``parser`` with program-specific arguments."""
+        parser.add_argument(
+            "--version", action="version", version=f"%(prog)s {self._version}"
+        )
+
+        sub_parsers = parser.add_subparsers()
+
+        for group in self._groups.values():
+            sub_parser = sub_parsers.add_parser(group.name, help=group.help)
+
+            group.init_parser(sub_parser)
+
+    def __call__(self) -> None:
+        """Run the program."""
+        parser = ArgumentParser(self._name, description=self._description)
+
+        self.init_parser(parser)
+
+        args = parser.parse_args()
+
+        args.command(args)
+
+    @property
+    def name(self) -> str:
+        """The name of the program."""
+        return self._name
+
+    @property
+    def version(self) -> str:
+        """The version of the program."""
+        return self._version
+
+    @property
+    def help(self) -> Optional[str]:
+        """The description of the program."""
+        return self._description
+
+
+class CliGroup:
+    """Represents a command group of a command line program."""
+
+    _name: str
+    _help: Optional[str]
+    _groups: Dict[str, CliGroup]
+    _commands: Dict[str, CliCommand]
+
+    def __init__(self, name: str, *, help: Optional[str] = None) -> None:
+        """
+        :param name:
+            The name of the command group.
+        :param help:
+            The help text of the command group.
+        """
+        self._name = name
+        self._help = help
+        self._groups = {}
+        self._commands = {}
+
+    def register_group(self, group: CliGroup) -> None:
+        """Register a sub-command group."""
+        self._check_name(group.name)
+
+        self._groups[group.name] = group
+
+    def register_command(self, command: CliCommand) -> None:
+        """Register a command."""
+        self._check_name(command.name)
+
+        self._commands[command.name] = command
+
+    def _check_name(self, name: str) -> None:
+        if name in self._groups:
+            raise ValueError(
+                f"`name` must be a unique name among groups and commands, but '{name}' is already registered as a group name."
+            )
+
+        if name in self._commands:
+            raise ValueError(
+                f"`name` must be a unique name among groups and commands, but '{name}' is already registered as a command name."
+            )
+
+    def get_group(self, name: str) -> CliGroup:
+        """Return the sub-command group of ``name``."""
+        try:
+            return self._groups[name]
+        except KeyError:
+            raise ValueError(
+                f"`name` must be a registered group name, but is '{name}' instead."
+            )
+
+    def get_command(self, name: str) -> CliCommand:
+        """Return the command of ``name``."""
+        try:
+            return self._commands[name]
+        except KeyError:
+            raise ValueError(
+                f"`name` must be a registered command name, but is '{name}' instead."
+            )
+
+    def init_parser(self, parser: ArgumentParser) -> None:
+        """Initialize ``parser`` with command group-specific arguments."""
+        sub_parsers = parser.add_subparsers()
+
+        for group in self._groups.values():
+            sub_parser = sub_parsers.add_parser(group.name, help=group.help)
+
+            group.init_parser(sub_parser)
+
+        for command in self._commands.values():
+            sub_parser = sub_parsers.add_parser(command.name, help=command.help)
+
+            sub_parser.set_defaults(command=command)
+
+            command.init_parser(sub_parser)
+
+    @property
+    def name(self) -> str:
+        """The name of the command group."""
+        return self._name
+
+    @property
+    def help(self) -> Optional[str]:
+        """The help text of the command group."""
+        return self._help
+
+
+class CliCommand(ABC):
+    """Represents a command of a command line program."""
+
+    @abstractmethod
+    def init_parser(self, parser: ArgumentParser) -> None:
+        """Initialize ``parser`` with command-specific arguments."""
+
+    @abstractmethod
+    def __call__(self, args: Namespace) -> None:
+        """Run the command."""
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """The name of the command."""
+
+    @property
+    @abstractmethod
+    def help(self) -> Optional[str]:
+        """The help text of the command."""
+
+
+RecipeConfigT = TypeVar("RecipeConfigT", bound=DataClass)
+
+RecipeConfigT_contra = TypeVar(
+    "RecipeConfigT_contra", bound=DataClass, contravariant=True
+)
+
+
+class RecipeLoader(Protocol[RecipeConfigT_contra]):
+    """Loads a recipe."""
+
+    def __call__(
+        self, config: RecipeConfigT_contra, output_dir: Path
+    ) -> Callable[[], None]:
+        """
+        :param name:
+            The configuration of the recipe.
+        :param output_dir:
+            The directory where to store the recipe artifacts.
+        """
+
+
+@final
+class RecipeCommand(CliCommand, Generic[RecipeConfigT]):
+    """Runs a recipe over command line."""
+
+    _name: str
+    _help: Optional[str]
+    _loader: RecipeLoader[RecipeConfigT]
+    _preset_configs: ConfigRegistry[RecipeConfigT]
+    _default_preset: str
+    _parser: Optional[ArgumentParser]
+    _env_setters: EnvironmentSetterRegistry
+    _value_converter: ValueConverter
+
+    def __init__(
+        self,
+        name: str,
+        loader: RecipeLoader[RecipeConfigT],
+        preset_configs: ConfigRegistry[RecipeConfigT],
+        default_preset: str,
+        *,
+        help: Optional[str] = None,
+        env_setters: Optional[EnvironmentSetterRegistry] = None,
+        value_converter: Optional[ValueConverter] = None,
+    ) -> None:
+        """
+        :param name:
+            The name of the command.
+        :param loader:
+            The recipe laoder.
+        :param preset_configs:
+            The registry containing the preset recipe configurations.
+        :param default_preset:
+            The name of the default preset.
+        :param help:
+            The help text of the command.
+        :param env_setters:
+            The registry containing cluster-specific :class:`EnvironmentSetter`
+            instances.
+        :param value_converter:
+            The :class:`ValueConverter` instance to use. If ``None``, the
+            default instance will be used.
+        """
+        self._name = name
+        self._help = help
+        self._loader = loader
+        self._preset_configs = preset_configs
+        self._default_preset = default_preset
+        self._env_setters = env_setters or default_env_setters
+        self._value_converter = value_converter or default_value_converter
+        self._parser = None
+
+    @override
+    def init_parser(self, parser: ArgumentParser) -> None:
+        self._parser = parser
+
+        parser.add_argument(
+            "--list-presets",
+            action="store_true",
+            help="list available preset configurations",
+        )
+
+        parser.add_argument(
+            "--preset",
+            default=self._default_preset,
+            help="preset configuration (default: %(default)s)",
+        )
+
+        parser.add_argument(
+            "--config-file",
+            dest="config_files",
+            metavar="CONFIG_FILE",
+            type=Path,
+            nargs="*",
+            help="yaml configuration file(s)",
+        )
+
+        parser.add_argument(
+            "--config",
+            dest="config_overrides",
+            action=ConfigAction,
+            help="configuration overrides",
+        )
+
+        parser.add_argument(
+            "--dump-config",
+            action="store_true",
+            help="dump the configuration to standard output",
+        )
+
+        parser.add_argument(
+            "--no-sweep-dir",
+            action="store_true",
+            help="do not create sweep directory",
+        )
+
+        clusters = list(self._env_setters.names())
+
+        clusters.sort()
+
+        parser.add_argument(
+            "--cluster",
+            choices=["auto"] + clusters,
+            default="auto",
+            help="cluster on which the recipe runs (default: %(default)s)",
+        )
+
+        parser.add_argument(
+            "--debug",
+            action=BooleanOptionalAction,
+            help="log at debug level",
+        )
+
+        parser.add_argument(
+            "output_dir",
+            type=Path,
+            nargs=OPTIONAL,
+            help="directory to store recipe artifacts",
+        )
+
+    @override
+    def __call__(self, args: Namespace) -> None:
+        with exception_logger(log):
+            self._run_recipe(args)
+
+    def _run_recipe(self, args: Namespace) -> None:
+        setup_basic_logging(debug=args.debug)
+
+        assert self._parser is not None
+
+        # If requested, list the preset configurations and exit.
+        if args.list_presets:
+            if self._preset_configs:
+                print("available presets:")
+
+                for preset in self._preset_configs.names():
+                    if preset == self._default_preset:
+                        print(f"  - {preset} (default)")
+                    else:
+                        print(f"  - {preset}")
+            else:
+                print("no preset configuration found.")
+
+            sys.exit()
+
+        # Load the specified preset configuration.
+        try:
+            preset_config = self._preset_configs.get(args.preset)
+        except ValueError:
+            log.error("'{}' is not a valid preset configuration name. Use `--list-presets` to see the available preset configurations.", args.preset)  # fmt: skip
+
+            sys.exit(1)
+
+        config = deepcopy(preset_config)
+
+        # Update the configuration with `--config-file`.
+        if args.config_files:
+            for config_file in args.config_files:
+                try:
+                    fp = config_file.open()
+                except OSError:
+                    log.exception("Configuration file '{}' cannot be read.", config_file)  # fmt: skip
+
+                    sys.exit(1)
+
+                try:
+                    config_overrides = yaml.safe_load(fp)
+                except (OSError, YAMLError):
+                    log.exception("Configuration file '{}' cannot be read.", config_file)  # fmt: skip
+
+                    sys.exit(1)
+                finally:
+                    fp.close()
+
+                if not isinstance(config_overrides, dict):
+                    log.error("Configuration file '{}' must contain a dictionary.", config_file)  # fmt: skip
+
+                    sys.exit(1)
+
+                try:
+                    unknown_fields = update_dataclass(
+                        config, config_overrides, value_converter=self._value_converter
+                    )
+                except FieldError as ex:
+                    log.exception("Value of the field '{}' in the configuration file '{}' is invalid.", ex.field_name, config_file)  # fmt: skip
+
+                    sys.exit(1)
+
+                if unknown_fields:
+                    log.error("Following fields in the configuration file '{}' are unknown: {}", config_file, ", ".join(unknown_fields))  # fmt: skip
+
+                    sys.exit(1)
+
+        # Update the configuration with `--config`.
+        if args.config_overrides:
+            try:
+                unknown_fields = update_dataclass(
+                    config, args.config_overrides, value_converter=self._value_converter
+                )
+            except FieldError as ex:
+                log.exception("Value of the field '{}' in `--config` is invalid.", ex.field_name)  # fmt: skip
+
+                sys.exit(1)
+
+            if unknown_fields:
+                log.error("Following fields in `--config` are unknown: {}", ", ".join(unknown_fields))  # fmt: skip
+
+                sys.exit(1)
+
+        if args.dump_config:
+            dump_dataclass(config, sys.stdout)
+
+            sys.exit()
+
+        # If we are not dumping configuration, `--output-dir` is required.
+        if not args.output_dir:
+            self._parser.error("the following arguments are required: output_dir")
+
+        self._parser = None
+
+        # Determine the output directory.
+        if args.no_sweep_dir:
+            output_dir = args.output_dir
+        else:
+            tag = generate_sweep_tag(args.preset, preset_config, config)
+
+            output_dir = args.output_dir.joinpath(tag)
+
+        # Set up cluster-specific environment variables.
+        if args.cluster == "auto":
+            env_setter = self._env_setters.get_for_inferred_cluster()
+        else:
+            try:
+                env_setter = self._env_setters.get(args.cluster)
+            except RuntimeError:
+                log.exception("Recipe is not running on a '{}' cluster.", args.cluster)  # fmt: skip
+
+                sys.exit(1)
+
+        try:
+            env_setter.set_torch_distributed_env()
+        except RuntimeError:
+            log.exception("'{}' cluster environment cannot be set.", env_setter.cluster)  # fmt: skip
+
+            sys.exit(1)
+
+        # Set up distributed logging.
+        log_dir = output_dir.joinpath("logs/rank_{rank}.log")
+
+        try:
+            setup_logging(log_dir, debug=args.debug)
+        except RuntimeError:
+            log.exception("Recipe logging cannot be set up.")
+
+            sys.exit(1)
+
+        # Run the recipe.
+        recipe = self._loader(config, output_dir)
+
+        recipe()
+
+    @property
+    @override
+    def name(self) -> str:
+        return self._name
+
+    @property
+    @override
+    def help(self) -> Optional[str]:
+        return self._help

--- a/src/fairseq2/recipes/llama/__init__.py
+++ b/src/fairseq2/recipes/llama/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from fairseq2.recipes.cli import Cli, CliGroup
+
+
+def _setup_llama_cli(cli: Cli) -> None:
+    llama_group = CliGroup(name="llama", help="LLaMA recipes")
+
+    cli.register_group(llama_group)

--- a/src/fairseq2/recipes/lm/__init__.py
+++ b/src/fairseq2/recipes/lm/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from fairseq2.recipes.cli import Cli, CliGroup, RecipeCommand
+
+
+def _setup_lm_cli(cli: Cli) -> None:
+    lm_group = CliGroup(name="lm", help="Language Model recipes.")
+
+    cli.register_group(lm_group)

--- a/src/fairseq2/recipes/logging.py
+++ b/src/fairseq2/recipes/logging.py
@@ -1,0 +1,143 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+import os
+import time
+from logging import DEBUG, INFO, FileHandler, Formatter, Handler, getLogger
+from pathlib import Path
+from typing import TYPE_CHECKING, List
+
+from fairseq2n import DOC_MODE
+from rich.console import Console
+from rich.logging import RichHandler
+
+console = Console(stderr=True)
+
+
+def setup_basic_logging(*, debug: bool = False, utc_time: bool = False) -> None:
+    """Set up logging for a command line program.
+
+    :param debug:
+        If ``True``, sets the log level to ``DEBUG``; otherwise, to ``INFO``.
+    :param utc_time:
+        If ``True``, logs dates and times in UTC.
+    """
+    from fairseq2.gang import get_rank  # Avoid circular import.
+
+    if utc_time:
+        Formatter.converter = time.gmtime
+
+    handlers: List[Handler] = []
+
+    if get_rank() == 0:
+        handler = RichHandler(console=console, show_path=False, keywords=[])
+
+        fmt = Formatter("%(name)s - %(message)s")
+
+        handler.setFormatter(fmt)
+
+        handlers.append(handler)
+
+    datefmt = "%Y-%m-%d %H:%M:%S"
+
+    logging.basicConfig(
+        level=DEBUG if debug else INFO, handlers=handlers, datefmt=datefmt, force=True
+    )
+
+
+def setup_logging(
+    log_file: Path, *, debug: bool = False, utc_time: bool = False, force: bool = False
+) -> None:
+    """Set up logging for a distributed job.
+
+    :param log_file:
+        The file to which logs will be written. Must have a 'rank' replacement
+        field; for example '/path/to/train_{rank}.log'.
+    :param debug:
+        If ``True``, sets the log level to ``DEBUG``; otherwise, to ``INFO``.
+    :param utc_time:
+        If ``True``, logs dates and times in UTC.
+    :param force:
+        If ``True``, overwrites existing ATen and NCCL log configurations.
+    """
+    from fairseq2.gang import get_rank  # Avoid circular import.
+
+    rank = get_rank()
+
+    filename = log_file.name.format(rank=rank)
+
+    if filename == log_file.name:
+        raise ValueError(
+            f"`log_file` must contain a 'rank' replacement field (i.e. {{rank}}) in its filename, but is '{log_file}' instead."
+        )
+
+    log_file = log_file.with_name(filename)
+
+    try:
+        log_file.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as ex:
+        raise RuntimeError(
+            f"The log directory ({log_file.parent}) cannot be created. See nested exception for details."
+        ) from ex
+
+    setup_basic_logging(debug=debug, utc_time=utc_time)
+
+    handler = FileHandler(log_file)
+
+    fmt = Formatter(f"[Rank {rank}] %(asctime)s %(levelname)s %(name)s - %(message)s")
+
+    handler.setFormatter(fmt)
+
+    getLogger().addHandler(handler)
+
+    _setup_aten_logging(log_file, force)
+    _setup_nccl_logging(log_file, force)
+
+
+def _setup_aten_logging(log_file: Path, force: bool) -> None:
+    if "TORCH_CPP_LOG_LEVEL" in os.environ and not force:
+        return
+
+    aten_log_file = log_file.parent.joinpath("aten", log_file.name)
+
+    try:
+        aten_log_file.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as ex:
+        raise RuntimeError(
+            f"The ATen log directory ({aten_log_file.parent}) cannot be created. See nested exception for details."
+        ) from ex
+
+    _enable_aten_logging(aten_log_file)
+
+    # This variable has no effect at this point. We set it for completeness.
+    os.environ["TORCH_CPP_LOG_LEVEL"] = "INFO"
+
+
+if TYPE_CHECKING or DOC_MODE:
+
+    def _enable_aten_logging(log_file: Path) -> Path:
+        ...
+
+else:
+    from fairseq2n.bindings import _enable_aten_logging
+
+
+def _setup_nccl_logging(log_file: Path, force: bool) -> None:
+    if "NCCL_DEBUG" in os.environ and not force:
+        return
+
+    nccl_log_file = log_file.parent.joinpath("nccl", log_file.name)
+
+    try:
+        nccl_log_file.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as ex:
+        raise RuntimeError(
+            f"The NCCL log directory ({nccl_log_file.parent}) cannot be created. See nested exception for details."
+        ) from ex
+
+    os.environ["NCCL_DEBUG"] = "INFO"
+    os.environ["NCCL_DEBUG_FILE"] = str(nccl_log_file)

--- a/src/fairseq2/recipes/utils/argparse.py
+++ b/src/fairseq2/recipes/utils/argparse.py
@@ -1,0 +1,129 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from argparse import (
+    SUPPRESS,
+    ZERO_OR_MORE,
+    Action,
+    ArgumentError,
+    ArgumentParser,
+    Namespace,
+)
+from typing import Any, Dict, List, Optional, final
+
+import yaml
+from yaml.parser import ParserError
+
+
+@final
+class ConfigAction(Action):
+    """Adds support for reading key-value pairs in format ``<key>=<yaml_value>``."""
+
+    def __init__(
+        self,
+        option_strings: List[str],
+        dest: str,
+        help: Optional[str] = None,
+    ) -> None:
+        super().__init__(
+            option_strings,
+            nargs=ZERO_OR_MORE,
+            help=help,
+            metavar="NAME=VALUE",
+            dest=dest,
+        )
+
+    def __call__(
+        self,
+        parser: ArgumentParser,
+        namespace: Namespace,
+        values: Any,
+        option_string: Optional[str] = None,
+    ) -> None:
+        data: Dict[str, Any] = {}
+
+        for item in values:
+            key_value = item.split("=", maxsplit=1)
+            if len(key_value) != 2:
+                raise ArgumentError(self, f"invalid key-value pair: {item}")
+
+            key, value = [kv.strip() for kv in key_value]
+
+            try:
+                parsed_value = yaml.safe_load(value)
+            except ParserError:
+                raise ArgumentError(
+                    self, f"invalid key-value pair: {item} (value must be yaml)"
+                )
+
+            fields = key.split(".")
+
+            if not all(f.isidentifier() for f in fields):
+                raise ArgumentError(
+                    self, f"invalid key-value pair: {item} (key must be identifier)"
+                )
+
+            tmp = data
+
+            for field in fields[:-1]:
+                try:
+                    d = tmp[field]
+                except KeyError:
+                    d = None
+
+                if not isinstance(d, dict):
+                    d = {}
+
+                    tmp[field] = d
+
+                    tmp = d
+
+            tmp[fields[-1]] = parsed_value
+
+        setattr(namespace, self.dest, data)
+
+
+@final
+class BooleanOptionalAction(Action):
+    """Adds support for reading boolean flags in format ``--<flag>, --no-<flag>``."""
+
+    def __init__(
+        self,
+        option_strings: List[str],
+        dest: str,
+        default: Any = None,
+        help: Optional[str] = None,
+    ) -> None:
+        all_option_strings = []
+
+        for option_string in option_strings:
+            all_option_strings.append(option_string)
+
+            if option_string.startswith("--"):
+                all_option_strings.append(f"--no-{option_string[2:]}")
+
+        if help is not None:
+            if default is not None and default is not SUPPRESS:
+                help += " (default: %(default)s)"
+
+        super().__init__(
+            all_option_strings, nargs=0, default=default, help=help, dest=dest
+        )
+
+    def __call__(
+        self,
+        parser: ArgumentParser,
+        namespace: Namespace,
+        values: Any,
+        option_string: Optional[str] = None,
+    ) -> None:
+        if option_string and option_string in self.option_strings:
+            setattr(namespace, self.dest, not option_string.startswith("--no-"))
+
+    def format_usage(self) -> str:
+        return " | ".join(self.option_strings)

--- a/src/fairseq2/recipes/utils/cli.py
+++ b/src/fairseq2/recipes/utils/cli.py
@@ -12,9 +12,16 @@ from rich.progress import (
     TimeRemainingColumn,
 )
 
+from fairseq2.gang import get_rank
+from fairseq2.recipes.logging import console
+
 
 def create_rich_progress() -> Progress:
-    """Create a :class:`Progress` instance to report training progress."""
-    return Progress(
-        BarColumn(), MofNCompleteColumn(), TaskProgressColumn(), TimeRemainingColumn()
-    )
+    """Create a :class:`Progress` instance to report job progress."""
+    columns = [
+        BarColumn(), MofNCompleteColumn(), TaskProgressColumn(), TimeRemainingColumn()  # fmt: skip
+    ]
+
+    rank = get_rank()
+
+    return Progress(*columns, console=console, disable=rank != 0)

--- a/src/fairseq2/recipes/utils/environment.py
+++ b/src/fairseq2/recipes/utils/environment.py
@@ -1,0 +1,169 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import subprocess
+from abc import ABC, abstractmethod
+from random import Random
+from typing import AbstractSet, Dict, Type, final
+
+from fairseq2.typing import override
+
+
+class EnvironmentSetter(ABC):
+    """Sets job environment variables."""
+
+    @abstractmethod
+    def set_torch_distributed_env(self) -> None:
+        """Set environment variables required to initialize ``torch.distributed``."""
+
+    @property
+    @abstractmethod
+    def cluster(self) -> str:
+        """The cluster type that this instance supports."""
+
+
+@final
+class SlurmEnvironmentSetter(EnvironmentSetter):
+    """Sets job environment variables on a Slurm cluster."""
+
+    _job_id: int
+
+    def __init__(self) -> None:
+        try:
+            job_id = os.environ["SLURM_JOB_ID"]
+        except KeyError:
+            raise RuntimeError(
+                "Slurm not detected. `SLURM_JOB_ID` environment variable cannot be found."
+            )
+
+        try:
+            self._job_id = int(job_id)
+        except ValueError as ex:
+            raise RuntimeError("Slurm job ID cannot be parsed.") from ex
+
+    @override
+    def set_torch_distributed_env(self) -> None:
+        try:
+            os.environ["WORLD_SIZE"] = os.environ["SLURM_NTASKS"]
+            os.environ["RANK"] = os.environ["SLURM_PROCID"]
+
+            try:
+                os.environ["LOCAL_WORLD_SIZE"] = os.environ["SLURM_NTASKS_PER_NODE"]
+            except KeyError:
+                os.environ["LOCAL_WORLD_SIZE"] = "1"
+
+            os.environ["LOCAL_RANK"] = os.environ["SLURM_LOCALID"]
+
+            os.environ["MASTER_ADDR"] = self._get_master_addr()
+            os.environ["MASTER_PORT"] = self._get_master_port()
+
+            os.environ["CUDA_VISIBLE_DEVICES"] = os.environ["SLURM_LOCALID"]
+        except KeyError as ex:
+            raise RuntimeError(
+                "Slurm job environment variables are not correctly set. If you are within an allocated job (i.e. `salloc`), make sure to run with `srun`."
+            ) from ex
+
+    def _get_master_addr(self) -> str:
+        nodes = os.environ["SLURM_JOB_NODELIST"]
+
+        result = subprocess.run(
+            ["scontrol", "show", "hostnames", nodes], capture_output=True, text=True
+        )
+
+        if result.returncode == 0:
+            if node_list := result.stdout.split("\n"):
+                return node_list[0]
+
+        raise RuntimeError(
+            "The hostname or IP address of the Slurm node corresponding to rank 0 cannot be retrieved."
+        )
+
+    def _get_master_port(self) -> str:
+        try:
+            return os.environ["MASTER_PORT"]
+        except KeyError:
+            pass
+
+        return str(Random(self._job_id).randint(20_000, 60_000))
+
+    @property
+    @override
+    def cluster(self) -> str:
+        return "slurm"
+
+
+@final
+class _NoneEnvironmentSetter(EnvironmentSetter):
+    @override
+    def set_torch_distributed_env(self) -> None:
+        return
+
+    @property
+    @override
+    def cluster(self) -> str:
+        return "none"
+
+
+class EnvironmentSetterRegistry:
+    """Holds cluster type to :class:`EnvironmentSetter` mappings."""
+
+    _types: Dict[str, Type[EnvironmentSetter]]
+
+    def __init__(self) -> None:
+        self._types = {"slurm": SlurmEnvironmentSetter, "none": _NoneEnvironmentSetter}
+
+    def get(self, cluster: str) -> EnvironmentSetter:
+        """Return the :class:`EnvironmentSetter` of the specified cluster type."""
+        try:
+            kls = self._types[cluster]
+        except KeyError:
+            raise ValueError(
+                f"`cluster` must be a registered cluster name, but is '{cluster}' instead."
+            )
+
+        try:
+            return kls()
+        except TypeError as ex:
+            raise RuntimeError(f"`{kls}` has no default constructor.") from ex
+
+    def get_for_inferred_cluster(self) -> EnvironmentSetter:
+        """Return the :class:`EnvironmentSetter` of the inferred cluster."""
+        for cluster, kls in self._types.items():
+            if cluster == "none":
+                continue
+
+            try:
+                return kls()
+            except RuntimeError:
+                pass
+            except TypeError as ex:
+                raise RuntimeError(f"`{kls}` has no default constructor.") from ex
+
+        return self.get("none")
+
+    def register(self, cluster: str, kls: Type[EnvironmentSetter]) -> None:
+        """Register a new :class:`EnvironmentSetter`.
+
+        :param cluster:
+            The cluster type.
+        :param kls:
+            The :class:`EnvironmentSetter` subclass. Must have an ``__init__``
+            method that takes no arguments.
+        """
+        if cluster in self._types:
+            raise ValueError(
+                f"`cluster` must be a unique cluster name, but '{cluster}' has already a registered environment setter."
+            )
+
+        self._types[cluster] = kls
+
+    def names(self) -> AbstractSet[str]:
+        """Return the supported cluster types."""
+        return self._types.keys()
+
+
+default_env_setters = EnvironmentSetterRegistry()

--- a/src/fairseq2/recipes/utils/log.py
+++ b/src/fairseq2/recipes/utils/log.py
@@ -1,0 +1,2 @@
+# compat
+from fairseq2.utils.log import *  # noqa: F401,F403

--- a/src/fairseq2/recipes/utils/sweep.py
+++ b/src/fairseq2/recipes/utils/sweep.py
@@ -1,0 +1,112 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import re
+from dataclasses import fields
+from enum import Enum
+from typing import Any, Mapping, Optional, Sequence
+
+from fairseq2.typing import DataClass, DataType, is_dataclass_instance
+
+
+def generate_sweep_tag(preset: str, preset_config: DataClass, config: DataClass) -> str:
+    """Generate a sweep tag from the diff of ``preset_config`` and ``config``."""
+    if type(config) is not type(preset_config):
+        raise ValueError(
+            f"`config` must be of the same type as `preset_config` (`{type(preset_config)}`), but is of type `{type(config)}` instead."
+        )
+
+    output = [_remove_non_word(preset)]
+
+    def generate(config: DataClass) -> None:
+        for field in fields(config):
+            value = getattr(config, field.name)
+
+            if is_dataclass_instance(value):
+                generate(config)
+            else:
+                if s := _to_tag_value(value):
+                    output.append(f"{field.name}_{s}")
+
+    def generate_from_diff(preset_config: DataClass, config: DataClass) -> None:
+        for field in fields(config):
+            value = getattr(config, field.name)
+
+            preset_value = getattr(preset_config, field.name)
+
+            if is_dataclass_instance(preset_value):
+                if type(value) is type(preset_value):
+                    generate_from_diff(preset_value, value)
+                else:
+                    generate(value)
+            else:
+                if preset_value == value:
+                    continue
+
+                if s := _to_tag_value(value):
+                    output.append(f"{field.name}_{s}")
+
+    generate_from_diff(preset_config, config)
+
+    s = ".".join(output)
+
+    return s[:256]  # Cap to maximum 256 characters.
+
+
+def _to_tag_value(value: Any) -> Optional[str]:
+    if isinstance(value, str):
+        return _remove_non_word(value)
+
+    if isinstance(value, bool):
+        return "t" if value else "f"
+
+    if isinstance(value, (int, float)):
+        return f"{value}"
+
+    if isinstance(value, DataType):
+        return f"{value}"[6:]
+
+    if isinstance(value, Enum):
+        return value.name
+
+    if isinstance(value, Sequence):
+        output = []
+
+        for v in value:
+            if s := _to_tag_value(v):
+                output.append(s)
+
+        if not output:
+            return None
+
+        s = "-".join(output)
+
+        return f"b{s}e"
+
+    if isinstance(value, Mapping):
+        output = []
+
+        for k, v in value.items():
+            ks = _to_tag_value(k)
+            vs = _to_tag_value(v)
+
+            if ks and vs:
+                output.append(f"{ks}_{vs}")
+
+        if not output:
+            return None
+
+        output.sort()
+
+        s = "-".join(output)
+
+        return f"b{s}e"
+
+    return None
+
+
+def _remove_non_word(s: str) -> str:
+    return re.sub(r"[^\w]", "", s)

--- a/src/fairseq2/utils/log.py
+++ b/src/fairseq2/utils/log.py
@@ -22,9 +22,9 @@ from torch.cuda import OutOfMemoryError
 from torch.nn import Module
 
 import fairseq2
+from fairseq2.logging import LogWriter
 from fairseq2.typing import DataClass, Device
 from fairseq2.utils.dataclass import dump_dataclass
-from fairseq2.utils.logging import LogWriter
 
 
 @contextmanager
@@ -55,7 +55,8 @@ def log_config(config: DataClass, log: LogWriter, file: Optional[Path] = None) -
         The output file to write ``config`` in YAML format.
     """
     if file is not None:
-        dump_dataclass(config, file)
+        with file.open("w") as fp:
+            dump_dataclass(config, fp)
 
     log.info("Job Config:\n{}", pretty_repr(config, max_width=88))
 

--- a/src/fairseq2/utils/logging.py
+++ b/src/fairseq2/utils/logging.py
@@ -1,2 +1,3 @@
 # compat
 from fairseq2.logging import *  # noqa: F401,F403
+from fairseq2.recipes.logging import *  # noqa: F401,F403

--- a/src/fairseq2/utils/rng.py
+++ b/src/fairseq2/utils/rng.py
@@ -109,7 +109,7 @@ class RngBag:
             raise ValueError("`state_dict` must contain an item named `generators`.")
 
         if not isinstance(states, list):
-            raise ValueError(
+            raise TypeError(
                 f"The `generators` item of `state_dict` must be of type `{list}`, but is of type `{type(states)}` instead."
             )
 
@@ -120,7 +120,7 @@ class RngBag:
 
         for idx, state in enumerate(states):
             if not isinstance(state, Tensor):
-                raise ValueError(
+                raise TypeError(
                     f"The generator states in `state_dict` must be of type `{Tensor}`, but the element at index {idx} is of type `{type(state)}` instead."
                 )
 

--- a/src/fairseq2/utils/value_converter.py
+++ b/src/fairseq2/utils/value_converter.py
@@ -1,0 +1,312 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from enum import Enum
+from pathlib import Path
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Literal,
+    Sequence,
+    Type,
+    Union,
+    cast,
+    get_args,
+    get_origin,
+)
+
+import torch
+
+from fairseq2.typing import DataType, Device
+
+
+class ValueConverter:
+    """Structures and unstructures objects using provided type hints."""
+
+    _structure_fns: Dict[object, Callable[[Any, Any, Any], Any]]
+    _unstructure_fns: Dict[object, Callable[[Any, Any], Any]]
+
+    def __init__(self) -> None:
+        NoneType = type(None)
+
+        self._structure_fns = {
+            # fmt: off
+            bool:     self._structure_identity,
+            DataType: self._structure_dtype,
+            Device:   self._structure_device,
+            dict:     self._structure_dict,
+            float:    self._structure_primitive,
+            Enum:     self._structure_enum,
+            int:      self._structure_primitive,
+            list:     self._structure_list,
+            Literal:  self._structure_literal,
+            NoneType: self._structure_identity,
+            Path:     self._structure_path,
+            str:      self._structure_identity,
+            tuple:    self._structure_tuple,
+            Union:    self._structure_union,
+            # fmt: on
+        }
+
+        self._unstructure_fns = {
+            # fmt: off
+            bool:     self._unstructure_identity,
+            DataType: self._unstructure_dtype,
+            Device:   self._unstructure_device,
+            dict:     self._unstructure_dict,
+            float:    self._unstructure_identity,
+            Enum:     self._unstructure_enum,
+            int:      self._unstructure_identity,
+            list:     self._unstructure_sequence,
+            NoneType: self._unstructure_identity,
+            Path:     self._unstructure_path,
+            str:      self._unstructure_identity,
+            tuple:    self._unstructure_sequence,
+            # fmt: on
+        }
+
+    def structure(self, obj: Any, type_hint: Any) -> Any:
+        """
+        :param obj:
+            The object to structure based on ``type_hint``.
+        :param type_hint:
+            The type hints. Typically retrieved via ``typing.get_type_hints()``.
+        """
+        kls, kls_args = get_origin(type_hint), get_args(type_hint)
+
+        if kls is None:
+            kls = type_hint
+
+        if isinstance(kls, type):
+            lookup_kls = Enum if issubclass(kls, Enum) else kls
+        else:
+            lookup_kls = kls  # typing special form
+
+        try:
+            fn = self._structure_fns[lookup_kls]
+        except KeyError:
+            supported_types = ", ".join(str(t) for t in self._structure_fns.keys())
+
+            raise TypeError(
+                f"`obj` must be of one of the following types, but is of type `{type(obj)}` instead: {supported_types}"
+            )
+
+        try:
+            return fn(kls, kls_args, obj)
+        except (TypeError, ValueError) as ex:
+            raise TypeError(
+                f"`obj` cannot be structured to type `{type_hint}`."
+            ) from ex
+
+    def _structure_identity(cls, kls: Any, kls_args: Any, obj: Any) -> Any:
+        if isinstance(obj, kls):
+            return obj
+
+        raise TypeError(
+            f"`obj` must be of type `{kls}`, but is of type `{type(obj)}` instead."
+        )
+
+    @staticmethod
+    def _structure_primitive(kls: Any, kls_args: Any, obj: Any) -> Any:
+        if isinstance(obj, kls):
+            return obj
+
+        return kls(obj)
+
+    @staticmethod
+    def _structure_dtype(kls: Any, kls_args: Any, obj: Any) -> Any:
+        if isinstance(obj, DataType):
+            return obj
+
+        if isinstance(obj, str):
+            if obj.startswith("torch."):
+                obj = obj[6:]
+
+            if isinstance(dtype := getattr(torch, obj, None), DataType):
+                return dtype
+
+            raise ValueError(
+                f"`obj` must be a `torch.dtype` identifier, but is '{obj}' instead."
+            )
+
+        raise TypeError(
+            f"`obj` must be of type `{DataType}` or `{str}`, but is of type `{type(obj)}` instead."
+        )
+
+    @staticmethod
+    def _structure_device(kls: Any, kls_args: Any, obj: Any) -> Any:
+        if isinstance(obj, Device):
+            return obj
+
+        if isinstance(obj, str):
+            try:
+                return Device(obj)
+            except RuntimeError as ex:
+                raise ValueError(str(ex))
+
+        raise TypeError(
+            f"`obj` must be of type `{Device}` or `{str}`, but is of type `{type(obj)}` instead."
+        )
+
+    def _structure_dict(self, kls: Any, kls_args: Any, obj: Any) -> Any:
+        if isinstance(obj, dict):
+            output = {}
+
+            for k, v in obj.items():
+                k = self.structure(k, kls_args[0])
+                v = self.structure(v, kls_args[1])
+
+                output[k] = v
+
+            return output
+
+        raise TypeError(
+            f"`obj` must be of type `{dict}`, but is of type `{type(obj)}` instead."
+        )
+
+    @staticmethod
+    def _structure_enum(kls: Any, kls_args: Any, obj: Any) -> Any:
+        enum_kls = cast(Type[Enum], kls)
+
+        if isinstance(obj, enum_kls):
+            return obj
+
+        if isinstance(obj, str):
+            try:
+                return enum_kls[obj]  # type: ignore[index]
+            except KeyError:
+                raise ValueError(
+                    f"`obj` must be one of the following enumeration values, but is '{obj}' instead: {', '.join(e.name for e in enum_kls)}."
+                )
+
+        raise TypeError(
+            f"`obj` must be of type `{kls}` or `{str}`, but is of type `{type(obj)}` instead."
+        )
+
+    def _structure_list(self, kls: Any, kls_args: Any, obj: Any) -> Any:
+        if isinstance(obj, Sequence):
+            output = []
+
+            for e in obj:
+                output.append(self.structure(e, kls_args[0]))
+
+            return output
+
+        raise TypeError(
+            f"`obj` must be of type `{Sequence}`, but is of type `{type(obj)}` instead."
+        )
+
+    @staticmethod
+    def _structure_literal(kls: Any, kls_args: Any, obj: Any) -> Any:
+        if isinstance(obj, str):
+            if obj in kls_args:
+                return obj
+
+            raise ValueError(
+                f"`obj` must be one of the following values, but is '{obj}' instead: {', '.join(kls_args)}."
+            )
+
+        raise TypeError(
+            f"`obj` must be of type `{str}`, but is of type `{type(obj)}` instead."
+        )
+
+    @staticmethod
+    def _structure_path(kls: Any, kls_args: Any, obj: Any) -> Any:
+        if isinstance(obj, Path):
+            return obj
+
+        if isinstance(obj, str):
+            return Path(obj)
+
+        raise TypeError(
+            f"`obj` must be of type `{Path}` or `{str}`, but is of type `{type(obj)}` instead."
+        )
+
+    def _structure_tuple(self, kls: Any, kls_args: Any, obj: Any) -> Any:
+        if isinstance(obj, Sequence):
+            num_args = len(kls_args)
+
+            if num_args == 2 and kls_args[1] is Ellipsis:  # homogeneous
+                output = []
+
+                for e in obj:
+                    output.append(self.structure(e, kls_args[0]))
+
+                return tuple(output)
+
+            if len(obj) != num_args:  # heterogeneous
+                raise TypeError(
+                    f"`obj` must be have {num_args} elements, but it has {len(obj)} elements."
+                )
+
+            output = []
+
+            for i, e in enumerate(obj):
+                output.append(self.structure(e, kls_args[i]))
+
+            return tuple(output)
+
+        raise TypeError(
+            f"`obj` must be of type `{tuple}` or `{Sequence}`, but is of type `{type(obj)}` instead."
+        )
+
+    def _structure_union(self, kls: Any, kls_args: Any, obj: Any) -> Any:
+        for kls_ in kls_args:
+            try:
+                return self.structure(obj, kls_)
+            except (TypeError, ValueError):
+                continue
+
+        raise TypeError(
+            f"`obj` must be parseable as one of the following union types: {', '.join(str(t) for t in kls_args)}"
+        )
+
+    def unstructure(self, obj: Any) -> Any:
+        kls = type(obj)
+
+        lookup_kls = Enum if issubclass(kls, Enum) else kls
+
+        try:
+            fn = self._unstructure_fns[lookup_kls]
+        except KeyError:
+            supported_types = ", ".join(str(t) for t in self._unstructure_fns.keys())
+
+            raise TypeError(
+                f"`obj` must be of one of the following types, but is of type `{type(obj)}` instead: {supported_types}"
+            )
+
+        return fn(kls, obj)
+
+    @staticmethod
+    def _unstructure_identity(kls: Any, obj: Any) -> Any:
+        return obj
+
+    @staticmethod
+    def _unstructure_dtype(kls: Any, obj: Any) -> Any:
+        return str(obj)[6:]  # strip 'torch.'
+
+    @staticmethod
+    def _unstructure_device(kls: Any, obj: Any) -> Any:
+        return str(obj)
+
+    def _unstructure_dict(self, kls: Any, obj: Any) -> Any:
+        return {self.unstructure(k): self.unstructure(v) for k, v in obj.items()}
+
+    def _unstructure_enum(self, kls: Any, obj: Any) -> Any:
+        return obj.name
+
+    def _unstructure_sequence(self, kls: Any, obj: Any) -> Any:
+        return [self.unstructure(e) for e in obj]
+
+    @staticmethod
+    def _unstructure_path(kls: Any, obj: Any) -> Any:
+        return str(obj)
+
+
+default_value_converter = ValueConverter()

--- a/tests/unit/test_config_registry.py
+++ b/tests/unit/test_config_registry.py
@@ -48,7 +48,7 @@ class TestConfigRegistry:
 
         with pytest.raises(
             ValueError,
-            match=r"^`name` must be a unique configuration name, but 'name' is already registered\.$",
+            match=r"^`name` must be a unique configuration name, but 'name' has already a registered configuration factory\.$",
         ):
             registry.register("name", lambda: Foo("config"))
 

--- a/tests/unit/utils/test_dataclass.py
+++ b/tests/unit/utils/test_dataclass.py
@@ -9,7 +9,7 @@ from typing import Optional
 
 import pytest
 
-from fairseq2.utils.dataclass import update_dataclass
+from fairseq2.utils.dataclass import FieldError, update_dataclass
 
 
 @dataclass
@@ -32,9 +32,11 @@ class TestUpdateDataclassFunction:
 
         overrides = {"b": "a", "c": {"x": None, "y": "foo4"}, "d": None}
 
-        update_dataclass(obj, overrides)
+        unknown_fields = update_dataclass(obj, overrides)
 
         assert obj == Foo1(a=1, b="a", c=Foo2(x=None, y="foo4"), d=None)
+
+        assert unknown_fields == []
 
     def test_call_works_when_overrides_is_empty(self) -> None:
         obj = Foo1(a=1, b="b", c=Foo2(x=2, y="foo3"), d=Foo2(x=3, y="foo3"))
@@ -43,30 +45,30 @@ class TestUpdateDataclassFunction:
 
         assert obj == Foo1(a=1, b="b", c=Foo2(x=2, y="foo3"), d=Foo2(x=3, y="foo3"))
 
-        update_dataclass(obj, {"c": {}})
+        unknown_fields = update_dataclass(obj, {"c": {}})
 
         assert obj == Foo1(a=1, b="b", c=Foo2(x=2, y="foo3"), d=Foo2(x=3, y="foo3"))
 
-    def test_call_raises_error_when_override_has_invalid_type(self) -> None:
+        assert unknown_fields == []
+
+    def test_call_raises_error_when_there_are_invalid_overrides(self) -> None:
         obj = Foo1(a=1, b="b", c=Foo2(x=2, y=3), d=Foo2(x=3, y="foo3"))  # type: ignore[arg-type]
 
         overrides = {"c": 4}  # type: ignore[dict-item]
 
         with pytest.raises(
-            TypeError,
-            match=r"^The value of the key 'c' in `overrides` must be of a mapping type \(e\.g\. `dict`\), but is of type `<class 'int'>` instead\.$",
+            FieldError,
+            match=rf"^The field 'c' is expected to be of type `{Foo2}`, but is of type `{int}` instead\.$",
         ):
             update_dataclass(obj, overrides)
 
-    def test_call_raises_error_when_there_are_leftover_overrides(self) -> None:
+    def test_call_works_when_there_are_unknown_overrides(self) -> None:
         obj = Foo1(a=1, b="b", c=Foo2(x=2, y="foo3"), d=Foo2(x=3, y="foo3"))
 
         overrides = {"b": "a", "c": {"y": "foo4", "z": 2}, "e": 4}
 
-        with pytest.raises(
-            ValueError,
-            match=r"^`overrides` must contain only keys that are present in `obj`, but the following keys do not exist in `obj`: \['c\.z', 'e'\]$",
-        ):
-            update_dataclass(obj, overrides)
+        unknown_fields = update_dataclass(obj, overrides)
 
         assert obj == Foo1(a=1, b="a", c=Foo2(x=2, y="foo4"), d=Foo2(x=3, y="foo3"))
+
+        assert unknown_fields == ["c.z", "e"]


### PR DESCRIPTION
This is more of an entire project merge rather than a PR. Although I very much dislike this sort of PRs, due to urgency of several P0 items, I am making a rare exception this time. This "PR" introduces the command line interface of fairseq2 which can be extended by third-party projects within the same Python environment with new commands and command groups. We also have a pre-built `RecipeCommand` that can take any callable along with a configuration `dataclass` and convert it to a CLI command. `RecipeCommand` is also "cluster-aware" and can set the required distributed settings on the fly (e.g. `torch.distributed` based on Slurm variables). The simplest use is:

```python
fairseq2 lm instruct-finetune --preset llama2_7b_chat <path/to/logs_and_checkpoints>
```
which just finetunes the LLaMA 7B chat model with the default settings on a single machine/process (this is just a demonstration, in real life this will very likely OOM)

The "presest" configurations of a recipe can be listed with:

```python
fairseq2 lm instruct-finetune --list-presets
```

The presets can be adjusted/overwritten with `--config-file` and `--config` options:

```python
fairseq2 lm instruct-finetue --preset llama2_7b_chat --config-file foo1.yaml foo2.yaml --config model_name=llama2_70b_chat tensor_parallelism=8  <path/to/logs_and_checkpoints>
```

`--config` inputs have precedence over `--config-file` and the list of files have precedence over each other in reverse order.

A specific effective configuration can be dumped to a YAML file for diagnose or later use:

```python
fairseq2 lm instruct-finetune --preset llama2_7b_chat --config-file foo1.yaml --dump-config
```

3rd party libraries can extend the CLI with new command groups and commands:

```python
fairseq2 my_lib_commands my_model train <path/to/artifacts>
```

The recipes can be run interactively with `srun` (or `torchrun`) or with `sbatch` without any extra configuration. Assume we have already allocated resources for a job with `salloc` for interactive use. A fully distributed recipe over the entire allocation can be run be only prefixing the command line with `srun`)

```python
srun fairseq2 lm instruct-finetune <path/to/checkpoints>
```

Several new components lack unit tests in this PR. Those unit tests will be landed next week after I clean them up. Locally verified that all new types pass their tests.