### PR TITLE
Expose vocab_info in wav2vec2 ASR model

### DIFF
--- a/src/fairseq2/models/wav2vec2/asr/factory.py
+++ b/src/fairseq2/models/wav2vec2/asr/factory.py
@@ -120,7 +120,7 @@ class Wav2Vec2AsrBuilder:
         return Wav2Vec2AsrModel(
             encoder_frontend,
             encoder,
-            self._config.vocab_info.size,
+            self._config.vocab_info,
             masker=masker,
             final_dropout_p=self._config.final_dropout_p,
             device=self._device,


### PR DESCRIPTION
This is a small PR that slightly updates `Wav2Vec2AsrModel` to follow the `vocab_info` accessor convention of other models in fairseq2.