### PR TITLE
Repeatless sample and round robin

### DIFF
--- a/native/python/src/fairseq2n/bindings/data/data_pipeline.cc
+++ b/native/python/src/fairseq2n/bindings/data/data_pipeline.cc
@@ -322,7 +322,9 @@ def_data_pipeline(py::module_ &data_module)
         .def_static(
             "round_robin",
             [](
-                std::vector<std::reference_wrapper<data_pipeline>> &refs, bool stop_at_shortest)
+                std::vector<std::reference_wrapper<data_pipeline>> &refs, 
+                bool stop_at_shortest,
+                bool allow_repeats)
             {
                 std::vector<data_pipeline> pipelines{};
 
@@ -333,16 +335,18 @@ def_data_pipeline(py::module_ &data_module)
                         return std::move(r.get());
                     });
 
-                return data_pipeline::round_robin(std::move(pipelines), stop_at_shortest);
+                return data_pipeline::round_robin(std::move(pipelines), stop_at_shortest, allow_repeats);
             },
             py::arg("pipelines"),
-            py::arg("stop_at_shortest") = false)
+            py::arg("stop_at_shortest") = false,
+            py::arg("allow_repeats") = true)
         .def_static(
             "sample",
             [](
                 std::vector<std::reference_wrapper<data_pipeline>> &refs,
                 std::optional<std::vector<float>> maybe_weights,
-                std::optional<std::uint64_t> maybe_seed)
+                std::optional<std::uint64_t> maybe_seed,
+                bool allow_repeats)
             {
                 std::vector<data_pipeline> pipelines{};
 
@@ -354,11 +358,12 @@ def_data_pipeline(py::module_ &data_module)
                     });
 
                 return data_pipeline::sample(
-                    std::move(pipelines), std::move(maybe_weights), maybe_seed);
+                    std::move(pipelines), std::move(maybe_weights), maybe_seed, allow_repeats);
             },
             py::arg("pipelines"),
             py::arg("weights") = std::nullopt,
