### PR TITLE
fix extra_repr in decoder frontend

### DIFF
--- a/src/fairseq2/models/transformer/frontend.py
+++ b/src/fairseq2/models/transformer/frontend.py
@@ -165,6 +165,6 @@ class TransformerEmbeddingFrontend(TransformerFrontend):
         s = super().extra_repr()
 
         if self.scale != 1.0:
-            s = f"{s:G}, no_scale=False"
+            s = f"{s}, no_scale=False"
 
         return s


### PR DESCRIPTION
**What does this PR do? Please describe:**
Fixing the problem of transformer models not being pretty-printed correctly, and raising an error instead. I think it was the result of a typo.

<details><summary>The error </summary>
<p>

```Python
File ~/.conda/envs/meres1/lib/python3.10/site-packages/torch/nn/modules/module.py:2490, in Module.__repr__(self)
   2488 child_lines = []
   2489 for key, module in self._modules.items():
-> 2490     mod_str = repr(module)
   2491     mod_str = _addindent(mod_str, 2)
   2492     child_lines.append('(' + key + '): ' + mod_str)

File ~/.conda/envs/meres1/lib/python3.10/site-packages/torch/nn/modules/module.py:2484, in Module.__repr__(self)
   2481 def __repr__(self):
   2482     # We treat the extra repr like the sub-module, one item per line
   2483     extra_lines = []
-> 2484     extra_repr = self.extra_repr()
   2485     # empty string will be split into list ['']
   2486     if extra_repr:

File ~/dev/fairseq2/src/fairseq2/models/transformer/frontend.py:168, in TransformerEmbeddingFrontend.extra_repr(self)
    165 s = super().extra_repr()
    167 if self.scale != 1.0:
--> 168     s = f"{s:G}, no_scale=False"
    170 return s

ValueError: Unknown format code 'G' for object of type 'str'
```

</p>
</details> 

**Does your PR introduce any breaking changes? If yes, please list them:**
None

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
