### PR TITLE
Introduce generic create_model

### DIFF
--- a/src/fairseq2/models/__init__.py
+++ b/src/fairseq2/models/__init__.py
@@ -11,11 +11,13 @@ from fairseq2.models.config_loader import ModelConfigLoader as ModelConfigLoader
 from fairseq2.models.config_loader import (
     StandardModelConfigLoader as StandardModelConfigLoader,
 )
+from fairseq2.models.factory import DelegatingModelFactory as DelegatingModelFactory
+from fairseq2.models.factory import ModelFactory as ModelFactory
+from fairseq2.models.factory import create_model as create_model
 from fairseq2.models.loader import CheckpointConverter as CheckpointConverter
 from fairseq2.models.loader import DelegatingModelLoader as DelegatingModelLoader
-from fairseq2.models.loader import DenseModelFactory as DenseModelFactory
-from fairseq2.models.loader import DenseModelLoader as DenseModelLoader
 from fairseq2.models.loader import ModelLoader as ModelLoader
+from fairseq2.models.loader import StandardModelLoader as StandardModelLoader
 from fairseq2.models.loader import load_model as load_model
 from fairseq2.models.model import Model as Model
 

--- a/src/fairseq2/models/factory.py
+++ b/src/fairseq2/models/factory.py
@@ -1,0 +1,172 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, Dict, Optional, Protocol, Tuple, Type, TypeVar, final
+
+from torch.nn import Module
+
+from fairseq2.config_registry import ConfigRegistry
+from fairseq2.typing import DataClass, DataType, Device
+from fairseq2.utils.dataclass import FieldError, update_dataclass
+from fairseq2.utils.value_converter import ValueConverter
+
+ModelT = TypeVar("ModelT", bound=Module)
+
+ModelT_co = TypeVar("ModelT_co", bound=Module, covariant=True)
+
+ModelConfigT = TypeVar("ModelConfigT", bound=DataClass)
+
+ModelConfigT_contra = TypeVar(
+    "ModelConfigT_contra", bound=DataClass, contravariant=True
+)
+
+
+class ModelFactory(Protocol[ModelConfigT_contra, ModelT_co]):
+    """Constructs models of type ``ModelT``."""
+
+    def __call__(
+        self,
+        config: ModelConfigT_contra,
+        *,
+        device: Optional[Device] = None,
+        dtype: Optional[DataType] = None,
+    ) -> ModelT_co:
+        """
+        :param config:
+            The model configuration.
+        :param device:
+            The device on which to initialize the model.
+        :param dtype:
+            The data type of the model parameters and buffers.
+        """
+
+
+class _GenericModelFactory(Protocol):
+    def __call__(
+        self,
+        arch: Optional[str],
+        config: Optional[Dict[str, Any]],
+        device: Optional[Device],
+        dtype: Optional[DataType],
+    ) -> Tuple[Module, DataClass]:
+        ...
+
+
+@final
+class DelegatingModelFactory:
+    """Constructs models using registered factories."""
+
+    _factories: Dict[str, _GenericModelFactory]
+
+    def __init__(self) -> None:
+        self._factories = {}
+
+    def __call__(
+        self,
+        family: str,
+        arch: Optional[str],
+        config: Optional[Dict[str, Any]],
+        *,
+        device: Optional[Device] = None,
+        dtype: Optional[DataType] = None,
+    ) -> Tuple[Module, DataClass]:
+        """
+        :param family:
+            The family of the model.
+        :param arch:
+            The architecture of the model. If ``None``, uses the default model
+            configuration.
+        :param config:
+            The weakly-typed model configuration. Keys within ``config`` will
+            override corresponding fields in model configuration object. Keys
+            that are not present in ``config`` will have their default values
+            set based on ``arch``.
+        """
+
+        try:
+            factory = self._factories[family]
+        except KeyError:
+            raise ValueError("`family` must have a registered model factory.") from None
+
+        return factory(arch, config, device, dtype)
+
+    def register(
+        self,
+        *,
+        family: str,
+        factory: ModelFactory[ModelConfigT, ModelT],
+        config_kls: Type[ModelConfigT],
+        arch_configs: Optional[ConfigRegistry[ModelConfigT]],
+        value_converter: Optional[ValueConverter] = None,
+    ) -> None:
+        """Register a model factory.
+
+        :param family:
+            The model family supported by ``factory``.
+        :param factory:
+            The model factory.
+        :param config_kls:
+            The type of the model configuration.
+        :param arch_configs:
+            The registry containing all supported model architectures.
+        :param value_converter:
+            The :class:`ValueConverter` instance to use. If ``None``, the
+            default instance will be used.
+        """
+        if family in self._factories:
+            raise ValueError(
+                f"`family` must be a unique model family name, but '{family}' has already a registered factory."
+            )
+
+        def create_model(
+            arch: Optional[str],
+            config: Optional[Dict[str, Any]],
+            device: Optional[Device],
+            dtype: Optional[DataType],
+        ) -> Tuple[Module, DataClass]:
+            if arch is None:
+                try:
+                    config_ = config_kls()
+                except TypeError as ex:
+                    raise RuntimeError(
+                        f"The {family} model family has not default configuration."
+                    ) from ex
+            else:
+                if arch_configs is None:
+                    raise ValueError(
+                        f"`arch` must be a registered architecture, but the '{family}' model family has no architecture named '{arch}'."
+                    )
+
+                try:
+                    config_ = arch_configs.get(arch)
+                except ValueError:
+                    raise ValueError(
+                        f"`arch` must be a registered architecture, but the '{family}' model family has no architecture named '{arch}'."
+                    ) from None
+
+            if config is not None:
+                try:
+                    unknown_fields = update_dataclass(
+                        config_, config, value_converter=value_converter
+                    )
+                except FieldError as ex:
+                    raise ValueError(
+                        f"`config` must be a valid model configuration, but the value of the configuration field '{ex.field_name}' is invalid. See nested exception for details."
+                    ) from ex
+
+                if unknown_fields:
+                    raise ValueError(
+                        f"`config` must be a valid model configuration, but the following configuration fields are unknown: {', '.join(unknown_fields)}"
+                    )
+
+            model = factory(config_, device=device, dtype=dtype)
+
+            return model, config_
+
+        self._factories[family] = create_model
+
+
+create_model = DelegatingModelFactory()

--- a/src/fairseq2/models/llama/__init__.py
+++ b/src/fairseq2/models/llama/__init__.py
@@ -4,8 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from fairseq2.models.llama.archs import llama_arch as llama_arch
-from fairseq2.models.llama.archs import llama_archs as llama_archs
 from fairseq2.models.llama.chatbot import LLaMA3Chatbot as LLaMA3Chatbot
 from fairseq2.models.llama.chatbot import LLaMAChatbot as LLaMAChatbot
 from fairseq2.models.llama.chatbot import create_llama_chatbot as create_llama_chatbot
