### PR TITLE
Fix model loading with skipping meta initialization 

### DIFF
--- a/src/fairseq2/models/utils/generic_loaders.py
+++ b/src/fairseq2/models/utils/generic_loaders.py
@@ -326,7 +326,7 @@ class ModelLoader(Generic[ModelT, ConfigT]):
         else:
             if self.skip_meta_init:
                 model = self.model_factory(config, device=device, dtype=dtype)
-                model_device = device
+                model_device = device or CPU
             else:
                 try:
                     # Try to construct the model on the meta device.

--- a/src/fairseq2/models/utils/generic_loaders.py
+++ b/src/fairseq2/models/utils/generic_loaders.py
@@ -326,6 +326,7 @@ class ModelLoader(Generic[ModelT, ConfigT]):
         else:
             if self.skip_meta_init:
                 model = self.model_factory(config, device=device, dtype=dtype)
+                model_device = device
             else:
                 try:
                     # Try to construct the model on the meta device.


### PR DESCRIPTION
**What does this PR do? Please describe:**
Fixes an error `UnboundLocalError: local variable 'model_device' referenced before assignment` when using a `ModelLoader` with `skip_meta_init=True` 

**Does your PR introduce any breaking changes? If yes, please list them:**
None

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
