### PR TITLE
Suppress noisy FSDP logs

### DIFF
--- a/src/fairseq2/checkpoint.py
+++ b/src/fairseq2/checkpoint.py
@@ -484,7 +484,7 @@ class FileCheckpointManager(CheckpointManager):
 
         self._root_gang.barrier()
 
-        log.info("Model state dictionary extracted. Saving to file on data parallel rank 0.")  # fmt: skip
+        log.info("Model state dictionary extracted. Saving to file on data parallel rank 0 (per shard).")  # fmt: skip
 
         if self._dp_gang.rank == 0:
             tmp_model_file = self._checkpoint_dir.joinpath(


### PR DESCRIPTION
This PR suppresses the noisy trace information dumped by FSDP. Reported (and fixed) in https://github.com/pytorch/pytorch/issues/125025.