### PR TITLE
Introduce temporary_manual_seed()

### DIFF
--- a/src/fairseq2/assets/store.py
+++ b/src/fairseq2/assets/store.py
@@ -173,7 +173,7 @@ class StandardAssetStore(AssetStore):
             name = name[:-1]
 
         raise AssetNotFoundError(
-            name, f"An asset with the name '{name}' cannot be found. Run `fairseq2 assets list` command to see the list of available assets."  # fmt: skip
+            name, f"An asset with the name '{name}' cannot be found. Run `fairseq2 assets list` to see the list of available assets."  # fmt: skip
         )
 
     @override

--- a/src/fairseq2/models/loader.py
+++ b/src/fairseq2/models/loader.py
@@ -185,7 +185,7 @@ class DenseModelLoader(ModelLoader[ModelT], Generic[ModelT, ModelConfigT]):
         if gang is not None:
             if device is None:
                 device = gang.device
-            elif device != gang.device and device != META:
+            elif device != gang.device and device.type != "meta":
                 raise ValueError(
                     "`device` must either match `gang['tp'].device` or must be of type `meta`."
                 )
@@ -224,7 +224,7 @@ class DenseModelLoader(ModelLoader[ModelT], Generic[ModelT, ModelConfigT]):
 
         config = self._config_loader(card)
 
-        if device == META:
+        if device.type == "meta":
             try:
                 model = self._factory(config, device=META, dtype=dtype)
             except NotImplementedError as ex:
@@ -314,7 +314,7 @@ class DenseModelLoader(ModelLoader[ModelT], Generic[ModelT, ModelConfigT]):
                 f"{card.name} cannot be loaded. See nested exception for details."
             ) from ex
 
-        if model_device == META:
+        if model_device.type == "meta":
             # Non-persistent buffers are not included in the checkpoint, so we
             # have to explicitly initialize them.
             reset_non_persistent_buffers(model)

--- a/src/fairseq2/models/utils/generic_loaders.py
+++ b/src/fairseq2/models/utils/generic_loaders.py
@@ -330,7 +330,7 @@ class ModelLoader(Generic[ModelT, ConfigT]):
                         "`model_factory` returned a model that is not constructed correctly. See nested exception for details."
                     ) from ex
 
-        if model_device == META:
+        if model_device.type == "meta":
             # Move the model to the actual device without initializing. Its
             # state will be overwritten by the checkpoint anyways.
             to_empty(model, device=device or CPU)
@@ -350,7 +350,7 @@ class ModelLoader(Generic[ModelT, ConfigT]):
                 f"{card.name} cannot be loaded. See nested exception for details."
             ) from ex
 
-        if model_device == META:
+        if model_device.type == "meta":
             # Non-persistent buffers are not included in the checkpoint, so we
             # have to explicitly initialize them.
             reset_non_persistent_buffers(model)

--- a/src/fairseq2/nn/embedding.py
+++ b/src/fairseq2/nn/embedding.py
@@ -163,7 +163,7 @@ class VocabShardedEmbedding(Embedding):
         """
         device = embed.weight.device
 
-        if device != gang.device and device != META:
+        if device != gang.device and device.type != "meta":
             raise ValueError(
                 "The device of `embed` must either match `gang.device` or must be of type `meta`."
             )
@@ -178,7 +178,7 @@ class VocabShardedEmbedding(Embedding):
             dtype=embed.weight.dtype,
         )
 
-        if device != META:
+        if device.type != "meta":
             to_empty(sharded, device)
 
         sharded._copy_weight(embed)
@@ -223,7 +223,7 @@ class VocabShardedEmbedding(Embedding):
 
         if device is None:
             device = gang.device
-        elif device != gang.device and device != META:
+        elif device != gang.device and device.type != "meta":
             raise ValueError(
                 "`device` must either match `gang.device` or must be of type `meta`."
             )
@@ -343,7 +343,7 @@ class ShardedEmbedding(Embedding):
         """
         device = embed.weight.device
 
