### PR TITLE
Fix bucketing bug

### DIFF
--- a/src/fairseq2/data/data_pipeline.py
+++ b/src/fairseq2/data/data_pipeline.py
@@ -531,13 +531,15 @@ def create_bucket_sizes(
 
     bucket_size = max_num_elements
 
-    while seq_len <= max_seq_len:
+    while seq_len < max_seq_len:
         if seq_len >= min_seq_len:
             bucket_sizes.append((bucket_size, seq_len))
 
         bucket_size = max_num_elements // (seq_len + 1)
 
         seq_len = max_num_elements // bucket_size
+
+    bucket_sizes.append((bucket_size, max_seq_len))
 
     if num_seqs_multiple_of == 1:
         return bucket_sizes

--- a/tests/unit/data/data_pipeline/test_bucket_by_length.py
+++ b/tests/unit/data/data_pipeline/test_bucket_by_length.py
@@ -21,3 +21,11 @@ def test_create_bucket_sizes_with_num_seqs_multiple_of() -> None:
     )
 
     assert bucket_sizes == [(8, 2), (4, 3), (4, 4), (2, 5), (2, 8)]
+
+
+def test_create_bucket_sizes_with_max_seq_len_equals_max_num_elements() -> None:
+    bucket_sizes = create_bucket_sizes(
+        max_num_elements=16, max_seq_len=16, min_seq_len=2
+    )
+
+    assert bucket_sizes == [(8, 2), (5, 3), (4, 4), (3, 5), (2, 8), (1, 16)]


### PR DESCRIPTION
This PR fixes the division by zero error in `create_bucket_sizes` if `max_seq_len` equals `max_num_elements`.