### PR TITLE
Introduce tokenizer_ref

### DIFF
--- a/src/fairseq2/assets/cards/models/llama.yaml
+++ b/src/fairseq2/assets/cards/models/llama.yaml
@@ -9,6 +9,7 @@ model_type: llama  # compat
 model_family: llama
 checkpoint: "https://ai.meta.com/llama/;gated=true"
 tokenizer: "https://ai.meta.com/llama/;gated=true"
+tokenizer_family: llama
 
 ---
 
@@ -23,6 +24,7 @@ model_type: llama  # compat
 model_family: llama
 checkpoint: "https://ai.meta.com/llama/;gated=true"
 tokenizer: "https://ai.meta.com/llama/;gated=true"
+tokenizer_family: llama
 
 ---
 
@@ -69,6 +71,7 @@ model_type: llama  # compat
 model_family: llama
 checkpoint: "https://ai.meta.com/llama/;gated=true"
 tokenizer: "https://ai.meta.com/llama/;gated=true"
+tokenizer_family: llama
 use_v2_tokenizer: true
 
 ---

--- a/src/fairseq2/assets/cards/models/mistral.yaml
+++ b/src/fairseq2/assets/cards/models/mistral.yaml
@@ -10,6 +10,7 @@ model_family: mistral
 model_arch: 7b
 checkpoint: "https://files.mistral-7b-v0-1.mistral.ai/mistral-7B-v0.1.tar;path=mistral-7B-v0.1%2Fconsolidated.00.pth"
 tokenizer: "https://files.mistral-7b-v0-1.mistral.ai/mistral-7B-v0.1.tar;path=mistral-7B-v0.1%2Ftokenizer.model"
+tokenizer_family: mistral
 
 ---
 
@@ -19,3 +20,4 @@ model_family: mistral
 model_arch: 7b
 checkpoint: "https://files.mistral-7b-v0-1.mistral.ai/mistral-7B-instruct-v0.1b.tar;path=Mistral-7B-instruct-v0.1%2Fconsolidated.00.pth"
 tokenizer: "https://files.mistral-7b-v0-1.mistral.ai/mistral-7B-instruct-v0.1b.tar;path=Mistral-7B-instruct-v0.1%2Ftokenizer.model"
+tokenizer_family: mistral

--- a/src/fairseq2/assets/cards/models/s2t_conformer.yaml
+++ b/src/fairseq2/assets/cards/models/s2t_conformer.yaml
@@ -12,6 +12,7 @@ task: translation
 target_langs: [de]
 checkpoint: "https://dl.fbaipublicfiles.com/fairseq/conformer/covost2/en_de/abs_asr_pt_avg_last_10_checkpoint.pt"
 tokenizer: "https://dl.fbaipublicfiles.com/fairseq/s2t/covost2_en_de_st_vocab_char.zip;path=spm_char.model"
+tokenizer_family: s2t_transformer
 
 ---
 
@@ -25,3 +26,4 @@ task: translation
 target_langs: [de]
 checkpoint: "https://dl.fbaipublicfiles.com/fairseq/conformer/covost2/en_de/rel_pos_asr_pt_avg_last_10_checkpoint.pt"
 tokenizer: "https://dl.fbaipublicfiles.com/fairseq/s2t/covost2_en_de_st_vocab_char.zip;path=spm_char.model"
+tokenizer_family: s2t_transformer

--- a/src/fairseq2/assets/cards/models/s2t_transformer.yaml
+++ b/src/fairseq2/assets/cards/models/s2t_transformer.yaml
@@ -15,6 +15,7 @@ task: transcription
 target_langs: [en]
 checkpoint: "https://dl.fbaipublicfiles.com/fairseq/s2t/mustc_de_asr_transformer_s.pt"
 tokenizer: "https://dl.fbaipublicfiles.com/fairseq/s2t/mustc_de_asr_vocab_unigram5000.zip;path=spm_unigram_5000.model"
+tokenizer_family: s2t_transformer
 
 ---
 
