### PR TITLE
Add `target_twoway` mode in the NLLB tokenizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [0.2.1] - TBD
 - Introduced `kv_dim` option to `StandardMultiheadAttention` (for different sizes of encoder and decoder)
 - Added the `CheckpointManager.get_model_checkpoint_path` method
+- Added the `target_twoway mode` in the NLLB tokenizer for formatting target sequences in NLLB or SONAR-like models
 
 ## [0.2.0] - 2023-11-29
 - Introduced LLaMA and LLaMA 2

--- a/src/fairseq2/models/nllb/tokenizer.py
+++ b/src/fairseq2/models/nllb/tokenizer.py
@@ -100,6 +100,13 @@ class NllbTokenizer(SentencePieceTokenizer):
             # the language token.
             prefix_tokens = ["</s>", f"__{lang}__"]
             suffix_tokens = []
+        elif mode == "target_twoway":
+            # Encode a sentence with the EOS both in the beginning and in the end.
+            # Then its prefix without the last token (e.g. "</s> __eng_Latn__ Hello world !") could serve as the decoder input,
+            # and its suffix without the first token (e.g. "__eng_Latn__ Hello world ! </s>") could serve as the decoder target.
+            # This is an elegant way to make sure that decoder inputs and targets are always consistent.
+            prefix_tokens = ["</s>", f"__{lang}__"]
+            suffix_tokens = ["</s>"]
         else:
             raise ValueError(
                 f"`mode` must be 'source' or 'target', but is '{mode}' instead."

--- a/tests/integration/models/test_nllb.py
+++ b/tests/integration/models/test_nllb.py
@@ -50,3 +50,25 @@ def test_load_dense_distill_600m() -> None:
         max_source_len=1024,
     )
     text, _ = translator(ENG_SENTENCE * 20)
+
+
+def test_tokenizer_special_tokens() -> None:
+    model_name = "nllb-200_dense_distill_600m"
+    tokenizer = load_nllb_tokenizer(model_name, progress=False)
+    text = "Hello world!"
+
+    # by default, the "source" mode is active.
+    tokens = tokenizer.create_encoder(mode=None).encode_as_tokens(text)
+    assert tokens == ["__eng_Latn__", "▁Hello", "▁world", "!", "</s>"]
+    tokens = tokenizer.create_encoder(mode="source").encode_as_tokens(text)
+    assert tokens == ["__eng_Latn__", "▁Hello", "▁world", "!", "</s>"]
+
+    # "target" mode creates the decoder input tokens
+    tokens = tokenizer.create_encoder(mode="target").encode_as_tokens(text)
+    assert tokens == ["</s>", "__eng_Latn__", "▁Hello", "▁world", "!"]
+
+    # "target_twoway" mode creates a sequence of tokens which can be trimmed
+    # to serve as decoder inputs (all tokens except the last one)
+    # or to serve as decoder targets (all tokens except the first one)
+    tokens = tokenizer.create_encoder(mode="target_twoway").encode_as_tokens(text)
+    assert tokens == ["</s>", "__eng_Latn__", "▁Hello", "▁world", "!", "</s>"]


### PR DESCRIPTION
**What does this PR do? Please describe:**

This PR introduces a `target_twoway` mode in the NLLB tokenizer. It represents the target text as `</s>__lang_code__ The text.</s>`. 

This mode is handy for training translation models (like NLLB) or text decoding models (like SONAR decoders). With this mode, all-but-the last tokens (e.g. `</s>__lang_code__ The text.`) can be used as teacher-forced inputs to the decoder using its training, and all-but-the-first tokens (e.g. `__lang_code__ The text.</s>`) can be used as the next-token targets for the same decoder. Which is how NLLB (and also SONAR) models are supposed to be trained. 

Without this change, the similar result could be achieved in less straightforward ways:
- either by tokenizing the decoder inputs in the `target` mode and the decoder outputs in the `source` mode, and passing both the sequences to the training step, and truncating/collating/padding both of them identically - which seems slightly brittle;
- or by tokenizing the decoder inputs in the `target` mode and then turning them into decoder targets by removing the first `</s>` token and adding the one after the text - which is not an easy operation on a padded batch of different-length sequences, and may add an `</s>` token incorrectly to a sequence that has been truncated;
- or by tokenizing the decoder targets in the `source` mode and then turning them into decoder inputs by removing the last token (either `</s>` or pad token) and adding an `</s>` token in the beginning - which is actually fine (e.g. the `transformers` implementation of NLLB does it with their [shift_tokens_right](https://github.com/huggingface/transformers/blob/main/src/transformers/models/m2m_100/modeling_m2m_100.py#L60) function), but it requires either concatenating tensors or copying and filling them in place, which is slightly less efficient then just selecting all-but-the-first or all-but-the-last tokens.

I believe that by having a single token sequence and selecting the right tokens from it to be decoder inputs or decoder targets is the simplest strategy, so this new tokenization mode is introduced to enable it.

**Does your PR introduce any breaking changes? If yes, please list them:**
None

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**?
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
