### PR TITLE
Remove mmap parameter from ModelLoader

### DIFF
--- a/src/fairseq2/checkpoint.py
+++ b/src/fairseq2/checkpoint.py
@@ -537,7 +537,7 @@ class FileCheckpointManager(CheckpointManager):
             for filename in filenames:
                 try:
                     part = load_checkpoint(
-                        step_dir.joinpath(filename), map_location=CPU, mmap=True
+                        step_dir.joinpath(filename), map_location=CPU
                     )
                 except FileNotFoundError:
                     part = None
@@ -590,7 +590,7 @@ class FileCheckpointManager(CheckpointManager):
         )
 
         try:
-            metadata = load_checkpoint(metadata_file, map_location=CPU, mmap=True)
+            metadata = load_checkpoint(metadata_file, map_location=CPU)
         except FileNotFoundError:
             metadata = None
         except (RuntimeError, OSError, PickleError) as ex:

--- a/src/fairseq2/models/llama/setup.py
+++ b/src/fairseq2/models/llama/setup.py
@@ -87,7 +87,6 @@ load_llama_model = LLaMAModelLoader(
     config_loader=load_llama_config,
     factory=create_llama_model,
     checkpoint_converter=convert_llama_checkpoint,
-    mmap=True,
 )
 
 

--- a/src/fairseq2/models/loader.py
+++ b/src/fairseq2/models/loader.py
@@ -122,7 +122,6 @@ class DenseModelLoader(ModelLoader[ModelT], Generic[ModelT, ModelConfigT]):
     _config_loader: ModelConfigLoader[ModelConfigT]
     _factory: DenseModelFactory[ModelConfigT, ModelT]
     _checkpoint_converter: Optional[CheckpointConverter[ModelConfigT]]
-    _mmap: bool
     _restrict_checkpoints: bool
     _skip_meta_init: bool
 
@@ -132,7 +131,6 @@ class DenseModelLoader(ModelLoader[ModelT], Generic[ModelT, ModelConfigT]):
         config_loader: ModelConfigLoader[ModelConfigT],
         factory: DenseModelFactory[ModelConfigT, ModelT],
         checkpoint_converter: Optional[CheckpointConverter[ModelConfigT]] = None,
-        mmap: bool = False,
         restrict_checkpoints: bool = True,
         skip_meta_init: bool = False,
         asset_store: Optional[AssetStore] = None,
@@ -146,9 +144,6 @@ class DenseModelLoader(ModelLoader[ModelT], Generic[ModelT, ModelConfigT]):
         :param checkpoint_converter:
             The converter to which loaded checkpoints will be passed for further
             processing.
-        :param mmap:
-            If ``True``, indicates whether the checkpoint should be memory
-            mapped.
         :param restrict_checkpoints:
             If ``True``, restricts the Python unpickler to load only tensors,
             primitive types, and dictionaries.
@@ -166,7 +161,6 @@ class DenseModelLoader(ModelLoader[ModelT], Generic[ModelT, ModelConfigT]):
         self._config_loader = config_loader
         self._factory = factory
         self._checkpoint_converter = checkpoint_converter
-        self._mmap = mmap
         self._restrict_checkpoints = restrict_checkpoints
         self._skip_meta_init = skip_meta_init
 
@@ -262,7 +256,6 @@ class DenseModelLoader(ModelLoader[ModelT], Generic[ModelT, ModelConfigT]):
             checkpoint = load_checkpoint(
                 path,
                 map_location=CPU,
-                mmap=self._mmap,
                 restrict=self._restrict_checkpoints,
                 converter=checkpoint_converter,
             )

--- a/src/fairseq2/models/mistral/setup.py
+++ b/src/fairseq2/models/mistral/setup.py
@@ -56,7 +56,6 @@ load_mistral_model = DenseModelLoader(
     config_loader=load_mistral_config,
     factory=create_mistral_model,
     checkpoint_converter=convert_mistral_checkpoint,
-    mmap=True,
 )
 
 load_mistral_tokenizer = default_basic_sentencepiece_tokenizer_loader

--- a/src/fairseq2/models/nllb/setup.py
+++ b/src/fairseq2/models/nllb/setup.py
@@ -95,7 +95,6 @@ load_nllb_model = DenseModelLoader(
     config_loader=load_nllb_config,
     factory=create_nllb_model,
     checkpoint_converter=convert_nllb_checkpoint,
-    mmap=True,
     restrict_checkpoints=False,
 )
 

--- a/src/fairseq2/models/s2t_transformer/setup.py
+++ b/src/fairseq2/models/s2t_transformer/setup.py
@@ -93,7 +93,6 @@ load_s2t_transformer_model = DenseModelLoader(
     config_loader=load_s2t_transformer_config,
     factory=create_s2t_transformer_model,
     checkpoint_converter=convert_s2t_transformer_checkpoint,
-    mmap=True,
     restrict_checkpoints=False,
 )
 

--- a/src/fairseq2/models/utils/checkpoint.py
+++ b/src/fairseq2/models/utils/checkpoint.py
@@ -15,7 +15,6 @@ from torch import Tensor
 from typing_extensions import TypeAlias
 
 from fairseq2.typing import Device
