### PR TITLE
Start using ValueConverter in AssetCard

### DIFF
--- a/src/fairseq2/assets/card.py
+++ b/src/fairseq2/assets/card.py
@@ -7,7 +7,6 @@
 from __future__ import annotations
 
 import os
-from os import PathLike
 from pathlib import Path
 from typing import (
     AbstractSet,
@@ -17,19 +16,14 @@ from typing import (
     Mapping,
     MutableMapping,
     Optional,
-    Set,
-    Type,
     TypeVar,
-    cast,
     final,
-    overload,
 )
 from urllib.parse import urlparse, urlunparse
 
-from typing_extensions import Self
-
 from fairseq2.assets.error import AssetError
 from fairseq2.assets.utils import _starts_with_scheme
+from fairseq2.utils.value_converter import ValueConverter, default_value_converter
 
 T = TypeVar("T")
 
@@ -41,11 +35,14 @@ class AssetCard:
     _name: str
     _metadata: MutableMapping[str, Any]
     _base: Optional[AssetCard]
+    _value_converter: ValueConverter
 
     def __init__(
         self,
         metadata: MutableMapping[str, Any],
         base: Optional[AssetCard] = None,
+        *,
+        value_converter: Optional[ValueConverter] = None,
     ) -> None:
         """
         :param metadata:
@@ -53,6 +50,9 @@ class AssetCard:
             contain a specific piece of information about the asset.
         :param base:
             The card that this card derives from.
+        :param value_converter:
+            The :class:`ValueConverter` instance to use. If ``None``, the
+            default instance will be used.
         """
         try:
             name = metadata["name"]
@@ -67,6 +67,7 @@ class AssetCard:
         self._name = name
         self._metadata = metadata
         self._base = base
+        self._value_converter = value_converter or default_value_converter
 
     def field(self, name: str) -> AssetCardField:
         """Return a field of this card.
@@ -152,7 +153,7 @@ class AssetCard:
         """Return the type of the asset represented by this card."""
         for field in ["model_type", "dataset_type", "tokenizer_type"]:
             try:
-                return self.field(field).as_(str)
+                return self.field(field).as_(str)  # type: ignore[no-any-return]
             except AssetCardFieldNotFoundError:
                 continue
 
@@ -164,7 +165,7 @@ class AssetCard:
         """Return the family of the asset represented by this card."""
         for field in ["model_family", "dataset_family", "tokenizer_family"]:
             try:
-                return self.field(field).as_(str)
+                return self.field(field).as_(str)  # type: ignore[no-any-return]
             except AssetCardFieldNotFoundError:
                 continue
 
@@ -213,67 +214,40 @@ class AssetCardField:
         """
         return AssetCardField(self._card, self._path + [name])
 
-    def is_none(self) -> bool:
-        """Return ``True`` if the value of the field is ``None``."""
-        value = self._card._get_field_value(self._card.name, self._path)
-
-        return value is None
-
-    def exists(self, *, allow_empty: bool = False) -> bool:
+    def exists(self) -> bool:
+        """Return ``True`` if the field exists."""
         try:
-            self.as_(object, allow_empty=allow_empty)
+            self._card._get_field_value(self._card.name, self._path)
 
             return True
         except AssetCardFieldNotFoundError:
             return False
 
-    @overload
-    def get_as_(self, kls: Type[T], default: T, *, allow_empty: bool = False) -> T:
-        ...
-
-    @overload
-    def get_as_(
-        self, kls: Type[T], default: None = None, *, allow_empty: bool = False
-    ) -> Optional[T]:
-        ...
-
-    def get_as_(
-        self, kls: Type[T], default: Optional[T] = None, *, allow_empty: bool = False
-    ) -> Optional[T]:
-        """Return the value of this field if it exists; otherwise, return ``default``.
-
-        :param default:
-            The default value.
-        :param allow_empty:
-            If ``True``, allows the field to be empty.
-        """
-        try:
-            return self.as_(kls, allow_empty=True)
-        except AssetCardFieldNotFoundError:
-            return default
-
-    def as_(self, kls: Type[T], *, allow_empty: bool = False) -> T:
+    def as_(self, type_hint: Any, *, allow_empty: bool = False) -> Any:
         """Return the value of this field.
 
-        :param kls:
-            The type of the field.
+        :param type_hint:
+            The type hint of the field.
         :param allow_empty:
             If ``True``, allows the field to be empty.
         """
-        value = self._card._get_field_value(self._card.name, self._path)
+        unstructured_value = self._card._get_field_value(self._card.name, self._path)
+
+        try:
+            value = self._card._value_converter.structure(unstructured_value, type_hint)
+        except ValueError as ex:
+            raise ValueError(
+                "`type_hint` must be a supported type annotation. See nested exception for details."
+            ) from ex
+        except TypeError as ex:
+            pathname = ".".join(self._path)
+
+            raise AssetCardError(
+                f"The value of the field '{pathname}' of the asset card '{self._card.name}' cannot be retrieved as `{type_hint}`. See nested exception for details."
+            ) from ex
+
         if value is None:
-            pathname = ".".join(self._path)
-
-            raise AssetCardError(
-                f"The value of the field '{pathname}' of the asset card '{self._card.name}' must not be `None`."
-            )
-
-        if not isinstance(value, kls):
-            pathname = ".".join(self._path)
-
-            raise AssetCardError(
-                f"The value of the field '{pathname}' of the asset card '{self._card.name}' must be of type `{kls}`, but is of type `{type(value)}` instead."
-            )
+            return value
 
         if not allow_empty and not value:
             pathname = ".".join(self._path)
@@ -284,65 +258,16 @@ class AssetCardField:
 
         return value
 
-    def as_list(self, kls: Type[T], *, allow_empty: bool = False) -> List[T]:
-        """Return the value of this field as a :class:`list` of type ``kls``.
-
-        :param kls:
-            The type of the field elements.
-        :param allow_empty:
-            If ``True``, allows the list to be empty.
-        """
-        value = self.as_(list, allow_empty=allow_empty)
-
-        for idx, element in enumerate(value):
-            if not isinstance(element, kls):
-                pathname = ".".join(self._path)
-
-                raise AssetCardError(
-                    f"The elements of the field '{pathname}' of the asset card '{self._card.name}' must be of type `{kls}`, but the element at index {idx} is of type `{type(element)}` instead."
-                )
-
-        return value
-
-    def as_dict(self, kls: Type[T], *, allow_empty: bool = False) -> Dict[str, T]:
-        """Return the value of this field as a :class:`dict` of type ``kls``.
-
-        :param kls:
-            The type of the field values.
-        :param allow_empty:
-            If ``True``, allows the dictionary to be empty.
-        """
-        value = self.as_(dict, allow_empty=allow_empty)
-
-        for key, val in value.items():
-            if not isinstance(val, kls):
-                pathname = ".".join(self._path)
-
-                raise AssetCardError(
-                    f"The items of the field '{pathname}' of the asset card '{self._card.name}' must be of type `{kls}`, but the item '{key}' is of type `{type(val)}` instead."
-                )
-
-        return value
-
-    def as_set(self, kls: Type[T], *, allow_empty: bool = False) -> Set[T]:
-        """Return the value of this field as a :class:`set` of type ``kls``.
-
-        :param kls:
-            The type of the field elements.
-        :param allow_empty:
-            If ``True``, allows the list to be empty.
-        """
-        value = self.as_list(kls, allow_empty=allow_empty)
-
-        return set(value)
-
-    def as_one_of(self, valid_values: AbstractSet[T]) -> T:
+    def as_one_of(self, valid_values: AbstractSet[str]) -> str:
         """Return the value of this field as one of the values in ``valid_values``
 
         :param values:
             The values to check against.
         """
-        value = self.as_(object)
+        if not valid_values:
+            raise ValueError("`valid_values` must not be empty.")
+
+        value = self.as_(str)
 
         if value not in valid_values:
             pathname = ".".join(self._path)
@@ -355,21 +280,14 @@ class AssetCardField:
                 f"The value of the field '{pathname}' of the asset card '{self._card.name}' must be one of {repr(values)}, but is {repr(value)} instead."
             )
 