@@ -14,7 +12,13 @@ from fairseq2.models.llama.factory import LLaMABuilder as LLaMABuilder
 from fairseq2.models.llama.factory import LLaMAConfig as LLaMAConfig
 from fairseq2.models.llama.factory import create_llama_model as create_llama_model
 from fairseq2.models.llama.factory import get_llama_lora_config as get_llama_lora_config
+from fairseq2.models.llama.factory import llama_arch as llama_arch
+from fairseq2.models.llama.factory import llama_archs as llama_archs
 from fairseq2.models.llama.loader import load_llama_config as load_llama_config
 from fairseq2.models.llama.loader import load_llama_model as load_llama_model
 from fairseq2.models.llama.loader import load_llama_tokenizer as load_llama_tokenizer
 from fairseq2.models.llama.tokenizer import LLaMA3Tokenizer as LLaMA3Tokenizer
+
+# isort: split
+
+import fairseq2.models.llama.archs  # Register architectures.

--- a/src/fairseq2/models/llama/archs.py
+++ b/src/fairseq2/models/llama/archs.py
@@ -4,13 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from fairseq2.config_registry import ConfigRegistry
 from fairseq2.data import VocabularyInfo
-from fairseq2.models.llama.factory import LLaMAConfig
-
-llama_archs = ConfigRegistry[LLaMAConfig]()
-
-llama_arch = llama_archs.decorator
+from fairseq2.models.llama.factory import LLaMAConfig, llama_arch
 
 
 @llama_arch("7b")

--- a/src/fairseq2/models/llama/factory.py
+++ b/src/fairseq2/models/llama/factory.py
@@ -7,7 +7,9 @@
 from dataclasses import dataclass, field
 from typing import Final, Optional
 
+from fairseq2.config_registry import ConfigRegistry
 from fairseq2.data import VocabularyInfo
