### PR TITLE
Add checkpoint for wav2vec2 asr base 10h

### DIFF
--- a/src/fairseq2/assets/cards/models/wav2vec2.yaml
+++ b/src/fairseq2/assets/cards/models/wav2vec2.yaml
@@ -28,11 +28,11 @@ checkpoint: "https://dl.fbaipublicfiles.com/fairseq/wav2vec/wav2vec2_fs2_large_l
 
 ---
 
-name: wav2vec2_asr_base_10m
+name: wav2vec2_asr_base_10h
 model_type: wav2vec2_asr  # compat
 model_family: wav2vec2_asr
-model_arch: base
-checkpoint: "https://dl.fbaipublicfiles.com/fairseq/wav2vec/wav2vec2_asr_fs2_small_10m.pt"
+model_arch: base_10h
+checkpoint: "https://dl.fbaipublicfiles.com/fairseq/wav2vec/wav2vec2_asr_fs2_base_10h.pt"
 
 ---
 

--- a/src/fairseq2/models/wav2vec2/asr/factory.py
+++ b/src/fairseq2/models/wav2vec2/asr/factory.py
@@ -20,21 +20,13 @@ from fairseq2.typing import DataType, Device
 WAV2VEC2_ASR_FAMILY: Final = "wav2vec2_asr"
 
 
-def _base_10h_encoder() -> Wav2Vec2EncoderConfig:
+def _base_encoder() -> Wav2Vec2EncoderConfig:
     config = wav2vec2_encoder_archs.get("base")
 
     config.feature_gradient_scale = 1.0
     config.dropout_p = 0.0
     config.attn_dropout_p = 0.0
     config.ffn_inner_dropout_p = 0.1
-
-    return config
-
-
-def _base_100h_encoder() -> Wav2Vec2EncoderConfig:
-    config = _base_10h_encoder()
-
-    config.layer_drop_p = 0.1
 
     return config
 
@@ -51,7 +43,7 @@ def _large_encoder() -> Wav2Vec2EncoderConfig:
     return config
 
 
-def _large_lv60k_encoder() -> Wav2Vec2EncoderConfig:
+def _large_lv60k_encoder() -> Wav2Vec2EncoderConfig:  # LibriVox 60K
     config = wav2vec2_encoder_archs.get("large_lv60k")
 
     config.feature_gradient_scale = 1.0
@@ -71,7 +63,7 @@ class Wav2Vec2AsrConfig:
     :cite:t:`https://doi.org/10.48550/arxiv.2006.11477`.
     """
 
-    encoder_config: Wav2Vec2EncoderConfig = field(default_factory=_base_10h_encoder)
+    encoder_config: Wav2Vec2EncoderConfig = field(default_factory=_base_encoder)
     """The configuration of the encoder."""
 
     final_dim: int = 32
@@ -119,7 +111,8 @@ def _base_10h() -> Wav2Vec2AsrConfig:
 def _base_100h() -> Wav2Vec2AsrConfig:
     config = _base_10h()
 
-    config.encoder_config = _base_100h_encoder()
+    config.encoder_config.layer_drop_p = 0.1
+
     return config
 
 
@@ -145,9 +138,8 @@ def _large_100h() -> Wav2Vec2AsrConfig:
     return config
 
 
-@wav2vec2_asr_arch("large_lv60k_10h")
+@wav2vec2_asr_arch("large_lv60k_10h")  # LibriVox 60K
 def _large_lv60k_10h() -> Wav2Vec2AsrConfig:
-    """wav2vec2 large arch trained on the LibriVox 60k dataset."""
     config = _base_10h()
 
     config.encoder_config = _large_lv60k_encoder()
@@ -157,9 +149,8 @@ def _large_lv60k_10h() -> Wav2Vec2AsrConfig:
     return config
 
 
-@wav2vec2_asr_arch("large_lv60k_100h")
+@wav2vec2_asr_arch("large_lv60k_100h")  # LibriVox 60K
 def _large_lv60k_100h() -> Wav2Vec2AsrConfig:
-    """wav2vec2 large arch trained on the LibriVox 60k dataset."""
     config = _base_10h()
 
     config.encoder_config = _large_lv60k_encoder()

--- a/src/fairseq2/models/wav2vec2/factory.py
+++ b/src/fairseq2/models/wav2vec2/factory.py
@@ -163,24 +163,28 @@ def _base_encoder() -> Wav2Vec2EncoderConfig:
 
 @wav2vec2_encoder_arch("large")
 def _large_encoder() -> Wav2Vec2EncoderConfig:
-    return Wav2Vec2EncoderConfig(
-        model_dim=1024,
-        num_encoder_layers=24,
-        num_encoder_attn_heads=16,
-        ffn_inner_dim=4096,
-        dropout_p=0.0,
-        layer_drop_p=0.2,
-    )
+    config = _base_encoder()
+
+    config.model_dim = 1024
+    config.num_encoder_layers = 24
+    config.num_encoder_attn_heads = 16
+    config.ffn_inner_dim = 4096
+    config.dropout_p = 0.0
+    config.layer_drop_p = 0.2
+
+    return config
 
 
-@wav2vec2_encoder_arch("large_lv60k")
+@wav2vec2_encoder_arch("large_lv60k")  # LibriVox 60K
 def _large_lv60k_encoder() -> Wav2Vec2EncoderConfig:
     config = _large_encoder()
-    config.feature_extractor_layer_norm_convs = True
-    config.feature_extractor_bias = True
-    config.norm_order = TransformerNormOrder.PRE
+
     config.layer_norm_features = False
+    config.feature_extractor_bias = True
+    config.feature_extractor_layer_norm_convs = True
     config.layer_drop_p = 0.0
+    config.norm_order = TransformerNormOrder.PRE
+
     return config
 
 
@@ -257,22 +261,25 @@ def _base() -> Wav2Vec2Config:
 
 @wav2vec2_arch("large")
 def _large() -> Wav2Vec2Config:
-    return Wav2Vec2Config(
-        encoder_config=_large_encoder(),
-        quantized_dim=768,
-        final_dim=768,
-    )
+    config = _base()
+
+    config.encoder_config = _large_encoder()
+    config.quantized_dim = 768
+    config.final_dim = 768
+
+    return config
 
 
-@wav2vec2_arch("large_lv60k")
+@wav2vec2_arch("large_lv60k")  # LibriVox 60K
 def _large_lv60k() -> Wav2Vec2Config:
-    """wav2vec2 large arch to train on the LibriVox 60k dataset."""
-    return Wav2Vec2Config(
-        encoder_config=_large_lv60k_encoder(),
-        quantized_dim=768,
-        final_dim=768,
-        codebook_sampling_temperature=(2.0, 0.1, 0.999995),
-    )
+    config = _base()
+
+    config.encoder_config = _large_lv60k_encoder()
+    config.quantized_dim = 768
+    config.final_dim = 768
+    config.codebook_sampling_temperature = (2.0, 0.1, 0.999995)
+
+    return config
 
 
 @wav2vec2_arch("pseudo_dinosr_base")


### PR DESCRIPTION
This PR adds the fairseq2-compatible wav2vec2 ASR base 10h checkpoint and does some cosmetic updates in architecture definitions.