-        return cast(T, value)
+        return value  # type: ignore[no-any-return]
 
     def as_uri(self) -> str:
         """Return the value of this field as a URI."""
-        value = self.as_(object)
-
-        if not isinstance(value, (str, PathLike)):
-            pathname = ".".join(self._path)
-
-            raise AssetCardError(
-                f"The value of the field '{pathname}' of the asset card '{self._card.name}' must be of type `{str}` or `{PathLike}`, but is of type `{type(value)}` instead."
-            )
+        value = self.as_(str)
 
         try:
-            if isinstance(value, PathLike) or not _starts_with_scheme(value):
+            if not _starts_with_scheme(value):
                 path = Path(value)
                 if not path.is_absolute():
                     base_path = self._card.metadata.get("__base_path__")
@@ -378,7 +296,7 @@ class AssetCardField:
 
                 return path.as_uri()
 
-            return urlunparse(urlparse(value))
+            return urlunparse(urlparse(value))  # type: ignore[no-any-return]
         except ValueError as ex:
             pathname = ".".join(self._path)
 
@@ -397,22 +315,33 @@ class AssetCardField:
                 f"The value of the field '{pathname}' of the asset card '{self._card.name}' must be a filename, but is '{value}' instead."
             )
 
-        return value
+        return value  # type: ignore[no-any-return]
+
+    def get_as_(
+        self, type_hint: Any, default: Optional[T] = None, *, allow_empty: bool = False
+    ) -> Any:
+        """Return the value of this field if it exists; otherwise, return ``default``.
+
+        :param default:
+            The default value.
+        :param allow_empty:
+            If ``True``, allows the field to be empty.
+        """
+        try:
+            return self.as_(type_hint, allow_empty=True)
+        except AssetCardFieldNotFoundError:
+            return default
 
     def set(self, value: Any) -> None:
         """Set the value of this field."""
