### PR TITLE
Move model arch definitions from factory.py

### DIFF
--- a/src/fairseq2/assets/cards/models/nllb-200.yaml
+++ b/src/fairseq2/assets/cards/models/nllb-200.yaml
@@ -5,8 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 name: nllb-200
-model_type: nllb  # compat
-model_family: nllb
+model_type: transformer  # compat
+model_family: transformer
 tokenizer: "https://tinyurl.com/flores200sacrebleuspm"
 default_lang: eng_Latn
 langs:
@@ -217,26 +217,26 @@ langs:
 
 name: nllb-200_dense_1b
 base: nllb-200
-model_arch: dense_1b
+model_arch: nllb-200_dense_1b
 checkpoint: "https://tinyurl.com/nllb200dense1bcheckpoint"
 
 ---
 
 name: nllb-200_dense_3b
 base: nllb-200
-model_arch: dense_3b
+model_arch: nllb-200_dense_3b
 checkpoint: "https://tinyurl.com/nllb200dense3bcheckpoint"
 
 ---
 
 name: nllb-200_dense_distill_1b
 base: nllb-200
-model_arch: dense_1b
+model_arch: nllb-200_dense_1b
 checkpoint: "https://tinyurl.com/nllb200densedst1bcheckpoint"
 
 ---
 
 name: nllb-200_dense_distill_600m
 base: nllb-200
-model_arch: dense_600m
+model_arch: nllb-200_dense_600m
 checkpoint: "https://tinyurl.com/nllb200densedst600mcheckpoint"

--- a/src/fairseq2/models/__init__.py
+++ b/src/fairseq2/models/__init__.py
@@ -25,6 +25,7 @@ from fairseq2.models.llama import _register_llama
 from fairseq2.models.mistral import _register_mistral
 from fairseq2.models.nllb import _register_nllb
 from fairseq2.models.s2t_transformer import _register_s2t_transformer
+from fairseq2.models.transformer import _register_transformer
 from fairseq2.models.w2vbert import _register_w2vbert
 from fairseq2.models.wav2vec2 import _register_wav2vec2
 from fairseq2.models.wav2vec2.asr import _register_wav2vec2_asr
@@ -35,6 +36,7 @@ def _register_models() -> None:
     _register_mistral()
     _register_nllb()
     _register_s2t_transformer()
+    _register_transformer()
     _register_w2vbert()
     _register_wav2vec2()
     _register_wav2vec2_asr()

--- a/src/fairseq2/models/llama/__init__.py
+++ b/src/fairseq2/models/llama/__init__.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from fairseq2.models.llama.archs import llama_arch as llama_arch
+from fairseq2.models.llama.archs import llama_archs as llama_archs
 from fairseq2.models.llama.chatbot import LLaMA3Chatbot as LLaMA3Chatbot
 from fairseq2.models.llama.chatbot import LLaMAChatbot as LLaMAChatbot
 from fairseq2.models.llama.chatbot import create_llama_chatbot as create_llama_chatbot
@@ -12,21 +14,22 @@ from fairseq2.models.llama.factory import LLaMABuilder as LLaMABuilder
 from fairseq2.models.llama.factory import LLaMAConfig as LLaMAConfig
 from fairseq2.models.llama.factory import create_llama_model as create_llama_model
 from fairseq2.models.llama.factory import get_llama_lora_config as get_llama_lora_config
-from fairseq2.models.llama.factory import llama_arch as llama_arch
-from fairseq2.models.llama.factory import llama_archs as llama_archs
-from fairseq2.models.llama.setup import load_llama_config as load_llama_config
-from fairseq2.models.llama.setup import load_llama_model as load_llama_model
-from fairseq2.models.llama.setup import load_llama_tokenizer as load_llama_tokenizer
+from fairseq2.models.llama.loader import load_llama_config as load_llama_config
+from fairseq2.models.llama.loader import load_llama_model as load_llama_model
+from fairseq2.models.llama.loader import load_llama_tokenizer as load_llama_tokenizer
 from fairseq2.models.llama.tokenizer import LLaMA3Tokenizer as LLaMA3Tokenizer
 
 # isort: split
 
 from fairseq2.data.text import load_text_tokenizer
 from fairseq2.models.chatbot import create_chatbot
+from fairseq2.models.llama.archs import _register_llama_archs
 from fairseq2.models.loader import load_model
 
 
 def _register_llama() -> None:
+    _register_llama_archs()
+
     load_model.register(LLAMA_FAMILY, load_llama_model)
 
     load_text_tokenizer.register(LLAMA_FAMILY, load_llama_tokenizer)

--- a/src/fairseq2/models/llama/archs.py
+++ b/src/fairseq2/models/llama/archs.py
@@ -1,0 +1,112 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from fairseq2.config_registry import ConfigRegistry
+from fairseq2.data import VocabularyInfo
+from fairseq2.models.llama.factory import LLaMAConfig
+
+llama_archs = ConfigRegistry[LLaMAConfig]()
+
+llama_arch = llama_archs.decorator
+
+
+def _register_llama_archs() -> None:
+    @llama_arch("7b")
+    def _7b() -> LLaMAConfig:
+        return LLaMAConfig()
+
+    @llama_arch("13b")
+    def _13b() -> LLaMAConfig:
+        config = _7b()
+
+        config.model_dim = 5120
+        config.num_attn_heads = 40
+        config.num_key_value_heads = 40
+        config.ffn_inner_dim = 5120 * 4
+
+        return config
+
+    @llama_arch("33b")
+    def _33b() -> LLaMAConfig:
+        config = _7b()
+
+        config.model_dim = 6656
+        config.num_layers = 60
+        config.num_attn_heads = 52
+        config.num_key_value_heads = 52
+        config.ffn_inner_dim = 6656 * 4
+
+        return config
+
+    @llama_arch("65b")
+    def _65b() -> LLaMAConfig:
+        config = _7b()
+
+        config.model_dim = 8192
+        config.num_layers = 80
+        config.num_attn_heads = 64
+        config.num_key_value_heads = 64
+        config.ffn_inner_dim = 8192 * 4
+
+        return config
+
+    @llama_arch("llama2_7b")
+    def llama2_7b() -> LLaMAConfig:
+        config = _7b()
+
+        config.max_seq_len = 4096
+
+        return config
+
+    @llama_arch("llama2_13b")
+    def llama2_13b() -> LLaMAConfig:
+        config = _13b()
+
+        config.max_seq_len = 4096
+
+        return config
+
+    @llama_arch("llama2_70b")
+    def llama2_70b() -> LLaMAConfig:
+        config = _65b()
+
+        config.max_seq_len = 4096
+        config.num_key_value_heads = 8
+        config.ffn_inner_dim = int(8192 * 4 * 1.3)  # See A.2.1 in LLaMA 2
+        config.ffn_inner_dim_to_multiple = 4096
+
+        return config
+
+    @llama_arch("llama3_8b")
+    def llama3_8b() -> LLaMAConfig:
+        config = llama2_7b()
+
+        config.max_seq_len = 8192
+
+        config.vocab_info = VocabularyInfo(
+            size=128_256, unk_idx=None, bos_idx=128_000, eos_idx=128_001, pad_idx=None
+        )
+
+        config.num_key_value_heads = 8
+        config.ffn_inner_dim = int(4096 * 4 * 1.3)
+        config.ffn_inner_dim_to_multiple = 1024
+        config.rope_theta = 500_000.0
+
+        return config
+
+    @llama_arch("llama3_70b")
+    def llama3_70b() -> LLaMAConfig:
+        config = llama2_70b()
+
+        config.max_seq_len = 8192
+
+        config.vocab_info = VocabularyInfo(
+            size=128_256, unk_idx=None, bos_idx=128_000, eos_idx=128_001, pad_idx=None
+        )
+
+        config.rope_theta = 500_000.0
+
+        return config

--- a/src/fairseq2/models/llama/factory.py
+++ b/src/fairseq2/models/llama/factory.py
@@ -7,7 +7,6 @@
 from dataclasses import dataclass, field
 from typing import Final, Optional
 