-            py::arg("seed") = std::nullopt)
+            py::arg("seed") = std::nullopt,
+            py::arg("allow_repeats") = true)
         .def_static(
             "zip",
             [](

--- a/native/src/fairseq2n/data/data_pipeline.h
+++ b/native/src/fairseq2n/data/data_pipeline.h
@@ -83,13 +83,17 @@ public:
     count(std::int64_t start = 0, std::int64_t step = 1, std::optional<std::string> key = {});
 
     static data_pipeline_builder
-    round_robin(std::vector<data_pipeline> pipelines, bool stop_at_shortest = false);
+    round_robin(
+        std::vector<data_pipeline> pipelines, 
+        bool stop_at_shortest = false, 
+        bool allow_repeats = true);
 
     static data_pipeline_builder
     sample(
         std::vector<data_pipeline> pipelines,
         std::optional<std::vector<float>> maybe_weights = {},
-        std::optional<std::uint64_t> maybe_seed = {});
+        std::optional<std::uint64_t> maybe_seed = {},
+        bool allow_repeats = true);
 
     static data_pipeline_builder
     zip(

--- a/native/src/fairseq2n/data/round_robin_data_source.h
+++ b/native/src/fairseq2n/data/round_robin_data_source.h
@@ -51,8 +51,8 @@ private:
     std::size_t buffer_idx_ = 0;
     std::vector<bool> is_epoch_done_;
     bool is_eod_ = false;
-    bool allow_repeats_;
     bool stop_at_shortest_;
+    bool allow_repeats_;
     data_source_finitude_type finitude_type_;
 };
 

--- a/native/src/fairseq2n/data/round_robin_data_source.h
+++ b/native/src/fairseq2n/data/round_robin_data_source.h
@@ -18,7 +18,10 @@ namespace fairseq2n::detail {
 class round_robin_data_source final : public data_source {
 public:
     explicit
-    round_robin_data_source(std::vector<data_pipeline> &&pipelines, bool stop_at_shortest);
+    round_robin_data_source(
+        std::vector<data_pipeline> &&pipelines, 
+        bool stop_at_shortest,
+        bool allow_repeats);
 
     std::optional<data>
     next() override;
@@ -48,6 +51,7 @@ private:
     std::size_t buffer_idx_ = 0;
     std::vector<bool> is_epoch_done_;
     bool is_eod_ = false;
+    bool allow_repeats_;
     bool stop_at_shortest_;
     data_source_finitude_type finitude_type_;
 };

--- a/native/src/fairseq2n/data/sample_data_source.cc
+++ b/native/src/fairseq2n/data/sample_data_source.cc
@@ -49,7 +49,8 @@ sample_data_source::sample_data_source(
             s /= sum;
     }
 
-    original_weight_cumsums_ = weight_cumsums_;
+    if (!allow_repeats_)
+        original_weight_cumsums_ = weight_cumsums_;
 
     buffer_.reserve(pipelines_.size());
 

--- a/native/src/fairseq2n/data/sample_data_source.cc
+++ b/native/src/fairseq2n/data/sample_data_source.cc
@@ -23,8 +23,11 @@ namespace fairseq2n::detail {
 sample_data_source::sample_data_source(
     std::vector<data_pipeline> &&pipelines,
     std::vector<float32> &&weights,
-    std::optional<std::uint64_t> maybe_seed)
-  : pipelines_(std::move(pipelines)), is_epoch_done_(pipelines_.size())
+    std::optional<std::uint64_t> maybe_seed,
+    bool allow_repeats)
+  : pipelines_(std::move(pipelines)), 
+    is_epoch_done_(pipelines_.size()),
+    allow_repeats_{allow_repeats}
 {
     seed_ = maybe_seed ? *maybe_seed : pseudo_random();
 
@@ -45,6 +48,8 @@ sample_data_source::sample_data_source(
         for (float32 &s : weight_cumsums_)
             s /= sum;
     }
+
+    original_weight_cumsums_ = weight_cumsums_;
 
     buffer_.reserve(pipelines_.size());
 
@@ -73,7 +78,6 @@ sample_data_source::next()
     }
 
     std::size_t pipeline_idx = random_pipeline_index();
-
     return std::exchange(buffer_[pipeline_idx], next_in_pipeline(pipeline_idx));
 }
 
@@ -88,6 +92,9 @@ sample_data_source::reset(bool reset_rng)
 
     if (reset_rng)
         generator_.set_current_seed(seed_);
+
+    if (!allow_repeats_)
+        weight_cumsums_ = original_weight_cumsums_;
 
     for (data_pipeline &pipeline : pipelines_)
         pipeline.reset(reset_rng);
@@ -106,6 +113,8 @@ sample_data_source::record_position(tape &t, bool strict) const
 
     t.record(generator_.get_state());
 
+    t.record(weight_cumsums_);
+
     for (const data_pipeline &pipeline : pipelines_)
         pipeline.record_position(t, strict);
 }
@@ -114,7 +123,7 @@ void
 sample_data_source::reload_position(tape &t, bool strict)
 {
     if (strict) {
-        buffer_ = t.read<std::vector<data>>();
+        buffer_ = t.read<std::vector<std::optional<data>>>();
 
         is_epoch_done_ = t.read<std::vector<bool>>();
     } else {
@@ -128,6 +137,8 @@ sample_data_source::reload_position(tape &t, bool strict)
     seed_ = t.read<std::uint64_t>();
 
     generator_.set_state(t.read<at::Tensor>());
+
+    weight_cumsums_ = t.read<std::vector<float32>>();
 
     for (data_pipeline &pipeline : pipelines_)
         pipeline.reload_position(t);
@@ -161,7 +172,7 @@ sample_data_source::random_pipeline_index()
     return lptr;
 }
 
-data
+std::optional<data>
 sample_data_source::next_in_pipeline(std::size_t pipeline_idx)
 {
     data_pipeline &pipeline = pipelines_[pipeline_idx];
@@ -170,17 +181,49 @@ sample_data_source::next_in_pipeline(std::size_t pipeline_idx)
     if (!maybe_example) {
         is_epoch_done_[pipeline_idx] = true;
 
-        pipeline.reset();
+        if (allow_repeats_) {
+            pipeline.reset();
 
-        // Circle back to the first example.
-        maybe_example = pipeline.next();
-        if (!maybe_example)
-            throw_data_pipeline_error(/*maybe_example=*/std::nullopt, /*recoverable=*/false,
-                "The data pipeline at index {} is empty and cannot be sampled.", pipeline_idx);
+            // Circle back to the first example.
+            maybe_example = pipeline.next();
+            if (!maybe_example)
+                throw_data_pipeline_error(/*maybe_example=*/std::nullopt, /*recoverable=*/false,
+                    "The data pipeline at index {} is empty and cannot be sampled.", pipeline_idx);
+        } else
+            block(pipeline_idx);
     } else if (pipeline.finitude_type() == data_source_finitude_type::pseudo_infinite)
         is_epoch_done_[pipeline_idx] = true;
 
-    return std::move(*maybe_example);
+    return maybe_example;
+}
+
+void
+sample_data_source::block(std::size_t idx)
+{
+    float32 weight = weight_cumsums_[idx];
+    if (idx > 0) {
+        weight -= weight_cumsums_[idx - 1];
+        weight_cumsums_[idx] = weight_cumsums_[idx - 1];
+    } else {
+        weight_cumsums_[idx] = 0.0F;
+    }
+    for (std::size_t i = idx + 1; i < weight_cumsums_.size(); ++i) {
+        weight_cumsums_[i] -= weight;
+    }
+
+    float32 sum = weight_cumsums_.back();
+
+    if (!are_close(sum, 1.0F)) {
+        for (float32 &s : weight_cumsums_)
+            s /= sum;
+    }
+}
+
+void
+sample_data_source::sum_weights()
+{
+    weight_cumsums_.clear();
+
 }
 
 bool

--- a/native/src/fairseq2n/data/sample_data_source.cc
+++ b/native/src/fairseq2n/data/sample_data_source.cc
@@ -219,13 +219,6 @@ sample_data_source::block(std::size_t idx)
     }
 }
 
