### PR TITLE
Introduce generation metric bags

### DIFF
--- a/src/fairseq2/metrics/recorder.py
+++ b/src/fairseq2/metrics/recorder.py
@@ -46,26 +46,33 @@ def format_as_float(value: Any, *, postfix: Optional[str] = None) -> str:
 
 _metric_formatters: Dict[str, Tuple[str, int, Callable[[Any], str]]] = {
     # fmt: off
-    "ctc_loss":                  ("CTC Loss",                        100, format_as_float),
-    "nll_loss":                  ("NLL Loss",                        100, format_as_float),
-    "uer":                       ("Unit Error Rate (UER)",           200, format_as_float),
-    "wer":                       ("Word Error Rate (WER)",           200, format_as_float),
-    "gradient_norm":             ("Gradient Norm",                   300, format_as_float),
-    "elapsed_time":              ("Elapsed Time",                    500, format_as_seconds),
-    "wall_time":                 ("Wall Time",                       510, format_as_seconds),
-    "lr":                        ("Learning Rate",                   800, format_as_float),
-    "loss_scale":                ("Loss Scale",                      810, format_as_float),
-    "batch_size":                ("Batch Size",                      900, format_as_int),
-    "elements_per_batch":        ("Elements per Batch",              900, format_as_int),
-    "elements_per_second":       ("Elements per Second",             900, format_as_int),
-    "num_examples":              ("Number of Examples",              900, format_as_int),
-    "num_elements":              ("Number of Elements",              910, format_as_int),
-    "num_source_elements":       ("Number of Source Elements",       910, format_as_int),
-    "num_target_elements":       ("Number of Target Elements",       910, format_as_int),
-    "total_num_examples":        ("Total Number of Examples",        920, format_as_int),
-    "total_num_elements":        ("Total Number of Elements",        930, format_as_int),
-    "total_num_source_elements": ("Total Number of Source Elements", 930, format_as_int),
-    "total_num_target_elements": ("Total Number of Target Elements", 930, format_as_int),
+    "ctc_loss":                      ("CTC Loss",                        100, format_as_float),
+    "nll_loss":                      ("NLL Loss",                        100, format_as_float),
+    "uer":                           ("Unit Error Rate (UER)",           200, format_as_float),
+    "wer":                           ("Word Error Rate (WER)",           200, format_as_float),
+    "gradient_norm":                 ("Gradient Norm",                   300, format_as_float),
+    "elapsed_time":                  ("Elapsed Time",                    500, format_as_seconds),
+    "wall_time":                     ("Wall Time",                       510, format_as_seconds),
+    "lr":                            ("Learning Rate",                   700, format_as_float),
+    "loss_scale":                    ("Loss Scale",                      710, format_as_float),
+
+    # Batch Metrics
+    "batch_size":                    ("Batch Size",                      800, format_as_int),
+    "elements_per_batch":            ("Elements per Batch",              800, format_as_int),
+    "elements_per_second":           ("Elements per Second",             810, format_as_int),
+    "num_examples":                  ("Number of Examples",              820, format_as_int),
+    "num_elements":                  ("Number of Elements",              830, format_as_int),
+    "num_source_elements":           ("Number of Source Elements",       830, format_as_int),
+    "num_target_elements":           ("Number of Target Elements",       830, format_as_int),
+    "total_num_examples":            ("Total Number of Examples",        840, format_as_int),
+    "total_num_elements":            ("Total Number of Elements",        850, format_as_int),
+    "total_num_source_elements":     ("Total Number of Source Elements", 850, format_as_int),
+    "total_num_target_elements":     ("Total Number of Target Elements", 850, format_as_int),
+
+    # Sequence Generator Metrics
+    "generator_prefill_size":        ("Generator/Prefill Size",          900, format_as_int),
+    "generator_num_elements":        ("Generator/Number of Elements",    901, format_as_int),
+    "generator_elements_per_second": ("Generator/Elements per Second",   902, format_as_int),
     # fmt: on
 }
 


### PR DESCRIPTION
This PR introduces two new metric bags for sequence generation to be used in first-party recipes.