-from fairseq2.config_registry import ConfigRegistry
 from fairseq2.data import VocabularyInfo
 from fairseq2.models.transformer import (
     TransformerDecoderModel,
@@ -80,117 +79,6 @@ class LLaMAConfig:
 
     dropout_p: float = 0.1
     """The dropout probability on outputs of Transformer layers."""
-
-
-llama_archs = ConfigRegistry[LLaMAConfig]()
-
-llama_arch = llama_archs.decorator
-
-
-@llama_arch("7b")
-def _7b() -> LLaMAConfig:
-    return LLaMAConfig()
-
-
-@llama_arch("13b")
-def _13b() -> LLaMAConfig:
-    config = _7b()
-
-    config.model_dim = 5120
-    config.num_attn_heads = 40
-    config.num_key_value_heads = 40
-    config.ffn_inner_dim = 5120 * 4
-
-    return config
-
-
-@llama_arch("33b")
-def _33b() -> LLaMAConfig:
-    config = _7b()
-
-    config.model_dim = 6656
-    config.num_layers = 60
-    config.num_attn_heads = 52
-    config.num_key_value_heads = 52
-    config.ffn_inner_dim = 6656 * 4
-
-    return config
-
-
-@llama_arch("65b")
-def _65b() -> LLaMAConfig:
-    config = _7b()
-
-    config.model_dim = 8192
-    config.num_layers = 80
-    config.num_attn_heads = 64
-    config.num_key_value_heads = 64
-    config.ffn_inner_dim = 8192 * 4
-
-    return config
-
-
-@llama_arch("llama2_7b")
-def _llama2_7b() -> LLaMAConfig:
-    config = _7b()
-
-    config.max_seq_len = 4096
-
-    return config
-
-
-@llama_arch("llama2_13b")
-def _llama2_13b() -> LLaMAConfig:
-    config = _13b()
-
-    config.max_seq_len = 4096
-
-    return config
-
-
-@llama_arch("llama2_70b")
-def _llama2_70b() -> LLaMAConfig:
-    config = _65b()
-
-    config.max_seq_len = 4096
-    config.num_key_value_heads = 8
-    config.ffn_inner_dim = int(8192 * 4 * 1.3)  # See A.2.1 in LLaMA 2
-    config.ffn_inner_dim_to_multiple = 4096
-
-    return config
-
-
-@llama_arch("llama3_8b")
-def _llama3_8b() -> LLaMAConfig:
-    config = _llama2_7b()
-
-    config.max_seq_len = 8192
-
-    config.vocab_info = VocabularyInfo(
-        size=128_256, unk_idx=None, bos_idx=128_000, eos_idx=128_001, pad_idx=None
-    )
-
-    config.num_key_value_heads = 8
-    config.ffn_inner_dim = int(4096 * 4 * 1.3)
-    config.ffn_inner_dim_to_multiple = 1024
-    config.rope_theta = 500_000.0
-
-    return config
-
-
-@llama_arch("llama3_70b")
-def _llama3_70b() -> LLaMAConfig:
-    config = _llama2_70b()
-
-    config.max_seq_len = 8192
-
-    config.vocab_info = VocabularyInfo(
-        size=128_256, unk_idx=None, bos_idx=128_000, eos_idx=128_001, pad_idx=None
-    )
-
-    config.rope_theta = 500_000.0
-
-    return config
 
 
 class LLaMABuilder:

--- a/src/fairseq2/models/llama/loader.py
+++ b/src/fairseq2/models/llama/loader.py
@@ -15,12 +15,8 @@ from fairseq2.data.text import (
 )
 from fairseq2.gang import Gang
 from fairseq2.models.config_loader import StandardModelConfigLoader
-from fairseq2.models.llama.factory import (
-    LLAMA_FAMILY,
-    LLaMAConfig,
-    create_llama_model,
-    llama_archs,
-)
+from fairseq2.models.llama.archs import llama_archs
+from fairseq2.models.llama.factory import LLAMA_FAMILY, LLaMAConfig, create_llama_model
 from fairseq2.models.llama.tokenizer import LLaMA3Tokenizer
 from fairseq2.models.loader import DenseModelLoader
 from fairseq2.models.transformer import (

--- a/src/fairseq2/models/mistral/__init__.py
+++ b/src/fairseq2/models/mistral/__init__.py
@@ -4,16 +4,16 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from fairseq2.models.mistral.archs import mistral_arch as mistral_arch
+from fairseq2.models.mistral.archs import mistral_archs as mistral_archs
 from fairseq2.models.mistral.chatbot import MistralChatbot as MistralChatbot
 from fairseq2.models.mistral.factory import MISTRAL_FAMILY as MISTRAL_FAMILY
 from fairseq2.models.mistral.factory import MistralBuilder as MistralBuilder
 from fairseq2.models.mistral.factory import MistralConfig as MistralConfig
 from fairseq2.models.mistral.factory import create_mistral_model as create_mistral_model
-from fairseq2.models.mistral.factory import mistral_arch as mistral_arch
-from fairseq2.models.mistral.factory import mistral_archs as mistral_archs
-from fairseq2.models.mistral.setup import load_mistral_config as load_mistral_config
-from fairseq2.models.mistral.setup import load_mistral_model as load_mistral_model
-from fairseq2.models.mistral.setup import (
+from fairseq2.models.mistral.loader import load_mistral_config as load_mistral_config
+from fairseq2.models.mistral.loader import load_mistral_model as load_mistral_model
+from fairseq2.models.mistral.loader import (
     load_mistral_tokenizer as load_mistral_tokenizer,
 )
 
@@ -22,9 +22,12 @@ from fairseq2.models.mistral.setup import (
 from fairseq2.data.text import load_text_tokenizer
 from fairseq2.models.chatbot import create_chatbot
 from fairseq2.models.loader import load_model
+from fairseq2.models.mistral.archs import _register_mistral_archs
 
 
 def _register_mistral() -> None:
+    _register_mistral_archs()
+
     load_model.register(MISTRAL_FAMILY, load_mistral_model)
 
     load_text_tokenizer.register(MISTRAL_FAMILY, load_mistral_tokenizer)

--- a/src/fairseq2/models/mistral/archs.py
+++ b/src/fairseq2/models/mistral/archs.py
@@ -1,0 +1,18 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from fairseq2.config_registry import ConfigRegistry
+from fairseq2.models.mistral.factory import MistralConfig
+
+mistral_archs = ConfigRegistry[MistralConfig]()
+
+mistral_arch = mistral_archs.decorator
+
+
+def _register_mistral_archs() -> None:
+    @mistral_arch("7b")
+    def _7b() -> MistralConfig:
+        return MistralConfig()

--- a/src/fairseq2/models/mistral/factory.py
+++ b/src/fairseq2/models/mistral/factory.py
@@ -7,7 +7,6 @@
 from dataclasses import dataclass, field
 from typing import Final, Optional
 
-from fairseq2.config_registry import ConfigRegistry
 from fairseq2.data import VocabularyInfo
 from fairseq2.models.transformer import (
     TransformerDecoderModel,
@@ -73,16 +72,6 @@ class MistralConfig:
 
     dropout_p: float = 0.1
     """The dropout probability on outputs of Transformer layers."""
-
-
-mistral_archs = ConfigRegistry[MistralConfig]()
-
-mistral_arch = mistral_archs.decorator
-
-
-@mistral_arch("7b")
-def _7b() -> MistralConfig:
-    return MistralConfig()
 
 
 class MistralBuilder:

--- a/src/fairseq2/models/mistral/loader.py
+++ b/src/fairseq2/models/mistral/loader.py
@@ -9,11 +9,11 @@ from typing import Any, Dict
 from fairseq2.data.text import default_basic_sentencepiece_tokenizer_loader
 from fairseq2.models.config_loader import StandardModelConfigLoader
 from fairseq2.models.loader import DenseModelLoader
+from fairseq2.models.mistral.archs import mistral_archs
 from fairseq2.models.mistral.factory import (
     MISTRAL_FAMILY,
     MistralConfig,
     create_mistral_model,
-    mistral_archs,
 )
 from fairseq2.models.utils.checkpoint import convert_model_state_dict
 

--- a/src/fairseq2/models/nllb/__init__.py
+++ b/src/fairseq2/models/nllb/__init__.py
@@ -4,24 +4,24 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from fairseq2.models.nllb.factory import NLLB_FAMILY as NLLB_FAMILY
-from fairseq2.models.nllb.factory import NllbBuilder as NllbBuilder
-from fairseq2.models.nllb.factory import NllbConfig as NllbConfig
-from fairseq2.models.nllb.factory import create_nllb_model as create_nllb_model
-from fairseq2.models.nllb.factory import nllb_arch as nllb_arch
-from fairseq2.models.nllb.factory import nllb_archs as nllb_archs
-from fairseq2.models.nllb.setup import load_nllb_config as load_nllb_config
-from fairseq2.models.nllb.setup import load_nllb_model as load_nllb_model
-from fairseq2.models.nllb.setup import load_nllb_tokenizer as load_nllb_tokenizer
+from fairseq2.models.nllb.loader import load_nllb_tokenizer as load_nllb_tokenizer
 from fairseq2.models.nllb.tokenizer import NllbTokenizer as NllbTokenizer
 
 # isort: split
 
 from fairseq2.data.text import load_text_tokenizer
-from fairseq2.models.loader import load_model
+from fairseq2.models.nllb.archs import _register_nllb_archs
 
 
 def _register_nllb() -> None:
-    load_model.register(NLLB_FAMILY, load_nllb_model)
+    _register_nllb_archs()
 
-    load_text_tokenizer.register(NLLB_FAMILY, load_nllb_tokenizer)
+    load_text_tokenizer.register("nllb", load_nllb_tokenizer)
+
+
+# isort: split
+
+# compat
+from fairseq2.models.transformer import load_transformer_model
+
+load_nllb_model = load_transformer_model

--- a/src/fairseq2/models/nllb/archs.py
+++ b/src/fairseq2/models/nllb/archs.py
@@ -1,0 +1,50 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from fairseq2.data import VocabularyInfo
+from fairseq2.models.transformer import (
+    TransformerConfig,
+    transformer_arch,
+    transformer_archs,
+)
+from fairseq2.nn.transformer import TransformerNormOrder
+
+
+def _register_nllb_archs() -> None:
+    @transformer_arch("nllb-200_dense_600m")
+    def dense_600m() -> TransformerConfig:
+        config = dense_1b()
+
+        config.num_encoder_layers = 12
+        config.num_decoder_layers = 12
+        config.ffn_inner_dim = 1024 * 4
+
+        return config
+
+    @transformer_arch("nllb-200_dense_1b")
+    def dense_1b() -> TransformerConfig:
+        config = transformer_archs.get("base")
+
+        config.model_dim = 1024
+        config.vocab_info = VocabularyInfo(
+            size=256206, unk_idx=1, bos_idx=2, eos_idx=3, pad_idx=0
+        )
+        config.num_encoder_layers = 24
+        config.num_decoder_layers = 24
+        config.num_encoder_attn_heads = 16
+        config.num_decoder_attn_heads = 16
+        config.ffn_inner_dim = 1024 * 8
+        config.norm_order = TransformerNormOrder.PRE
+
+        return config
+
+    @transformer_arch("nllb-200_dense_3b")
+    def dense_3b() -> TransformerConfig:
+        config = dense_1b()
+
+        config.model_dim = 2048
+
+        return config

--- a/src/fairseq2/models/nllb/loader.py
+++ b/src/fairseq2/models/nllb/loader.py
@@ -1,0 +1,29 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from pathlib import Path
+from typing import List, final
+
+from fairseq2.assets import AssetCard
+from fairseq2.data.text import AbstractTextTokenizerLoader
+from fairseq2.models.nllb.tokenizer import NllbTokenizer
+from fairseq2.typing import override
+
+
+@final
+class NllbTokenizerLoader(AbstractTextTokenizerLoader[NllbTokenizer]):
+    """Loads NLLB tokenizers."""
+
+    @override
+    def _load(self, path: Path, card: AssetCard) -> NllbTokenizer:
+        langs = card.field("langs").as_(List[str])
+
+        default_lang = card.field("default_lang").as_(str)
+
+        return NllbTokenizer(path, langs, default_lang)
+
+
+load_nllb_tokenizer = NllbTokenizerLoader()

--- a/src/fairseq2/models/s2t_transformer/__init__.py
+++ b/src/fairseq2/models/s2t_transformer/__init__.py
@@ -4,6 +4,12 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from fairseq2.models.s2t_transformer.archs import (
+    s2t_transformer_arch as s2t_transformer_arch,
+)
+from fairseq2.models.s2t_transformer.archs import (
+    s2t_transformer_archs as s2t_transformer_archs,
+)
 from fairseq2.models.s2t_transformer.factory import (
     S2T_TRANSFORMER_FAMILY as S2T_TRANSFORMER_FAMILY,
 )
@@ -16,25 +22,19 @@ from fairseq2.models.s2t_transformer.factory import (
 from fairseq2.models.s2t_transformer.factory import (
     create_s2t_transformer_model as create_s2t_transformer_model,
 )
-from fairseq2.models.s2t_transformer.factory import (
-    s2t_transformer_arch as s2t_transformer_arch,
-)
-from fairseq2.models.s2t_transformer.factory import (
-    s2t_transformer_archs as s2t_transformer_archs,
-)
 from fairseq2.models.s2t_transformer.feature_extractor import (
     Conv1dFbankSubsampler as Conv1dFbankSubsampler,
 )
 from fairseq2.models.s2t_transformer.frontend import (
     S2TTransformerFrontend as S2TTransformerFrontend,
 )
-from fairseq2.models.s2t_transformer.setup import (
+from fairseq2.models.s2t_transformer.loader import (
     load_s2t_transformer_config as load_s2t_transformer_config,
 )
-from fairseq2.models.s2t_transformer.setup import (
+from fairseq2.models.s2t_transformer.loader import (
     load_s2t_transformer_model as load_s2t_transformer_model,
 )
-from fairseq2.models.s2t_transformer.setup import (
+from fairseq2.models.s2t_transformer.loader import (
     load_s2t_transformer_tokenizer as load_s2t_transformer_tokenizer,
 )
 from fairseq2.models.s2t_transformer.tokenizer import (
@@ -45,9 +45,12 @@ from fairseq2.models.s2t_transformer.tokenizer import (
 
 from fairseq2.data.text import load_text_tokenizer
 from fairseq2.models.loader import load_model
+from fairseq2.models.s2t_transformer.archs import _register_s2t_transformer_archs
 
 
 def _register_s2t_transformer() -> None:
+    _register_s2t_transformer_archs()
+
     load_model.register(S2T_TRANSFORMER_FAMILY, load_s2t_transformer_model)
 
     load_text_tokenizer.register(S2T_TRANSFORMER_FAMILY, load_s2t_transformer_tokenizer)

--- a/src/fairseq2/models/s2t_transformer/archs.py
+++ b/src/fairseq2/models/s2t_transformer/archs.py
@@ -1,0 +1,78 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from fairseq2.config_registry import ConfigRegistry
+from fairseq2.data import VocabularyInfo
+from fairseq2.models.s2t_transformer.factory import S2TTransformerConfig
+
+s2t_transformer_archs = ConfigRegistry[S2TTransformerConfig]()
+
+s2t_transformer_arch = s2t_transformer_archs.decorator
+
+
+def _register_s2t_transformer_archs() -> None:
+    @s2t_transformer_arch("tiny")
+    def tiny() -> S2TTransformerConfig:
+        config = medium()
+
+        config.model_dim = 256
+        config.num_encoder_layers = 6
+        config.num_decoder_layers = 3
+        config.num_encoder_attn_heads = 4
+        config.num_decoder_attn_heads = 4
+        config.ffn_inner_dim = 256 * 4
+        config.dropout_p = 0.3
+
+        return config
+
+    @s2t_transformer_arch("small")
+    def small() -> S2TTransformerConfig:
+        config = medium()
+
+        config.model_dim = 256
+        config.num_encoder_attn_heads = 4
+        config.num_decoder_attn_heads = 4
+        config.ffn_inner_dim = 256 * 8
+        config.dropout_p = 0.1
+
+        return config
+
+    @s2t_transformer_arch("medium")
+    def medium() -> S2TTransformerConfig:
+        return S2TTransformerConfig()
+
+    @s2t_transformer_arch("large")
+    def large() -> S2TTransformerConfig:
+        config = medium()
+
+        config.model_dim = 1024
+        config.num_encoder_attn_heads = 16
+        config.num_decoder_attn_heads = 16
+        config.ffn_inner_dim = 1024 * 4
+        config.dropout_p = 0.2
+
+        return config
+
+    @s2t_transformer_arch("conformer_medium")
+    def conformer_medium() -> S2TTransformerConfig:
+        return S2TTransformerConfig(
+            model_dim=256,
+            max_source_seq_len=6000,
+            num_fbank_channels=80,
+            max_target_seq_len=1024,
+            target_vocab_info=VocabularyInfo(
+                size=181, unk_idx=3, bos_idx=0, eos_idx=2, pad_idx=1
+            ),
+            use_relative_pos=False,
+            use_conformer=True,
+            num_encoder_layers=12,
+            num_decoder_layers=6,
+            num_encoder_attn_heads=4,
+            num_decoder_attn_heads=8,
+            ffn_inner_dim=512 * 4,
+            dropout_p=0.1,
+            depthwise_conv_kernel_size=31,
+        )

--- a/src/fairseq2/models/s2t_transformer/factory.py
+++ b/src/fairseq2/models/s2t_transformer/factory.py
@@ -9,7 +9,6 @@ from typing import Final, Optional
 
 from torch.nn import SiLU
 
-from fairseq2.config_registry import ConfigRegistry
 from fairseq2.data import VocabularyInfo
 from fairseq2.models.conformer import ConformerBlock, ConformerConvolution
 from fairseq2.models.s2t_transformer.feature_extractor import Conv1dFbankSubsampler
@@ -103,79 +102,6 @@ class S2TTransformerConfig:
 
     depthwise_conv_kernel_size: int = 0
     """The kernel size of depthwise convolutions in Conformer blocks."""
-
-
-s2t_transformer_archs = ConfigRegistry[S2TTransformerConfig]()
-
-s2t_transformer_arch = s2t_transformer_archs.decorator
-
-
-@s2t_transformer_arch("tiny")
-def _tiny() -> S2TTransformerConfig:
-    config = _medium()
-
-    config.model_dim = 256
-    config.num_encoder_layers = 6
-    config.num_decoder_layers = 3
-    config.num_encoder_attn_heads = 4
-    config.num_decoder_attn_heads = 4
-    config.ffn_inner_dim = 256 * 4
-    config.dropout_p = 0.3
-
-    return config
-
-
-@s2t_transformer_arch("small")
-def _small() -> S2TTransformerConfig:
-    config = _medium()
-
-    config.model_dim = 256
-    config.num_encoder_attn_heads = 4
-    config.num_decoder_attn_heads = 4
-    config.ffn_inner_dim = 256 * 8
-    config.dropout_p = 0.1
-
-    return config
-
-
-@s2t_transformer_arch("medium")
-def _medium() -> S2TTransformerConfig:
-    return S2TTransformerConfig()
-
-
-@s2t_transformer_arch("large")
-def _large() -> S2TTransformerConfig:
-    config = _medium()
-
-    config.model_dim = 1024
-    config.num_encoder_attn_heads = 16
-    config.num_decoder_attn_heads = 16
-    config.ffn_inner_dim = 1024 * 4
-    config.dropout_p = 0.2
-
-    return config
-
-
-@s2t_transformer_arch("conformer_medium")
-def _conformer_medium() -> S2TTransformerConfig:
-    return S2TTransformerConfig(
-        model_dim=256,
-        max_source_seq_len=6000,
-        num_fbank_channels=80,
-        max_target_seq_len=1024,
-        target_vocab_info=VocabularyInfo(
-            size=181, unk_idx=3, bos_idx=0, eos_idx=2, pad_idx=1
-        ),
-        use_relative_pos=False,
-        use_conformer=True,
-        num_encoder_layers=12,
-        num_decoder_layers=6,
-        num_encoder_attn_heads=4,
-        num_decoder_attn_heads=8,
-        ffn_inner_dim=512 * 4,
-        dropout_p=0.1,
-        depthwise_conv_kernel_size=31,
-    )
 
 
 class S2TTransformerBuilder:

--- a/src/fairseq2/models/s2t_transformer/loader.py
+++ b/src/fairseq2/models/s2t_transformer/loader.py
@@ -11,11 +11,11 @@ from fairseq2.assets import AssetCard
 from fairseq2.data.text import AbstractTextTokenizerLoader
 from fairseq2.models.config_loader import StandardModelConfigLoader
 from fairseq2.models.loader import DenseModelLoader
+from fairseq2.models.s2t_transformer.archs import s2t_transformer_archs
 from fairseq2.models.s2t_transformer.factory import (
     S2T_TRANSFORMER_FAMILY,
     S2TTransformerConfig,
     create_s2t_transformer_model,
-    s2t_transformer_archs,
 )
 from fairseq2.models.s2t_transformer.tokenizer import S2TTransformerTokenizer
 from fairseq2.models.utils.checkpoint import convert_fairseq_checkpoint

--- a/src/fairseq2/models/transformer/__init__.py
+++ b/src/fairseq2/models/transformer/__init__.py
@@ -4,11 +4,19 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from fairseq2.models.transformer.archs import transformer_arch as transformer_arch
+from fairseq2.models.transformer.archs import transformer_archs as transformer_archs
 from fairseq2.models.transformer.decoder_model import (
     TransformerDecoderModel as TransformerDecoderModel,
 )
 from fairseq2.models.transformer.decoder_model import (
     shard_transformer_decoder_model as shard_transformer_decoder_model,
+)
+from fairseq2.models.transformer.factory import TRANSFORMER_FAMILY as TRANSFORMER_FAMILY
+from fairseq2.models.transformer.factory import TransformerBuilder as TransformerBuilder
+from fairseq2.models.transformer.factory import TransformerConfig as TransformerConfig
+from fairseq2.models.transformer.factory import (
+    create_transformer_model as create_transformer_model,
 )
 from fairseq2.models.transformer.frontend import (
     TransformerEmbeddingFrontend as TransformerEmbeddingFrontend,
@@ -16,7 +24,24 @@ from fairseq2.models.transformer.frontend import (
 from fairseq2.models.transformer.frontend import (
     TransformerFrontend as TransformerFrontend,
 )
+from fairseq2.models.transformer.loader import (
+    load_transformer_config as load_transformer_config,
+)
+from fairseq2.models.transformer.loader import (
+    load_transformer_model as load_transformer_model,
+)
 from fairseq2.models.transformer.model import TransformerModel as TransformerModel
 from fairseq2.models.transformer.model import (
     init_final_projection as init_final_projection,
 )
+
+# isort: split
+
+from fairseq2.models.loader import load_model
+from fairseq2.models.transformer.archs import _register_transformer_archs
+
+
+def _register_transformer() -> None:
+    _register_transformer_archs()
+
+    load_model.register(TRANSFORMER_FAMILY, load_transformer_model)

--- a/src/fairseq2/models/transformer/archs.py
+++ b/src/fairseq2/models/transformer/archs.py
@@ -1,0 +1,30 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from fairseq2.config_registry import ConfigRegistry
+from fairseq2.models.transformer.factory import TransformerConfig
+
+transformer_archs = ConfigRegistry[TransformerConfig]()
+
+transformer_arch = transformer_archs.decorator
+
+
+def _register_transformer_archs() -> None:
+    @transformer_arch("base")
+    def base() -> TransformerConfig:
+        return TransformerConfig()
+
+    @transformer_arch("big")
+    def big() -> TransformerConfig:
+        config = TransformerConfig()
+
+        config.model_dim = 1024
+        config.num_encoder_attn_heads = 16
+        config.num_decoder_attn_heads = 16
+        config.ffn_inner_dim = 4096
+        config.dropout_p = 0.3
+
+        return config

--- a/src/fairseq2/models/transformer/loader.py
+++ b/src/fairseq2/models/transformer/loader.py
@@ -4,34 +4,31 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from pathlib import Path
-from typing import Any, Dict, List, final
+from typing import Any, Dict
 
 import torch
 
-from fairseq2.assets import AssetCard
-from fairseq2.data.text import AbstractTextTokenizerLoader
 from fairseq2.models.config_loader import StandardModelConfigLoader
 from fairseq2.models.loader import DenseModelLoader
-from fairseq2.models.nllb.factory import (
-    NLLB_FAMILY,
-    NllbConfig,
-    create_nllb_model,
-    nllb_archs,
+from fairseq2.models.transformer.archs import transformer_archs
+from fairseq2.models.transformer.factory import (
+    TRANSFORMER_FAMILY,
+    TransformerConfig,
+    create_transformer_model,
 )
-from fairseq2.models.nllb.tokenizer import NllbTokenizer
 from fairseq2.models.utils.checkpoint import convert_fairseq_checkpoint
-from fairseq2.typing import override
 
-load_nllb_config = StandardModelConfigLoader(
-    family=NLLB_FAMILY, config_kls=NllbConfig, arch_configs=nllb_archs
+load_transformer_config = StandardModelConfigLoader(
+    family=TRANSFORMER_FAMILY,
+    config_kls=TransformerConfig,
+    arch_configs=transformer_archs,
 )
 
 
-def convert_nllb_checkpoint(
-    checkpoint: Dict[str, Any], config: NllbConfig
+def convert_transformer_checkpoint(
+    checkpoint: Dict[str, Any], config: TransformerConfig
 ) -> Dict[str, Any]:
-    """Convert a fairseq NLLB checkpoint to fairseq2 format."""
+    """Convert a fairseq Transformer checkpoint to fairseq2 format."""
     state_dict = checkpoint["model"]
 
     # Check if we have a fairseq2 checkpoint.
@@ -91,25 +88,9 @@ def convert_nllb_checkpoint(
     return checkpoint
 
 
-load_nllb_model = DenseModelLoader(
-    config_loader=load_nllb_config,
-    factory=create_nllb_model,
-    checkpoint_converter=convert_nllb_checkpoint,
+load_transformer_model = DenseModelLoader(
+    config_loader=load_transformer_config,
+    factory=create_transformer_model,
+    checkpoint_converter=convert_transformer_checkpoint,
     restrict_checkpoints=False,
 )
-
-
-@final
-class NllbTokenizerLoader(AbstractTextTokenizerLoader[NllbTokenizer]):
-    """Loads NLLB tokenizers."""
-
-    @override
-    def _load(self, path: Path, card: AssetCard) -> NllbTokenizer:
-        langs = card.field("langs").as_(List[str])
-
-        default_lang = card.field("default_lang").as_(str)
-
-        return NllbTokenizer(path, langs, default_lang)
-
-
-load_nllb_tokenizer = NllbTokenizerLoader()

--- a/src/fairseq2/models/w2vbert/__init__.py
+++ b/src/fairseq2/models/w2vbert/__init__.py
@@ -5,22 +5,25 @@
 # LICENSE file in the root directory of this source tree.
 
 
+from fairseq2.models.w2vbert.archs import w2vbert_arch as w2vbert_arch
+from fairseq2.models.w2vbert.archs import w2vbert_archs as w2vbert_archs
 from fairseq2.models.w2vbert.factory import W2VBERT_FAMILY as W2VBERT_FAMILY
 from fairseq2.models.w2vbert.factory import W2VBertBuilder as W2VBertBuilder
 from fairseq2.models.w2vbert.factory import W2VBertConfig as W2VBertConfig
 from fairseq2.models.w2vbert.factory import create_w2vbert_model as create_w2vbert_model
-from fairseq2.models.w2vbert.factory import w2vbert_arch as w2vbert_arch
-from fairseq2.models.w2vbert.factory import w2vbert_archs as w2vbert_archs
+from fairseq2.models.w2vbert.loader import load_w2vbert_config as load_w2vbert_config
+from fairseq2.models.w2vbert.loader import load_w2vbert_model as load_w2vbert_model
 from fairseq2.models.w2vbert.model import W2VBertLoss as W2VBertLoss
 from fairseq2.models.w2vbert.model import W2VBertModel as W2VBertModel
 from fairseq2.models.w2vbert.model import W2VBertOutput as W2VBertOutput
-from fairseq2.models.w2vbert.setup import load_w2vbert_config as load_w2vbert_config
-from fairseq2.models.w2vbert.setup import load_w2vbert_model as load_w2vbert_model
 
 # isort: split
 
 from fairseq2.models.loader import load_model
+from fairseq2.models.w2vbert.archs import _register_w2vbert_archs
 
 
 def _register_w2vbert() -> None:
+    _register_w2vbert_archs()
+
     load_model.register(W2VBERT_FAMILY, load_w2vbert_model)

--- a/src/fairseq2/models/w2vbert/archs.py
+++ b/src/fairseq2/models/w2vbert/archs.py
@@ -1,0 +1,42 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from fairseq2.config_registry import ConfigRegistry
+from fairseq2.models.w2vbert.factory import W2VBertConfig
+from fairseq2.models.wav2vec2.archs import wav2vec2_encoder_arch
+from fairseq2.models.wav2vec2.factory import Wav2Vec2EncoderConfig
+
+w2vbert_archs = ConfigRegistry[W2VBertConfig]()
+
+w2vbert_arch = w2vbert_archs.decorator
+
+
+def _register_w2vbert_archs() -> None:
+    @wav2vec2_encoder_arch("bert_600m")
+    def _600m_encoder() -> Wav2Vec2EncoderConfig:
+        config = _600m()
+
+        return config.w2v2_config.encoder_config
+
+    @wav2vec2_encoder_arch("bert_300m")
+    def _300m_encoder() -> Wav2Vec2EncoderConfig:
+        config = _300m()
+
+        return config.w2v2_config.encoder_config
+
+    @w2vbert_arch("600m")
+    def _600m() -> W2VBertConfig:
+        return W2VBertConfig()
+
+    @w2vbert_arch("300m")
+    def _300m() -> W2VBertConfig:
+        config = _600m()
+
+        config.w2v2_config.encoder_config.num_encoder_layers = 12
+
+        config.num_bert_encoder_layers = 8
+
+        return config

--- a/src/fairseq2/models/w2vbert/factory.py
+++ b/src/fairseq2/models/w2vbert/factory.py
@@ -7,60 +7,17 @@
 from dataclasses import dataclass, field
 from typing import Final, Optional
 
-from fairseq2.config_registry import ConfigRegistry
 from fairseq2.models.w2vbert.model import W2VBertModel
 from fairseq2.models.wav2vec2 import (
     Wav2Vec2Builder,
     Wav2Vec2Config,
     Wav2Vec2EncoderBuilder,
     Wav2Vec2EncoderConfig,
-    wav2vec2_encoder_arch,
 )
 from fairseq2.nn.transformer import TransformerNormOrder
 from fairseq2.typing import DataType, Device
 
 W2VBERT_FAMILY: Final = "w2vbert"
-
-
-@wav2vec2_encoder_arch("bert_600m")
-def _600m_encoder() -> Wav2Vec2EncoderConfig:
-    return Wav2Vec2EncoderConfig(
-        model_dim=1024,
-        max_seq_len=4096,
-        feature_dim=160,
-        use_fbank=True,
-        first_pass_dropout_p=0.0,
-        layer_norm_features=False,
-        feature_extractor_layer_descs=[],
-        feature_extractor_bias=False,
-        feature_extractor_layer_norm_convs=False,
-        feature_gradient_scale=0.0,
-        num_fbank_channels=80,
-        fbank_stride=2,
-        sample_fbank_every_k=1,
-        pos_encoder_type="relative",
-        pos_encoder_depth=0,
-        pos_conv_kernel_size=0,
-        num_pos_conv_groups=0,
-        use_conformer=True,
-        num_encoder_layers=24,
-        num_encoder_attn_heads=16,
-        ffn_inner_dim=4096,
-        dropout_p=0.0,
-        attn_dropout_p=0.0,
-        layer_drop_p=0.0,
-        norm_order=TransformerNormOrder.POST,
-        depthwise_conv_kernel_size=31,
-    )
-
-
-@wav2vec2_encoder_arch("bert_300m")
-def _300m_encoder() -> Wav2Vec2EncoderConfig:
-    config = _600m_encoder()
-
-    config.num_encoder_layers = 12
-
-    return config
 
 
 @dataclass
@@ -73,7 +30,34 @@ class W2VBertConfig:
 
     w2v2_config: Wav2Vec2Config = field(
         default_factory=lambda: Wav2Vec2Config(
-            encoder_config=_600m_encoder(),
+            encoder_config=Wav2Vec2EncoderConfig(
+                model_dim=1024,
+                max_seq_len=4096,
+                feature_dim=160,
+                use_fbank=True,
+                first_pass_dropout_p=0.0,
+                layer_norm_features=False,
+                feature_extractor_layer_descs=[],
+                feature_extractor_bias=False,
+                feature_extractor_layer_norm_convs=False,
+                feature_gradient_scale=0.0,
+                num_fbank_channels=80,
+                fbank_stride=2,
+                sample_fbank_every_k=1,
+                pos_encoder_type="relative",
+                pos_encoder_depth=0,
+                pos_conv_kernel_size=0,
+                num_pos_conv_groups=0,
+                use_conformer=True,
+                num_encoder_layers=24,
+                num_encoder_attn_heads=16,
+                ffn_inner_dim=4096,
+                dropout_p=0.0,
+                attn_dropout_p=0.0,
+                layer_drop_p=0.0,
+                norm_order=TransformerNormOrder.POST,
+                depthwise_conv_kernel_size=31,
+            ),
             final_dim=768,
             final_proj_bias=True,
             temporal_mask_span_len=10,
@@ -97,27 +81,6 @@ class W2VBertConfig:
 
     num_target_codebooks: int = 1
     """The number of consecutive codebooks to use as masked prediction targets."""
-
-
-w2vbert_archs = ConfigRegistry[W2VBertConfig]()
-
-w2vbert_arch = w2vbert_archs.decorator
-
-
-@w2vbert_arch("600m")
-def _600m() -> W2VBertConfig:
-    return W2VBertConfig()
-
-
-@w2vbert_arch("300m")
-def _300m() -> W2VBertConfig:
-    config = _600m()
-
-    config.w2v2_config.encoder_config = _300m_encoder()
-
-    config.num_bert_encoder_layers = 8
-
-    return config
 
 
 class W2VBertBuilder:

--- a/src/fairseq2/models/w2vbert/loader.py
+++ b/src/fairseq2/models/w2vbert/loader.py
@@ -11,11 +11,11 @@ import torch
 from fairseq2.models.config_loader import StandardModelConfigLoader
 from fairseq2.models.loader import DenseModelLoader
 from fairseq2.models.utils.checkpoint import convert_fairseq_checkpoint
+from fairseq2.models.w2vbert.archs import w2vbert_archs
 from fairseq2.models.w2vbert.factory import (
     W2VBERT_FAMILY,
     W2VBertConfig,
     create_w2vbert_model,
-    w2vbert_archs,
 )
 
 load_w2vbert_config = StandardModelConfigLoader(

--- a/src/fairseq2/models/wav2vec2/__init__.py
+++ b/src/fairseq2/models/wav2vec2/__init__.py
@@ -4,6 +4,14 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from fairseq2.models.wav2vec2.archs import wav2vec2_arch as wav2vec2_arch
+from fairseq2.models.wav2vec2.archs import wav2vec2_archs as wav2vec2_archs
+from fairseq2.models.wav2vec2.archs import (
+    wav2vec2_encoder_arch as wav2vec2_encoder_arch,
+)
+from fairseq2.models.wav2vec2.archs import (
+    wav2vec2_encoder_archs as wav2vec2_encoder_archs,
+)
 from fairseq2.models.wav2vec2.factory import WAV2VEC2_FAMILY as WAV2VEC2_FAMILY
 from fairseq2.models.wav2vec2.factory import Wav2Vec2Builder as Wav2Vec2Builder
 from fairseq2.models.wav2vec2.factory import Wav2Vec2Config as Wav2Vec2Config
@@ -16,14 +24,6 @@ from fairseq2.models.wav2vec2.factory import (
 from fairseq2.models.wav2vec2.factory import (
     create_wav2vec2_model as create_wav2vec2_model,
 )
-from fairseq2.models.wav2vec2.factory import wav2vec2_arch as wav2vec2_arch
-from fairseq2.models.wav2vec2.factory import wav2vec2_archs as wav2vec2_archs
-from fairseq2.models.wav2vec2.factory import (
-    wav2vec2_encoder_arch as wav2vec2_encoder_arch,
-)
-from fairseq2.models.wav2vec2.factory import (
-    wav2vec2_encoder_archs as wav2vec2_encoder_archs,
-)
 from fairseq2.models.wav2vec2.feature_extractor import (
     Wav2Vec2FbankFeatureExtractor as Wav2Vec2FbankFeatureExtractor,
 )
@@ -31,6 +31,8 @@ from fairseq2.models.wav2vec2.feature_extractor import (
     Wav2Vec2FeatureExtractor as Wav2Vec2FeatureExtractor,
 )
 from fairseq2.models.wav2vec2.frontend import Wav2Vec2Frontend as Wav2Vec2Frontend
+from fairseq2.models.wav2vec2.loader import load_wav2vec2_config as load_wav2vec2_config
+from fairseq2.models.wav2vec2.loader import load_wav2vec2_model as load_wav2vec2_model
 from fairseq2.models.wav2vec2.masker import Wav2Vec2Masker as Wav2Vec2Masker
 from fairseq2.models.wav2vec2.model import Wav2Vec2Features as Wav2Vec2Features
 from fairseq2.models.wav2vec2.model import Wav2Vec2Loss as Wav2Vec2Loss
@@ -42,13 +44,14 @@ from fairseq2.models.wav2vec2.position_encoder import (
 from fairseq2.models.wav2vec2.position_encoder import (
     Wav2Vec2StackedPositionEncoder as Wav2Vec2StackedPositionEncoder,
 )
-from fairseq2.models.wav2vec2.setup import load_wav2vec2_config as load_wav2vec2_config
-from fairseq2.models.wav2vec2.setup import load_wav2vec2_model as load_wav2vec2_model
 
 # isort: split
 
 from fairseq2.models.loader import load_model
+from fairseq2.models.wav2vec2.archs import _register_wav2vec2_archs
 
 
 def _register_wav2vec2() -> None:
+    _register_wav2vec2_archs()
+
     load_model.register(WAV2VEC2_FAMILY, load_wav2vec2_model)

--- a/src/fairseq2/models/wav2vec2/archs.py
+++ b/src/fairseq2/models/wav2vec2/archs.py
@@ -1,0 +1,73 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from fairseq2.config_registry import ConfigRegistry
+from fairseq2.models.wav2vec2.factory import Wav2Vec2Config, Wav2Vec2EncoderConfig
+from fairseq2.nn.transformer import TransformerNormOrder
+
+wav2vec2_encoder_archs = ConfigRegistry[Wav2Vec2EncoderConfig]()
+
+wav2vec2_encoder_arch = wav2vec2_encoder_archs.decorator
+
+wav2vec2_archs = ConfigRegistry[Wav2Vec2Config]()
+
+wav2vec2_arch = wav2vec2_archs.decorator
+
+
+def _register_wav2vec2_archs() -> None:
+    @wav2vec2_encoder_arch("base")
+    def base_encoder() -> Wav2Vec2EncoderConfig:
+        config = base()
+
+        return config.encoder_config
+
+    @wav2vec2_encoder_arch("large")
+    def large_encoder() -> Wav2Vec2EncoderConfig:
+        config = large()
+
+        return config.encoder_config
+
+    @wav2vec2_encoder_arch("large_lv60k")  # LibriVox 60K
+    def large_lv60k_encoder() -> Wav2Vec2EncoderConfig:
+        config = large_lv60k()
+
+        return config.encoder_config
+
+    @wav2vec2_arch("base")
+    def base() -> Wav2Vec2Config:
+        return Wav2Vec2Config()
+
+    @wav2vec2_arch("large")
+    def large() -> Wav2Vec2Config:
+        config = base()
+
+        config.encoder_config.model_dim = 1024
+        config.encoder_config.num_encoder_layers = 24
+        config.encoder_config.num_encoder_attn_heads = 16
+        config.encoder_config.ffn_inner_dim = 4096
+        config.encoder_config.dropout_p = 0.0
+        config.encoder_config.layer_drop_p = 0.2
+        config.quantized_dim = 768
+        config.final_dim = 768
+
+        return config
+
+    @wav2vec2_arch("large_lv60k")  # LibriVox 60K
+    def large_lv60k() -> Wav2Vec2Config:
+        config = large()
+
+        config.encoder_config.layer_norm_features = False
+        config.encoder_config.feature_extractor_bias = True
+        config.encoder_config.feature_extractor_layer_norm_convs = True
+        config.encoder_config.layer_drop_p = 0.0
+        config.encoder_config.norm_order = TransformerNormOrder.PRE
+        config.codebook_sampling_temperature = (2.0, 0.1, 0.999995)
+
+        return config
+
+    @wav2vec2_arch("pseudo_dinosr_base")
+    def pseudo_dinosr_base() -> Wav2Vec2Config:
+        return Wav2Vec2Config()

--- a/src/fairseq2/models/wav2vec2/asr/__init__.py
+++ b/src/fairseq2/models/wav2vec2/asr/__init__.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from fairseq2.models.wav2vec2.asr.archs import wav2vec2_asr_arch as wav2vec2_asr_arch
+from fairseq2.models.wav2vec2.asr.archs import wav2vec2_asr_archs as wav2vec2_asr_archs
 from fairseq2.models.wav2vec2.asr.factory import (
     WAV2VEC2_ASR_FAMILY as WAV2VEC2_ASR_FAMILY,
 )
@@ -14,23 +16,22 @@ from fairseq2.models.wav2vec2.asr.factory import Wav2Vec2AsrConfig as Wav2Vec2As
 from fairseq2.models.wav2vec2.asr.factory import (
     create_wav2vec2_asr_model as create_wav2vec2_asr_model,
 )
-from fairseq2.models.wav2vec2.asr.factory import wav2vec2_asr_arch as wav2vec2_asr_arch
-from fairseq2.models.wav2vec2.asr.factory import (
-    wav2vec2_asr_archs as wav2vec2_asr_archs,
+from fairseq2.models.wav2vec2.asr.loader import (
+    load_wav2vec2_asr_config as load_wav2vec2_asr_config,
+)
+from fairseq2.models.wav2vec2.asr.loader import (
+    load_wav2vec2_asr_model as load_wav2vec2_asr_model,
 )
 from fairseq2.models.wav2vec2.asr.model import Wav2Vec2AsrModel as Wav2Vec2AsrModel
 from fairseq2.models.wav2vec2.asr.model import Wav2Vec2AsrOutput as Wav2Vec2AsrOutput
-from fairseq2.models.wav2vec2.asr.setup import (
-    load_wav2vec2_asr_config as load_wav2vec2_asr_config,
-)
-from fairseq2.models.wav2vec2.asr.setup import (
-    load_wav2vec2_asr_model as load_wav2vec2_asr_model,
-)
 
 # isort: split
 
 from fairseq2.models.loader import load_model
+from fairseq2.models.wav2vec2.asr.archs import _register_wav2vec2_asr_archs
 
 
 def _register_wav2vec2_asr() -> None:
+    _register_wav2vec2_asr_archs()
+
     load_model.register(WAV2VEC2_ASR_FAMILY, load_wav2vec2_asr_model)

--- a/src/fairseq2/models/wav2vec2/asr/archs.py
+++ b/src/fairseq2/models/wav2vec2/asr/archs.py
@@ -1,0 +1,77 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from fairseq2.config_registry import ConfigRegistry
+from fairseq2.models.wav2vec2.archs import wav2vec2_encoder_archs
+from fairseq2.models.wav2vec2.asr.factory import Wav2Vec2AsrConfig
+
+wav2vec2_asr_archs = ConfigRegistry[Wav2Vec2AsrConfig]()
+
+wav2vec2_asr_arch = wav2vec2_asr_archs.decorator
+
+
+def _register_wav2vec2_asr_archs() -> None:
+    @wav2vec2_asr_arch("base_10h")
+    def base_10h() -> Wav2Vec2AsrConfig:
+        return Wav2Vec2AsrConfig()
+
+    @wav2vec2_asr_arch("base_100h")
+    def base_100h() -> Wav2Vec2AsrConfig:
+        config = base_10h()
+
+        config.encoder_config.layer_drop_p = 0.1
+
+        return config
+
+    @wav2vec2_asr_arch("large_10h")
+    def large_10h() -> Wav2Vec2AsrConfig:
+        config = base_10h()
+
+        config.encoder_config = wav2vec2_encoder_archs.get("large")
+        config.encoder_config.feature_gradient_scale = 1.0
+        config.encoder_config.dropout_p = 0.0
+        config.encoder_config.attn_dropout_p = 0.0
+        config.encoder_config.ffn_inner_dropout_p = 0.1
+        config.encoder_config.layer_drop_p = 0.1
+
+        config.max_temporal_mask_prob = 0.80
+        config.max_spatial_mask_prob = 0.30
+
+        return config
+
+    @wav2vec2_asr_arch("large_100h")
+    def large_100h() -> Wav2Vec2AsrConfig:
+        config = large_10h()
+
+        config.max_temporal_mask_prob = 0.53
+        config.max_spatial_mask_prob = 0.55
+
+        return config
+
+    @wav2vec2_asr_arch("large_lv60k_10h")  # LibriVox 60K
+    def large_lv60k_10h() -> Wav2Vec2AsrConfig:
+        config = base_10h()
+
+        config.encoder_config = wav2vec2_encoder_archs.get("large_lv60k")
+        config.encoder_config.feature_gradient_scale = 1.0
+        config.encoder_config.dropout_p = 0.0
+        config.encoder_config.attn_dropout_p = 0.0
+        config.encoder_config.ffn_inner_dropout_p = 0.1
+        config.encoder_config.layer_drop_p = 0.1
+
+        config.max_temporal_mask_prob = 0.80
+        config.max_spatial_mask_prob = 0.30
+
+        return config
+
+    @wav2vec2_asr_arch("large_lv60k_100h")  # LibriVox 60K
+    def large_lv60k_100h() -> Wav2Vec2AsrConfig:
+        config = large_lv60k_10h()
+
+        config.max_temporal_mask_prob = 0.53
+        config.max_spatial_mask_prob = 0.55
+
+        return config

--- a/src/fairseq2/models/wav2vec2/asr/factory.py
+++ b/src/fairseq2/models/wav2vec2/asr/factory.py
@@ -7,52 +7,15 @@
 from dataclasses import dataclass, field
 from typing import Final, Optional
 
-from fairseq2.config_registry import ConfigRegistry
 from fairseq2.models.wav2vec2.asr.model import Wav2Vec2AsrModel
 from fairseq2.models.wav2vec2.factory import (
     Wav2Vec2EncoderBuilder,
     Wav2Vec2EncoderConfig,
-    wav2vec2_encoder_archs,
 )
 from fairseq2.models.wav2vec2.masker import Wav2Vec2Masker
 from fairseq2.typing import DataType, Device
 
 WAV2VEC2_ASR_FAMILY: Final = "wav2vec2_asr"
-
-
-def _base_encoder() -> Wav2Vec2EncoderConfig:
-    config = wav2vec2_encoder_archs.get("base")
-
-    config.feature_gradient_scale = 1.0
-    config.dropout_p = 0.0
-    config.attn_dropout_p = 0.0
-    config.ffn_inner_dropout_p = 0.1
-
-    return config
-
-
-def _large_encoder() -> Wav2Vec2EncoderConfig:
-    config = wav2vec2_encoder_archs.get("large")
-
-    config.feature_gradient_scale = 1.0
-    config.dropout_p = 0.0
-    config.attn_dropout_p = 0.0
-    config.ffn_inner_dropout_p = 0.1
-    config.layer_drop_p = 0.1
-
-    return config
-
-
-def _large_lv60k_encoder() -> Wav2Vec2EncoderConfig:  # LibriVox 60K
-    config = wav2vec2_encoder_archs.get("large_lv60k")
-
-    config.feature_gradient_scale = 1.0
-    config.dropout_p = 0.0
-    config.attn_dropout_p = 0.0
-    config.ffn_inner_dropout_p = 0.1
-    config.layer_drop_p = 0.1
-
-    return config
 
 
 @dataclass
@@ -63,7 +26,14 @@ class Wav2Vec2AsrConfig:
     :cite:t:`https://doi.org/10.48550/arxiv.2006.11477`.
     """
 
-    encoder_config: Wav2Vec2EncoderConfig = field(default_factory=_base_encoder)
+    encoder_config: Wav2Vec2EncoderConfig = field(
+        default_factory=lambda: Wav2Vec2EncoderConfig(
+            feature_gradient_scale=1.0,
+            dropout_p=0.0,
+            attn_dropout_p=0.0,
+            ffn_inner_dropout_p=0.1,
+        )
+    )
     """The configuration of the encoder."""
 
     final_dim: int = 32
@@ -95,69 +65,6 @@ class Wav2Vec2AsrConfig:
 
     min_num_spatial_mask_spans: int = 2
     """The minimum number of spatial masks sampled per sequence."""
-
-
-wav2vec2_asr_archs = ConfigRegistry[Wav2Vec2AsrConfig]()
-
-wav2vec2_asr_arch = wav2vec2_asr_archs.decorator
-
-
-@wav2vec2_asr_arch("base_10h")
-def _base_10h() -> Wav2Vec2AsrConfig:
-    return Wav2Vec2AsrConfig()
-
-
-@wav2vec2_asr_arch("base_100h")
-def _base_100h() -> Wav2Vec2AsrConfig:
-    config = _base_10h()
-
-    config.encoder_config.layer_drop_p = 0.1
-
-    return config
-
-
-@wav2vec2_asr_arch("large_10h")
-def _large_10h() -> Wav2Vec2AsrConfig:
-    config = _base_10h()
-
-    config.encoder_config = _large_encoder()
-    config.max_temporal_mask_prob = 0.80
-    config.max_spatial_mask_prob = 0.30
-
-    return config
-
-
-@wav2vec2_asr_arch("large_100h")
-def _large_100h() -> Wav2Vec2AsrConfig:
-    config = _base_10h()
-
-    config.encoder_config = _large_encoder()
-    config.max_temporal_mask_prob = 0.53
-    config.max_spatial_mask_prob = 0.55
-
-    return config
-
-
-@wav2vec2_asr_arch("large_lv60k_10h")  # LibriVox 60K
-def _large_lv60k_10h() -> Wav2Vec2AsrConfig:
-    config = _base_10h()
-
-    config.encoder_config = _large_lv60k_encoder()
-    config.max_temporal_mask_prob = 0.80
-    config.max_spatial_mask_prob = 0.30
-
-    return config
-
-
-@wav2vec2_asr_arch("large_lv60k_100h")  # LibriVox 60K
-def _large_lv60k_100h() -> Wav2Vec2AsrConfig:
-    config = _base_10h()
-
-    config.encoder_config = _large_lv60k_encoder()
-    config.max_temporal_mask_prob = 0.53
-    config.max_spatial_mask_prob = 0.55
-
-    return config
 
 
 class Wav2Vec2AsrBuilder:

--- a/src/fairseq2/models/wav2vec2/asr/loader.py
+++ b/src/fairseq2/models/wav2vec2/asr/loader.py
@@ -9,11 +9,11 @@ from typing import Any, Dict
 from fairseq2.models.config_loader import StandardModelConfigLoader
 from fairseq2.models.loader import DenseModelLoader
 from fairseq2.models.utils.checkpoint import convert_fairseq_checkpoint
+from fairseq2.models.wav2vec2.asr.archs import wav2vec2_asr_archs
 from fairseq2.models.wav2vec2.asr.factory import (
     WAV2VEC2_ASR_FAMILY,
     Wav2Vec2AsrConfig,
     create_wav2vec2_asr_model,
-    wav2vec2_asr_archs,
 )
 from fairseq2.nn.transformer import TransformerNormOrder
 

--- a/src/fairseq2/models/wav2vec2/factory.py
+++ b/src/fairseq2/models/wav2vec2/factory.py
@@ -9,7 +9,6 @@ from typing import Final, List, Optional, Tuple
 
 from torch.nn import GELU, SiLU
 
-from fairseq2.config_registry import ConfigRegistry
 from fairseq2.models.conformer import ConformerBlock, ConformerConvolution
 from fairseq2.models.feature_extractor import SequenceFeatureExtractor
 from fairseq2.models.wav2vec2.feature_extractor import (
@@ -151,43 +150,6 @@ class Wav2Vec2EncoderConfig:
     """The kernel size of depthwise convolutions in Conformer blocks."""
 
 
-wav2vec2_encoder_archs = ConfigRegistry[Wav2Vec2EncoderConfig]()
-
-wav2vec2_encoder_arch = wav2vec2_encoder_archs.decorator
-
-
-@wav2vec2_encoder_arch("base")
-def _base_encoder() -> Wav2Vec2EncoderConfig:
-    return Wav2Vec2EncoderConfig()
-
-
-@wav2vec2_encoder_arch("large")
-def _large_encoder() -> Wav2Vec2EncoderConfig:
-    config = _base_encoder()
-
-    config.model_dim = 1024
-    config.num_encoder_layers = 24
-    config.num_encoder_attn_heads = 16
-    config.ffn_inner_dim = 4096
-    config.dropout_p = 0.0
-    config.layer_drop_p = 0.2
-
-    return config
-
-
-@wav2vec2_encoder_arch("large_lv60k")  # LibriVox 60K
-def _large_lv60k_encoder() -> Wav2Vec2EncoderConfig:
-    config = _large_encoder()
-
-    config.layer_norm_features = False
-    config.feature_extractor_bias = True
-    config.feature_extractor_layer_norm_convs = True
-    config.layer_drop_p = 0.0
-    config.norm_order = TransformerNormOrder.PRE
-
-    return config
-
-
 @dataclass
 class Wav2Vec2Config:
     """Holds the configuration of a wav2vec 2.0 model.
@@ -196,7 +158,7 @@ class Wav2Vec2Config:
     :cite:t:`https://doi.org/10.48550/arxiv.2006.11477`.
     """
 
-    encoder_config: Wav2Vec2EncoderConfig = field(default_factory=_base_encoder)
+    encoder_config: Wav2Vec2EncoderConfig = field(default_factory=Wav2Vec2EncoderConfig)
     """The configuration of the wav2vec 2.0 encoder."""
 
     final_dim: int = 256
@@ -247,44 +209,6 @@ class Wav2Vec2Config:
 
     logit_temp: float = 0.1
     """The temperature to divide logits by."""
-
-
-wav2vec2_archs = ConfigRegistry[Wav2Vec2Config]()
-
-wav2vec2_arch = wav2vec2_archs.decorator
-
-
-@wav2vec2_arch("base")
-def _base() -> Wav2Vec2Config:
-    return Wav2Vec2Config()
-
-
-@wav2vec2_arch("large")
-def _large() -> Wav2Vec2Config:
-    config = _base()
-
-    config.encoder_config = _large_encoder()
-    config.quantized_dim = 768
-    config.final_dim = 768
-
-    return config
-
-
-@wav2vec2_arch("large_lv60k")  # LibriVox 60K
-def _large_lv60k() -> Wav2Vec2Config:
-    config = _base()
-
-    config.encoder_config = _large_lv60k_encoder()
-    config.quantized_dim = 768
-    config.final_dim = 768
-    config.codebook_sampling_temperature = (2.0, 0.1, 0.999995)
-
-    return config
-
-
-@wav2vec2_arch("pseudo_dinosr_base")
-def _pseudo_dinosr_base() -> Wav2Vec2Config:
-    return Wav2Vec2Config()
 
 
 class Wav2Vec2EncoderBuilder:

--- a/src/fairseq2/models/wav2vec2/loader.py
+++ b/src/fairseq2/models/wav2vec2/loader.py
@@ -11,11 +11,11 @@ import torch
 from fairseq2.models.config_loader import StandardModelConfigLoader
 from fairseq2.models.loader import DenseModelLoader
 from fairseq2.models.utils.checkpoint import convert_fairseq_checkpoint
+from fairseq2.models.wav2vec2.archs import wav2vec2_archs
 from fairseq2.models.wav2vec2.factory import (
     WAV2VEC2_FAMILY,
     Wav2Vec2Config,
     create_wav2vec2_model,
-    wav2vec2_archs,
 )
 from fairseq2.nn.transformer import TransformerNormOrder
 

--- a/tests/integration/generation/test_incremental_decode.py
+++ b/tests/integration/generation/test_incremental_decode.py
@@ -8,7 +8,8 @@ from typing import Final
 
 import torch
 
-from fairseq2.models.nllb import load_nllb_model, load_nllb_tokenizer
+from fairseq2.models.nllb import load_nllb_tokenizer
+from fairseq2.models.transformer import load_transformer_model
 from fairseq2.nn import IncrementalStateBag
 from fairseq2.nn.padding import pad_seqs
 from tests.common import assert_close, device
@@ -22,7 +23,7 @@ EN_SENTENCE: Final = "Lion prides act much like packs of wolves or dogs, animals
 def test_incremental_decoding_works() -> None:
     model_name = "nllb-200_dense_distill_600m"
 
-    model = load_nllb_model(
+    model = load_transformer_model(
         model_name, device=device, dtype=torch.float32, progress=False
     )
 

--- a/tests/integration/models/test_llama.py
+++ b/tests/integration/models/test_llama.py
@@ -11,7 +11,7 @@ import pytest
 from fairseq2.assets import asset_store, download_manager
 from fairseq2.models.llama import create_llama_model, llama_archs
 from fairseq2.models.llama.integ import convert_to_reference_checkpoint
-from fairseq2.models.llama.setup import convert_llama_checkpoint
+from fairseq2.models.llama.loader import convert_llama_checkpoint
 from fairseq2.typing import CPU
 from fairseq2.utils.file import load_tensors
 from tests.common import device

--- a/tests/unit/nn/utils/test_module.py
+++ b/tests/unit/nn/utils/test_module.py
@@ -6,15 +6,15 @@
 
 from torch.nn import Parameter
 
-from fairseq2.models.nllb import create_nllb_model, nllb_archs
+from fairseq2.models.transformer import create_transformer_model, transformer_archs
 from fairseq2.nn.utils.module import select_parameters
 from fairseq2.typing import META
 
 
 def test_select_parameters() -> None:
-    model_config = nllb_archs.get("dense_1b")
+    model_config = transformer_archs.get("nllb-200_dense_1b")
 
-    model = create_nllb_model(model_config, device=META)
+    model = create_transformer_model(model_config, device=META)
 
     output = select_parameters(model, [r".*\.encoder_decoder_attn_layer_norm\.bias$"])
 
@@ -27,9 +27,9 @@ def test_select_parameters() -> None:
 
 
 def test_select_parameters_when_exclude_is_true() -> None:
-    model_config = nllb_archs.get("dense_1b")
+    model_config = transformer_archs.get("nllb-200_dense_1b")
 
-    model = create_nllb_model(model_config, device=META)
+    model = create_transformer_model(model_config, device=META)
 
     names = [r".*\.encoder_decoder_attn_layer_norm\.bias$", "decoder.layer_norm.weight"]
 


### PR DESCRIPTION
This PR includes two changes (1) moves model architecture definitions to a separate `archs.py` per model and explicitly registers them in `__init__.py` instead of relying on implicit import statements (2) refactors NLLB model definition and defines a vanilla Transformer model that NLLB is now based on (i.e. `load_transformer_model()` instead of `load_nllb_model()`). In order to preserve backwards compatibility `load_nllb_model()` still exists though.