### PR TITLE
Fix metric name handling

### DIFF
--- a/src/fairseq2/metrics/bag.py
+++ b/src/fairseq2/metrics/bag.py
@@ -195,9 +195,9 @@ def sync_and_compute_metrics(bags: Sequence[MetricBag]) -> Optional[Dict[str, An
 
             all_metrics.update(bag._metrics)
 
-    logging.disable(logging.WARNING)  # Suppress "No calls to update()".
-
     try:
+        logging.disable(logging.WARNING)  # Suppress "No calls to update()".
+
         if gang.size == 1:
             values = {name: m.compute() for name, m in all_metrics.items()}
         else:
@@ -207,6 +207,14 @@ def sync_and_compute_metrics(bags: Sequence[MetricBag]) -> Optional[Dict[str, An
 
     if gang.rank == 0:
         assert values is not None
+
+        def strip_underscore(s: str) -> str:
+            if s.startswith("_"):
+                s = s[1:]
+
+            return s
+
+        values = {strip_underscore(n): v for n, v in values.items()}
 
         for bag in bags:
             bag.process_metric_values(values)

--- a/src/fairseq2/metrics/recorder.py
+++ b/src/fairseq2/metrics/recorder.py
@@ -180,9 +180,6 @@ class LogMetricRecorder(MetricRecorder):
         values_and_formatters = []
 
         for name, value in values.items():
-            if name and name[0] == "_":
-                name = name[1:]
-
             formatter = _metric_formatters.get(name)
             if formatter is None:
                 formatter = (name, 999, str)
@@ -249,9 +246,6 @@ class TensorBoardRecorder(MetricRecorder):
             return
 
         for name, value in values.items():
-            if name and name[0] == "_":
-                name = name[1:]
-
             pair = _metric_formatters.get(name)
             if pair is None:
                 display_name = name

--- a/src/fairseq2/recipes/wav2vec2/asr/metrics.py
+++ b/src/fairseq2/recipes/wav2vec2/asr/metrics.py
@@ -166,7 +166,7 @@ class Wav2Vec2AsrValidMetricBag(Wav2Vec2AsrMetricBag):
     def process_metric_values(self, values: Dict[str, Any]) -> None:
         super().process_metric_values(values)
 
-        uer, wer = values.pop("_wer")
+        uer, wer = values.pop("wer")
 
         values["uer"] = uer
         values["wer"] = wer


### PR DESCRIPTION
This PR moves the "private" metric name handling to `sync_and_compute`.