-void
-sample_data_source::sum_weights()
-{
-    weight_cumsums_.clear();
-
-}
-
 bool
 sample_data_source::are_all_done() noexcept
 {

--- a/native/src/fairseq2n/data/sample_data_source.h
+++ b/native/src/fairseq2n/data/sample_data_source.h
@@ -24,7 +24,8 @@ public:
     sample_data_source(
         std::vector<data_pipeline> &&pipelines,
         std::vector<float32> &&weights,
-        std::optional<std::uint64_t> maybe_seed);
+        std::optional<std::uint64_t> maybe_seed,
+        bool allow_repeats);
 
     std::optional<data>
     next() override;
@@ -45,20 +46,26 @@ private:
     std::size_t
     random_pipeline_index();
 
-    data
+    std::optional<data>
     next_in_pipeline(std::size_t pipeline_idx);
 
     bool
     are_all_done() noexcept;
 
+    void block(std::size_t idx);
+
+    void sum_weights();
+
 private:
     std::vector<data_pipeline> pipelines_;
+    std::vector<float32> original_weight_cumsums_;
     std::vector<float32> weight_cumsums_;
-    std::vector<data> buffer_{};
+    std::vector<std::optional<data>> buffer_{};
     std::vector<bool> is_epoch_done_;
     bool is_eod_ = false;
     data_source_finitude_type finitude_type_;
     std::uint64_t seed_;
+    bool allow_repeats_;
     at::Generator generator_;
 };
 

--- a/src/fairseq2/data/data_pipeline.py
+++ b/src/fairseq2/data/data_pipeline.py
@@ -141,16 +141,20 @@ if TYPE_CHECKING or DOC_MODE:
 
         @staticmethod
         def round_robin(
-            pipelines: Sequence[DataPipeline], stop_at_shortest: bool = False
+            pipelines: Sequence[DataPipeline],
+            stop_at_shortest: bool = False,
+            allow_repeats: bool = True,
         ) -> DataPipelineBuilder:
             """Extract examples from ``pipelines`` in round robin.
 
             :param pipelines:
                 The data pipelines to round robin.
             :param stop_at_shortest:
-                If ``True``, stop round_robin when first pipeline reaches its end.
-                If ``False``, circle around finished pipelines until all pipelines
+                If ``True``, stops round_robin when first pipeline reaches its end.
+            :param allow_repeats:
+                If ``True``, circles around finished pipelines until all pipelines
                 reach their end.
+                If ``False``, does not repeat pipelines that have reached their end.
             """
 
         @staticmethod
@@ -158,6 +162,7 @@ if TYPE_CHECKING or DOC_MODE:
             pipelines: Sequence[DataPipeline],
             weights: Optional[Sequence[float]] = None,
             seed: Optional[int] = None,
