### PR TITLE
Update wav2vec2 assets

### DIFF
--- a/src/fairseq2/assets/cards/datasets/librilight.yaml
+++ b/src/fairseq2/assets/cards/datasets/librilight.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+name: librilight_asr_10h
+dataset_family: generic_asr

--- a/src/fairseq2/assets/cards/datasets/librispeech.yaml
+++ b/src/fairseq2/assets/cards/datasets/librispeech.yaml
@@ -8,3 +8,8 @@ name: librispeech_asr
 dataset_family: generic_asr
 tokenizer_family: librispeech_asr
 tokenizer: "https://dl.fbaipublicfiles.com/fairseq/wav2vec/librispeech_asr.model"
+
+---
+
+name: librispeech_asr_100h
+base: librispeech_asr

--- a/src/fairseq2/assets/cards/models/llama.yaml
+++ b/src/fairseq2/assets/cards/models/llama.yaml
@@ -19,7 +19,10 @@ model_arch: 7b
 ---
 
 name: llama2
-base: llama
+model_type: llama  # compat
+model_family: llama
+checkpoint: "https://ai.meta.com/llama/;gated=true"
+tokenizer: "https://ai.meta.com/llama/;gated=true"
 
 ---
 
@@ -32,6 +35,18 @@ model_arch: llama2_7b
 name: llama2_7b_chat
 base: llama2
 model_arch: llama2_7b
+
+---
+
+name: llama2_13b
+base: llama2
+model_arch: llama2_13b
+
+---
+
+name: llama2_13b_chat
+base: llama2
+model_arch: llama2_13b
 
 ---
 

--- a/src/fairseq2/datasets/asr/generic.py
+++ b/src/fairseq2/datasets/asr/generic.py
@@ -83,9 +83,6 @@ class GenericAsrDataset(AsrDataset):
             The maximum number of file descriptors to keep open while reading
             audio files.
         """
-        if split == "valid":  # pseudo-split
-            split = "dev_other"
-
         if split not in self._splits:
             raise ValueError(
                 f"`split` must be a valid split name, but the {self._dataset_name} dataset has no split named '{split}'."

--- a/src/fairseq2/recipes/wav2vec2/asr/train.py
+++ b/src/fairseq2/recipes/wav2vec2/asr/train.py
@@ -51,11 +51,17 @@ class Wav2Vec2AsrTrainConfig:
     """
 
     # Data
-    dataset_name: str = "librispeech_asr_10h"
+    dataset_name: str = "librilight_asr_10h"
     """The dataset to train with."""
 
     tokenizer_name: str = "librispeech_asr"
     """The tokenizer to use."""
+
+    train_split: str = "train"
+    """The name of the dataset split to train width."""
+
+    valid_split: str = "dev_other"
+    """The name of the dataset split to validate with."""
 
     min_audio_len: int = 1
     """The minimum audio sequence length."""
@@ -209,7 +215,7 @@ def load_wav2vec2_asr_trainer(
     dataset = load_asr_dataset(config.dataset_name)
 
     train_data_reader = dataset.create_reader(
-        split="train",
+        split=config.train_split,
         tokenizer=tokenizer,
         gang=gang,
         dtype=config.dtype,
@@ -224,7 +230,7 @@ def load_wav2vec2_asr_trainer(
     )
 
     valid_data_reader = dataset.create_reader(
-        split="valid",
+        split=config.valid_split,
         tokenizer=tokenizer,
         gang=gang,
         dtype=config.dtype,


### PR DESCRIPTION
This PR revises the names of wav2vec2 default recipe assets and also allows specifying different splits for training and validation.