### PR TITLE
Rename llama instruct models

### DIFF
--- a/src/fairseq2/assets/cards/models/llama.yaml
+++ b/src/fairseq2/assets/cards/models/llama.yaml
@@ -79,7 +79,7 @@ model_arch: llama3_8b
 
 ---
 
-name: llama3_8b_chat
+name: llama3_8b_instruct
 base: llama3
 model_arch: llama3_8b
 model_config:
@@ -96,7 +96,7 @@ shard_embed_dim: false
 
 ---
 
-name: llama3_70b_chat
+name: llama3_70b_instruct
 base: llama3
 model_arch: llama3_70b
 model_config:

--- a/src/fairseq2/recipes/lm/instruction_finetune.py
+++ b/src/fairseq2/recipes/lm/instruction_finetune.py
@@ -56,7 +56,7 @@ class InstructionFinetuneConfig:
     dataset_name: str = "openeft"  # TODO: fix!
     """The dataset to train with."""
 
-    tokenizer_name: str = "llama3_8b_chat"
+    tokenizer_name: str = "llama3_8b_instruct"
     """The tokenizer to use."""
 
     max_seq_len: int = 4096


### PR DESCRIPTION
This PR renames LLaMA-3 instruct models from `chat` to `instruct` suffix to align with the original model names.