### PR TITLE
Fix parametrization bug in wav2vec2 eval

### DIFF
--- a/src/fairseq2/models/wav2vec2/position_encoder.py
+++ b/src/fairseq2/models/wav2vec2/position_encoder.py
@@ -125,13 +125,14 @@ class Wav2Vec2PositionalConv1d(Conv1d):
             self.weight, mean=0.0, std=(4.0 / (kernel_size * model_dim)) ** 0.5
         )
 
-        with catch_warnings():
-            warnings.simplefilter("ignore")  # Suppress the deprecation warning.
+        if not getattr(self, "no_parametrization", False):
+            with catch_warnings():
+                warnings.simplefilter("ignore")  # Suppress the deprecation warning.
 
-            weight_norm(self, dim=2)
+                weight_norm(self, dim=2)
 
-        self.weight_v.requires_grad_(weight.requires_grad)
-        self.weight_g.requires_grad_(weight.requires_grad)
+            self.weight_v.requires_grad_(weight.requires_grad)
+            self.weight_g.requires_grad_(weight.requires_grad)
 
         if self.bias is not None:
             nn.init.constant_(self.bias, 0.0)

--- a/src/fairseq2/nn/utils/module.py
+++ b/src/fairseq2/nn/utils/module.py
@@ -347,6 +347,8 @@ def remove_parametrizations(module: Module, *, recurse: bool = True) -> None:
     def remove(name: str, m: Module) -> None:
         try:
             remove_weight_norm(m)
+
+            setattr(m, "no_parametrization", True)
         except ValueError:
             pass
 

--- a/src/fairseq2/recipes/wav2vec2/asr/eval.py
+++ b/src/fairseq2/recipes/wav2vec2/asr/eval.py
@@ -132,12 +132,12 @@ def load_wav2vec2_asr_evaluator(
     log.info("Initializing the model.")
 
     if gang.rank == 0:
-        device = gang.device
+        init_device = gang.device
     else:
-        device = META
+        init_device = META
 
     model = load_wav2vec2_asr_model(
-        config.model_name, device=device, dtype=config.dtype
+        config.model_name, device=init_device, dtype=config.dtype
     )
 
     # No need for weight normalization outside training.
@@ -149,7 +149,7 @@ def load_wav2vec2_asr_evaluator(
     if gang.size == 1:
         dp_model = model
     elif config.data_parallelism == "ddp":
-        to_device(model, device)
+        to_device(model, gang.device)
 
         dp_model = to_ddp(model, gang)
     elif config.data_parallelism == "fsdp":


### PR DESCRIPTION
This PR fixes the parametrization (i.e. weight_norm removal) bug in wav2vec2 eval recipe.