### PR TITLE
Set per-rank seed in trainer

### DIFF
--- a/src/fairseq2/recipes/lm/instruction_finetune.py
+++ b/src/fairseq2/recipes/lm/instruction_finetune.py
@@ -362,9 +362,6 @@ def load_instruction_finetuner(
         final_lr=config.lr * config.final_lr_ratio,
     )
 
-    # Set the seed for training.
-    rng_bag.manual_seed(config.seed + dp_gang.rank)
-
     # Set up the finetuner.
     return StandardTrainer[SequenceBatch](
         criterion=criterion,
@@ -386,7 +383,7 @@ def load_instruction_finetuner(
         publish_metrics_every_n_steps=config.publish_metrics_every_n_steps,
         profile=config.profile,
         anomaly_detection=config.anomaly_detection,
-        rng_bag=rng_bag,
+        seed=config.seed,
         wall_watch=wall_watch,
     )
 

--- a/src/fairseq2/recipes/wav2vec2/asr/train.py
+++ b/src/fairseq2/recipes/wav2vec2/asr/train.py
@@ -379,9 +379,6 @@ def load_wav2vec2_asr_trainer(
         final_lr_scale=config.final_lr_scale,
     )
 
-    # Set the seed for training.
-    rng_bag.manual_seed(config.seed + gang.rank)
-
     # Initialize the trainer.
     return StandardTrainer[Seq2SeqBatch](
         criterion=criterion,
@@ -403,6 +400,6 @@ def load_wav2vec2_asr_trainer(
         publish_metrics_every_n_steps=config.publish_metrics_every_n_steps,
         profile=config.profile,
         anomaly_detection=config.anomaly_detection,
-        rng_bag=rng_bag,
+        seed=config.seed,
         wall_watch=wall_watch,
     )


### PR DESCRIPTION
This PR moves the `manual_seed` call for per-rank RNG initialization to `StandardTrainer`.