+from fairseq2.models.factory import create_model
 from fairseq2.models.transformer import (
     TransformerDecoderModel,
     TransformerEmbeddingFrontend,
@@ -79,6 +81,11 @@ class LLaMAConfig:
 
     dropout_p: float = 0.1
     """The dropout probability on outputs of Transformer layers."""
+
+
+llama_archs = ConfigRegistry[LLaMAConfig]()
+
+llama_arch = llama_archs.decorator
 
 
 class LLaMABuilder:
@@ -257,6 +264,14 @@ def create_llama_model(
     model = LLaMABuilder(config, device=device, dtype=dtype).build_model()
 
     return model.set_family(LLAMA_FAMILY)
+
+
+create_model.register(
+    family=LLAMA_FAMILY,
+    factory=create_llama_model,
+    config_kls=LLaMAConfig,
+    arch_configs=llama_archs,
+)
 
 
 def get_llama_lora_config() -> LoRAConfig:

--- a/src/fairseq2/models/llama/loader.py
+++ b/src/fairseq2/models/llama/loader.py
@@ -16,10 +16,14 @@ from fairseq2.data.text import (
 )
 from fairseq2.gang import Gang
 from fairseq2.models.config_loader import StandardModelConfigLoader
-from fairseq2.models.llama.archs import llama_archs
-from fairseq2.models.llama.factory import LLAMA_FAMILY, LLaMAConfig, create_llama_model
+from fairseq2.models.llama.factory import (
+    LLAMA_FAMILY,
+    LLaMAConfig,
+    create_llama_model,
+    llama_archs,
+)
 from fairseq2.models.llama.tokenizer import LLaMA3Tokenizer
-from fairseq2.models.loader import DenseModelLoader, load_model
+from fairseq2.models.loader import StandardModelLoader, load_model
 from fairseq2.models.transformer import (
     TransformerDecoderModel,
     shard_transformer_decoder_model,
@@ -33,7 +37,7 @@ load_llama_config = StandardModelConfigLoader(
 
 
 @final
-class LLaMAModelLoader(DenseModelLoader[TransformerDecoderModel, LLaMAConfig]):
+class LLaMAModelLoader(StandardModelLoader[TransformerDecoderModel, LLaMAConfig]):
     """Loads LLaMA models."""
 
     @override

--- a/src/fairseq2/models/loader.py
+++ b/src/fairseq2/models/loader.py
@@ -24,6 +24,7 @@ from fairseq2.assets.utils import retrieve_asset_card
 from fairseq2.gang import Gang
 from fairseq2.logging import get_log_writer
 from fairseq2.models.config_loader import ModelConfigLoader
+from fairseq2.models.factory import ModelFactory
 from fairseq2.nn.utils.module import (
     infer_device,
     load_state_dict,
@@ -96,35 +97,15 @@ class CheckpointConverter(Protocol[ModelConfigT_contra]):
         """
 
 
-class DenseModelFactory(Protocol[ModelConfigT_contra, ModelT_co]):
-    """Constructs dense models of type ``ModelT``."""
-
-    def __call__(
-        self,
-        config: ModelConfigT_contra,
-        *,
-        device: Optional[Device] = None,
-        dtype: Optional[DataType] = None,
-    ) -> ModelT_co:
-        """
-        :param config:
-            The model configuration.
-        :param device:
-            The device on which to initialize the model.
-        :param dtype:
-            The data type of the model parameters and buffers.
-        """
-
-
-class DenseModelLoader(ModelLoader[ModelT], Generic[ModelT, ModelConfigT]):
-    """Loads dense models of type ``ModelT``."""
+class StandardModelLoader(ModelLoader[ModelT], Generic[ModelT, ModelConfigT]):
+    """Loads models of type ``ModelT``."""
 
     _asset_store: AssetStore
     _download_manager: AssetDownloadManager
     _tensor_loader: TensorLoader
     _checkpoint_converter: Optional[CheckpointConverter[ModelConfigT]]
     _config_loader: ModelConfigLoader[ModelConfigT]
-    _factory: DenseModelFactory[ModelConfigT, ModelT]
+    _factory: ModelFactory[ModelConfigT, ModelT]
     _restrict_checkpoints: bool
     _skip_meta_init: bool
 
@@ -132,7 +113,7 @@ class DenseModelLoader(ModelLoader[ModelT], Generic[ModelT, ModelConfigT]):
         self,
         *,
         config_loader: ModelConfigLoader[ModelConfigT],
-        factory: DenseModelFactory[ModelConfigT, ModelT],
+        factory: ModelFactory[ModelConfigT, ModelT],
         restrict_checkpoints: bool = True,
         skip_meta_init: bool = False,
         asset_store: Optional[AssetStore] = None,
@@ -230,6 +211,9 @@ class DenseModelLoader(ModelLoader[ModelT], Generic[ModelT, ModelConfigT]):
             try:
                 model = self._factory(config, device=META, dtype=dtype)
             except NotImplementedError as ex:
+                if not "'Meta' backend" in str(ex):
+                    raise
+
                 raise RuntimeError(
                     f"One or more operators in {card.name} constructor do not support the meta device. See nested exception for details."
                 ) from ex
@@ -273,7 +257,10 @@ class DenseModelLoader(ModelLoader[ModelT], Generic[ModelT, ModelConfigT]):
             try:
                 # Try to construct the model on the meta device.
                 model = self._factory(config, device=META, dtype=dtype)
-            except NotImplementedError:
+            except NotImplementedError as ex:
+                if not "'Meta' backend" in str(ex):
+                    raise
+
                 log.warning("One or more operators in {} constructor do not support the meta device. Skipping meta device initialization.", card.name)  # fmt: skip
 
         if model is None:
@@ -329,7 +316,7 @@ class DenseModelLoader(ModelLoader[ModelT], Generic[ModelT, ModelConfigT]):
 
     def _shard(self, model: ModelT, gangs: Dict[str, Gang], card: AssetCard) -> None:
         raise RuntimeError(
-            f"{card.name} has a sharded checkpoint, but has no model sharder. Please file a bug report."
+            f"{card.name} has a sharded checkpoint, but has no model sharder. Please file a bug report to the model author."
         )
 
 

--- a/src/fairseq2/models/mistral/__init__.py
+++ b/src/fairseq2/models/mistral/__init__.py
@@ -4,15 +4,19 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from fairseq2.models.mistral.archs import mistral_arch as mistral_arch
-from fairseq2.models.mistral.archs import mistral_archs as mistral_archs
 from fairseq2.models.mistral.chatbot import MistralChatbot as MistralChatbot
 from fairseq2.models.mistral.factory import MISTRAL_FAMILY as MISTRAL_FAMILY
 from fairseq2.models.mistral.factory import MistralBuilder as MistralBuilder
 from fairseq2.models.mistral.factory import MistralConfig as MistralConfig
 from fairseq2.models.mistral.factory import create_mistral_model as create_mistral_model
+from fairseq2.models.mistral.factory import mistral_arch as mistral_arch
+from fairseq2.models.mistral.factory import mistral_archs as mistral_archs
 from fairseq2.models.mistral.loader import load_mistral_config as load_mistral_config
 from fairseq2.models.mistral.loader import load_mistral_model as load_mistral_model
 from fairseq2.models.mistral.loader import (
     load_mistral_tokenizer as load_mistral_tokenizer,
 )
+
+# isort: split
+
+import fairseq2.models.mistral.archs  # Register architectures.

--- a/src/fairseq2/models/mistral/archs.py
+++ b/src/fairseq2/models/mistral/archs.py
@@ -4,12 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from fairseq2.config_registry import ConfigRegistry
-from fairseq2.models.mistral.factory import MistralConfig
-
-mistral_archs = ConfigRegistry[MistralConfig]()
-
-mistral_arch = mistral_archs.decorator
+from fairseq2.models.mistral.factory import MistralConfig, mistral_arch
 
 
 @mistral_arch("7b")

--- a/src/fairseq2/models/mistral/factory.py
+++ b/src/fairseq2/models/mistral/factory.py
@@ -7,7 +7,9 @@
 from dataclasses import dataclass, field
 from typing import Final, Optional
 
+from fairseq2.config_registry import ConfigRegistry
 from fairseq2.data import VocabularyInfo
+from fairseq2.models.factory import create_model
 from fairseq2.models.transformer import (
     TransformerDecoderModel,
     TransformerEmbeddingFrontend,
@@ -72,6 +74,11 @@ class MistralConfig:
 
     dropout_p: float = 0.1
     """The dropout probability on outputs of Transformer layers."""
+
+
+mistral_archs = ConfigRegistry[MistralConfig]()
+
+mistral_arch = mistral_archs.decorator
 
 
 class MistralBuilder:
@@ -254,3 +261,11 @@ def create_mistral_model(
     model = MistralBuilder(config, device=device, dtype=dtype).build_model()
 
     return model.set_family(MISTRAL_FAMILY)
+
+
+create_model.register(
+    family=MISTRAL_FAMILY,
+    factory=create_mistral_model,
+    config_kls=MistralConfig,
+    arch_configs=mistral_archs,
+)

--- a/src/fairseq2/models/mistral/loader.py
+++ b/src/fairseq2/models/mistral/loader.py
@@ -11,12 +11,12 @@ from fairseq2.data.text import (
     load_text_tokenizer,
 )
 from fairseq2.models.config_loader import StandardModelConfigLoader
-from fairseq2.models.loader import DenseModelLoader, load_model
-from fairseq2.models.mistral.archs import mistral_archs
+from fairseq2.models.loader import StandardModelLoader, load_model
 from fairseq2.models.mistral.factory import (
     MISTRAL_FAMILY,
     MistralConfig,
     create_mistral_model,
+    mistral_archs,
 )
 from fairseq2.models.utils.checkpoint import convert_model_state_dict
 
@@ -54,7 +54,7 @@ def convert_mistral_checkpoint(
     return {"model": checkpoint}
 
 
-load_mistral_model = DenseModelLoader(
+load_mistral_model = StandardModelLoader(
     config_loader=load_mistral_config,
     factory=create_mistral_model,
     checkpoint_converter=convert_mistral_checkpoint,

--- a/src/fairseq2/models/s2t_transformer/__init__.py
+++ b/src/fairseq2/models/s2t_transformer/__init__.py
@@ -4,12 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from fairseq2.models.s2t_transformer.archs import (
-    s2t_transformer_arch as s2t_transformer_arch,
-)
-from fairseq2.models.s2t_transformer.archs import (
-    s2t_transformer_archs as s2t_transformer_archs,
-)
 from fairseq2.models.s2t_transformer.factory import (
     S2T_TRANSFORMER_FAMILY as S2T_TRANSFORMER_FAMILY,
 )
@@ -21,6 +15,12 @@ from fairseq2.models.s2t_transformer.factory import (
 )
 from fairseq2.models.s2t_transformer.factory import (
     create_s2t_transformer_model as create_s2t_transformer_model,
+)
+from fairseq2.models.s2t_transformer.factory import (
+    s2t_transformer_arch as s2t_transformer_arch,
+)
+from fairseq2.models.s2t_transformer.factory import (
+    s2t_transformer_archs as s2t_transformer_archs,
 )
 from fairseq2.models.s2t_transformer.feature_extractor import (
     Conv1dFbankSubsampler as Conv1dFbankSubsampler,
@@ -40,3 +40,7 @@ from fairseq2.models.s2t_transformer.loader import (
 from fairseq2.models.s2t_transformer.tokenizer import (
     S2TTransformerTokenizer as S2TTransformerTokenizer,
 )
+
+# isort: split
+
+import fairseq2.models.s2t_transformer.archs  # Register architectures.

--- a/src/fairseq2/models/s2t_transformer/archs.py
+++ b/src/fairseq2/models/s2t_transformer/archs.py
@@ -4,13 +4,11 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from fairseq2.config_registry import ConfigRegistry
 from fairseq2.data import VocabularyInfo
-from fairseq2.models.s2t_transformer.factory import S2TTransformerConfig
-
-s2t_transformer_archs = ConfigRegistry[S2TTransformerConfig]()
-
-s2t_transformer_arch = s2t_transformer_archs.decorator
+from fairseq2.models.s2t_transformer.factory import (
+    S2TTransformerConfig,
+    s2t_transformer_arch,
+)
 
 
 @s2t_transformer_arch("tiny")

--- a/src/fairseq2/models/s2t_transformer/factory.py
+++ b/src/fairseq2/models/s2t_transformer/factory.py
@@ -9,8 +9,10 @@ from typing import Final, Optional
 
 from torch.nn import SiLU
 
+from fairseq2.config_registry import ConfigRegistry
 from fairseq2.data import VocabularyInfo
 from fairseq2.models.conformer import ConformerBlock, ConformerConvolution
+from fairseq2.models.factory import create_model
 from fairseq2.models.s2t_transformer.feature_extractor import Conv1dFbankSubsampler
 from fairseq2.models.s2t_transformer.frontend import S2TTransformerFrontend
 from fairseq2.models.transformer import (
@@ -102,6 +104,11 @@ class S2TTransformerConfig:
 
     depthwise_conv_kernel_size: int = 0
     """The kernel size of depthwise convolutions in Conformer blocks."""
+
+
+s2t_transformer_archs = ConfigRegistry[S2TTransformerConfig]()
+
+s2t_transformer_arch = s2t_transformer_archs.decorator
 
 
 class S2TTransformerBuilder:
@@ -398,3 +405,11 @@ def create_s2t_transformer_model(
     model = S2TTransformerBuilder(config, device=device, dtype=dtype).build_model()
 
     return model.set_family(S2T_TRANSFORMER_FAMILY)
+
+
+create_model.register(
+    family=S2T_TRANSFORMER_FAMILY,
+    factory=create_s2t_transformer_model,
+    config_kls=S2TTransformerConfig,
+    arch_configs=s2t_transformer_archs,
+)

--- a/src/fairseq2/models/s2t_transformer/loader.py
+++ b/src/fairseq2/models/s2t_transformer/loader.py
@@ -10,12 +10,12 @@ from typing import Any, Dict, Final, List, final
 from fairseq2.assets import AssetCard
 from fairseq2.data.text import AbstractTextTokenizerLoader, load_text_tokenizer
 from fairseq2.models.config_loader import StandardModelConfigLoader
-from fairseq2.models.loader import DenseModelLoader, load_model
-from fairseq2.models.s2t_transformer.archs import s2t_transformer_archs
+from fairseq2.models.loader import StandardModelLoader, load_model
 from fairseq2.models.s2t_transformer.factory import (
     S2T_TRANSFORMER_FAMILY,
     S2TTransformerConfig,
     create_s2t_transformer_model,
+    s2t_transformer_archs,
 )
 from fairseq2.models.s2t_transformer.tokenizer import S2TTransformerTokenizer
 from fairseq2.models.utils.checkpoint import convert_fairseq_checkpoint
@@ -87,7 +87,7 @@ def convert_s2t_transformer_checkpoint(
     return convert_fairseq_checkpoint(checkpoint, key_map)
 
 
-load_s2t_transformer_model = DenseModelLoader(
+load_s2t_transformer_model = StandardModelLoader(
     config_loader=load_s2t_transformer_config,
     factory=create_s2t_transformer_model,
     checkpoint_converter=convert_s2t_transformer_checkpoint,

--- a/src/fairseq2/models/transformer/__init__.py
+++ b/src/fairseq2/models/transformer/__init__.py
@@ -4,8 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from fairseq2.models.transformer.archs import transformer_arch as transformer_arch
-from fairseq2.models.transformer.archs import transformer_archs as transformer_archs
 from fairseq2.models.transformer.decoder_model import (
     TransformerDecoderModel as TransformerDecoderModel,
 )
@@ -18,6 +16,8 @@ from fairseq2.models.transformer.factory import TransformerConfig as Transformer
 from fairseq2.models.transformer.factory import (
     create_transformer_model as create_transformer_model,
 )
+from fairseq2.models.transformer.factory import transformer_arch as transformer_arch
+from fairseq2.models.transformer.factory import transformer_archs as transformer_archs
 from fairseq2.models.transformer.frontend import (
     TransformerEmbeddingFrontend as TransformerEmbeddingFrontend,
 )
@@ -34,3 +34,7 @@ from fairseq2.models.transformer.model import TransformerModel as TransformerMod
 from fairseq2.models.transformer.model import (
     init_final_projection as init_final_projection,
 )
+
+# isort: split
+
+import fairseq2.models.transformer.archs  # Register architectures.

--- a/src/fairseq2/models/transformer/archs.py
+++ b/src/fairseq2/models/transformer/archs.py
@@ -4,12 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from fairseq2.config_registry import ConfigRegistry
-from fairseq2.models.transformer.factory import TransformerConfig
-
-transformer_archs = ConfigRegistry[TransformerConfig]()
-
-transformer_arch = transformer_archs.decorator
+from fairseq2.models.transformer.factory import TransformerConfig, transformer_arch
 
 
 @transformer_arch("base")

--- a/src/fairseq2/models/transformer/factory.py
+++ b/src/fairseq2/models/transformer/factory.py
@@ -7,7 +7,9 @@
 from dataclasses import dataclass, field
 from typing import Final, Optional
 
+from fairseq2.config_registry import ConfigRegistry
 from fairseq2.data import VocabularyInfo
+from fairseq2.models.factory import create_model
 from fairseq2.models.transformer.frontend import (
     TransformerEmbeddingFrontend,
     TransformerFrontend,
@@ -82,6 +84,11 @@ class TransformerConfig:
 
     dropout_p: float = 0.1
     """The dropout probability on outputs of Transformer layers."""
+
+
+transformer_archs = ConfigRegistry[TransformerConfig]()
+
+transformer_arch = transformer_archs.decorator
 
 
 class TransformerBuilder:
@@ -265,3 +272,11 @@ def create_transformer_model(
     model = TransformerBuilder(config, device=device, dtype=dtype).build_model()
 
     return model.set_family(TRANSFORMER_FAMILY)
+
+
+create_model.register(
+    family=TRANSFORMER_FAMILY,
+    factory=create_transformer_model,
+    config_kls=TransformerConfig,
+    arch_configs=transformer_archs,
+)

--- a/src/fairseq2/models/transformer/loader.py
+++ b/src/fairseq2/models/transformer/loader.py
@@ -9,12 +9,12 @@ from typing import Any, Dict
 import torch
 
 from fairseq2.models.config_loader import StandardModelConfigLoader
-from fairseq2.models.loader import DenseModelLoader, load_model
-from fairseq2.models.transformer.archs import transformer_archs
+from fairseq2.models.loader import StandardModelLoader, load_model
 from fairseq2.models.transformer.factory import (
     TRANSFORMER_FAMILY,
     TransformerConfig,
     create_transformer_model,
+    transformer_archs,
 )
 from fairseq2.models.utils.checkpoint import convert_fairseq_checkpoint
 
@@ -86,7 +86,7 @@ def convert_transformer_checkpoint(
     return checkpoint
 
 
-load_transformer_model = DenseModelLoader(
+load_transformer_model = StandardModelLoader(
     config_loader=load_transformer_config,
     factory=create_transformer_model,
     checkpoint_converter=convert_transformer_checkpoint,

--- a/src/fairseq2/models/w2vbert/__init__.py
+++ b/src/fairseq2/models/w2vbert/__init__.py
@@ -5,14 +5,18 @@
 # LICENSE file in the root directory of this source tree.
 
 
-from fairseq2.models.w2vbert.archs import w2vbert_arch as w2vbert_arch
-from fairseq2.models.w2vbert.archs import w2vbert_archs as w2vbert_archs
 from fairseq2.models.w2vbert.factory import W2VBERT_FAMILY as W2VBERT_FAMILY
 from fairseq2.models.w2vbert.factory import W2VBertBuilder as W2VBertBuilder
 from fairseq2.models.w2vbert.factory import W2VBertConfig as W2VBertConfig
 from fairseq2.models.w2vbert.factory import create_w2vbert_model as create_w2vbert_model
+from fairseq2.models.w2vbert.factory import w2vbert_arch as w2vbert_arch
+from fairseq2.models.w2vbert.factory import w2vbert_archs as w2vbert_archs
 from fairseq2.models.w2vbert.loader import load_w2vbert_config as load_w2vbert_config
 from fairseq2.models.w2vbert.loader import load_w2vbert_model as load_w2vbert_model
 from fairseq2.models.w2vbert.model import W2VBertLoss as W2VBertLoss
 from fairseq2.models.w2vbert.model import W2VBertModel as W2VBertModel
 from fairseq2.models.w2vbert.model import W2VBertOutput as W2VBertOutput
+
+# isort: split
+
+import fairseq2.models.w2vbert.archs  # Register architectures.

--- a/src/fairseq2/models/w2vbert/archs.py
+++ b/src/fairseq2/models/w2vbert/archs.py
@@ -4,13 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from fairseq2.config_registry import ConfigRegistry
-from fairseq2.models.w2vbert.factory import W2VBertConfig
+from fairseq2.models.w2vbert.factory import W2VBertConfig, w2vbert_arch
 from fairseq2.models.wav2vec2 import Wav2Vec2EncoderConfig, wav2vec2_encoder_arch
-
-w2vbert_archs = ConfigRegistry[W2VBertConfig]()
-
-w2vbert_arch = w2vbert_archs.decorator
 
 
 @w2vbert_arch("600m")

--- a/src/fairseq2/models/w2vbert/factory.py
+++ b/src/fairseq2/models/w2vbert/factory.py
@@ -7,6 +7,8 @@
 from dataclasses import dataclass, field
 from typing import Final, Optional
 
+from fairseq2.config_registry import ConfigRegistry
+from fairseq2.models.factory import create_model
 from fairseq2.models.w2vbert.model import W2VBertModel
 from fairseq2.models.wav2vec2 import (
     Wav2Vec2Builder,
@@ -81,6 +83,11 @@ class W2VBertConfig:
 
     num_target_codebooks: int = 1
     """The number of consecutive codebooks to use as masked prediction targets."""
+
+
+w2vbert_archs = ConfigRegistry[W2VBertConfig]()
+
+w2vbert_arch = w2vbert_archs.decorator
 
 
 class W2VBertBuilder:
@@ -174,3 +181,11 @@ def create_w2vbert_model(
     builder = W2VBertBuilder(config, w2v2_builder, device=device, dtype=dtype)
 
     return builder.build_model().set_family(W2VBERT_FAMILY)
+
+
+create_model.register(
+    family=W2VBERT_FAMILY,
+    factory=create_w2vbert_model,
+    config_kls=W2VBertConfig,
+    arch_configs=w2vbert_archs,
+)

--- a/src/fairseq2/models/w2vbert/loader.py
+++ b/src/fairseq2/models/w2vbert/loader.py
@@ -9,13 +9,13 @@ from typing import Any, Dict
 import torch
 
 from fairseq2.models.config_loader import StandardModelConfigLoader
-from fairseq2.models.loader import DenseModelLoader, load_model
+from fairseq2.models.loader import StandardModelLoader, load_model
 from fairseq2.models.utils.checkpoint import convert_fairseq_checkpoint
-from fairseq2.models.w2vbert.archs import w2vbert_archs
 from fairseq2.models.w2vbert.factory import (
     W2VBERT_FAMILY,
     W2VBertConfig,
     create_w2vbert_model,
+    w2vbert_archs,
 )
 
 load_w2vbert_config = StandardModelConfigLoader(
@@ -73,7 +73,7 @@ def convert_w2vbert_checkpoint(
     return convert_fairseq_checkpoint(checkpoint, key_map)
 
 
-load_w2vbert_model = DenseModelLoader(
+load_w2vbert_model = StandardModelLoader(
     config_loader=load_w2vbert_config,
     factory=create_w2vbert_model,
     checkpoint_converter=convert_w2vbert_checkpoint,

--- a/src/fairseq2/models/wav2vec2/__init__.py
+++ b/src/fairseq2/models/wav2vec2/__init__.py
@@ -4,14 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from fairseq2.models.wav2vec2.archs import wav2vec2_arch as wav2vec2_arch
-from fairseq2.models.wav2vec2.archs import wav2vec2_archs as wav2vec2_archs
-from fairseq2.models.wav2vec2.archs import (
-    wav2vec2_encoder_arch as wav2vec2_encoder_arch,
-)
-from fairseq2.models.wav2vec2.archs import (
-    wav2vec2_encoder_archs as wav2vec2_encoder_archs,
-)
 from fairseq2.models.wav2vec2.factory import WAV2VEC2_FAMILY as WAV2VEC2_FAMILY
 from fairseq2.models.wav2vec2.factory import Wav2Vec2Builder as Wav2Vec2Builder
 from fairseq2.models.wav2vec2.factory import Wav2Vec2Config as Wav2Vec2Config
@@ -23,6 +15,14 @@ from fairseq2.models.wav2vec2.factory import (
 )
 from fairseq2.models.wav2vec2.factory import (
     create_wav2vec2_model as create_wav2vec2_model,
+)
+from fairseq2.models.wav2vec2.factory import wav2vec2_arch as wav2vec2_arch
+from fairseq2.models.wav2vec2.factory import wav2vec2_archs as wav2vec2_archs
+from fairseq2.models.wav2vec2.factory import (
+    wav2vec2_encoder_arch as wav2vec2_encoder_arch,
+)
+from fairseq2.models.wav2vec2.factory import (
+    wav2vec2_encoder_archs as wav2vec2_encoder_archs,
 )
 from fairseq2.models.wav2vec2.feature_extractor import (
     Wav2Vec2FbankFeatureExtractor as Wav2Vec2FbankFeatureExtractor,
@@ -44,3 +44,7 @@ from fairseq2.models.wav2vec2.position_encoder import (
 from fairseq2.models.wav2vec2.position_encoder import (
     Wav2Vec2StackedPositionEncoder as Wav2Vec2StackedPositionEncoder,
 )
+
+# isort: split
+
+import fairseq2.models.wav2vec2.archs  # Register architectures.

--- a/src/fairseq2/models/wav2vec2/archs.py
+++ b/src/fairseq2/models/wav2vec2/archs.py
@@ -4,13 +4,13 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from fairseq2.config_registry import ConfigRegistry
-from fairseq2.models.wav2vec2.factory import Wav2Vec2Config, Wav2Vec2EncoderConfig
+from fairseq2.models.wav2vec2.factory import (
+    Wav2Vec2Config,
+    Wav2Vec2EncoderConfig,
+    wav2vec2_arch,
+    wav2vec2_encoder_arch,
+)
 from fairseq2.nn.transformer import TransformerNormOrder
-
-wav2vec2_archs = ConfigRegistry[Wav2Vec2Config]()
-
-wav2vec2_arch = wav2vec2_archs.decorator
 
 
 @wav2vec2_arch("base")
@@ -51,6 +51,7 @@ def _large_lv60k() -> Wav2Vec2Config:
 @wav2vec2_arch("pseudo_dinosr_base")
 def _pseudo_dinosr_base() -> Wav2Vec2Config:
     layer_descs = [(512, 10, 5)] + [(512, 3, 2)] * 4 + [(512, 2, 2)] * 3
+
     encoder_config = Wav2Vec2EncoderConfig(
         model_dim=768,
         max_seq_len=100000,
@@ -79,6 +80,7 @@ def _pseudo_dinosr_base() -> Wav2Vec2Config:
         norm_order=TransformerNormOrder.POST,
         depthwise_conv_kernel_size=31,
     )
+
     return Wav2Vec2Config(
         encoder_config,
         final_dim=256,
@@ -94,11 +96,6 @@ def _pseudo_dinosr_base() -> Wav2Vec2Config:
         num_distractors=100,
         logit_temp=0.1,
     )
-
-
-wav2vec2_encoder_archs = ConfigRegistry[Wav2Vec2EncoderConfig]()
-
-wav2vec2_encoder_arch = wav2vec2_encoder_archs.decorator
 
 
 @wav2vec2_encoder_arch("base")

--- a/src/fairseq2/models/wav2vec2/asr/__init__.py
+++ b/src/fairseq2/models/wav2vec2/asr/__init__.py
@@ -4,8 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from fairseq2.models.wav2vec2.asr.archs import wav2vec2_asr_arch as wav2vec2_asr_arch
-from fairseq2.models.wav2vec2.asr.archs import wav2vec2_asr_archs as wav2vec2_asr_archs
 from fairseq2.models.wav2vec2.asr.factory import (
     WAV2VEC2_ASR_FAMILY as WAV2VEC2_ASR_FAMILY,
 )
@@ -16,6 +14,10 @@ from fairseq2.models.wav2vec2.asr.factory import Wav2Vec2AsrConfig as Wav2Vec2As
 from fairseq2.models.wav2vec2.asr.factory import (
     create_wav2vec2_asr_model as create_wav2vec2_asr_model,
 )
+from fairseq2.models.wav2vec2.asr.factory import wav2vec2_asr_arch as wav2vec2_asr_arch
+from fairseq2.models.wav2vec2.asr.factory import (
+    wav2vec2_asr_archs as wav2vec2_asr_archs,
+)
 from fairseq2.models.wav2vec2.asr.loader import (
     load_wav2vec2_asr_config as load_wav2vec2_asr_config,
 )
@@ -24,3 +26,7 @@ from fairseq2.models.wav2vec2.asr.loader import (
 )
 from fairseq2.models.wav2vec2.asr.model import Wav2Vec2AsrModel as Wav2Vec2AsrModel
 from fairseq2.models.wav2vec2.asr.model import Wav2Vec2AsrOutput as Wav2Vec2AsrOutput
+
+# isort: split
+
+import fairseq2.models.wav2vec2.asr.archs  # Register architectures.

--- a/src/fairseq2/models/wav2vec2/asr/archs.py
+++ b/src/fairseq2/models/wav2vec2/asr/archs.py
@@ -4,13 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from fairseq2.config_registry import ConfigRegistry
-from fairseq2.models.wav2vec2.archs import wav2vec2_encoder_archs
-from fairseq2.models.wav2vec2.asr.factory import Wav2Vec2AsrConfig
-
-wav2vec2_asr_archs = ConfigRegistry[Wav2Vec2AsrConfig]()
-
-wav2vec2_asr_arch = wav2vec2_asr_archs.decorator
+from fairseq2.models.wav2vec2.asr.factory import Wav2Vec2AsrConfig, wav2vec2_asr_arch
+from fairseq2.models.wav2vec2.factory import wav2vec2_encoder_archs
 
 
 @wav2vec2_asr_arch("base_10h")

--- a/src/fairseq2/models/wav2vec2/asr/factory.py
+++ b/src/fairseq2/models/wav2vec2/asr/factory.py
@@ -7,7 +7,9 @@
 from dataclasses import dataclass, field
 from typing import Final, Optional
 
+from fairseq2.config_registry import ConfigRegistry
 from fairseq2.data import VocabularyInfo
+from fairseq2.models.factory import create_model
 from fairseq2.models.wav2vec2.asr.model import Wav2Vec2AsrModel
 from fairseq2.models.wav2vec2.factory import (
     Wav2Vec2EncoderBuilder,
@@ -70,6 +72,11 @@ class Wav2Vec2AsrConfig:
 
     min_num_spatial_mask_spans: int = 2
     """The minimum number of spatial masks sampled per sequence."""
+
+
+wav2vec2_asr_archs = ConfigRegistry[Wav2Vec2AsrConfig]()
+
+wav2vec2_asr_arch = wav2vec2_asr_archs.decorator
 
 
 class Wav2Vec2AsrBuilder:
@@ -167,3 +174,11 @@ def create_wav2vec2_asr_model(
     builder = Wav2Vec2AsrBuilder(config, encoder_builder, device=device, dtype=dtype)
 
     return builder.build_model().set_family(WAV2VEC2_ASR_FAMILY)
+
+
+create_model.register(
+    family=WAV2VEC2_ASR_FAMILY,
+    factory=create_wav2vec2_asr_model,
+    config_kls=Wav2Vec2AsrConfig,
+    arch_configs=wav2vec2_asr_archs,
+)

--- a/src/fairseq2/models/wav2vec2/asr/loader.py
+++ b/src/fairseq2/models/wav2vec2/asr/loader.py
@@ -7,13 +7,13 @@
 from typing import Any, Dict
 
 from fairseq2.models.config_loader import StandardModelConfigLoader
-from fairseq2.models.loader import DenseModelLoader, load_model
+from fairseq2.models.loader import StandardModelLoader, load_model
 from fairseq2.models.utils.checkpoint import convert_fairseq_checkpoint
-from fairseq2.models.wav2vec2.asr.archs import wav2vec2_asr_archs
 from fairseq2.models.wav2vec2.asr.factory import (
     WAV2VEC2_ASR_FAMILY,
     Wav2Vec2AsrConfig,
     create_wav2vec2_asr_model,
+    wav2vec2_asr_archs,
 )
 from fairseq2.nn.transformer import TransformerNormOrder
 
@@ -71,7 +71,7 @@ def convert_wav2vec2_asr_checkpoint(
     return convert_fairseq_checkpoint(checkpoint, key_map)
 
 
-load_wav2vec2_asr_model = DenseModelLoader(
+load_wav2vec2_asr_model = StandardModelLoader(
     config_loader=load_wav2vec2_asr_config,
     factory=create_wav2vec2_asr_model,
     checkpoint_converter=convert_wav2vec2_asr_checkpoint,

--- a/src/fairseq2/models/wav2vec2/loader.py
+++ b/src/fairseq2/models/wav2vec2/loader.py
@@ -9,13 +9,13 @@ from typing import Any, Dict
 import torch
 
 from fairseq2.models.config_loader import StandardModelConfigLoader
-from fairseq2.models.loader import DenseModelLoader, load_model
+from fairseq2.models.loader import StandardModelLoader, load_model
 from fairseq2.models.utils.checkpoint import convert_fairseq_checkpoint
-from fairseq2.models.wav2vec2.archs import wav2vec2_archs
 from fairseq2.models.wav2vec2.factory import (
     WAV2VEC2_FAMILY,
     Wav2Vec2Config,
     create_wav2vec2_model,
+    wav2vec2_archs,
 )
 from fairseq2.nn.transformer import TransformerNormOrder
 
@@ -70,7 +70,7 @@ def convert_wav2vec2_checkpoint(
     return convert_fairseq_checkpoint(checkpoint, key_map)
 
 
-load_wav2vec2_model = DenseModelLoader(
+load_wav2vec2_model = StandardModelLoader(
     config_loader=load_wav2vec2_config,
     factory=create_wav2vec2_model,
     checkpoint_converter=convert_wav2vec2_checkpoint,

--- a/src/fairseq2/nn/position_encoder.py
+++ b/src/fairseq2/nn/position_encoder.py
@@ -18,6 +18,7 @@ from torch.nn.parameter import Parameter
 from fairseq2.nn.incremental_state import IncrementalStateBag
 from fairseq2.nn.padding import PaddingMask
 from fairseq2.typing import DataType, Device, override
+from fairseq2.utils.version import torch_greater_or_equal
 
 
 class PositionEncoder(Module, ABC):
@@ -351,9 +352,10 @@ class RotaryEncoder(PositionEncoder):
 
         device = self.freqs.device
 
-        # As of PyTorch 2.0, `torch.polar` does not support meta device.
-        if device.type == "meta":
-            return
+        # In PyTorch 2.0 and 2.1, `torch.polar` does not support meta device.
+        if not torch_greater_or_equal(2, 2):
+            if device.type == "meta":
+                return
 
         complex_freqs = torch.view_as_complex(self.freqs)
 

--- a/src/fairseq2/recipes/lm/chatbot.py
+++ b/src/fairseq2/recipes/lm/chatbot.py
@@ -27,7 +27,7 @@ from fairseq2.recipes.cli import CliCommandHandler
 from fairseq2.recipes.logging import setup_basic_logging
 from fairseq2.recipes.utils.argparse import parse_dtype
 from fairseq2.recipes.utils.environment import default_env_setters
-from fairseq2.recipes.utils.setup import setup_gangs
+from fairseq2.recipes.utils.setup import check_model_type, setup_gangs
 from fairseq2.typing import CPU, override
 from fairseq2.utils.rng import RngBag
 
@@ -145,10 +145,7 @@ class ChatbotCommandHandler(CliCommandHandler):
 
         model = load_model(args.model_name, gangs=gangs, dtype=args.dtype)
 
-        if not isinstance(model, DecoderModel):
-            log.error("The model must be a decoder model.")
-
-            sys.exit(1)
+        check_model_type(model, DecoderModel)
 
         log.info("Model loaded.")
 
@@ -156,7 +153,7 @@ class ChatbotCommandHandler(CliCommandHandler):
         sampler = TopPSampler(p=args.top_p)
 
         generator = SamplingSequenceGenerator(
-            model, sampler, temperature=args.temperature, max_gen_len=args.max_gen_len
+            model, sampler, temperature=args.temperature, max_gen_len=args.max_gen_len  # type: ignore[arg-type]
         )
 
         chatbot = create_chatbot(generator, tokenizer)

--- a/src/fairseq2/recipes/lm/instruction_finetune.py
+++ b/src/fairseq2/recipes/lm/instruction_finetune.py
@@ -31,7 +31,6 @@ from fairseq2.models import load_model
 from fairseq2.models.decoder import DecoderModel
 from fairseq2.models.sequence import (
     SequenceBatch,
-    SequenceModel,
     SequenceModelOutput,
     as_auto_regressive_input,
 )
@@ -285,8 +284,7 @@ def load_instruction_finetuner(
 
         log.info("Model loaded on data parallel rank 0.")
 
-    if not isinstance(model, DecoderModel):
-        raise ValueError("`model` must specify a decoder model.")
+    check_model_type(model, DecoderModel)
 
     checkpoint_manager.save_model_metadata(
         base_asset=model_card.name, family=model.family
@@ -392,7 +390,7 @@ class InstructionFinetuneUnit(AbstractTrainUnit[SequenceBatch]):
         """
         super().__init__(model)
 
-        check_model_type(model, SequenceModel)
+        check_model_type(model, DecoderModel)
 
         self._metric_bag = SequenceMetricBag(gang)
 

--- a/src/fairseq2/recipes/trainer.py
+++ b/src/fairseq2/recipes/trainer.py
@@ -894,7 +894,7 @@ class Trainer(StatefulObjectBag, Generic[BatchT]):
         if not unit_scores:
             if self._root_gang.rank == 0:
                 raise RuntimeError(
-                    "None of the validation units returned a score metric value. Please file a bug report with the recipe author."
+                    "None of the validation units returned a score metric value. Please file a bug report to the recipe author."
                 )
 
             return None

--- a/src/fairseq2/recipes/transformer/eval.py
+++ b/src/fairseq2/recipes/transformer/eval.py
@@ -29,9 +29,10 @@ from fairseq2.generation import Seq2SeqGenerator
 from fairseq2.generation.text import SequenceToTextConverter
 from fairseq2.logging import get_log_writer
 from fairseq2.metrics.text import BleuMetric, ChrfMetric
+from fairseq2.models import load_model
+from fairseq2.models.encoder_decoder import EncoderDecoderModel
 from fairseq2.models.seq2seq import Seq2SeqBatch, as_auto_regressive_input
 from fairseq2.models.sequence import SequenceModelOutput
-from fairseq2.models.transformer import load_transformer_model
 from fairseq2.recipes.common_metrics import Seq2SeqGenerationMetricBag, Seq2SeqMetricBag
 from fairseq2.recipes.evaluator import AbstractEvalUnit, Evaluator, EvalUnit
 from fairseq2.recipes.transformer.translate import (
@@ -40,7 +41,11 @@ from fairseq2.recipes.transformer.translate import (
     _create_sequence_generator,
 )
 from fairseq2.recipes.utils.log import log_model
-from fairseq2.recipes.utils.setup import broadcast_model, setup_root_gang
+from fairseq2.recipes.utils.setup import (
+    broadcast_model,
+    check_model_type,
+    setup_root_gang,
+)
 from fairseq2.typing import META, DataType, override
 from fairseq2.utils.profiler import Stopwatch
 
@@ -166,7 +171,9 @@ def load_transformer_evaluator(
     else:
         init_device = META
 
-    model = load_transformer_model(model_card, device=init_device, dtype=config.dtype)
+    model = load_model(model_card, device=init_device, dtype=config.dtype)
+
+    check_model_type(model, EncoderDecoderModel)
 
     gang.barrier()
 
@@ -180,7 +187,7 @@ def load_transformer_evaluator(
 
     # Initialize the sequence generator.
     generator = _create_sequence_generator(
-        model, config.generator_mode, config.beam_search, config.sampling
+        model, config.generator_mode, config.beam_search, config.sampling  # type: ignore[arg-type]
     )
 
     # Initialize the evaluation units.
@@ -331,6 +338,8 @@ class TransformerLossEvalUnit(AbstractEvalUnit[Seq2SeqBatch]):
             The amount of label smoothing to apply while computing the loss.
         """
         super().__init__(model, display_name=f"loss/{direction}")
+
+        check_model_type(model, EncoderDecoderModel)
 
         self._label_smoothing = label_smoothing
 

--- a/src/fairseq2/recipes/transformer/translate.py
+++ b/src/fairseq2/recipes/transformer/translate.py
@@ -31,13 +31,17 @@ from fairseq2.generation import (
 )
 from fairseq2.generation.text import SequenceToTextConverter
 from fairseq2.logging import get_log_writer
+from fairseq2.models import load_model
 from fairseq2.models.encoder_decoder import EncoderDecoderModel
 from fairseq2.models.sequence import SequenceBatch
-from fairseq2.models.transformer import load_transformer_model
 from fairseq2.recipes.common_metrics import Seq2SeqGenerationMetricBag
 from fairseq2.recipes.generator import AbstractGeneratorUnit, Generator
 from fairseq2.recipes.utils.log import log_model
-from fairseq2.recipes.utils.setup import broadcast_model, setup_root_gang
+from fairseq2.recipes.utils.setup import (
+    broadcast_model,
+    check_model_type,
+    setup_root_gang,
+)
 from fairseq2.typing import META, DataType, override
 from fairseq2.utils.profiler import Stopwatch
 
@@ -244,7 +248,9 @@ def load_text_translator(
     else:
         init_device = META
 
-    model = load_transformer_model(model_card, device=init_device, dtype=config.dtype)
+    model = load_model(model_card, device=init_device, dtype=config.dtype)
+
+    check_model_type(model, EncoderDecoderModel)
 
     gang.barrier()
 
@@ -258,7 +264,7 @@ def load_text_translator(
 
     # Initialize the sequence generator.
     generator = _create_sequence_generator(
-        model, config.generator_mode, config.beam_search, config.sampling
+        model, config.generator_mode, config.beam_search, config.sampling  # type: ignore[arg-type]
     )
 
     # Initialize the generator unit.

--- a/src/fairseq2/recipes/utils/setup.py
+++ b/src/fairseq2/recipes/utils/setup.py
@@ -20,8 +20,6 @@ from fairseq2.nn.ddp import to_ddp
 from fairseq2.nn.fsdp import to_fsdp
 from fairseq2.nn.utils.module import broadcast_module, to_device
 from fairseq2.recipes.utils.log import log_environment_info
-from fairseq2.typing import DataClass
-from fairseq2.utils.dataclass import FieldError, update_dataclass
 
 
 def setup_root_gang(
@@ -199,20 +197,5 @@ def check_model_type(model: Module, kls: Type[Module]) -> None:
 
     if not isinstance(model, kls):
         raise ValueError(
-            f"`model` must be of type `{kls}`, but is of type `{type(model)}` instead."
-        )
-
-
-def update_model_config(config: DataClass, overrides: Dict[str, Any]) -> None:
-    """Update ``config`` with the data contained in ``overrides``."""
-    try:
-        unknown_fields = update_dataclass(config, overrides)
-    except FieldError as ex:
-        raise ValueError(
-            f"`model_config` must be a valid model configuration, but the value of the configuration field '{ex.field_name}' is invalid. See nested exception for details."
-        ) from ex
-
-    if unknown_fields:
-        raise ValueError(
-            f"`model_config` must be a valid model configuration, but the following configuration fields are unknown: {', '.join(unknown_fields)}"
+            f"The specified model must be of type `{kls}`, but is of type `{type(model)}` instead."
         )

--- a/src/fairseq2/recipes/wav2vec2/asr/eval.py
+++ b/src/fairseq2/recipes/wav2vec2/asr/eval.py
@@ -23,9 +23,10 @@ from fairseq2.datasets.asr import GenericAsrDataset, load_asr_dataset
 from fairseq2.gang import Gang
 from fairseq2.logging import get_log_writer
 from fairseq2.metrics.text import WerMetric
+from fairseq2.models import load_model
 from fairseq2.models.seq2seq import Seq2SeqBatch
 from fairseq2.models.sequence import SequenceBatch
-from fairseq2.models.wav2vec2.asr import Wav2Vec2AsrModel, load_wav2vec2_asr_model
+from fairseq2.models.wav2vec2.asr import Wav2Vec2AsrModel
 from fairseq2.models.wav2vec2.asr.model import Wav2Vec2AsrOutput
 from fairseq2.nn.utils.module import remove_parametrizations
 from fairseq2.recipes.evaluator import AbstractEvalUnit, Evaluator
@@ -147,7 +148,9 @@ def load_wav2vec2_asr_evaluator(
     else:
         init_device = META
 
-    model = load_wav2vec2_asr_model(model_card, device=init_device, dtype=config.dtype)
+    model = load_model(model_card, device=init_device, dtype=config.dtype)
+
+    check_model_type(model, Wav2Vec2AsrModel)
 
     gang.barrier()
 


### PR DESCRIPTION
This PR introduces the generic `create_model()` function similar to `load_model()`, to construct any model by passing a family, architecture, and configuration dictionary. Since we have a pretty robust `ValueConverter.struct()` implementation now, this is completely type safe and configuration values are guarded well for malicious inputs. This change enables us to make the first-party recipes even more generic (a follow-up PR will switch "transformer" recipes to "mt" -machine translation- recipes to support any encoder-decoder based model).

Although the PR touches many files, except the `fairseq2.models.factory.py` and some few nit changes in `config_loader`, the rest of the changes are pretty boilerplate.