### PR TITLE
Nit docstr fix

### DIFF
--- a/src/fairseq2/recipes/lm/instruction_finetune.py
+++ b/src/fairseq2/recipes/lm/instruction_finetune.py
@@ -137,10 +137,10 @@ class InstructionFinetuneConfig:
     """The step interval at which to checkpoint."""
 
     keep_last_n_checkpoints: Optional[int] = 1
-    """The number of checkpoints to keep."""
+    """The number of checkpoints to keep. If ``None``, none will be deleted."""
 
     keep_last_n_models: Optional[int] = None
-    """The number of checkpoint models to keep."""
+    """The number of checkpoint models to keep. If ``None``, none will be deleted."""
 
     publish_metrics_every_n_steps: int = 10
     """The step interval at which to publish training metrics."""

--- a/src/fairseq2/recipes/trainer.py
+++ b/src/fairseq2/recipes/trainer.py
@@ -261,11 +261,10 @@ class Trainer(StatefulObjectBag, Generic[BatchT]):
         :param checkpoint_every_n_steps:
             The step interval at which to checkpoint.
         :param keep_last_n_checkpoints:
-            The number of checkpoints to keep. If ``None``, no checkpoint will
-            be deleted.
+            The number of checkpoints to keep. If ``None``, none will be deleted.
         :param keep_best_n_checkpoints:
             The number of checkpoints to keep based on their validation score.
-            If ``None``, no checkpoint will be deleted.
+            If ``None``, none will be deleted.
         :param keep_last_n_models:
             The number of checkpoint models to keep. Must be greater than or
             equal to ``keep_last_n_checkpoints``.

--- a/src/fairseq2/recipes/wav2vec2/asr/train.py
+++ b/src/fairseq2/recipes/wav2vec2/asr/train.py
@@ -162,7 +162,8 @@ class Wav2Vec2AsrTrainConfig:
     """The step interval at which to checkpoint."""
 
     keep_best_n_checkpoints: Optional[int] = None
-    """The number of checkpoints to keep based on their validation score."""
+    """The number of checkpoints to keep based on their validation score. If
+    ``None``, none will be deleted."""
 
     publish_metrics_every_n_steps: int = 200
     """The step interval at which to publish metrics."""


### PR DESCRIPTION
A very nit PR that fixes the docstr of `keep_n_checkpoint` parameters.