+            allow_repeats: bool = True,
         ) -> DataPipelineBuilder:
             """Extract examples from ``pipelines`` by sampling based on
             ``weights``. Circles around pipelines until all have reached their
@@ -167,6 +172,10 @@ if TYPE_CHECKING or DOC_MODE:
                 The data pipelines to sample from.
             :param weights:
                 Desired distribution of pipelines. If ``None``, use uniform distribution.
+            :param allow_repeats:
+                If ``True``, circles around finished pipelines until all pipelines
+                reach their end.
+                If ``False``, does not repeat pipelines that have reached their end.
             """
 
         @staticmethod

--- a/tests/unit/data/data_pipeline/test_round_robin.py
+++ b/tests/unit/data/data_pipeline/test_round_robin.py
@@ -124,6 +124,22 @@ class TestRoundRobinOp:
 
             pipeline.reset()
 
+    def test_op_works_when_pipelines_allow_repeats_false_is_specified(self) -> None:
+        pipeline1 = read_sequence([1, 2, 3, 4]).and_return()
+        pipeline2 = read_sequence([5, 6]).and_return()
+        pipeline3 = read_sequence([7, 8, 9, 0, 1, 2]).and_return()
+
+        pipeline = DataPipeline.round_robin(
+            [pipeline1, pipeline2, pipeline3], allow_repeats=False
+        ).and_return()
+
+        seq = [1, 5, 7, 2, 6, 8, 3, 9, 4, 0, 1, 2]
+
+        for _ in range(2):
+            assert list(pipeline) == seq
+
+            pipeline.reset()
+
     def test_op_raises_error_when_one_of_the_pipelines_is_broken(self) -> None:
         # Force a non-recoverable error.
         pipeline1 = read_text(path=Path(" &^#")).and_return()

--- a/tests/unit/data/data_pipeline/test_sample.py
+++ b/tests/unit/data/data_pipeline/test_sample.py
@@ -41,6 +41,23 @@ class TestSampleOp:
 
             pipeline.reset(reset_rng=True)
 
+    def test_op_works_when_allow_repeats_false_is_specified(self) -> None:
+        pipeline1 = read_sequence([1, 2, 3, 4]).and_return()
+        pipeline2 = read_sequence([5, 6]).and_return()
+        pipeline3 = read_sequence([7, 8, 9, 10, 11, 12]).and_return()
+
+        pipeline = DataPipeline.sample(
+            [pipeline1, pipeline2, pipeline3],
+            weights=[0.3, 0.6, 0.1],
+            allow_repeats=False,
+            seed=1234,
+        ).and_return()
+
+        for _ in range(2):
+            assert list(pipeline) == [1, 5, 2, 6, 3, 4, 7, 8, 9, 10, 11, 12]
+
+            pipeline.reset(reset_rng=True)
+
     def test_op_works_when_a_single_pipeline_is_specified(self) -> None:
         pipeline1 = read_sequence([1, 2, 3, 4]).and_return()
 
@@ -202,3 +219,35 @@ class TestSampleOp:
 
         with pytest.raises(StopIteration):
             next(iter(pipeline))
+
+    def test_op_saves_and_restores_state_when_allow_repeats_false_is_specified(
+        self,
+    ) -> None:
+        pipeline1 = read_sequence([1, 2, 3, 4]).and_return()
+        pipeline2 = read_sequence([5, 6]).and_return()
+        pipeline3 = read_sequence([7, 8, 9, 10, 11, 12]).and_return()
+
+        pipeline = DataPipeline.sample(
+            [pipeline1, pipeline2, pipeline3],
+            weights=[0.3, 0.6, 0.1],
+            allow_repeats=False,
+            seed=1234,
+        ).and_return()
+
+        it = iter(pipeline)
+
+        for _ in range(2):
+            assert next(it) == 1
+            assert next(it) == 5
+            assert next(it) == 2
+            assert next(it) == 6
+
+            state_dict = pipeline.state_dict()
+
+            assert list(pipeline) == [3, 4, 7, 8, 9, 10, 11, 12]
+
+            pipeline.load_state_dict(state_dict)
+
+            assert list(pipeline) == [3, 4, 7, 8, 9, 10, 11, 12]
+
+            pipeline.reset(reset_rng=True)


### PR DESCRIPTION
**What does this PR do? Please describe:**
sample() and round_robin() now have an allow_repeats boolean flag - True by default.
When set to False, exhausted pipelines are not reset, and examples are no longer sampled from them.

Fixes #685 

**Does your PR introduce any breaking changes? If yes, please list them:**
N/A

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [ ] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