-        if device != gang.device and device != META:
+        if device != gang.device and device.type != "meta":
             raise ValueError(
                 "The device of `embed` must either match `gang.device` or must be of type `meta`."
             )
@@ -358,7 +358,7 @@ class ShardedEmbedding(Embedding):
             dtype=embed.weight.dtype,
         )
 
-        if device != META:
+        if device.type != "meta":
             to_empty(sharded, device)
 
         sharded._copy_weight(embed)
@@ -403,7 +403,7 @@ class ShardedEmbedding(Embedding):
 
         if device is None:
             device = gang.device
-        elif device != gang.device and device != META:
+        elif device != gang.device and device.type != "meta":
             raise ValueError(
                 "`device` must either match `gang.device` or must be of type `meta`."
             )

--- a/src/fairseq2/nn/fsdp.py
+++ b/src/fairseq2/nn/fsdp.py
@@ -31,7 +31,7 @@ from fairseq2.nn.utils.module import (
     reset_parameters,
     to_empty,
 )
-from fairseq2.typing import META, DataType, Device
+from fairseq2.typing import DataType, Device
 from fairseq2.utils.version import torch_greater_or_equal
 
 log = get_log_writer(__name__)
@@ -116,7 +116,8 @@ def to_fsdp(
 
     param_init_fn = None
 
-    if infer_device(module) == META:
+    module_device = infer_device(module)
+    if module_device.type == "meta":
         if not torch_greater_or_equal(2, 1):
             log.warning("FSDP meta initialization is only supported on PyTorch 2.1.0 and later.")  # fmt: skip
 
@@ -128,6 +129,8 @@ def to_fsdp(
             param_init_fn = FSDPParameterInitializer(gang.device, skip_init)
 
     if mixed_precision_dtype is None:
+        mp = None
+    elif mixed_precision_dtype == torch.float32:
         mp = None
     else:
         reduce_dtype = torch.float32 if fp32_reduce else mixed_precision_dtype

--- a/src/fairseq2/nn/position_encoder.py
+++ b/src/fairseq2/nn/position_encoder.py
@@ -17,7 +17,7 @@ from torch.nn.parameter import Parameter
 
 from fairseq2.nn.incremental_state import IncrementalStateBag
 from fairseq2.nn.padding import PaddingMask
-from fairseq2.typing import META, DataType, Device, override
+from fairseq2.typing import DataType, Device, override
 
 
 class PositionEncoder(Module, ABC):
@@ -352,7 +352,7 @@ class RotaryEncoder(PositionEncoder):
         device = self.freqs.device
 
         # As of PyTorch 2.0, `torch.polar` does not support meta device.
-        if device == META:
+        if device.type == "meta":
             return
 
         complex_freqs = torch.view_as_complex(self.freqs)

--- a/src/fairseq2/nn/projection.py
+++ b/src/fairseq2/nn/projection.py
@@ -162,7 +162,7 @@ class ColumnShardedLinear(Projection):
         """
         device = linear.weight.device
 
-        if device != gang.device and device != META:
+        if device != gang.device and device.type != "meta":
             raise ValueError(
                 "The device of `linear` must either match `gang.device` or must be of type `meta`."
             )
@@ -178,7 +178,7 @@ class ColumnShardedLinear(Projection):
             dtype=linear.weight.dtype,
         )
 
-        if device != META:
+        if device.type != "meta":
             to_empty(sharded, device)
 
         sharded._copy_weight(linear)
@@ -224,7 +224,7 @@ class ColumnShardedLinear(Projection):
 
         if device is None:
             device = gang.device
-        elif device != gang.device and device != META:
+        elif device != gang.device and device.type != "meta":
             raise ValueError(
                 "`device` must either match `gang.device` or must be of type `meta`."
             )
@@ -362,7 +362,7 @@ class RowShardedLinear(Projection):
         """
         device = linear.weight.device
 
-        if device != gang.device and device != META:
+        if device != gang.device and device.type != "meta":
             raise ValueError(
                 "The device of `linear` must either match `gang.device` or must be of type `meta`."
             )
@@ -378,7 +378,7 @@ class RowShardedLinear(Projection):
             dtype=linear.weight.dtype,
         )
 
-        if device != META:
+        if device.type != "meta":
             to_empty(sharded, device)
 
         sharded._copy_weight(linear)
@@ -425,7 +425,7 @@ class RowShardedLinear(Projection):
 
         if device is None:
             device = gang.device
-        elif device != gang.device and device != META:
+        elif device != gang.device and device.type != "meta":
             raise ValueError(
                 "`device` must either match `gang.device` or must be of type `meta`."
             )

--- a/tests/common.py
+++ b/tests/common.py
@@ -4,8 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from contextlib import contextmanager
-from typing import Any, Generator, List, Union
+from typing import Any, List, Union
 
 import torch
 from torch import Tensor
@@ -41,22 +40,3 @@ def has_no_inf(a: Tensor) -> bool:
 def has_no_nan(a: Tensor) -> bool:
     """Return ``True`` if ``a`` has no NaN element."""
     return not torch.any(torch.isnan(a))
-
-
-@contextmanager
-def tmp_rng_seed(device: Device, seed: int = 0) -> Generator[None, None, None]:
-    """Set a temporary manual RNG seed.
-
-    The RNG is reset to its original state once the block is exited.
-    """
-    device = Device(device)
-
-    if device.type == "cuda":
-        devices = [device]
-    else:
-        devices = []
-
-    with torch.random.fork_rng(devices):
-        torch.manual_seed(seed)
-
-        yield

--- a/tests/unit/nn/test_position_encoder.py
+++ b/tests/unit/nn/test_position_encoder.py
@@ -14,7 +14,8 @@ from fairseq2.nn import (
     RotaryEncoder,
     SinusoidalPositionEncoder,
 )
-from tests.common import assert_close, device, tmp_rng_seed
+from fairseq2.utils.rng import temporary_manual_seed
+from tests.common import assert_close, device
 
 
 class TestSinusoidalPositionEncoder:
@@ -172,12 +173,12 @@ class TestSinusoidalPositionEncoder:
 
 class TestLearnedPositionEncoder:
     def test_init_works(self) -> None:
-        with tmp_rng_seed(device):
+        with temporary_manual_seed([device], seed=2):
             m = LearnedPositionEncoder(encoding_dim=32, max_seq_len=10, device=device)
 
         assert m.weight.dtype == torch.float32
 
-        with tmp_rng_seed(device):
+        with temporary_manual_seed([device], seed=2):
             expected_weight = torch.randn(10, 32, device=device)
 
         assert_close(m.weight, expected_weight)

--- a/tests/unit/optim/test_adamw.py
+++ b/tests/unit/optim/test_adamw.py
@@ -15,7 +15,8 @@ from torch.optim import AdamW as BaseAdamW
 
 from fairseq2.optim import AdamW
 from fairseq2.typing import DataType
-from tests.common import assert_close, device, tmp_rng_seed
+from fairseq2.utils.rng import temporary_manual_seed
+from tests.common import assert_close, device
 
 
 class AdamWTestNet(Module):
@@ -55,10 +56,10 @@ class TestAdamW:
                 assert_close(p1, p2)
 
     def run_step(self, dtype: DataType) -> Tuple[Module, Module]:
-        with tmp_rng_seed(device):
+        with temporary_manual_seed([device], seed=2):
             net1 = AdamWTestNet(dtype)
 
-        with tmp_rng_seed(device):
+        with temporary_manual_seed([device], seed=2):
             net2 = AdamWTestNet(dtype)
 
         opt1 = AdamW(


### PR DESCRIPTION
This PR introduces a new `temporary_manual_seed()` function which is a "cleaner" way to `torch.random.fork_rng() + torch.manual_seed()` as it internally uses `RngBag` to correctly set the seed only for the passed devices. It also extends `reset_parameters()` and `to_device()` utility functions with an extra convenience `seed` parameter.