### PR TITLE
Introduce resume_checkpoint_dir to wav2vec2 ASR finetuning

### DIFF
--- a/src/fairseq2/checkpoint.py
+++ b/src/fairseq2/checkpoint.py
@@ -727,7 +727,7 @@ class CheckpointModelMetadataProvider(AbstractAssetMetadataProvider):
         metadata_file = self._checkpoint_dir.joinpath("model.yaml")
         if not metadata_file.exists():
             raise AssetMetadataError(
-                "The checkpoint model metadata cannot be found. Make sure to call `FileCheckpointManager.save_model_metadata()` first."
+                f"The checkpoint model metadata (model.yaml) cannot be found under the directory '{self._checkpoint_dir}'. Make sure that the specified directory is the *base* checkpoint directory used during training (i.e. directory passed to `FileCheckpointManager.save_model_metadata()`)."
             )
 
         cache = dict(_load_metadata_file(metadata_file))


### PR DESCRIPTION
This is a follow-up PR to #617 to introduce `resume_checkpoint_dir` to wav2vec2 ASR finetuning recipe.