### PR TITLE
Handle torchrun correctly within srun

### DIFF
--- a/src/fairseq2/assets/utils.py
+++ b/src/fairseq2/assets/utils.py
@@ -21,7 +21,7 @@ def _starts_with_scheme(s: str) -> bool:
 def _get_path_from_env(
     var_name: str, log: LogWriter, missing_ok: bool = False
 ) -> Optional[Path]:
-    pathname = os.getenv(var_name)
+    pathname = os.environ.get(var_name)
     if not pathname:
         return None
 

--- a/src/fairseq2/gang.py
+++ b/src/fairseq2/gang.py
@@ -505,7 +505,7 @@ def _determine_default_device() -> Device:
     if _default_device is not None:
         return _default_device
 
-    device_str = os.getenv("FAIRSEQ2_DEVICE")
+    device_str = os.environ.get("FAIRSEQ2_DEVICE")
     if device_str is not None:
         try:
             _default_device = Device(device_str)
@@ -530,7 +530,7 @@ def _determine_default_device() -> Device:
 
 
 def _determine_default_cuda_device() -> Device:
-    visible_devices = os.getenv("CUDA_VISIBLE_DEVICES")
+    visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES")
     if visible_devices is not None:
         try:
             int(visible_devices)
@@ -610,7 +610,7 @@ def get_local_rank() -> int:
 
 
 def _get_int_from_env(var_name: str, allow_zero: bool = False) -> Optional[int]:
-    s = os.getenv(var_name)
+    s = os.environ.get(var_name)
     if s is None:
         return None
 

--- a/src/fairseq2/recipes/utils/environment.py
+++ b/src/fairseq2/recipes/utils/environment.py
@@ -132,6 +132,9 @@ class EnvironmentSetterRegistry:
 
     def get_for_inferred_cluster(self) -> EnvironmentSetter:
         """Return the :class:`EnvironmentSetter` of the inferred cluster."""
+        if "TORCHELASTIC_RUN_ID" in os.environ:  # means we are in `torchrun`.
+            return self.get("none")
+
         for cluster, kls in self._types.items():
             if cluster == "none":
                 continue

--- a/src/fairseq2/utils/log.py
+++ b/src/fairseq2/utils/log.py
@@ -208,7 +208,7 @@ def log_software_info(log: LogWriter, device: Optional[Device] = None) -> None:
     )
 
     for venv_type, venv_env in [("Conda", "CONDA_PREFIX"), ("venv", "VIRTUAL_ENV")]:
-        if venv_path := os.getenv(venv_env):
+        if venv_path := os.environ.get(venv_env):
             s = f"{s} | Python Environment: {venv_type} ({venv_path})"
 
     log.info("Software - {}", s)


### PR DESCRIPTION
This PR fixes the handling of torchrun executed within srun in `EnvironmentSetter`. Also replaces uses of `getenv` with `environ.get` to be consistent with the rest of the code base.