### PR TITLE
Rename FileMetricRecorder to JsonFileMetricRecorder

### DIFF
--- a/src/fairseq2/metrics/__init__.py
+++ b/src/fairseq2/metrics/__init__.py
@@ -8,7 +8,7 @@ from fairseq2.metrics.bag import MetricBag as MetricBag
 from fairseq2.metrics.bag import merge_metric_states as merge_metric_states
 from fairseq2.metrics.bag import reset_metrics as reset_metrics
 from fairseq2.metrics.bag import sync_and_compute_metrics as sync_and_compute_metrics
-from fairseq2.metrics.recorder import FileMetricRecorder as FileMetricRecorder
+from fairseq2.metrics.recorder import JsonFileMetricRecorder as JsonFileMetricRecorder
 from fairseq2.metrics.recorder import LogMetricRecorder as LogMetricRecorder
 from fairseq2.metrics.recorder import MetricRecorder as MetricRecorder
 from fairseq2.metrics.recorder import TensorBoardRecorder as TensorBoardRecorder

--- a/src/fairseq2/metrics/recorder.py
+++ b/src/fairseq2/metrics/recorder.py
@@ -274,7 +274,7 @@ class LogMetricRecorder(MetricRecorder):
 
 
 @final
-class FileMetricRecorder(MetricRecorder):
+class JsonFileMetricRecorder(MetricRecorder):
     """Records metric values to JSONL files."""
 
     _RUN_PART_REGEX: Final = re.compile("^[-_a-zA-Z0-9]+$")

--- a/src/fairseq2/recipes/evaluator.py
+++ b/src/fairseq2/recipes/evaluator.py
@@ -18,7 +18,7 @@ from fairseq2.datasets import DataReader
 from fairseq2.gang import FakeGang, Gang
 from fairseq2.logging import get_log_writer
 from fairseq2.metrics import (
-    FileMetricRecorder,
+    JsonFileMetricRecorder,
     LogMetricRecorder,
     MetricBag,
     MetricRecorder,
@@ -188,7 +188,7 @@ class Evaluator(Generic[BatchT]):
                 self._metric_recorders.append(TensorBoardRecorder(tb_dir))
 
             if metrics_dir is not None:
-                self._metric_recorders.append(FileMetricRecorder(metrics_dir))
+                self._metric_recorders.append(JsonFileMetricRecorder(metrics_dir))
         else:
             self._metric_recorders = []
 

--- a/src/fairseq2/recipes/generator.py
+++ b/src/fairseq2/recipes/generator.py
@@ -18,7 +18,7 @@ from fairseq2.datasets import DataReader
 from fairseq2.gang import FakeGang, Gang
 from fairseq2.logging import get_log_writer
 from fairseq2.metrics import (
-    FileMetricRecorder,
+    JsonFileMetricRecorder,
     LogMetricRecorder,
     MetricBag,
     MetricRecorder,
@@ -143,7 +143,7 @@ class Generator(Generic[BatchT]):
             self._metric_recorders = [LogMetricRecorder(log)]
 
             if metrics_dir is not None:
-                self._metric_recorders.append(FileMetricRecorder(metrics_dir))
+                self._metric_recorders.append(JsonFileMetricRecorder(metrics_dir))
         else:
             self._metric_recorders = []
 

--- a/src/fairseq2/recipes/trainer.py
+++ b/src/fairseq2/recipes/trainer.py
@@ -37,7 +37,7 @@ from fairseq2.datasets import DataReader
 from fairseq2.gang import FakeGang, Gang
 from fairseq2.logging import get_log_writer
 from fairseq2.metrics import (
-    FileMetricRecorder,
+    JsonFileMetricRecorder,
     LogMetricRecorder,
     MetricBag,
     MetricRecorder,
@@ -402,7 +402,7 @@ class Trainer(StatefulObjectBag, Generic[BatchT]):
                 self._metric_recorders.append(TensorBoardRecorder(tb_dir))
 
             if metrics_dir is not None:
-                self._metric_recorders.append(FileMetricRecorder(metrics_dir))
+                self._metric_recorders.append(JsonFileMetricRecorder(metrics_dir))
         else:
             self._metric_recorders = []
 


### PR DESCRIPTION
This PR renamed `FileMetricRecorder` to `JsonFileMetricRecorder`.