### PR TITLE
Add a supports helper method to asset loaders

### DIFF
--- a/native/python/src/fairseq2n/__init__.py
+++ b/native/python/src/fairseq2n/__init__.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+__version__ = "0.3.0.dev0"
+
 import platform
 import site
 from ctypes import CDLL, RTLD_GLOBAL
@@ -18,8 +20,6 @@ from fairseq2n.config import (
     _TORCH_VARIANT,
     _TORCH_VERSION,
 )
-
-__version__ = "0.3.0.dev0"
 
 
 def get_lib() -> Path:

--- a/src/fairseq2/__init__.py
+++ b/src/fairseq2/__init__.py
@@ -6,10 +6,10 @@
 
 __version__ = "0.3.0.dev0"
 
-# Report any fairseq2n initialization error eagerly.
-import fairseq2n
+import fairseq2n  # Report any fairseq2n initialization error eagerly.
 
-# Register asset types.
+# isort: split
+
 import fairseq2.datasets
 import fairseq2.models
 

--- a/src/fairseq2/assets/metadata_provider.py
+++ b/src/fairseq2/assets/metadata_provider.py
@@ -212,21 +212,21 @@ def _load_metadata_file(file: Path) -> List[Tuple[str, Dict[str, Any]]]:
         for idx, metadata in enumerate(all_metadata):
             if not isinstance(metadata, dict):
                 raise AssetMetadataError(
-                    f"The asset metadata at index {idx} in the file '{file}' has an invalid format."
+                    f"The asset metadata at index {idx} in {file} has an invalid format."
                 )
 
             try:
                 name = metadata.pop("name")
             except KeyError:
                 raise AssetMetadataError(
-                    f"The asset metadata at index {idx} in the file '{file}' does not have a name entry."
+                    f"The asset metadata at index {idx} in {file} does not have a name entry."
                 )
 
             try:
                 canonical_name = _canonicalize_name(name)
             except ValueError as ex:
                 raise AssetMetadataError(
-                    f"The asset metadata at index {idx} in the file '{file}' has an invalid name. See nested exception for details."
+                    f"The asset metadata at index {idx} in {file} has an invalid name. See nested exception for details."
                 ) from ex
 
             metadata["__base_path__"] = file.parent

--- a/src/fairseq2/checkpoint.py
+++ b/src/fairseq2/checkpoint.py
@@ -727,7 +727,7 @@ class CheckpointModelMetadataProvider(AbstractAssetMetadataProvider):
         metadata_file = self._checkpoint_dir.joinpath("model.yaml")
         if not metadata_file.exists():
             raise AssetMetadataError(
-                f"The checkpoint model metadata (model.yaml) cannot be found under the directory '{self._checkpoint_dir}'. Make sure that the specified directory is the *base* checkpoint directory used during training (i.e. directory passed to `FileCheckpointManager.save_model_metadata()`)."
+                f"The checkpoint model metadata (model.yaml) cannot be found under {self._checkpoint_dir}. Make sure that the specified directory is the *base* checkpoint directory used during training (i.e. directory passed to `FileCheckpointManager.save_model_metadata()`)."
             )
 
         cache = dict(_load_metadata_file(metadata_file))

--- a/src/fairseq2/datasets/loader.py
+++ b/src/fairseq2/datasets/loader.py
@@ -134,13 +134,13 @@ class DelegatingDatasetLoader(DatasetLoader[DatasetT]):
     ) -> DatasetT:
         card = retrieve_asset_card(dataset_name_or_card, self._asset_store)
 
-        dataset_family = card.field("dataset_family").as_(str)
+        family = card.field("dataset_family").as_(str)
 
         try:
-            loader = self._loaders[dataset_family]
+            loader = self._loaders[family]
         except KeyError:
             raise AssetError(
-                f"The value of the field 'dataset_family' of the asset card '{card.name}' must be a supported dataset family, but '{dataset_family}' has no registered loader."
+                f"The value of the field 'dataset_family' of the asset card '{card.name}' must be a supported dataset family, but '{family}' has no registered loader."
             )
 
         return loader(card, force=force, progress=progress)
@@ -160,3 +160,11 @@ class DelegatingDatasetLoader(DatasetLoader[DatasetT]):
             )
 
         self._loaders[family] = loader
+
+    def supports(self, dataset_name_or_card: Union[str, AssetCard, Path]) -> bool:
+        """Return ``True`` if the specified dataset has a registered loader."""
+        card = retrieve_asset_card(dataset_name_or_card, self._asset_store)
+
+        family = card.field("dataset_family").as_(str)
+
+        return family in self._loaders

--- a/src/fairseq2/models/loader.py
+++ b/src/fairseq2/models/loader.py
@@ -362,13 +362,13 @@ class DelegatingModelLoader(ModelLoader[ModelT]):
     ) -> ModelT:
         card = retrieve_asset_card(model_name_or_card, self._asset_store)
 
-        model_family = card.field("model_family").as_(str)
+        family = card.field("model_family").as_(str)
 
         try:
-            loader = self._loaders[model_family]
+            loader = self._loaders[family]
         except KeyError:
             raise AssetError(
-                f"The value of the field 'model_family' of the asset card '{card.name}' must be a supported model family, but '{model_family}' has no registered loader."
+                f"The value of the field 'model_family' of the asset card '{card.name}' must be a supported model family, but '{family}' has no registered loader."
             )
 
         return loader(
@@ -395,6 +395,14 @@ class DelegatingModelLoader(ModelLoader[ModelT]):
             )
 
         self._loaders[family] = loader
+
+    def supports(self, model_name_or_card: Union[str, AssetCard, Path]) -> bool:
+        """Return ``True`` if the specified model has a registered loader."""
+        card = retrieve_asset_card(model_name_or_card, self._asset_store)
+
+        family = card.field("model_family").as_(str)
+
+        return family in self._loaders
 
 
 load_model = DelegatingModelLoader[Module]()


### PR DESCRIPTION
A small PR that introduces a `supports()` helper method in delegating asset loader types. It also includes a few nit formatting changes with no behavioral change.