### PR TITLE
[lm generate] save id if provided in the jsonl file

### DIFF
--- a/src/fairseq2/datasets/instruction.py
+++ b/src/fairseq2/datasets/instruction.py
@@ -294,6 +294,8 @@ class GenericInstructionDataset(InstructionDataset):
         builder.map(target_encoder, selector="tgt", num_parallel_calls=npc)
 
         def cat_source_and_target(example: Dict[str, Any]) -> Dict[str, Any]:
+            sample_id = example.get("id", None)
+
             prompt_indices = example["src"]
             target_indices = example["tgt"]
 
@@ -301,7 +303,7 @@ class GenericInstructionDataset(InstructionDataset):
 
             target_mask = torch.arange(len(indices)) >= len(prompt_indices)
 
-            return {"indices": indices, "target_mask": target_mask}
+            return {"indices": indices, "target_mask": target_mask, "id": sample_id}
 
         builder.map(cat_source_and_target, num_parallel_calls=npc)
 
@@ -396,9 +398,10 @@ class GenericInstructionDataset(InstructionDataset):
         text_encoder = tokenizer.create_encoder(mode="prompt")
 
         def encode(example: Dict[str, Any]) -> Dict[str, Any]:
+            sample_id = example.get("id", None)
             prompt = example["src"]
 
-            return {"prompt": prompt, "indices": text_encoder(prompt)}
+            return {"prompt": prompt, "indices": text_encoder(prompt), "id": sample_id}
 
         builder.map(encode, num_parallel_calls=npc)
 


### PR DESCRIPTION
**What does this PR do? Please describe:**

Introduce "id" in the example in both src+tgt and prompt readers of the generic instruction dataset.
Then text generate recipe saves the id field into the jsonl file.

Tested using both dataset with IDs and without, in the latter case id field will have null (None) value.