-        self._card._set_field_value(self._path, value)
+        try:
+            unstructured_value = self._card._value_converter.unstructure(value)
+        except TypeError as ex:
+            raise TypeError(
+                "`value` must be of a supported type. See nested exception for details."
+            ) from ex
 
-    def check_equals(self, value: Any) -> Self:
-        """Check if the value of this field equals to ``value``."""
-        if (v := self.as_(object)) != value:
-            pathname = ".".join(self._path)
-
-            raise AssetCardError(
-                f"The value of the field '{pathname}' of the asset card '{self._card.name}' must be {repr(value)}, but is {repr(v)} instead."
-            )
-
-        return self
+        self._card._set_field_value(self._path, unstructured_value)
 
 
 class AssetCardError(AssetError):

--- a/src/fairseq2/datasets/parallel_text.py
+++ b/src/fairseq2/datasets/parallel_text.py
@@ -455,10 +455,10 @@ class NllbDatasetLoader(AbstractDatasetLoader[NllbDataset]):
 
         splits_field = card.field("splits")
 
-        for split in splits_field.as_dict(dict).keys():
+        for split in splits_field.as_(Dict[str, str]).keys():
             lang_pairs = {}
 
-            for key, size in splits_field.field(split).as_dict(int).items():
+            for key, size in splits_field.field(split).as_(Dict[str, int]).items():
                 try:
                     source_lang, target_lang = key.split("-")
                 except ValueError as ex:

--- a/src/fairseq2/models/nllb/setup.py
+++ b/src/fairseq2/models/nllb/setup.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from pathlib import Path
-from typing import Any, Dict, final
+from typing import Any, Dict, List, final
 
 import torch
 
@@ -105,7 +105,7 @@ class NllbTokenizerLoader(AbstractTextTokenizerLoader[NllbTokenizer]):
 
     @override
     def _load(self, path: Path, card: AssetCard) -> NllbTokenizer:
-        langs = card.field("langs").as_list(str)
+        langs = card.field("langs").as_(List[str])
 
         default_lang = card.field("default_lang").as_(str)
 

--- a/src/fairseq2/models/s2t_transformer/setup.py
+++ b/src/fairseq2/models/s2t_transformer/setup.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from pathlib import Path
-from typing import Any, Dict, Final, final
+from typing import Any, Dict, Final, List, final
 
 from fairseq2.assets import AssetCard
 from fairseq2.data.text import AbstractTextTokenizerLoader
@@ -109,7 +109,7 @@ class S2TTransformerTokenizerLoader(
     def _load(self, path: Path, card: AssetCard) -> S2TTransformerTokenizer:
         task = card.field("task").as_one_of(self._VALID_TASKS)
 
-        target_langs = card.field("target_langs").as_list(str)
+        target_langs = card.field("target_langs").as_(List[str])
 
         return S2TTransformerTokenizer(
             path, task, set(target_langs), default_target_lang=target_langs[0]

--- a/src/fairseq2/utils/dataclass.py
+++ b/src/fairseq2/utils/dataclass.py
@@ -54,10 +54,10 @@ def update_dataclass(
             # Recursively traverse child dataclasses.
             if override is not None and is_dataclass_instance(value):
                 if not isinstance(override, Mapping):
-                    p = ".".join(field_path + [field.name])
+                    pathname = ".".join(field_path + [field.name])
 
                     raise FieldError(
-                        p, f"The field '{p}' is expected to be of type `{type(value)}`, but is of type `{type(override)}` instead."  # fmt: skip
+                        pathname, f"The field '{pathname}' is expected to be of type `{type(value)}`, but is of type `{type(override)}` instead."  # fmt: skip
                     )
 
                 field_path.append(field.name)
@@ -70,11 +70,11 @@ def update_dataclass(
 
                 try:
                     override = value_converter.structure(override, type_hint)
-                except TypeError as ex:
-                    p = ".".join(field_path + [field.name])
+                except (TypeError, ValueError) as ex:
+                    pathname = ".".join(field_path + [field.name])
 
                     raise FieldError(
-                        p, f"The value of the field '{p}' cannot be parsed. See nested exception for details"  # fmt: skip
+                        pathname, f"The value of the field '{pathname}' cannot be parsed. See nested exception for details"  # fmt: skip
                     ) from ex
 
                 setattr(obj_, field.name, override)


### PR DESCRIPTION
This PR revises the implementation of `AssetCard`. It now uses `ValueConverter` like the rest of the code base for stricter type checking/safety.