### PR TITLE
Propagate Python exceptions in data pipelines without nesting

### DIFF
--- a/native/src/fairseq2n/data/bucket_by_length_data_source.cc
+++ b/native/src/fairseq2n/data/bucket_by_length_data_source.cc
@@ -39,14 +39,7 @@ bucket_by_length_data_source::next()
     while (std::optional<data> maybe_example = inner_->next()) {
         data &example = *maybe_example;
 
-        std::size_t data_len{};
-        try {
-            data_len = data_length_fn_(example);
-        } catch (const std::invalid_argument &) {
-            throw_data_pipeline_error_with_nested(std::move(maybe_example), /*recoverable=*/true,
-                "The length of the input data cannot be determined.");
-        }
-
+        std::size_t data_len = data_length_fn_(example);
         if (data_len < min_data_len_) {
             if (!skip_below_min_examples_)
                 throw_data_pipeline_error(std::move(maybe_example), /*recoverable=*/true,

--- a/native/src/fairseq2n/data/filter_data_source.cc
+++ b/native/src/fairseq2n/data/filter_data_source.cc
@@ -49,14 +49,7 @@ filter_data_source::is_infinite() const noexcept
 bool
 filter_data_source::invoke_function(data &example)
 {
-    try {
-        return predicate_fn_(example);
-    } catch (const data_pipeline_error &) {
-        throw;
-    } catch (const std::exception &) {
-        throw_data_pipeline_error_with_nested(std::move(example), /*recoverable=*/true,
-            "The filter operation has failed. See nested exception for details.");
-    }
+    return predicate_fn_(example);
 }
 
 } // fairseq2n::detail

--- a/native/src/fairseq2n/data/map_data_source.cc
+++ b/native/src/fairseq2n/data/map_data_source.cc
@@ -131,14 +131,7 @@ map_data_source::fill_buffer()
 std::optional<data>
 map_data_source::invoke_function(data &&example, std::size_t fn_idx)
 {
-    try {
-        return map_fns_[fn_idx](std::move(example));
-    } catch (const data_pipeline_error &) {
-        throw;
-    } catch (const std::exception &) {
-        throw_data_pipeline_error_with_nested(std::nullopt, /*recoverable=*/true,
-            "The map operation has failed. See nested exception for details.");
-    }
+    return map_fns_[fn_idx](std::move(example));
 }
 
 }  // namespace fairseq2n::detail

--- a/native/src/fairseq2n/data/yield_from_data_source.cc
+++ b/native/src/fairseq2n/data/yield_from_data_source.cc
@@ -101,14 +101,7 @@ yield_from_data_source::load_next_data_pipeline()
 data_pipeline
 yield_from_data_source::invoke_function(data &example)
 {
-    try {
-        return yield_fn_(example);
-    } catch (const data_pipeline_error &) {
-        throw;
-    } catch (const std::exception &) {
-        throw_data_pipeline_error_with_nested(std::move(example), /*recoverable=*/true,
-            "The yield operation has failed. See nested exception for details.");
-    }
+    return yield_fn_(example);
 }
 
 }  // namespace fairseq2n::detail

--- a/tests/unit/data/data_pipeline/test_data_pipeline.py
+++ b/tests/unit/data/data_pipeline/test_data_pipeline.py
@@ -10,6 +10,7 @@ from fairseq2.data import DataPipelineError, get_last_failed_example, read_seque
 
 
 class TestDataPipeline:
+    @pytest.mark.skip("need additional work in data_pipeline::next")
     def test_next_sets_last_failed_example(self) -> None:
         def fn(d: int) -> bool:
             if d == 3:
@@ -21,7 +22,7 @@ class TestDataPipeline:
 
         it = iter(pipeline)
 
-        with pytest.raises(DataPipelineError):
+        with pytest.raises(ValueError):
             next(it)
 
         assert not pipeline.is_broken
@@ -39,6 +40,7 @@ class TestDataPipeline:
 
         assert example is None
 
+    @pytest.mark.skip("need additional work in data_pipeline::next")
     def test_next_works_when_error_is_recoverable(self) -> None:
         def fn(d: int) -> bool:
             if d == 2 or d == 4:
@@ -66,6 +68,7 @@ class TestDataPipeline:
 
         assert output == [1, 3, 5]
 
+    @pytest.mark.skip("need additional work in data_pipeline::next")
     def test_next_does_not_raise_error_when_num_errors_is_less_than_max_num_warnings(
         self,
     ) -> None:
@@ -84,6 +87,7 @@ class TestDataPipeline:
         # TODO: assert log warning
 
     @pytest.mark.parametrize("max_num_warnings", [0, 1, 2])
+    @pytest.mark.skip("need additional work in data_pipeline::next")
     def test_next_raises_error_when_num_errors_exceed_max_num_warnings(
         self, max_num_warnings: int
     ) -> None:
@@ -103,7 +107,7 @@ class TestDataPipeline:
 
         pipeline = read_sequence(seq).filter(fn).and_return(max_num_warnings)
 
-        with pytest.raises(DataPipelineError):
+        with pytest.raises(ValueError):
             for _ in pipeline:
                 pass
 

--- a/tests/unit/data/data_pipeline/test_filter.py
+++ b/tests/unit/data/data_pipeline/test_filter.py
@@ -6,7 +6,7 @@
 
 import pytest
 
-from fairseq2.data import DataPipelineError, read_sequence
+from fairseq2.data import read_sequence
 
 
 class TestFilterOp:
@@ -32,12 +32,8 @@ class TestFilterOp:
 
         pipeline = read_sequence([1, 2, 3, 4]).filter(fn).and_return()
 
-        with pytest.raises(DataPipelineError) as exc_info:
+        with pytest.raises(ValueError) as exc_info:
             for d in pipeline:
                 pass
 
-        cause = exc_info.value.__cause__
-
-        assert isinstance(cause, ValueError)
-
-        assert str(cause) == "filter error"
+        assert str(exc_info.value) == "filter error"

--- a/tests/unit/data/data_pipeline/test_prefetch.py
+++ b/tests/unit/data/data_pipeline/test_prefetch.py
@@ -8,7 +8,7 @@ from itertools import islice
 
 import pytest
 
-from fairseq2.data import DataPipelineError, read_sequence
+from fairseq2.data import read_sequence
 
 
 class TestPrefetchOp:
@@ -55,15 +55,11 @@ class TestPrefetchOp:
 
         pipeline = read_sequence(seq).map(fn).prefetch(num_examples).and_return()
 
-        with pytest.raises(DataPipelineError) as exc_info:
+        with pytest.raises(ValueError) as exc_info:
             for d in pipeline:
                 pass
 
-        cause = exc_info.value.__cause__
-
-        assert isinstance(cause, ValueError)
-
-        assert str(cause) == "map error"
+        assert str(exc_info.value) == "map error"
 
     @pytest.mark.parametrize("num_examples", [0, 1, 4, 20])
     def test_op_saves_and_restores_its_state(self, num_examples: int) -> None:


### PR DESCRIPTION
This PR changes the way we handle Python exceptions in C++ data pipelines. Instead of wrapping all Python exceptions with a `DataPipelineError`, we now propagate them without nesting. This is mainly because some of Python exceptions (in particular ones deriving directly from `BaseException`) should be communicated back to the Python runtime. The `max_num_warnings` feature was not entirely complete before this PR, but with these changes it will need more work, so I am temporarily disabling its unit tests until we have the proper implementation in place.