### PR TITLE
Move retrieve_asset_card to recipes

### DIFF
--- a/src/fairseq2/assets/__init__.py
+++ b/src/fairseq2/assets/__init__.py
@@ -37,11 +37,13 @@ from fairseq2.assets.metadata_provider import (
 from fairseq2.assets.metadata_provider import (
     PackageAssetMetadataProvider as PackageAssetMetadataProvider,
 )
+from fairseq2.assets.metadata_provider import load_metadata_file as load_metadata_file
 from fairseq2.assets.store import AssetStore as AssetStore
 from fairseq2.assets.store import EnvironmentResolver as EnvironmentResolver
 from fairseq2.assets.store import StandardAssetStore as StandardAssetStore
 from fairseq2.assets.store import default_asset_store as default_asset_store
 
 # For backwards-compatibility with v0.2
+# compat
 asset_store = default_asset_store
 download_manager = default_download_manager

--- a/src/fairseq2/assets/metadata_provider.py
+++ b/src/fairseq2/assets/metadata_provider.py
@@ -120,7 +120,7 @@ class FileAssetMetadataProvider(AbstractAssetMetadataProvider):
                 if file.suffix != ".yaml" and file.suffix != ".yml":
                     continue
 
-                for name, metadata in _load_metadata_file(file):
+                for name, metadata in load_metadata_file(file):
                     if name in cache:
                         raise AssetMetadataError(
                             f"Two assets under the directory '{self._base_dir}' have the same name '{name}'."
@@ -159,7 +159,7 @@ class PackageAssetMetadataProvider(AbstractAssetMetadataProvider):
             if file.suffix != ".yaml" and file.suffix != ".yml":
                 continue
 
-            for name, metadata in _load_metadata_file(file):
+            for name, metadata in load_metadata_file(file):
                 if name in cache:
                     raise AssetMetadataError(
                         f"Two assets under the namespace package '{self._package_name}' have the same name '{name}'."
@@ -191,7 +191,8 @@ class PackageAssetMetadataProvider(AbstractAssetMetadataProvider):
         return files
 
 
-def _load_metadata_file(file: Path) -> List[Tuple[str, Dict[str, Any]]]:
+def load_metadata_file(file: Path) -> List[Tuple[str, Dict[str, Any]]]:
+    """Load asset metadata included in ``file``."""
     output = []
 
     try:

--- a/src/fairseq2/checkpoint.py
+++ b/src/fairseq2/checkpoint.py
@@ -33,7 +33,7 @@ from torch.nn import Module
 from fairseq2.assets.metadata_provider import (
     AbstractAssetMetadataProvider,
     AssetMetadataError,
-    _load_metadata_file,
+    load_metadata_file,
 )
 from fairseq2.gang import Gang
 from fairseq2.logging import get_log_writer
@@ -730,7 +730,7 @@ class CheckpointModelMetadataProvider(AbstractAssetMetadataProvider):
                 f"The checkpoint model metadata (model.yaml) cannot be found under {self._checkpoint_dir}. Make sure that the specified directory is the *base* checkpoint directory used during training (i.e. directory passed to `FileCheckpointManager.save_model_metadata()`)."
             )
 
-        cache = dict(_load_metadata_file(metadata_file))
+        cache = dict(load_metadata_file(metadata_file))
 
         try:
             metadata = cache["checkpoint@"]

--- a/src/fairseq2/datasets/loader.py
+++ b/src/fairseq2/datasets/loader.py
@@ -19,7 +19,6 @@ from fairseq2.assets import (
     default_asset_store,
     default_download_manager,
 )
-from fairseq2.assets.utils import retrieve_asset_card
 
 DatasetT = TypeVar("DatasetT")
 
@@ -31,15 +30,14 @@ class DatasetLoader(Protocol[DatasetT_co]):
 
     def __call__(
         self,
-        dataset_name_or_card: Union[str, AssetCard, Path],
+        dataset_name_or_card: Union[str, AssetCard],
         *,
         force: bool = False,
         progress: bool = True,
     ) -> DatasetT_co:
         """
         :param dataset_name_or_card:
-            The name, asset card, or path to the asset card file of the dataset
-            to load.
+            The name or the asset card of the dataset to load.
         :param force:
             If ``True``, downloads the dataset even if it is already in cache.
         :param progress:
@@ -73,12 +71,15 @@ class AbstractDatasetLoader(ABC, DatasetLoader[DatasetT]):
     @final
     def __call__(
         self,
-        dataset_name_or_card: Union[str, AssetCard, Path],
+        dataset_name_or_card: Union[str, AssetCard],
         *,
         force: bool = False,
         progress: bool = True,
     ) -> DatasetT:
-        card = retrieve_asset_card(dataset_name_or_card, self._asset_store)
+        if isinstance(dataset_name_or_card, AssetCard):
+            card = dataset_name_or_card
+        else:
+            card = self._asset_store.retrieve_card(dataset_name_or_card)
 
         dataset_uri = card.field("data").as_uri()
 
@@ -127,12 +128,15 @@ class DelegatingDatasetLoader(DatasetLoader[DatasetT]):
 
     def __call__(
         self,
-        dataset_name_or_card: Union[str, AssetCard, Path],
+        dataset_name_or_card: Union[str, AssetCard],
         *,
         force: bool = False,
         progress: bool = True,
     ) -> DatasetT:
-        card = retrieve_asset_card(dataset_name_or_card, self._asset_store)
+        if isinstance(dataset_name_or_card, AssetCard):
+            card = dataset_name_or_card
+        else:
+            card = self._asset_store.retrieve_card(dataset_name_or_card)
 
         family = card.field("dataset_family").as_(str)
 
@@ -161,9 +165,12 @@ class DelegatingDatasetLoader(DatasetLoader[DatasetT]):
 
         self._loaders[family] = loader
 
-    def supports(self, dataset_name_or_card: Union[str, AssetCard, Path]) -> bool:
+    def supports(self, dataset_name_or_card: Union[str, AssetCard]) -> bool:
         """Return ``True`` if the specified dataset has a registered loader."""
-        card = retrieve_asset_card(dataset_name_or_card, self._asset_store)
+        if isinstance(dataset_name_or_card, AssetCard):
+            card = dataset_name_or_card
+        else:
+            card = self._asset_store.retrieve_card(dataset_name_or_card)
 
         family = card.field("dataset_family").as_(str)
 

--- a/src/fairseq2/recipes/lm/instruction_finetune.py
+++ b/src/fairseq2/recipes/lm/instruction_finetune.py
@@ -16,7 +16,6 @@ from torch import Tensor
 from torch.nn import Module
 
 from fairseq2.assets import AssetNotFoundError, default_asset_store
-from fairseq2.assets.utils import retrieve_asset_card
 from fairseq2.checkpoint import CheckpointModelMetadataProvider, FileCheckpointManager
 from fairseq2.config_registry import ConfigRegistry
 from fairseq2.data.text import load_text_tokenizer
@@ -40,6 +39,7 @@ from fairseq2.optim import AdamW
 from fairseq2.optim.lr_scheduler import CosineAnnealingLR
 from fairseq2.recipes.common_metrics import SequenceMetricBag
 from fairseq2.recipes.trainer import AbstractTrainUnit, Trainer
+from fairseq2.recipes.utils.asset import asset_as_path, retrieve_asset_card
 from fairseq2.recipes.utils.log import log_model
 from fairseq2.recipes.utils.setup import (
     check_model_type,
@@ -228,9 +228,9 @@ def load_instruction_finetuner(
 
     seed = config.seed
 
-    # Load the tokenizer.
     model_card = retrieve_asset_card(config.model)
 
+    # Load the tokenizer.
     log.info("Loading {} tokenizer.", model_card.name)
 
     tokenizer = load_text_tokenizer(model_card)
@@ -250,14 +250,9 @@ def load_instruction_finetuner(
 
         log.info("Dataset loaded.")
     else:
-        try:
-            path = Path(config.dataset)
-        except ValueError:
-            raise AssetNotFoundError(
-                config.dataset, f"An asset with the name '{config.dataset}' cannot be found."  # type: ignore[arg-type]
-            ) from None
+        dataset_path = asset_as_path(config.dataset)
 
-        dataset = GenericInstructionDataset.from_path(path)
+        dataset = GenericInstructionDataset.from_path(dataset_path)
 
     # Load the model.
     init_device = META
@@ -265,9 +260,14 @@ def load_instruction_finetuner(
     has_checkpoint = checkpoint_manager.has_checkpoint()
 
     if has_checkpoint:
-        model = load_model(
-            model_card, gangs=gangs, device=init_device, dtype=torch.float32
-        )
+        try:
+            model = load_model(
+                model_card, gangs=gangs, device=init_device, dtype=torch.float32
+            )
+        except ValueError as ex:
+            raise ValueError(
+                "The model cannot be initialized. See nested exception for details."
+            ) from ex
     # If we don't have a checkpoint, load the pretrained model on rank 0 and
     # broadcast it to the gang.
     else:
@@ -276,9 +276,14 @@ def load_instruction_finetuner(
         if dp_gang.rank == 0:
             init_device = root_gang.device
 
-        model = load_model(
-            model_card, gangs=gangs, device=init_device, dtype=torch.float32
-        )
+        try:
+            model = load_model(
+                model_card, gangs=gangs, device=init_device, dtype=torch.float32
+            )
+        except ValueError as ex:
+            raise ValueError(
+                "The model cannot be initialized. See nested exception for details."
+            ) from ex
 
         root_gang.barrier()
 

--- a/src/fairseq2/recipes/lm/text_generate.py
+++ b/src/fairseq2/recipes/lm/text_generate.py
@@ -14,7 +14,6 @@ from typing import Literal, Optional, TextIO, Union, final
 import torch
 
 from fairseq2.assets import AssetNotFoundError, default_asset_store
-from fairseq2.assets.utils import retrieve_asset_card
 from fairseq2.checkpoint import CheckpointModelMetadataProvider
 from fairseq2.config_registry import ConfigRegistry
 from fairseq2.data.text import TextTokenDecoder, TextTokenizer, load_text_tokenizer
@@ -39,6 +38,7 @@ from fairseq2.models.decoder import DecoderModel
 from fairseq2.models.sequence import SequenceBatch
 from fairseq2.recipes.common_metrics import SequenceGenerationMetricBag
 from fairseq2.recipes.generator import AbstractGeneratorUnit, Generator
+from fairseq2.recipes.utils.asset import asset_as_path, retrieve_asset_card
 from fairseq2.recipes.utils.log import log_model
 from fairseq2.recipes.utils.setup import broadcast_model, check_model_type, setup_gangs
 from fairseq2.typing import META, DataType, override
@@ -243,9 +243,9 @@ def load_text_generator(
 
     seed = config.seed
 
-    # Load the tokenizer.
     model_card = retrieve_asset_card(config.model)
 
+    # Load the tokenizer.
     log.info("Loading {} tokenizer.", model_card.name)
 
     tokenizer = load_text_tokenizer(model_card)
@@ -265,14 +265,9 @@ def load_text_generator(
 
         log.info("Dataset loaded.")
     else:
-        try:
-            path = Path(config.dataset)
-        except ValueError:
-            raise AssetNotFoundError(
-                config.dataset, f"An asset with the name '{config.dataset}' cannot be found."  # type: ignore[arg-type]
-            ) from None
+        dataset_path = asset_as_path(config.dataset)
 
-        dataset = GenericInstructionDataset.from_path(path)
+        dataset = GenericInstructionDataset.from_path(dataset_path)
 
     # Load the model.
     log.info("Loading {} model on data parallel rank 0 (per shard).", model_card.name)
@@ -282,7 +277,14 @@ def load_text_generator(
     else:
         init_device = META
 
-    model = load_model(model_card, gangs=gangs, device=init_device, dtype=config.dtype)
+    try:
+        model = load_model(
+            model_card, gangs=gangs, device=init_device, dtype=config.dtype
+        )
+    except ValueError as ex:
+        raise ValueError(
+            "The model cannot be initialized. See nested exception for details."
+        ) from ex
 
     check_model_type(model, DecoderModel)
 

--- a/src/fairseq2/recipes/utils/asset.py
+++ b/src/fairseq2/recipes/utils/asset.py
@@ -5,42 +5,34 @@
 # LICENSE file in the root directory of this source tree.
 
 from pathlib import Path
-from typing import Optional, Union
+from typing import Union
 
-from fairseq2.assets.card import AssetCard
-from fairseq2.assets.metadata_provider import (
+from fairseq2.assets import (
+    AssetCard,
     AssetMetadataError,
     AssetNotFoundError,
     InProcAssetMetadataProvider,
-    _load_metadata_file,
+    default_asset_store,
+    load_metadata_file,
 )
-from fairseq2.assets.store import AssetStore, StandardAssetStore, default_asset_store
 
 
-def retrieve_asset_card(
-    name_or_card: Union[str, AssetCard, Path], store: Optional[AssetStore] = None
-) -> AssetCard:
+def retrieve_asset_card(name_or_card: Union[str, AssetCard, Path]) -> AssetCard:
     """Retrieve the specified asset.
 
     :param name_or_card:
         The name, card, or path to the card file of the asset to load.
-    :param store:
-        The asset store where to check for available assets. If ``None``, the
-        default asset store will be used.
     """
     if isinstance(name_or_card, AssetCard):
         return name_or_card
 
-    if store is None:
-        store = default_asset_store
-
     if isinstance(name_or_card, Path):
-        return _card_from_file(name_or_card, store)
+        return _card_from_file(name_or_card)
 
     name = name_or_card
 
     try:
-        return store.retrieve_card(name)
+        return default_asset_store.retrieve_card(name)
     except AssetNotFoundError:
         pass
 
@@ -51,18 +43,13 @@ def retrieve_asset_card(
 
     if file is not None:
         if (file.suffix == ".yaml" or file.suffix == ".yml") and file.exists():
-            return _card_from_file(file, store)
+            return _card_from_file(file)
 
     raise AssetNotFoundError(name, f"An asset with the name '{name}' cannot be found.")
 
 
-def _card_from_file(file: Path, store: AssetStore) -> AssetCard:
-    if not isinstance(store, StandardAssetStore):
-        raise ValueError(
-            f"`store` must be of type `{StandardAssetStore}` when `name_or_card` is a pathname, but is of type {type(store)} instead."
-        )
-
-    all_metadata = _load_metadata_file(file)
+def _card_from_file(file: Path) -> AssetCard:
+    all_metadata = load_metadata_file(file)
 
     if len(all_metadata) != 1:
         raise AssetMetadataError(
@@ -78,4 +65,21 @@ def _card_from_file(file: Path, store: AssetStore) -> AssetCard:
     # Strip the environment tag.
     name, _ = name.split("@", maxsplit=1)
 
-    return store.retrieve_card(name, extra_provider=metadata_provider)
+    return default_asset_store.retrieve_card(name, extra_provider=metadata_provider)
+
+
+def asset_as_path(name_or_card: Union[str, Path]) -> Path:
+    if isinstance(name_or_card, Path):
+        return name_or_card
+
+    try:
+        path = Path(name_or_card)
+    except ValueError:
+        path = None
+
+    if path is None or not path.exists():
+        raise AssetNotFoundError(
+            name_or_card, f"An asset with the name '{name_or_card}' cannot be found."
+        ) from None
+
+    return path

--- a/src/fairseq2/recipes/wav2vec2/asr/eval.py
+++ b/src/fairseq2/recipes/wav2vec2/asr/eval.py
@@ -14,7 +14,6 @@ import torch
 from torch.nn import Module
 
 from fairseq2.assets import AssetNotFoundError, default_asset_store
-from fairseq2.assets.utils import retrieve_asset_card
 from fairseq2.checkpoint import CheckpointModelMetadataProvider
 from fairseq2.config_registry import ConfigRegistry
 from fairseq2.data.text import TextTokenDecoder, TextTokenizer, load_text_tokenizer
@@ -30,6 +29,7 @@ from fairseq2.models.wav2vec2.asr import Wav2Vec2AsrModel
 from fairseq2.models.wav2vec2.asr.model import Wav2Vec2AsrOutput
 from fairseq2.nn.utils.module import remove_parametrizations
 from fairseq2.recipes.evaluator import AbstractEvalUnit, Evaluator
+from fairseq2.recipes.utils.asset import asset_as_path, retrieve_asset_card
 from fairseq2.recipes.utils.log import log_model
 from fairseq2.recipes.utils.setup import (
     broadcast_model,
@@ -109,9 +109,9 @@ def load_wav2vec2_asr_evaluator(
 
     seed = config.seed
 
-    # Load the tokenizer.
     model_card = retrieve_asset_card(config.model)
 
+    # Load the tokenizer.
     log.info("Loading {} tokenizer.", model_card.name)
 
     tokenizer = load_text_tokenizer(model_card)
@@ -131,14 +131,9 @@ def load_wav2vec2_asr_evaluator(
 
         log.info("Dataset loaded.")
     else:
-        try:
-            path = Path(config.dataset)
-        except ValueError:
-            raise AssetNotFoundError(
-                config.dataset, f"An asset with the name '{config.dataset}' cannot be found."  # type: ignore[arg-type]
-            ) from None
+        dataset_path = asset_as_path(config.dataset)
 
-        dataset = GenericAsrDataset.from_path(path)
+        dataset = GenericAsrDataset.from_path(dataset_path)
 
     # Load the model.
     log.info("Loading {} model on rank 0.", model_card.name)
@@ -148,7 +143,12 @@ def load_wav2vec2_asr_evaluator(
     else:
         init_device = META
 
-    model = load_model(model_card, device=init_device, dtype=config.dtype)
+    try:
+        model = load_model(model_card, device=init_device, dtype=config.dtype)
+    except ValueError as ex:
+        raise ValueError(
+            "The model cannot be initialized. See nested exception for details."
+        ) from ex
 
     check_model_type(model, Wav2Vec2AsrModel)
 

--- a/src/fairseq2/recipes/wav2vec2/asr/train.py
+++ b/src/fairseq2/recipes/wav2vec2/asr/train.py
@@ -15,7 +15,6 @@ from torch import Tensor
 from torch.nn import Module
 
 from fairseq2.assets import AssetNotFoundError, default_asset_store
-from fairseq2.assets.utils import retrieve_asset_card
 from fairseq2.checkpoint import CheckpointModelMetadataProvider, FileCheckpointManager
 from fairseq2.config_registry import ConfigRegistry
 from fairseq2.data.text import load_text_tokenizer
@@ -32,6 +31,7 @@ from fairseq2.nn.utils.module import freeze_parameters, share_parameters, to_dev
 from fairseq2.optim import AdamW
 from fairseq2.optim.lr_scheduler import TriStageLR
 from fairseq2.recipes.trainer import AbstractTrainUnit, Trainer
+from fairseq2.recipes.utils.asset import asset_as_path, retrieve_asset_card
 from fairseq2.recipes.utils.log import log_model, log_model_config
 from fairseq2.recipes.utils.setup import (
     check_model_type,
@@ -41,7 +41,7 @@ from fairseq2.recipes.utils.setup import (
 )
 from fairseq2.recipes.wav2vec2.asr.common import Wav2Vec2AsrMetricBag
 from fairseq2.recipes.wav2vec2.asr.eval import Wav2Vec2AsrEvalUnit
-from fairseq2.typing import DataType, override
+from fairseq2.typing import META, DataType, override
 from fairseq2.utils.profiler import Stopwatch
 
 log = get_log_writer(__name__)
@@ -225,12 +225,12 @@ def load_wav2vec2_asr_trainer(
 
     seed = config.seed
 
-    # Load the tokenizer.
     tokenizer_card = retrieve_asset_card(config.tokenizer)
 
+    # Load the tokenizer.
     log.info("Loading {} tokenizer.", tokenizer_card.name)
 
-    tokenizer = load_text_tokenizer(config.tokenizer)
+    tokenizer = load_text_tokenizer(tokenizer_card)
 
     log.info("Tokenizer loaded.")
 
@@ -247,19 +247,18 @@ def load_wav2vec2_asr_trainer(
 
         log.info("Dataset loaded.")
     else:
-        try:
-            path = Path(config.dataset)
-        except ValueError:
-            raise AssetNotFoundError(
-                config.dataset, f"An asset with the name '{config.dataset}' cannot be found."  # type: ignore[arg-type]
-            ) from None
+        dataset_path = asset_as_path(config.dataset)
 
-        dataset = GenericAsrDataset.from_path(path)
+        dataset = GenericAsrDataset.from_path(dataset_path)
 
     # Initialize the model
     try:
         model, model_config = create_model(
-            config.model_family, config.model_arch, config.model_config
+            config.model_family,
+            config.model_arch,
+            config.model_config,
+            device=META,
+            dtype=torch.float32,
         )
     except ValueError as ex:
         raise ValueError(


### PR DESCRIPTION
This PR moves `retrieve_asset_card()` from `fairseq2.assets` to `fairseq2.recipes.utils` which is API-wise more appropriate due to its handling of paths.