### PR TITLE
Fix ProcessGroup new_group bug

### DIFF
--- a/src/fairseq2/gang.py
+++ b/src/fairseq2/gang.py
@@ -461,7 +461,7 @@ class ProcessGroupGang(AbstractGang):
 
         pg = dist.new_group(ranks, backend=backend)
 
-        if pg is None:
+        if self._rank not in ranks:
             return None
 
         if self._monitor_pg is not None:


### PR DESCRIPTION
This PR fixes the bug in `ProcessGroup`'s `new_group` and correctly handles ranks that are not part of the newly created gang.