### PR TITLE
Include rank in log_model

### DIFF
--- a/src/fairseq2/recipes/lm/instruction_finetune.py
+++ b/src/fairseq2/recipes/lm/instruction_finetune.py
@@ -330,7 +330,7 @@ def load_instruction_finetuner(
     # used with padded inputs.
     enable_memory_efficient_torch_sdpa(dp_model, False)
 
-    log_model(dp_model, log)
+    log_model(dp_model, log, rank=root_gang.rank)
 
     # Initialize the criterion and the optimizer.
     criterion = InstructionFinetuneCriterion(dp_model, dp_gang)

--- a/src/fairseq2/recipes/wav2vec2/asr/eval.py
+++ b/src/fairseq2/recipes/wav2vec2/asr/eval.py
@@ -173,7 +173,7 @@ def load_wav2vec2_asr_evaluator(
 
         log.info("Model wrapped and broadcasted to all ranks.")
 
-    log_model(dp_model, log)
+    log_model(dp_model, log, rank=gang.rank)
 
     # Initialize the criterion.
     wer_file = output_dir.joinpath(f"wer/rank_{gang.rank}.txt")

--- a/src/fairseq2/recipes/wav2vec2/asr/train.py
+++ b/src/fairseq2/recipes/wav2vec2/asr/train.py
@@ -369,7 +369,7 @@ def load_wav2vec2_asr_trainer(
 
         log.info("Encoder compiled.")
 
-    log_model(dp_model, log)
+    log_model(dp_model, log, rank=gang.rank)
 
     # Initialize the criterion and the optimizer.
     criterion = Wav2Vec2AsrCriterion(

--- a/src/fairseq2/utils/log.py
+++ b/src/fairseq2/utils/log.py
@@ -242,7 +242,7 @@ def log_environment_variables(log: LogWriter) -> None:
     log.info("Environment Variables - {}", s)
 
 
-def log_model(model: Module, log: LogWriter) -> None:
+def log_model(model: Module, log: LogWriter, *, rank: Optional[int] = None) -> None:
     """Log information about ``model``."""
     # compat
     # TODO: move to module scope.
@@ -250,6 +250,11 @@ def log_model(model: Module, log: LogWriter) -> None:
 
     if not log.is_enabled_for(logging.INFO):
         return
+
+    if rank is None:
+        r = ""
+    else:
+        r = f" (rank {rank})"
 
     si = get_module_size(model)
 
@@ -264,4 +269,4 @@ def log_model(model: Module, log: LogWriter) -> None:
         f"Total Size (bytes): {si.total_size_bytes:,}"
     )
 
-    log.info("Model - {} | Layout:\n{}", s, model)
+    log.info("Model{} - {} | Layout:\n{}", r, s, model)


### PR DESCRIPTION
A small PR that includes the rank in `log_model()` to indicate that the reported sizes are "per-rank" (i.e. sharded sizes)