### PR TITLE
Refactor load_checkpoint

### DIFF
--- a/src/fairseq2/datasets/data_reader.py
+++ b/src/fairseq2/datasets/data_reader.py
@@ -36,7 +36,7 @@ class DataReader(ABC, Iterator[List[BatchT_co]]):
 
     @abstractmethod
     def reset(self) -> None:
-        """Reset state and move back to the first example."""
+        """Reset state and move back to the first batch."""
 
     @abstractmethod
     def state_dict(self) -> Dict[str, Any]:

--- a/src/fairseq2/datasets/utils.py
+++ b/src/fairseq2/datasets/utils.py
@@ -15,7 +15,9 @@ from fairseq2.logging import LogWriter
 def _reduce_num_batches(num_batches: int, gang: Gang, log: LogWriter) -> int:
     all_num_batches = torch.zeros((gang.size,), device=gang.device, dtype=torch.int64)
 
-    gang.all_gather(all_num_batches, torch.tensor(num_batches, device=gang.device))
+    num_batches_ = torch.tensor(num_batches, device=gang.device)
+
+    gang.all_gather(all_num_batches, num_batches_)
 
     min_num_batches = int(all_num_batches.min())
     if min_num_batches != 0:

--- a/src/fairseq2/models/utils/checkpoint.py
+++ b/src/fairseq2/models/utils/checkpoint.py
@@ -5,66 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import re
-import warnings
-from pathlib import Path
-from typing import Any, Callable, Dict, Mapping, Optional, Protocol, Union
-from warnings import catch_warnings
-
-import torch
-from torch import Tensor
-from typing_extensions import TypeAlias
-
-from fairseq2.typing import Device
-
-MapLocation: TypeAlias = Optional[
-    Union[Callable[[Tensor, str], Tensor], Device, str, Dict[str, str]]
-]
-
-
-class CheckpointConverter(Protocol):
-    """Converts checkpoints to fairseq2 format."""
-
-    def __call__(self, checkpoint: Dict[str, Any]) -> Dict[str, Any]:
-        """
-        :param checkpoint:
-            The checkpoint to convert.
-        """
-
-
-def load_checkpoint(
-    path: Path,
-    *,
-    map_location: MapLocation = None,
-    restrict: bool = False,
-    converter: Optional[CheckpointConverter] = None,
-) -> Dict[str, Any]:
-    """Load the checkpoint stored in ``path``.
-
-    :param path:
-        The path to the checkpoint.
-    :param map_location:
-        Same as the ``map_location`` parameter of :meth:`torch.load`.
-    :param restrict:
-        If ``True``, restricts the Python unpickler to load only tensors,
-        primitive types, and dictionaries.
-    :param converter:
-        The converter to which the loaded checkpoint will be passed for further
-        processing.
-
-    :returns:
-        The loaded checkpoint.
-    """
-    with catch_warnings():
-        warnings.simplefilter("ignore")  # Suppress the deprecation warning.
-
-        checkpoint: Dict[str, Any] = torch.load(
-            str(path), map_location, weights_only=restrict
-        )
-
-    if converter is not None:
-        checkpoint = converter(checkpoint)
-
-    return checkpoint
+from typing import Any, Dict, Mapping
 
 
 def convert_model_state_dict(

--- a/src/fairseq2/recipes/llama/convert.py
+++ b/src/fairseq2/recipes/llama/convert.py
@@ -13,14 +13,13 @@ from pathlib import Path
 from typing import final
 from warnings import catch_warnings
 
-import torch
-
 from fairseq2.logging import get_log_writer
 from fairseq2.models.llama import load_llama_config
 from fairseq2.models.llama.integ import convert_to_reference_checkpoint
 from fairseq2.recipes.cli import CliCommandHandler
 from fairseq2.recipes.logging import console, setup_basic_logging
 from fairseq2.typing import override
+from fairseq2.utils.file import dump_tensors, load_tensors
 
 log = get_log_writer(__name__)
 
@@ -106,7 +105,7 @@ class ConvertCheckpointCommand(CliCommandHandler):
                     with catch_warnings():
                         warnings.simplefilter("ignore")
 
-                        checkpoint = torch.load(input_file, weights_only=True)
+                        checkpoint = load_tensors(input_file, restrict=True)
                 except RuntimeError:
                     log.exception(
                         "Checkpoint file {} cannot be loaded.", input_file.name
@@ -126,7 +125,7 @@ class ConvertCheckpointCommand(CliCommandHandler):
                 ref_state_dict = convert_to_reference_checkpoint(checkpoint)
 
                 try:
-                    torch.save(ref_state_dict, output_file)
+                    dump_tensors(ref_state_dict, output_file)
                 except RuntimeError:
                     log.exception(
                         "Checkpoint file {} cannot be saved.", output_file.name

--- a/src/fairseq2/utils/file.py
+++ b/src/fairseq2/utils/file.py
@@ -1,0 +1,77 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional, Protocol, Union
+from warnings import catch_warnings
+
+import torch
+from torch import Tensor
+from typing_extensions import TypeAlias
+
+from fairseq2.typing import Device
+
+MapLocation: TypeAlias = Optional[
+    Union[Callable[[Tensor, str], Tensor], Device, str, Dict[str, str]]
+]
+
+
+class TensorLoader(Protocol):
+    """Loads tensors from files."""
+
+    def __call__(
+        self,
+        path: Path,
+        *,
+        map_location: MapLocation = None,
+        restrict: bool = False,
+    ) -> Dict[str, Any]:
+        """
+        :param path:
+            The path to the file.
+        :param map_location:
+            Same as the ``map_location`` parameter of :meth:`torch.load`.
+        :param restrict:
+            If ``True``, restricts the Python unpickler to load only tensors,
+            primitive types, and dictionaries.
+        """
+
+
+class TensorDumper(Protocol):
+    """Dumps tensors to files."""
+
+    def __call__(self, data: Dict[str, Any], path: Path) -> None:
+        """
+        :param data:
+            The dictionary containing tensors and other auxiliary data.
+        :param path:
+            The path to the file.
+        """
+
+
+def load_tensors(
+    path: Path,
+    *,
+    map_location: MapLocation = None,
+    restrict: bool = False,
+) -> Dict[str, Any]:
+    """Load the PyTorch tensor file stored under ``path``."""
+    with catch_warnings():
+        warnings.simplefilter("ignore")  # Suppress the deprecation warning.
+
+        data: Dict[str, Any] = torch.load(
+            str(path), map_location, weights_only=restrict
+        )
+
+    return data
+
+
+def dump_tensors(data: Dict[str, Any], path: Path) -> None:
+    """Dump ``data`` to a PyTorch tensor file under ``path``."""
+    torch.save(data, path)

--- a/tests/integration/models/test_llama.py
+++ b/tests/integration/models/test_llama.py
@@ -12,8 +12,8 @@ from fairseq2.assets import asset_store, download_manager
 from fairseq2.models.llama import create_llama_model, llama_archs
 from fairseq2.models.llama.integ import convert_to_reference_checkpoint
 from fairseq2.models.llama.setup import convert_llama_checkpoint
-from fairseq2.models.utils.checkpoint import load_checkpoint
 from fairseq2.typing import CPU
+from fairseq2.utils.file import load_tensors
 from tests.common import device
 
 
@@ -29,7 +29,7 @@ def test_convert_to_reference_checkpoint() -> None:
         card.field("checkpoint").as_uri(), model_name="llama2_7b", progress=False
     )
 
-    checkpoint = load_checkpoint(path, map_location=CPU, restrict=True)
+    checkpoint = load_tensors(path, map_location=CPU, restrict=True)
 
     # Convert the reference checkpoint to fairseq2.
     checkpoint = convert_llama_checkpoint(checkpoint, model_config)


### PR DESCRIPTION
This PR refactors `load_checkpoint` utility function to more generic `load_tensors` and `dump_tensors` with accompanying protocols. This will enable us to start using HG safe tensors (as an alternative to torch.save/torch.load) in the near future.