### PR TITLE
allow loading experimental models

### DIFF
--- a/src/fairseq2/models/loader.py
+++ b/src/fairseq2/models/loader.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from pathlib import Path
 from pickle import PickleError
 from typing import Any, Dict, Generic, Optional, Protocol, TypeVar, Union, final
 
@@ -15,6 +16,7 @@ from fairseq2.assets import (
     AssetCardError,
     AssetDownloadManager,
     AssetError,
+    AssetNotFoundError,
     AssetStore,
     default_asset_store,
     default_download_manager,
@@ -356,7 +358,18 @@ class DelegatingModelLoader(ModelLoader[ModelT]):
         if isinstance(model_name_or_card, AssetCard):
             card = model_name_or_card
         else:
-            card = self._asset_store.retrieve_card(model_name_or_card)
+            try:
+                card = self._asset_store.retrieve_card(model_name_or_card)
+            except AssetNotFoundError as err:
+                model_path = Path(model_name_or_card)
+                # If the card is not found, try looking it up by interpreting model_name as a path to the yaml card.
+                if model_path.exists() and model_path.suffix == ".yaml":
+                    import yaml
+                    with open(model_path, "r", encoding="utf-8") as f:
+                        card_data = yaml.full_load(f)
+                        card = AssetCard(card_data)
+                else:
+                    raise err
 
         family = card.field("model_family").as_(str)
 


### PR DESCRIPTION
**What does this PR do? Please describe:**

We want to use fairseq2 to develop models. Before declaring the final model with model card in certain asset store, we want to be able to load the experimental models, e.g. for evaluation in downstream tasks.

This PR assumes the model card is in the form of a .YAML file (such files can be generated automatically , for instance as part of the training loop). It will try to load the .YAML file if the given model card name is not found in its officially registered stores 


- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
