### PR TITLE
Introduce broadcast_module

### DIFF
--- a/src/fairseq2/recipes/utils/setup.py
+++ b/src/fairseq2/recipes/utils/setup.py
@@ -8,10 +8,12 @@ from datetime import timedelta
 from typing import Dict, Optional, Tuple
 
 import torch
+from torch.nn import Module
 
 from fairseq2.device import determine_default_device
 from fairseq2.gang import Gang, setup_default_gang, setup_parallel_gangs
 from fairseq2.logging import LogWriter
+from fairseq2.nn.utils.module import broadcast_module
 from fairseq2.recipes.utils.log import log_environment_info
 
 
@@ -78,3 +80,12 @@ def setup_gangs(
     log.info("Data and tensor parallel gangs initialized.")
 
     return root_gang, gangs
+
+
+def broadcast_model(model: Module, gang: Gang, log: LogWriter) -> None:
+    """Broadcast ``model`` to all processes in ``gang``."""
+    log.info("Broadcasting the model to all processes.")
+
+    broadcast_module(model, gang)
+
+    log.info("Model broadcasted.")


### PR DESCRIPTION
This PR introduces the `broadcast_module()` helper function and updates the wav2vec2 ASR evaluation recipe to use it. This significantly reduces the pressure on disk I/O for large models and instead broadcasts the module state over the network fabric. DDP and FSDP already offer a similar feature, but this is standalone and can be used with evaluation and inference jobs as well. 

As of today, we rely on the private `torch.distributed._broadcast_coalesced` function although its c10d counterpart is a public API. Once the P0 items are delivered today, I will expose `c10d::broadcast_coelesced` in fairseq2n and remove the private API use.