### PR TITLE
Replace sweep tag skip list with allow list

### DIFF
--- a/src/fairseq2/recipes/transformer/__init__.py
+++ b/src/fairseq2/recipes/transformer/__init__.py
@@ -13,9 +13,12 @@ from fairseq2.recipes.transformer.translate import (
     load_text_translator,
     text_translate_presets,
 )
+from fairseq2.recipes.utils.sweep import default_sweep_tagger
 
 
 def _setup_transformer_cli(cli: Cli) -> None:
+    default_sweep_tagger.extend_allow_set("source_lang", "target_lang")
+
     group = cli.add_group(
         "transformer", help="Transformer-based machine translation recipes"
     )

--- a/src/fairseq2/recipes/utils/sweep.py
+++ b/src/fairseq2/recipes/utils/sweep.py
@@ -17,40 +17,56 @@ from fairseq2.typing import DataClass, DataType, is_dataclass_instance
 class SweepTagger:
     """Generates a sweep tag from the diff of two recipe configurations."""
 
-    _DEFAULT_SKIP_SET: Final = {
-        "activation_checkpointing",
-        "anomaly_detection",
-        "checkpoint_after_n_steps",
-        "checkpoint_every_n_steps",
-        "compute_scores",
-        "decode_capacity_increment",
-        "keep_best_n_checkpoints",
-        "keep_last_n_checkpoints",
-        "max_num_data_epochs",
-        "monitored_gang",
-        "num_prefetch",
-        "prefill_chunk_size",
-        "profile",
-        "publish_metrics_after_n_steps",
-        "publish_metrics_every_n_steps",
-        "torch_compile",
-        "validate_after_n_steps",
-        "validate_every_n_steps",
+    _DEFAULT_ALLOW_SET: Final = {
+        "batch_shuffle_window",
+        "betas",
+        "data_parallelism",
+        "dataset",
+        "dtype",
+        "example_shuffle_window",
+        "final_lr_ratio",
+        "final_lr_scale",
+        "fp16_loss_scale",
+        "fsdp_reshard_after_forward",
+        "fsdp_wrap_granularity",
+        "gradient_accumulation",
+        "label_smoothing",
+        "lr",
+        "lr_stage_ratios",
+        "max_gradient_norm",
+        "max_num_elements",
+        "max_num_steps",
+        "max_num_tokens",
+        "max_seq_len",
+        "model",
+        "model_arch",
+        "model_config",
+        "num_lr_warmup_steps",
+        "pretrained_model",
+        "seed",
+        "split",
+        "start_lr",
+        "start_lr_scale",
+        "tensor_parallel_size",
+        "tokenizer",
+        "train_split",
+        "valid_split",
+        "weight_decay",
     }
 
-    def __init__(self, *, skip_set: Optional[Set[str]] = None) -> None:
+    def __init__(self, *, allow_set: Optional[Set[str]] = None) -> None:
         """
-        :param skip_set:
-            The configuration field names to skip while generating the sweep tag.
+        :param allow_set:
+            The configuration field names allowed while generating the sweep tag.
         """
-        if skip_set is None:
-            skip_set = self._DEFAULT_SKIP_SET.copy()
+        if allow_set is None:
+            allow_set = self._DEFAULT_ALLOW_SET.copy()
 
-        self._skip_set = skip_set
+        self._allow_set = allow_set
 
-    def extend_skip_set(self, extras: Set[str]) -> None:
-        """Extend the skipped configuration field names with ``extras``."""
-        self._skip_set.update(extras)
+    def extend_allow_set(self, *extras: str) -> None:
+        """Extend the allowed configuration field names with ``extras``."""
+        self._allow_set.update(extras)
 
     def __call__(self, preset: str, preset_config: DataClass, config: DataClass) -> str:
         """
@@ -87,7 +103,7 @@ class SweepTagger:
 
                 if is_dataclass_instance(value):
                     generate(config)
-                elif not field.name in self._skip_set:
+                elif field.name in self._allow_set:
                     if s := self._to_tag_value(value):
                         output.append(f"{abbrv(field.name)}_{s}")
 
@@ -102,7 +118,7 @@ class SweepTagger:
                         generate_from_diff(preset_value, value)
                     else:
                         generate(value)
-                elif not field.name in self._skip_set:
+                elif field.name in self._allow_set:
                     if preset_value == value:
                         continue
 

--- a/src/fairseq2/recipes/wav2vec2/asr/__init__.py
+++ b/src/fairseq2/recipes/wav2vec2/asr/__init__.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from fairseq2.recipes.cli import Cli, RecipeCommandHandler
+from fairseq2.recipes.utils.sweep import default_sweep_tagger
 from fairseq2.recipes.wav2vec2.asr.eval import (
     load_wav2vec2_asr_evaluator,
     wav2vec2_asr_eval_presets,
@@ -16,6 +17,13 @@ from fairseq2.recipes.wav2vec2.asr.train import (
 
 
 def _setup_wav2vec2_asr_cli(cli: Cli) -> None:
+    default_sweep_tagger.extend_allow_set(
+        "freeze_encoder_for_n_steps",
+        "max_audio_len",
+        "min_audio_len",
+        "normalize_audio",
+    )
+
     group = cli.add_group("wav2vec2_asr", help="wav2vec 2.0 ASR recipes")
 
     # Train


### PR DESCRIPTION
This PR replaces the "skip list" of `SweepTagger` with "allow list" to have stricter control on the sweep directory naming.