### PR TITLE
Accept asset card paths in recipes

### DIFF
--- a/src/fairseq2/assets/card.py
+++ b/src/fairseq2/assets/card.py
@@ -7,11 +7,13 @@
 from __future__ import annotations
 
 import os
+import re
 from pathlib import Path
 from typing import (
     AbstractSet,
     Any,
     Dict,
+    Final,
     List,
     Mapping,
     MutableMapping,
@@ -22,7 +24,6 @@ from typing import (
 from urllib.parse import urlparse, urlunparse
 
 from fairseq2.assets.error import AssetError
-from fairseq2.assets.utils import _starts_with_scheme
 from fairseq2.utils.value_converter import ValueConverter, default_value_converter
 
 T = TypeVar("T")
@@ -350,3 +351,10 @@ class AssetCardError(AssetError):
 
 class AssetCardFieldNotFoundError(AssetCardError):
     """Raised when an asset card field cannot be found."""
+
+
+_SCHEME_REGEX: Final = re.compile("^[a-zA-Z0-9]+://")
+
+
+def _starts_with_scheme(s: str) -> bool:
+    return re.match(_SCHEME_REGEX, s) is not None

--- a/src/fairseq2/assets/cards/datasets/librispeech.yaml
+++ b/src/fairseq2/assets/cards/datasets/librispeech.yaml
@@ -6,8 +6,8 @@
 
 name: librispeech_asr
 dataset_family: generic_asr
-tokenizer_family: librispeech_asr
 tokenizer: "https://dl.fbaipublicfiles.com/fairseq/wav2vec/librispeech_asr.model"
+tokenizer_family: librispeech_asr
 
 ---
 

--- a/src/fairseq2/assets/download_manager.py
+++ b/src/fairseq2/assets/download_manager.py
@@ -20,8 +20,8 @@ from zipfile import BadZipFile, ZipFile
 
 from tqdm import tqdm  # type: ignore[import]
 
+from fairseq2.assets.card import _starts_with_scheme
 from fairseq2.assets.error import AssetError
-from fairseq2.assets.utils import _starts_with_scheme
 from fairseq2.logging import get_log_writer
 from fairseq2.typing import override
 from fairseq2.utils.env import get_path_from_env

--- a/src/fairseq2/assets/utils.py
+++ b/src/fairseq2/assets/utils.py
@@ -4,11 +4,78 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import re
-from typing import Final
+from pathlib import Path
+from typing import Optional, Union
 
-_SCHEME_REGEX: Final = re.compile("^[a-zA-Z0-9]+://")
+from fairseq2.assets.card import AssetCard
+from fairseq2.assets.metadata_provider import (
+    AssetMetadataError,
+    AssetNotFoundError,
+    InProcAssetMetadataProvider,
+    _load_metadata_file,
+)
+from fairseq2.assets.store import AssetStore, StandardAssetStore, default_asset_store
 
 
-def _starts_with_scheme(s: str) -> bool:
-    return re.match(_SCHEME_REGEX, s) is not None
+def retrieve_asset_card(
+    name_or_card: Union[str, AssetCard, Path], store: Optional[AssetStore] = None
+) -> AssetCard:
+    """Retrieve the specified asset.
+
+    :param name_or_card:
+        The name, card, or path to the card file of the asset to load.
+    :param store:
+        The asset store where to check for available assets. If ``None``, the
+        default asset store will be used.
+    """
+    if isinstance(name_or_card, AssetCard):
+        return name_or_card
+
+    if store is None:
+        store = default_asset_store
+
+    if isinstance(name_or_card, Path):
+        return _card_from_file(name_or_card, store)
+
+    name = name_or_card
+
+    try:
+        return store.retrieve_card(name)
+    except AssetNotFoundError:
+        pass
+
+    try:
+        file = Path(name)
+    except ValueError:
+        file = None
+
+    if file is not None:
+        if (file.suffix == ".yaml" or file.suffix == ".yml") and file.exists():
+            return _card_from_file(file, store)
+
+    raise AssetNotFoundError(name, f"An asset with the name '{name}' cannot be found.")
+
+
+def _card_from_file(file: Path, store: AssetStore) -> AssetCard:
+    if not isinstance(store, StandardAssetStore):
+        raise ValueError(
+            f"`store` must be of type `{StandardAssetStore}` when `name_or_card` is a pathname, but is of type {type(store)} instead."
+        )
+
+    all_metadata = _load_metadata_file(file)
+
+    if len(all_metadata) != 1:
+        raise AssetMetadataError(
+            f"The specified asset metadata file '{file}' contains metadata for more than one asset."
+        )
+
+    name, metadata = all_metadata[0]
+
+    metadata["name"] = name
+
+    metadata_provider = InProcAssetMetadataProvider([metadata], name="argument")
+
+    # Strip the environment tag.
+    name, _ = name.split("@", maxsplit=1)
+
+    return store.retrieve_card(name, extra_provider=metadata_provider)

--- a/src/fairseq2/recipes/assets.py
+++ b/src/fairseq2/recipes/assets.py
@@ -54,7 +54,8 @@ class ListAssetsCommand(CliCommandHandler):
     def __init__(self, asset_store: Optional[AssetStore] = None) -> None:
         """
         :param asset_store:
-            The asset store from which to retrieve the asset cards.
+            The asset store from which to retrieve the asset cards. If ``None``,
+            the default asset store will be used.
         """
         self._asset_store = asset_store or default_asset_store
 
@@ -162,7 +163,8 @@ class ShowAssetCommand(CliCommandHandler):
     def __init__(self, asset_store: Optional[AssetStore] = None) -> None:
         """
         :param asset_store:
-            The asset store from which to retrieve the asset cards.
+            The asset store from which to retrieve the asset cards. If ``None``,
+            the default asset store will be used.
         """
         self._asset_store = asset_store or default_asset_store
 

--- a/src/fairseq2/recipes/utils/sweep.py
+++ b/src/fairseq2/recipes/utils/sweep.py
@@ -73,9 +73,6 @@ class SweepTagger:
         output.append(f"ws_{world_size}")
 
         def abbrv(s: str) -> str:
-            if s.endswith("_name"):
-                s = s[:-5]
-
             if s.startswith("num_"):
                 s = f"n_{s[4:]}"
 

--- a/src/fairseq2/utils/value_converter.py
+++ b/src/fairseq2/utils/value_converter.py
@@ -112,7 +112,8 @@ class ValueConverter:
                 f"`obj` cannot be structured to type `{type_hint}`. See nested exception for details."
             ) from ex
 
-    def _structure_identity(cls, kls: Any, kls_args: Any, obj: Any) -> Any:
+    @staticmethod
+    def _structure_identity(kls: Any, kls_args: Any, obj: Any) -> Any:
         if isinstance(obj, kls):
             return obj
 


### PR DESCRIPTION
This PR extends Tuan's work in #598 to datasets and tokenizers. It also updates the first-party recipes to accept asset card paths instead of only asset names to give more flexiblity to users.