### PR TITLE
Update default dropout configs

### DIFF
--- a/src/fairseq2/models/conformer/block.py
+++ b/src/fairseq2/models/conformer/block.py
@@ -49,7 +49,7 @@ class ConformerBlock(TransformerEncoderLayer):
         conv: ConformerConvolution,
         ffn2: FeedForwardNetwork,
         *,
-        dropout_p: float = 0.1,
+        dropout_p: float = 0.0,
         layer_norm_factory: Optional[LayerNormFactory] = None,
         device: Optional[Device] = None,
         dtype: Optional[DataType] = None,

--- a/src/fairseq2/models/llama/factory.py
+++ b/src/fairseq2/models/llama/factory.py
@@ -239,6 +239,7 @@ class LLaMABuilder:
 
         return StandardTransformerDecoder(
             layers,
+            dropout_p=self._config.dropout_p,
             norm_order=TransformerNormOrder.PRE,
             layer_norm_factory=self.build_layer_norm,
             device=self._device,
@@ -257,7 +258,6 @@ class LLaMABuilder:
             self_attn,
             encoder_decoder_attn=None,
             ffn=ffn,
-            dropout_p=self._config.dropout_p,
             norm_order=TransformerNormOrder.PRE,
             layer_norm_factory=self.build_layer_norm,
             device=self._device,
@@ -296,6 +296,7 @@ class LLaMABuilder:
             bias=False,
             inner_dim_scale=self._config.ffn_inner_dim_scale,
             inner_dim_to_multiple=self._config.ffn_inner_dim_to_multiple,
+            inner_dropout_p=self._config.dropout_p,
             device=self._device,
             dtype=self._dtype,
         )

--- a/src/fairseq2/models/s2t_transformer/frontend.py
+++ b/src/fairseq2/models/s2t_transformer/frontend.py
@@ -36,7 +36,7 @@ class S2TTransformerFrontend(TransformerFrontend):
         pos_encoder: Optional[PositionEncoder],
         *,
         proj: bool = False,
-        dropout_p: float = 0.1,
+        dropout_p: float = 0.0,
         device: Optional[Device] = None,
         dtype: Optional[DataType] = None,
     ) -> None:

--- a/src/fairseq2/models/transformer/frontend.py
+++ b/src/fairseq2/models/transformer/frontend.py
@@ -84,7 +84,7 @@ class TransformerEmbeddingFrontend(TransformerFrontend):
         *,
         no_scale: bool = False,
         layer_norm: bool = False,
-        dropout_p: float = 0.1,
+        dropout_p: float = 0.0,
         layer_norm_factory: Optional[LayerNormFactory] = None,
         device: Optional[Device] = None,
         dtype: Optional[DataType] = None,

--- a/src/fairseq2/models/wav2vec2/frontend.py
+++ b/src/fairseq2/models/wav2vec2/frontend.py
@@ -41,7 +41,7 @@ class Wav2Vec2Frontend(TransformerFrontend):
         *,
         first_pass_dropout_p: float = 0.0,
         layer_norm: bool = False,
-        dropout_p: float = 0.1,
+        dropout_p: float = 0.0,
         device: Optional[Device] = None,
         dtype: Optional[DataType] = None,
     ) -> None:

--- a/src/fairseq2/nn/transformer/__init__.py
+++ b/src/fairseq2/nn/transformer/__init__.py
@@ -13,6 +13,9 @@ from fairseq2.nn.transformer.attention import (
     default_sdpa_factory as default_sdpa_factory,
 )
 from fairseq2.nn.transformer.attention import (
+    enable_memory_efficient_torch_sdpa as enable_memory_efficient_torch_sdpa,
+)
+from fairseq2.nn.transformer.attention import (
     set_default_sdpa_factory as set_default_sdpa_factory,
 )
 from fairseq2.nn.transformer.attention_mask import (

--- a/src/fairseq2/nn/transformer/decoder_layer.py
+++ b/src/fairseq2/nn/transformer/decoder_layer.py
@@ -112,7 +112,7 @@ class StandardTransformerDecoderLayer(TransformerDecoderLayer):
         ffn: FeedForwardNetwork,
         *,
         scale_residual: bool = False,
-        dropout_p: float = 0.1,
+        dropout_p: float = 0.0,
         norm_order: TransformerNormOrder = TransformerNormOrder.POST,
         layer_norm_factory: Optional[LayerNormFactory] = None,
         device: Optional[Device] = None,

--- a/src/fairseq2/nn/transformer/encoder_layer.py
+++ b/src/fairseq2/nn/transformer/encoder_layer.py
@@ -93,7 +93,7 @@ class StandardTransformerEncoderLayer(TransformerEncoderLayer):
         ffn: FeedForwardNetwork,
         *,
         scale_residual: bool = False,
-        dropout_p: float = 0.1,
+        dropout_p: float = 0.0,
         norm_order: TransformerNormOrder = TransformerNormOrder.POST,
         layer_norm_factory: Optional[LayerNormFactory] = None,
         device: Optional[Device] = None,


### PR DESCRIPTION
This PR updates the default dropout value of the current model configurations. As it is highly recipe specific, we always default to zero in model configurations to avoid accidental leaks.

I also squeezed a small utility function that turns on/off PyTorch's memory efficient SDPA implementation. Unfortunately that implementation can become quite unstable when used in 13B+ finetuning jobs along with padded inputs.