### PR TITLE
Sync batches even with static batching

### DIFF
--- a/src/fairseq2/datasets/asr.py
+++ b/src/fairseq2/datasets/asr.py
@@ -325,7 +325,7 @@ class GenericAsrDataset(AsrDataset):
             gang,
             num_accumulate=num_accumulate,
             drop_remainder=False,
-            sync_batches=not static_batching and sync_batches,
+            sync_batches=sync_batches,
         )
 
     def _retrieve_data_directory(self, split: str) -> Path:

--- a/src/fairseq2/datasets/instruction.py
+++ b/src/fairseq2/datasets/instruction.py
@@ -397,7 +397,7 @@ class GenericInstructionDataset(InstructionDataset):
             gang,
             num_accumulate=num_accumulate,
             drop_remainder=False,
-            sync_batches=not static_batching and sync_batches,
+            sync_batches=sync_batches,
         )
 
     @override
@@ -470,7 +470,7 @@ class GenericInstructionDataset(InstructionDataset):
         pipeline = builder.map(to_batch).and_return()
 
         return DataPipelineReader[SequenceBatch](
-            pipeline, gang, drop_remainder=drop_remainder, sync_batches=False
+            pipeline, gang, drop_remainder=drop_remainder, sync_batches=True
         )
 
     def _read_jsonl(self, path: Path, tokenizer: TextTokenizer) -> DataPipelineBuilder:

--- a/src/fairseq2/datasets/parallel_text.py
+++ b/src/fairseq2/datasets/parallel_text.py
@@ -386,14 +386,14 @@ class GenericParallelTextDataset(ParallelTextDataset):
         builder.map(encode, num_parallel_calls=npc)
 
         if isinstance(batching, LengthBatching):
-            # Bucket by the length of the source or target sequence. The longer
-            # one will be considered the length of the example.
             bucket_sizes = create_bucket_sizes(
                 max_seq_len=max_seq_len,
                 min_seq_len=min_seq_len,
                 max_num_elements=batching.max_num_elements,
             )
 
+            # Bucket by the length of the source or target sequence. The longer
+            # one will be considered the length of the example.
             builder.bucket_by_length(
                 bucket_sizes,
                 selector="source_indices,target_indices",
@@ -444,7 +444,7 @@ class GenericParallelTextDataset(ParallelTextDataset):
             gang,
             num_accumulate=num_accumulate,
             drop_remainder=False,
-            sync_batches=not static_batching and sync_batches,
+            sync_batches=sync_batches,
         )
 
     def _read_direction(self, split: str, direction: Direction) -> DataPipelineBuilder:

--- a/src/fairseq2/datasets/text.py
+++ b/src/fairseq2/datasets/text.py
@@ -248,7 +248,7 @@ class GenericTextDataset(TextDataset):
             gang,
             num_accumulate=num_accumulate,
             drop_remainder=drop_remainder,
-            sync_batches=not static_batching and sync_batches,
+            sync_batches=sync_batches,
         )
 
     @staticmethod


### PR DESCRIPTION
This PR fixes the bug caused by sequence length filtering that happens after sharding during data reading. Filtering causes the number of examples to differ between ranks, but static batching ignores this and does not enable batch synchronization.