@@ -29,6 +30,7 @@ task: transcription
 target_langs: [en]
 checkpoint: "https://dl.fbaipublicfiles.com/fairseq/s2t/mustc_es_asr_transformer_s.pt"
 tokenizer: "https://dl.fbaipublicfiles.com/fairseq/s2t/mustc_es_asr_vocab_unigram5000.zip;path=spm_unigram_5000.model"
+tokenizer_family: s2t_transformer
 
 ---
 
@@ -40,6 +42,7 @@ task: transcription
 target_langs: [en]
 checkpoint: "https://dl.fbaipublicfiles.com/fairseq/s2t/mustc_joint_asr_transformer_m.pt"
 tokenizer: "https://dl.fbaipublicfiles.com/fairseq/s2t/mustc_joint_asr_vocab_unigram10000.zip;path=spm_unigram_10000.model"
+tokenizer_family: s2t_transformer
 
 ---
 
@@ -54,6 +57,7 @@ task: translation
 target_langs: [de]
 checkpoint: "https://dl.fbaipublicfiles.com/fairseq/s2t/mustc_de_st_transformer_s.pt"
 tokenizer: "https://dl.fbaipublicfiles.com/fairseq/s2t/mustc_de_st_vocab_unigram8000.zip;path=spm_unigram_8000.model"
+tokenizer_family: s2t_transformer
 
 ---
 
@@ -65,3 +69,4 @@ task: translation
 target_langs: [de, es, fr, it, nl, pt, ro, ru]
 checkpoint: "https://dl.fbaipublicfiles.com/fairseq/s2t/mustc_multilingual_st_transformer_m.pt"
 tokenizer: "https://dl.fbaipublicfiles.com/fairseq/s2t/mustc_multilingual_st_vocab_unigram10000.zip;path=spm_unigram_10000.model"
+tokenizer_family: s2t_transformer

--- a/src/fairseq2/assets/cards/models/wav2vec2.yaml
+++ b/src/fairseq2/assets/cards/models/wav2vec2.yaml
@@ -33,6 +33,7 @@ model_type: wav2vec2_asr  # compat
 model_family: wav2vec2_asr
 model_arch: base_10h
 checkpoint: "https://dl.fbaipublicfiles.com/fairseq/wav2vec/wav2vec2_asr_fs2_base_10h.pt"
+tokenizer_ref: librispeech_asr
 
 ---
 

--- a/src/fairseq2/checkpoint.py
+++ b/src/fairseq2/checkpoint.py
@@ -231,6 +231,7 @@ class FileCheckpointManager(CheckpointManager):
         base_asset: Optional[str] = None,
         family: Optional[str] = None,
         config: Optional[DataClass] = None,
+        tokenizer_name: Optional[str] = None,
     ) -> None:
         """Set the model metadata.
 
@@ -240,6 +241,8 @@ class FileCheckpointManager(CheckpointManager):
             The family of the model.
         :param config:
             The configuration of the model.
+        :param tokenizer_name:
+            The name of the tokenizer the model is trained with.
         """
         if self._root_gang.rank == 0:
             metadata: Dict[str, Any] = {"name": "checkpoint"}
@@ -255,6 +258,9 @@ class FileCheckpointManager(CheckpointManager):
 
             if self._num_shards != 1:
                 metadata["num_shards"] = self._num_shards
+
+            if tokenizer_name is not None:
+                metadata["tokenizer_ref"] = tokenizer_name
 
             def raise_error(cause: Exception) -> NoReturn:
                 raise RuntimeError(
@@ -605,6 +611,7 @@ class FileCheckpointManager(CheckpointManager):
                     raise RuntimeError(f"Training step {step_nr} has no checkpoint.")
 
                 self._root_gang.barrier()
+
                 return
 
             if preserve_model:


### PR DESCRIPTION
This PR introduces a new `tokenizer_ref` attribute for asset cards. It is typically used if a model is trained with a tokenizer that is not necessarily associated with the model. Instead of duplicating the metadata of an existing tokenizer, in such case, the model card can simply refer to the existing tokenizer by `tokenizer_ref: foo`.