### PR TITLE
Begin metric update only for fp16

### DIFF
--- a/src/fairseq2/recipes/trainer.py
+++ b/src/fairseq2/recipes/trainer.py
@@ -630,7 +630,8 @@ class Trainer(StatefulObjectBag, Generic[BatchT]):
 
             num_targets = 0
 
-            self._metric_bag.begin_updates()
+            if self._loss_scaler.is_enabled:
+                self._metric_bag.begin_updates()
 
             # Accumulate.
             for batch_nr, batch in enumerate(batches):
@@ -677,7 +678,8 @@ class Trainer(StatefulObjectBag, Generic[BatchT]):
             else:
                 self._lr_scheduler.step()
 
-                self._metric_bag.commit_updates()
+                if self._loss_scaler.is_enabled:
+                    self._metric_bag.commit_updates()
 
                 self._metric_bag.gradient_norm.update(grad_norm)
 


### PR DESCRIPTION
A nit PR that begins a metric transaction update only when training in fp16. In other precisions we never repeat a step, so metric rollback is not necessary.