-from fairseq2.utils.version import torch_greater_or_equal
 
 MapLocation: TypeAlias = Optional[
     Union[Callable[[Tensor, str], Tensor], Device, str, Dict[str, str]]
@@ -36,7 +35,6 @@ def load_checkpoint(
     path: Path,
     *,
     map_location: MapLocation = None,
-    mmap: bool = False,
     restrict: bool = False,
     converter: Optional[CheckpointConverter] = None,
 ) -> Dict[str, Any]:
@@ -46,8 +44,6 @@ def load_checkpoint(
         The path to the checkpoint.
     :param map_location:
         Same as the ``map_location`` parameter of :meth:`torch.load`.
-    :param mmap:
-        If ``True``, indicates whether the checkpoint should be memory mapped.
     :param restrict:
         If ``True``, restricts the Python unpickler to load only tensors,
         primitive types, and dictionaries.
@@ -61,13 +57,8 @@ def load_checkpoint(
     with catch_warnings():
         warnings.simplefilter("ignore")  # Suppress the deprecation warning.
 
-        kwargs = {}
-
-        if mmap and torch_greater_or_equal(2, 1):
-            kwargs["mmap"] = True
-
         checkpoint: Dict[str, Any] = torch.load(
-            str(path), map_location, weights_only=restrict, **kwargs
+            str(path), map_location, weights_only=restrict
         )
 
     if converter is not None:

--- a/src/fairseq2/models/utils/generic_loaders.py
+++ b/src/fairseq2/models/utils/generic_loaders.py
@@ -206,7 +206,6 @@ class ModelLoader(Generic[ModelT, ConfigT]):
     config_loader: ConfigLoader[ConfigT]
     model_factory: ModelFactory[ConfigT, ModelT]
     checkpoint_converter: Optional[CheckpointConverter[ConfigT]]
-    mmap: bool
     restrict_checkpoints: bool
     skip_meta_init: bool
 
@@ -218,7 +217,6 @@ class ModelLoader(Generic[ModelT, ConfigT]):
         model_factory: ModelFactory[ConfigT, ModelT],
         checkpoint_converter: Optional[CheckpointConverter[ConfigT]] = None,
         *,
-        mmap: bool = False,
         restrict_checkpoints: bool = True,
         skip_meta_init: bool = False,
     ) -> None:
@@ -234,9 +232,6 @@ class ModelLoader(Generic[ModelT, ConfigT]):
         :param checkpoint_converter:
             The converter to which loaded checkpoints will be passed for further
             processing.
-        :param mmap:
-            If ``True``, indicates whether the checkpoint should be memory
-            mapped.
         :param restrict_checkpoints:
             If ``True``, restricts the Python unpickler to load only tensors,
             primitive types, and dictionaries.
@@ -250,7 +245,6 @@ class ModelLoader(Generic[ModelT, ConfigT]):
         self.config_loader = config_loader
         self.model_factory = model_factory
         self.checkpoint_converter = checkpoint_converter
-        self.mmap = mmap
         self.restrict_checkpoints = restrict_checkpoints
         self.skip_meta_init = skip_meta_init
 
@@ -310,7 +304,6 @@ class ModelLoader(Generic[ModelT, ConfigT]):
             checkpoint = load_checkpoint(
                 path,
                 map_location=CPU,
-                mmap=self.mmap,
                 restrict=self.restrict_checkpoints,
                 converter=checkpoint_converter,
             )

--- a/src/fairseq2/models/w2vbert/setup.py
+++ b/src/fairseq2/models/w2vbert/setup.py
@@ -78,5 +78,4 @@ load_w2vbert_model = DenseModelLoader(
     config_loader=load_w2vbert_config,
     factory=create_w2vbert_model,
     checkpoint_converter=convert_w2vbert_checkpoint,
-    mmap=True,
 )

--- a/src/fairseq2/models/wav2vec2/asr/setup.py
+++ b/src/fairseq2/models/wav2vec2/asr/setup.py
@@ -76,6 +76,5 @@ load_wav2vec2_asr_model = DenseModelLoader(
     config_loader=load_wav2vec2_asr_config,
     factory=create_wav2vec2_asr_model,
     checkpoint_converter=convert_wav2vec2_asr_checkpoint,
-    mmap=False,
     restrict_checkpoints=False,
 )

--- a/src/fairseq2/models/wav2vec2/setup.py
+++ b/src/fairseq2/models/wav2vec2/setup.py
@@ -76,6 +76,5 @@ load_wav2vec2_model = DenseModelLoader(
     config_loader=load_wav2vec2_config,
     factory=create_wav2vec2_model,
     checkpoint_converter=convert_wav2vec2_checkpoint,
-    mmap=False,
     restrict_checkpoints=False,
 )


### PR DESCRIPTION
This PR removes the `mmap` parameter from `ModelLoader`, `CheckpointManager`, and `load_checkpoint`. Although `mmap` is supposed to reduce the checkpoint loading times and reduce the memory pressure, it turns out mmap'ed tensors choke the file system buffer cache and cause deadlocks when the mmap'ed regions are on NFS. This issue surfaces when such tensors are loaded into device or host memory during `load_state_dict()`. Removing mmap will likely cause some slow-down in model loading times, but being stable and not end up with a hang Slurm job is more important.