### PR TITLE
Use passed Sequence instead of List in public APIs

### DIFF
--- a/src/fairseq2/generation/beam_search.py
+++ b/src/fairseq2/generation/beam_search.py
@@ -50,7 +50,7 @@ class BeamSearchSequenceGenerator(AbstractSequenceGenerator):
     _len_penalty: float
     _prefill_chunk_size: Optional[int]
     _decode_capacity_increment: Optional[int]
-    _step_processors: List[StepProcessor]
+    _step_processors: Sequence[StepProcessor]
 
     def __init__(
         self,
@@ -152,7 +152,7 @@ class BeamSearchSequenceGenerator(AbstractSequenceGenerator):
         self._decode_capacity_increment = decode_capacity_increment
 
         if step_processors:
-            self._step_processors = list(step_processors)
+            self._step_processors = step_processors
         else:
             self._step_processors = []
 
@@ -202,7 +202,7 @@ class BeamSearchSeq2SeqGenerator(AbstractSeq2SeqGenerator):
     _len_penalty: float
     _prefill_chunk_size: Optional[int]
     _decode_capacity_increment: Optional[int]
-    _step_processors: List[StepProcessor]
+    _step_processors: Sequence[StepProcessor]
 
     def __init__(
         self,
@@ -295,7 +295,7 @@ class BeamSearchSeq2SeqGenerator(AbstractSeq2SeqGenerator):
         self._decode_capacity_increment = decode_capacity_increment
 
         if step_processors:
-            self._step_processors = list(step_processors)
+            self._step_processors = step_processors
         else:
             self._step_processors = []
 
@@ -471,7 +471,7 @@ class _AbstractBeamSearchSequenceGeneratorOp(ABC):
     _unk_penalty: float
     _len_penalty: float
     _prefill_chunk_size: Optional[int]
-    _step_processors: List[StepProcessor]
+    _step_processors: Sequence[StepProcessor]
     _step_hooks: Dict[int, StepHook]
     _step_nr: int
     _state_bag: IncrementalStateBag
@@ -501,7 +501,7 @@ class _AbstractBeamSearchSequenceGeneratorOp(ABC):
         len_penalty: float,
         prefill_chunk_size: Optional[int],
         decode_capacity_increment: Optional[int],
-        step_processors: List[StepProcessor],
+        step_processors: Sequence[StepProcessor],
         step_hooks: Dict[int, StepHook],
     ) -> None:
         self._algorithm = algorithm
@@ -944,7 +944,7 @@ class _BeamSearchSequenceGeneratorOp(_AbstractBeamSearchSequenceGeneratorOp):
         len_penalty: float,
         prefill_chunk_size: Optional[int],
         decode_capacity_increment: Optional[int],
-        step_processors: List[StepProcessor],
+        step_processors: Sequence[StepProcessor],
         step_hooks: Dict[int, StepHook],
     ) -> None:
         super().__init__(
@@ -1005,7 +1005,7 @@ class _BeamSearchSeq2SeqGeneratorOp(_AbstractBeamSearchSequenceGeneratorOp):
         len_penalty: float,
         prefill_chunk_size: Optional[int],
         decode_capacity_increment: Optional[int],
-        step_processors: List[StepProcessor],
+        step_processors: Sequence[StepProcessor],
         step_hooks: Dict[int, StepHook],
     ) -> None:
         super().__init__(

--- a/src/fairseq2/generation/sampling.py
+++ b/src/fairseq2/generation/sampling.py
@@ -51,7 +51,7 @@ class SamplingSequenceGenerator(AbstractSequenceGenerator):
     _len_penalty: float
     _prefill_chunk_size: Optional[int]
     _decode_capacity_increment: Optional[int]
-    _step_processors: List[StepProcessor]
+    _step_processors: Sequence[StepProcessor]
 
     def __init__(
         self,
@@ -157,7 +157,7 @@ class SamplingSequenceGenerator(AbstractSequenceGenerator):
         self._decode_capacity_increment = decode_capacity_increment
 
         if step_processors:
-            self._step_processors = list(step_processors)
+            self._step_processors = step_processors
         else:
             self._step_processors = []
 
@@ -209,7 +209,7 @@ class SamplingSeq2SeqGenerator(AbstractSeq2SeqGenerator):
     _len_penalty: float
     _prefill_chunk_size: Optional[int]
     _decode_capacity_increment: Optional[int]
-    _step_processors: List[StepProcessor]
+    _step_processors: Sequence[StepProcessor]
 
     def __init__(
         self,
@@ -306,7 +306,7 @@ class SamplingSeq2SeqGenerator(AbstractSeq2SeqGenerator):
         self._decode_capacity_increment = decode_capacity_increment
 
         if step_processors:
-            self._step_processors = list(step_processors)
+            self._step_processors = step_processors
         else:
             self._step_processors = []
 
@@ -483,7 +483,7 @@ class _AbstractSamplingSequenceGeneratorOp(ABC):
     _unk_penalty: float
     _len_penalty: float
     _prefill_chunk_size: Optional[int]
-    _step_processors: List[StepProcessor]
+    _step_processors: Sequence[StepProcessor]
     _step_hooks: Dict[int, StepHook]
     _step_nr: int
     _state_bag: IncrementalStateBag
@@ -513,7 +513,7 @@ class _AbstractSamplingSequenceGeneratorOp(ABC):
         len_penalty: float,
         prefill_chunk_size: Optional[int],
         decode_capacity_increment: Optional[int],
-        step_processors: List[StepProcessor],
+        step_processors: Sequence[StepProcessor],
         step_hooks: Dict[int, StepHook],
     ) -> None:
         self._sampler = sampler
@@ -917,7 +917,7 @@ class _SamplingSequenceGeneratorOp(_AbstractSamplingSequenceGeneratorOp):
         len_penalty: float,
         prefill_chunk_size: Optional[int],
         decode_capacity_increment: Optional[int],
-        step_processors: List[StepProcessor],
+        step_processors: Sequence[StepProcessor],
         step_hooks: Dict[int, StepHook],
     ) -> None:
         super().__init__(
@@ -980,7 +980,7 @@ class _SamplingSeq2SeqGeneratorOp(_AbstractSamplingSequenceGeneratorOp):
         len_penalty: float,
         prefill_chunk_size: Optional[int],
         decode_capacity_increment: Optional[int],
-        step_processors: List[StepProcessor],
+        step_processors: Sequence[StepProcessor],
         step_hooks: Dict[int, StepHook],
     ) -> None:
         super().__init__(

--- a/src/fairseq2/models/wav2vec2/feature_extractor.py
+++ b/src/fairseq2/models/wav2vec2/feature_extractor.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import List, Optional, Sequence, Tuple, final
+from typing import Optional, Sequence, Tuple, final
 
 import torch
 import torch.nn as nn
@@ -26,7 +26,7 @@ class Wav2Vec2FeatureExtractor(SequenceFeatureExtractor):
     :cite:t:`https://doi.org/10.48550/arxiv.2006.11477`."""
 
     layers: Sequential
-    layer_descs: List[Tuple[int, int, int]]
+    layer_descs: Sequence[Tuple[int, int, int]]
     num_channels: int
     gradient_scale: float
 
@@ -119,7 +119,7 @@ class Wav2Vec2FeatureExtractor(SequenceFeatureExtractor):
 
             input_dim = output_dim
 
-        self.layer_descs = list(layer_descs)
+        self.layer_descs = layer_descs
 
         if gradient_scale <= 0.0 or gradient_scale > 1.0:
             raise ValueError(

--- a/src/fairseq2/recipes/evaluator.py
+++ b/src/fairseq2/recipes/evaluator.py
@@ -117,8 +117,8 @@ class AbstractEvalUnit(EvalUnit[BatchT]):
 class Evaluator(Generic[BatchT]):
     """Evaluates a machine learning model."""
 
-    _units: List[EvalUnit[BatchT]]
-    _data_readers: List[DataReader[BatchT]]
+    _units: Sequence[EvalUnit[BatchT]]
+    _data_readers: Sequence[DataReader[BatchT]]
     _root_gang: Gang
     _dp_gang: Gang
     _tp_gang: Gang
@@ -166,9 +166,9 @@ class Evaluator(Generic[BatchT]):
                 f"The number of data readers in `data_readers` must match the number of units in `units` ({len(units)}), but is {len(data_readers)} instead."
             )
 
-        self._units = list(units)
+        self._units = units
 
-        self._data_readers = list(data_readers)
+        self._data_readers = data_readers
 
         self._root_gang = root_gang
 

--- a/src/fairseq2/recipes/trainer.py
+++ b/src/fairseq2/recipes/trainer.py
@@ -140,8 +140,8 @@ class Trainer(StatefulObjectBag, Generic[BatchT]):
     _data_epoch_nr: int
     _max_num_data_epochs: Optional[int]
     _eod: bool
-    _valid_units: List[EvalUnit[BatchT]]
-    _valid_data_readers: List[DataReader[BatchT]]
+    _valid_units: Sequence[EvalUnit[BatchT]]
+    _valid_data_readers: Sequence[DataReader[BatchT]]
     _validate_after_n_steps: int
     _validate_every_n_steps: int
     _checkpoint_manager: CheckpointManager
@@ -333,9 +333,9 @@ class Trainer(StatefulObjectBag, Generic[BatchT]):
                     f"The number of data readers in `valid_data_readers` must match the number of units in `valid_units` ({len(valid_units)}), but is {len(valid_data_readers)} instead."
                 )
 
-            self._valid_units = list(valid_units)
+            self._valid_units = valid_units
 
-            self._valid_data_readers = list(valid_data_readers)
+            self._valid_data_readers = valid_data_readers
         else:
             raise ValueError(
                 "`valid_units` and `valid_data_readers` must be both specified."


### PR DESCRIPTION
A nit PR that avoids cloning passed arguments of type `Sequence` in various parts of the public API.