### PR TITLE
Remove static_batching check in datasets

### DIFF
--- a/src/fairseq2/datasets/asr.py
+++ b/src/fairseq2/datasets/asr.py
@@ -208,15 +208,8 @@ class GenericAsrDataset(AsrDataset):
 
         seed += 1
 
-        static_batching = isinstance(batching, StaticBatching)
-
         # Shard.
-        if static_batching:
-            allow_uneven = not sync_batches
-        else:
-            allow_uneven = True
-
-        builder.shard(gang.rank, gang.size, allow_uneven=allow_uneven)
+        builder.shard(gang.rank, gang.size, allow_uneven=True)
 
         seed += gang.rank
 
@@ -324,7 +317,7 @@ class GenericAsrDataset(AsrDataset):
             pipeline,
             gang,
             num_accumulate=num_accumulate,
-            drop_remainder=False,
+            drop_remainder=drop_remainder,
             sync_batches=sync_batches,
         )
 

--- a/src/fairseq2/datasets/instruction.py
+++ b/src/fairseq2/datasets/instruction.py
@@ -303,15 +303,8 @@ class GenericInstructionDataset(InstructionDataset):
 
         seed += 1
 
-        static_batching = isinstance(batching, StaticBatching)
-
         # Shard.
-        if static_batching:
-            allow_uneven = not sync_batches
-        else:
-            allow_uneven = True
-
-        builder.shard(gang.rank, gang.size, allow_uneven=allow_uneven)
+        builder.shard(gang.rank, gang.size, allow_uneven=True)
 
         seed += gang.rank
 
@@ -396,7 +389,7 @@ class GenericInstructionDataset(InstructionDataset):
             pipeline,
             gang,
             num_accumulate=num_accumulate,
-            drop_remainder=False,
+            drop_remainder=drop_remainder,
             sync_batches=sync_batches,
         )
 
@@ -426,7 +419,7 @@ class GenericInstructionDataset(InstructionDataset):
             builder = DataPipeline.concat(pipelines)
 
         # Shard
-        builder.shard(gang.rank, gang.size, allow_uneven=not sync_batches)
+        builder.shard(gang.rank, gang.size, allow_uneven=True)
 
         # Encode prompt texts.
         text_encoder = tokenizer.create_encoder(mode="prompt")

--- a/src/fairseq2/datasets/parallel_text.py
+++ b/src/fairseq2/datasets/parallel_text.py
@@ -360,15 +360,8 @@ class GenericParallelTextDataset(ParallelTextDataset):
 
         seed += 1
 
-        static_batching = isinstance(batching, StaticBatching)
-
         # Shard.
-        if static_batching:
-            allow_uneven = not sync_batches
-        else:
-            allow_uneven = True
-
-        builder.shard(gang.rank, gang.size, allow_uneven=allow_uneven)
+        builder.shard(gang.rank, gang.size, allow_uneven=True)
 
         seed += gang.rank
 
@@ -443,7 +436,7 @@ class GenericParallelTextDataset(ParallelTextDataset):
             pipeline,
             gang,
             num_accumulate=num_accumulate,
-            drop_remainder=False,
+            drop_remainder=drop_remainder,
             sync_batches=sync_batches,
         )
 

--- a/src/fairseq2/datasets/text.py
+++ b/src/fairseq2/datasets/text.py
@@ -174,15 +174,8 @@ class GenericTextDataset(TextDataset):
 
         seed += 1
 
-        static_batching = isinstance(batching, StaticBatching)
-
         # Shard.
-        if static_batching:
-            allow_uneven = not sync_batches
-        else:
-            allow_uneven = True
-
-        builder.shard(gang.rank, gang.size, allow_uneven=allow_uneven)
+        builder.shard(gang.rank, gang.size, allow_uneven=True)
 
         seed += gang.rank
 


### PR DESCRIPTION
Since we synchronize batches even with static batching, thir PR removes some extra checks that are remnants of the old behavior.