### PR TITLE
Refactor CheckpointManager

### DIFF
--- a/src/fairseq2/checkpoint/__init__.py
+++ b/src/fairseq2/checkpoint/__init__.py
@@ -1,0 +1,16 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from fairseq2.checkpoint.manager import CheckpointManager as CheckpointManager
+from fairseq2.checkpoint.manager import (
+    CheckpointNotFoundError as CheckpointNotFoundError,
+)
+from fairseq2.checkpoint.manager import FileCheckpointManager as FileCheckpointManager
+from fairseq2.checkpoint.metadata_provider import (
+    CheckpointModelMetadataProvider as CheckpointModelMetadataProvider,
+)

--- a/src/fairseq2/checkpoint/manager.py
+++ b/src/fairseq2/checkpoint/manager.py
@@ -21,7 +21,6 @@ from typing import (
     Mapping,
     NoReturn,
     Optional,
-    Set,
     Tuple,
     final,
 )
@@ -32,11 +31,6 @@ from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.distributed.fsdp.api import FullStateDictConfig, StateDictType
 from torch.nn import Module
 
-from fairseq2.assets.metadata_provider import (
-    AbstractAssetMetadataProvider,
-    AssetMetadataError,
-    load_metadata_file,
-)
 from fairseq2.gang import Gang
 from fairseq2.logging import get_log_writer
 from fairseq2.typing import CPU, DataClass, override
@@ -50,47 +44,55 @@ class CheckpointManager(ABC):
     """Saves and loads training checkpoints."""
 
     @abstractmethod
-    def save_checkpoint(
+    def begin_checkpoint(self, step_nr: int) -> None:
+        """Begin a transactional checkpoint operation.
+
+        :param step_nr:
+            The number of the training step.
+        """
+
+    @abstractmethod
+    def save_state(
         self,
-        step_nr: int,
-        checkpoint: Mapping[str, Any],
+        state: Mapping[str, Any],
         *,
         model_key: str = "model",
         replicated_keys: Optional[AbstractSet[str]] = None,
-        metadata: Optional[Dict[str, Any]] = None,
     ) -> None:
-        """Save the checkpoint of the specified training step.
+        """Save the training state.
 
-        :param step_nr:
-            The number of the training step.
-        :param checkpoint:
-            The checkpoint to save.
+        :param state:
+            The state to save.
         :param model_key:
-            The key of the model in ``checkpoint``.
+            The key of the model in ``state``.
         :param replicated_keys:
-            The keys in ``checkpoint`` whose values are replicated across all
+            The keys in ``state`` whose values are replicated across all
             processes in the gang.
-        :param metadata:
-            The checkpoint metadata to save. Must be pickeable.
         """
 
     @abstractmethod
-    def save_consolidated_fsdp_model(self, step_nr: int, model: Module) -> None:
-        """Save ``model`` with a ``state_dict`` consolidated from all processes.
+    def save_metadata(self, metadata: Mapping[str, Any]) -> None:
+        """Save ``metadata`` associated with the checkpoint.
 
-        :param step_nr:
-            The number of the training step.
-        :param model:
-            The model to save.
+        :param metadata:
+            The metadata to save. Must be pickeable.
         """
+
+    @abstractmethod
+    def save_score(self, score: Optional[float]) -> None:
+        """Save the score of the checkpoint."""
+
+    @abstractmethod
+    def save_consolidated_fsdp_model(self, model: Module) -> None:
+        """Save ``model`` with a ``state_dict`` consolidated from all processes."""
+
+    @abstractmethod
+    def commit_checkpoint(self) -> None:
+        """Commit the checkpoint after which it will be considered saved."""
 
     @abstractmethod
     def load_checkpoint(self, step_nr: int) -> Dict[str, Any]:
-        """Load the checkpoint of the specified training step.
-
-        :param step_nr:
-            The number of the training step.
-        """
+        """Load the checkpoint of the specified training step."""
 
     @abstractmethod
     def load_last_checkpoint(self) -> Tuple[int, Dict[str, Any]]:
@@ -103,11 +105,7 @@ class CheckpointManager(ABC):
 
     @abstractmethod
     def load_metadata(self, step_nr: int) -> Optional[Dict[str, Any]]:
-        """Load the checkpoint metadata of the specified training step.
-
-        :param step_nr:
-            The number of the training step.
-        """
+        """Load the checkpoint metadata of the specified training step."""
 
     @abstractmethod
     def delete_checkpoint(
@@ -126,6 +124,16 @@ class CheckpointManager(ABC):
     @abstractmethod
     def keep_last_n_checkpoints(self, n: int, *, preserve_model: bool = False) -> None:
         """Delete all but the last ``n`` checkpoints.
+
+        :param n:
+            The number of checkpoints to preserve.
+        :param preserve_model:
+            If ``True``, models in old checkpoints won't be deleted.
+        """
+
+    @abstractmethod
+    def keep_best_n_checkpoints(self, n: int, *, preserve_model: bool = False) -> None:
+        """Delete all but the best ``n`` checkpoints based on their score.
 
         :param n:
             The number of checkpoints to preserve.
@@ -158,9 +166,8 @@ class FileCheckpointManager(CheckpointManager):
     _shard_suffix: str
     _tensor_loader: TensorLoader
     _tensor_dumper: TensorDumper
-
-    # compat
-    replicated_keys: Set[str]
+    _lower_score_better: bool
+    _checkpoint_step_nr: Optional[int]
 
     def __init__(
         self,
@@ -171,6 +178,7 @@ class FileCheckpointManager(CheckpointManager):
         tp_gang: Optional[Gang] = None,
         tensor_loader: Optional[TensorLoader] = None,
         tensor_dumper: Optional[TensorDumper] = None,
+        lower_score_better: bool = False,
     ) -> None:
         """
         :param checkpoint_dir:
@@ -186,6 +194,8 @@ class FileCheckpointManager(CheckpointManager):
             The tensor loader to load checkpoints into memory.
         :param tensor_dumper:
             The tensor dumper to save checkpoints into file.
+        :param lower_score_better:
+            If ``True``, lower scores are considered better.
         """
         self._checkpoint_dir = checkpoint_dir.expanduser().resolve()
 
@@ -210,8 +220,9 @@ class FileCheckpointManager(CheckpointManager):
         self._tensor_loader = tensor_loader or load_tensors
         self._tensor_dumper = tensor_dumper or dump_tensors
 
-        # compat
-        self.replicated_keys = set()
+        self._lower_score_better = lower_score_better
+
+        self._checkpoint_step_nr = None
 
     def save_model_metadata(
         self,
@@ -224,13 +235,13 @@ class FileCheckpointManager(CheckpointManager):
         """Set the model metadata.
 
         :param base_asset:
-            The asset that the model is based on.
+            The name of the asset that the model is based on.
         :param family:
             The family of the model.
         :param config:
             The configuration of the model.
         :param tokenizer_name:
-            The name of the tokenizer the model is trained with.
+            The name of the tokenizer that the model is trained with.
         """
         if self._root_gang.rank == 0:
             metadata: Dict[str, Any] = {"name": "checkpoint"}
@@ -250,43 +261,55 @@ class FileCheckpointManager(CheckpointManager):
             if tokenizer_name is not None:
                 metadata["tokenizer_ref"] = tokenizer_name
 
-            def raise_error(cause: Exception) -> NoReturn:
-                raise RuntimeError(
-                    "The model metadata cannot be saved. See nested exception for details."
-                ) from cause
-
             try:
                 self._checkpoint_dir.mkdir(parents=True, exist_ok=True)
             except OSError as ex:
-                raise_error(ex)
+                raise RuntimeError(
+                    "The model metadata cannot be saved. See nested exception for details."
+                ) from ex
 
             metadata_file = self._checkpoint_dir.joinpath("model.yaml")
 
             try:
-                fp = metadata_file.open("w")
+                with metadata_file.open("w") as fp:
+                    yaml.safe_dump(metadata, fp, sort_keys=False)
             except OSError as ex:
-                raise_error(ex)
-
-            try:
-                yaml.safe_dump(metadata, fp, sort_keys=False)
-            except OSError as ex:
-                raise_error(ex)
-            finally:
-                fp.close()
+                raise RuntimeError(
+                    "The model metadata cannot be saved. See nested exception for details."
+                ) from ex
 
         self._root_gang.barrier()
 
     @override
-    def save_checkpoint(
+    def begin_checkpoint(self, step_nr: int) -> None:
+        if self._checkpoint_step_nr is not None:
+            raise ValueError("`begin_checkpoint()` has already been called.")
+
+        self.delete_checkpoint(step_nr, missing_ok=True)
+
+        if self._root_gang.rank == 0:
+            tmp_step_dir = self._checkpoint_dir.joinpath(f"step_{step_nr}.tmp")
+
+            try:
+                tmp_step_dir.mkdir(parents=True)
+            except OSError as ex:
+                raise RuntimeError(
+                    f"The checkpoint directory of training step {step_nr} cannot be created. See nested exception for details."
+                ) from ex
+
+        self._root_gang.barrier()
+
+        self._checkpoint_step_nr = step_nr
+
+    @override
+    def save_state(
         self,
-        step_nr: int,
-        checkpoint: Mapping[str, Any],
+        state: Mapping[str, Any],
         *,
         model_key: str = "model",
         replicated_keys: Optional[AbstractSet[str]] = None,
-        metadata: Optional[Dict[str, Any]] = None,
     ) -> None:
-        self.delete_checkpoint(step_nr, missing_ok=True)
+        step_nr = self._get_checkpoint_step_nr()
 
         def raise_error(cause: Exception) -> NoReturn:
             raise RuntimeError(
@@ -295,24 +318,10 @@ class FileCheckpointManager(CheckpointManager):
 
         tmp_step_dir = self._checkpoint_dir.joinpath(f"step_{step_nr}.tmp")
 
-        # Create the checkpoint directory.
-        if self._root_gang.rank == 0:
-            try:
-                tmp_step_dir.mkdir(parents=True)
-            except OSError as ex:
-                raise_error(ex)
-
-        self._root_gang.barrier()
-
-        # Do not modify `checkpoint` in-place. In case we fail, it should stay
-        # intact.
-        rank_part = dict(checkpoint)
+        # Copy `state`. In case we fail, it should stay intact.
+        rank_part = dict(state)
 
         rank_part["model_key"] = model_key
-
-        # compat
-        if replicated_keys is None:
-            replicated_keys = self.replicated_keys
 
         def model_replicated() -> bool:
             if self._dp_gang.size == 1:
@@ -323,9 +332,10 @@ class FileCheckpointManager(CheckpointManager):
 
             return model_key in replicated_keys or "*" in replicated_keys
 
-        # Save the model.
+        # Save the model into its own file if it is replicated.
         if model_replicated():
-            if (state_dict := rank_part.pop(model_key, None)) is not None:
+            state_dict = rank_part.pop(model_key, None)
+            if state_dict is not None:
                 del rank_part["model_key"]
 
                 if self._dp_gang.rank == 0:
@@ -376,7 +386,7 @@ class FileCheckpointManager(CheckpointManager):
             self._root_gang.barrier()
 
             # Check if anything is left to save for the rank.
-            skip_rank = not rank_part
+            skip_rank = len(rank_part) == 0
         else:
             skip_rank = False
 
@@ -393,48 +403,50 @@ class FileCheckpointManager(CheckpointManager):
 
             self._root_gang.barrier()
 
-        # Save the checkpoint metadata.
-        if metadata is not None:
-            if self._dp_gang.rank == 0:
-                metadata_file = tmp_step_dir.joinpath(
-                    f"metadata{self._shard_suffix}.pt"
-                )
+    @override
+    def save_metadata(self, metadata: Mapping[str, Any]) -> None:
+        step_nr = self._get_checkpoint_step_nr()
 
-                try:
-                    self._tensor_dumper(metadata, metadata_file)
-                except (RuntimeError, OSError, PickleError) as ex:
-                    raise_error(ex)
+        if metadata is None:
+            return
 
-            self._root_gang.barrier()
-
-        # Commit the checkpoint.
-        if self._root_gang.rank == 0:
-            step_dir = tmp_step_dir.with_suffix("")
+        if self._dp_gang.rank == 0:
+            metadata_file = self._checkpoint_dir.joinpath(
+                f"step_{step_nr}.tmp/metadata{self._shard_suffix}.pt"
+            )
 
             try:
-                tmp_step_dir.replace(step_dir)
-            except OSError as ex:
-                raise_error(ex)
-
-            # Update the 'last_step' symbolic link.
-            tmp_link = self._checkpoint_dir.joinpath("last_step.tmp")
-
-            try:
-                tmp_link.unlink(missing_ok=True)
-
-                tmp_link.symlink_to(step_dir.name, target_is_directory=True)
-
-                link = tmp_link.with_suffix("")
-
-                tmp_link.replace(link)
-            except OSError as ex:
-                raise_error(ex)
+                self._tensor_dumper(metadata, metadata_file)
+            except (RuntimeError, OSError, PickleError) as ex:
+                raise RuntimeError(
+                    f"The checkpoint metadata of training step {step_nr} cannot be saved. See nested exception for details."
+                ) from ex
 
         self._root_gang.barrier()
 
     @override
-    def save_consolidated_fsdp_model(self, step_nr: int, model: Module) -> None:
-        log.info("Extracting consolidated FSDP state dictionary of the model.")
+    def save_score(self, score: Optional[float]) -> None:
+        step_nr = self._get_checkpoint_step_nr()
+
+        if self._root_gang.rank == 0:
+            score_file = self._checkpoint_dir.joinpath(f"step_{step_nr}.tmp/score.txt")
+
+            try:
+                with score_file.open("w") as fp:
+                    fp.write(f"{score}\n")
+            except OSError as ex:
+                raise RuntimeError(
+                    f"The checkpoint score of training step {step_nr} cannot be saved. See nested exception for details.",
+                    step_nr,
+                ) from ex
+
+        self._root_gang.barrier()
+
+    @override
+    def save_consolidated_fsdp_model(self, model: Module) -> None:
+        step_nr = self._get_checkpoint_step_nr()
+
+        log.info("Extracting consolidated model state.")
 
         with FSDP.state_dict_type(
             model,
@@ -445,35 +457,50 @@ class FileCheckpointManager(CheckpointManager):
 
         self._root_gang.barrier()
 
-        log.info("Model state dictionary extracted. Saving to file on data parallel rank 0 (per shard).")  # fmt: skip
+        log.info("Model state extracted. Saving to file on data parallel rank 0 (per shard).")  # fmt: skip
 
         if self._dp_gang.rank == 0:
-            tmp_model_file = self._checkpoint_dir.joinpath(
-                f"step_{step_nr}/model{self._shard_suffix}.tmp"
+            model_file = self._checkpoint_dir.joinpath(
+                f"step_{step_nr}.tmp/model{self._shard_suffix}.pt"
             )
-
-            if not tmp_model_file.parent.exists():
-                raise RuntimeError(
-                    f"A consolidated FSDP model can only be saved for training steps that have a checkpoint, but training step {step_nr} has no checkpoint."
-                )
 
             try:
                 self._tensor_dumper(
-                    {"model": state_dict, "model_key": "model"}, tmp_model_file
+                    {"model": state_dict, "model_key": "model"}, model_file
                 )
             except (RuntimeError, OSError, PickleError) as ex:
                 raise RuntimeError(
-                    f"The model of training step {step_nr} cannot be saved. See nested exception for details."
-                ) from ex
-
-            try:
-                tmp_model_file.replace(tmp_model_file.with_suffix(".pt"))
-            except OSError as ex:
-                raise RuntimeError(
-                    f"The model of training step {step_nr} cannot be saved. See nested exception for details."
+                    f"The consolidated FSDP model of training step {step_nr} cannot be saved. See nested exception for details."
                 ) from ex
 
         self._root_gang.barrier()
+
+    @override
+    def commit_checkpoint(self) -> None:
+        step_nr = self._get_checkpoint_step_nr()
+
+        if self._root_gang.rank == 0:
+            tmp_step_dir = self._checkpoint_dir.joinpath(f"step_{step_nr}.tmp")
+
+            step_dir = tmp_step_dir.with_suffix("")
+
+            try:
+                tmp_step_dir.replace(step_dir)
+            except OSError as ex:
+                raise RuntimeError(
+                    f"The checkpoint of training step {step_nr} cannot be saved. See nested exception for details."
+                ) from ex
+
+        self._root_gang.barrier()
+
+        self._checkpoint_step_nr = None
+
+    def _get_checkpoint_step_nr(self) -> int:
+        step_nr = self._checkpoint_step_nr
+        if step_nr is None:
+            raise ValueError("`begin_checkpoint()` must be called first.")
+
+        return step_nr
 
     @override
     def load_checkpoint(self, step_nr: int) -> Dict[str, Any]:
@@ -599,7 +626,7 @@ class FileCheckpointManager(CheckpointManager):
 
             if preserve_model:
                 # Delete all PyTorch tensor files except 'model.X.pt' files that
-                # represent (consolidated) models.
+                # represent a (consolidated) model.
                 for pt_file in step_dir.glob("*.pt"):
                     if pt_file.is_dir() or pt_file.stem.startswith("model"):
                         continue
@@ -620,36 +647,69 @@ class FileCheckpointManager(CheckpointManager):
 
     @override
     def keep_last_n_checkpoints(self, n: int, *, preserve_model: bool = False) -> None:
+        if n == 0:
+            raise ValueError("`n` must be greater than zero.")
+
         step_numbers = self.get_step_numbers()
+        if not step_numbers:
+            return
 
         self._root_gang.barrier()
 
-        for step_number in step_numbers[:-n]:
-            self.delete_checkpoint(step_number, preserve_model=preserve_model)
+        for step_nr in step_numbers[:-n]:
+            self.delete_checkpoint(step_nr, preserve_model=preserve_model)
 
-    # compat
-    def get_model_checkpoint_path(
-        self, step_nr: Optional[int] = None
-    ) -> Optional[Path]:
-        """Return the path of the model of the specified training step.
+    @override
+    def keep_best_n_checkpoints(self, n: int, *, preserve_model: bool = False) -> None:
+        if n == 0:
+            raise ValueError("`n` must be greater than zero.")
 
-        :param step_nr:
-            The number of the training step. If ``None``, returns the path of
-            the last model in the training.
-        """
-        if step_nr is None:
-            step_numbers = self.get_step_numbers()
-            if not step_numbers:
-                return None
+        step_numbers = self.get_step_numbers()
+        if not step_numbers:
+            return
 
-            step_nr = step_numbers[-1]
+        last_step_nr = step_numbers[-1]
 
-        if step_nr is None:
-            return None
+        scores = self._load_scores(step_numbers)
+        if not scores:
+            return
 
-        return self._checkpoint_dir.joinpath(
-            f"step_{step_nr}/model{self._shard_suffix}.pt"
-        )
+        self._root_gang.barrier()
+
+        for _, step_nr in scores[:-n]:
+            # Always preserve the last checkpoint.
+            if step_nr != last_step_nr:
+                self.delete_checkpoint(step_nr, preserve_model=preserve_model)
+
+    def _load_scores(self, step_numbers: List[int]) -> List[Tuple[float, int]]:
+        scores = []
+
+        for step_nr in step_numbers:
+            score_file = self._checkpoint_dir.joinpath(f"step_{step_nr}/score.txt")
+
+            try:
+                with score_file.open() as fp:
+                    line = fp.readline()
+            except OSError as ex:
+                raise RuntimeError(
+                    f"The score of training step {step_nr} cannot be loaded. See nested exception for details."
+                ) from ex
+
+            try:
+                score = float(line)
+            except ValueError as ex:
+                raise RuntimeError(
+                    f"The score of training step {step_nr} cannot be loaded. See nested exception for details."
+                ) from ex
+
+            scores.append((score, step_nr))
+
+        if self._lower_score_better:
+            scores.sort(key=lambda e: (-e[0], e[1]))
+        else:
+            scores.sort()
+
+        return scores
 
     @override
     def has_checkpoint(self, step_nr: Optional[int] = None) -> bool:
@@ -688,74 +748,3 @@ class FileCheckpointManager(CheckpointManager):
 
 class CheckpointNotFoundError(RuntimeError):
     """Raised when a checkpoint is not found."""
-
-
-@final
-class CheckpointModelMetadataProvider(AbstractAssetMetadataProvider):
-    """Provides checkpoint model metadata saved by a :class:`FileCheckpointManager.`"""
-
-    _checkpoint_dir: Path
-
-    def __init__(self, checkpoint_dir: Path) -> None:
-        super().__init__()
-
-        self._checkpoint_dir = checkpoint_dir.expanduser().resolve()
-
-    @override
-    def _load_cache(self) -> Dict[str, Dict[str, Any]]:
-        metadata_file = self._checkpoint_dir.joinpath("model.yaml")
-        if not metadata_file.exists():
-            raise AssetMetadataError(
-                f"The checkpoint model metadata (model.yaml) cannot be found under {self._checkpoint_dir}. Make sure that the specified directory is the *base* checkpoint directory used during training (i.e. directory passed to `FileCheckpointManager.save_model_metadata()`)."
-            )
-
-        cache = dict(load_metadata_file(metadata_file))
-
-        try:
-            metadata = cache["checkpoint@"]
-        except KeyError as ex:
-            raise AssetMetadataError(
-                "The checkpoint model metadata has an invalid format."
-            ) from ex
-
-        try:
-            num_shards = int(metadata["num_shards"])
-        except KeyError:
-            num_shards = 1
-        except ValueError as ex:
-            raise AssetMetadataError(
-                "The checkpoint model metadata has an invalid format."
-            ) from ex
-
-        if num_shards == 1:
-            filename = "model.pt"
-        else:
-            filename = "model.{shard_idx}.pt"
-
-        def add_checkpoint_metadata(name: str, path: Path) -> None:
-            cache[name] = {"base": "checkpoint", "checkpoint": str(path)}
-
-        add_checkpoint_metadata(
-            "last_checkpoint@", self._checkpoint_dir.joinpath(f"last_step/{filename}")
-        )
-
-        try:
-            for step_dir in self._checkpoint_dir.glob("step_*"):
-                if not step_dir.is_dir():
-                    continue
-
-                try:
-                    step_nr = int(step_dir.name[5:])
-                except ValueError:
-                    continue
-
-                add_checkpoint_metadata(
-                    f"checkpoint_step_{step_nr}@", step_dir.joinpath(filename)
-                )
-
-        except OSError as ex:
-            raise RuntimeError(
-                "The base checkpoint directory cannot be traversed. See nested exception for details."
-            ) from ex
-
-        return cache

--- a/src/fairseq2/checkpoint/metadata_provider.py
+++ b/src/fairseq2/checkpoint/metadata_provider.py
@@ -1,0 +1,137 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, final
+
+from fairseq2.assets.metadata_provider import (
+    AbstractAssetMetadataProvider,
+    AssetMetadataError,
+    load_metadata_file,
+)
+from fairseq2.typing import override
+
+
+@final
+class CheckpointModelMetadataProvider(AbstractAssetMetadataProvider):
+    """Provides checkpoint model metadata saved by a :class:`FileCheckpointManager.`"""
+
+    _checkpoint_dir: Path
+    _lower_score_better: bool
+
+    def __init__(
+        self, checkpoint_dir: Path, *, lower_score_better: bool = False
+    ) -> None:
+        """
+        :param checkpoint_dir:
+            The base directory under which the checkpoints are stored.
+        :param lower_score_better:
+            If ``True``, lower scores are considered better.
+        """
+        super().__init__()
+
+        self._checkpoint_dir = checkpoint_dir.expanduser().resolve()
+
+        self._lower_score_better = lower_score_better
+
+    @override
+    def _load_cache(self) -> Dict[str, Dict[str, Any]]:
+        metadata_file = self._checkpoint_dir.joinpath("model.yaml")
+        if not metadata_file.exists():
+            raise AssetMetadataError(
+                f"The checkpoint model metadata (model.yaml) cannot be found under {self._checkpoint_dir}. Make sure that the specified directory is the *base* checkpoint directory used during training (i.e. directory passed to `FileCheckpointManager.save_model_metadata()`)."
+            )
+
+        cache = dict(load_metadata_file(metadata_file))
+
+        try:
+            metadata = cache["checkpoint@"]
+        except KeyError as ex:
+            raise AssetMetadataError(
+                "The checkpoint model metadata has an invalid format."
+            ) from ex
+
+        try:
+            num_shards = int(metadata["num_shards"])
+        except KeyError:
+            num_shards = 1
+        except ValueError as ex:
+            raise AssetMetadataError(
+                "The checkpoint model metadata has an invalid format."
+            ) from ex
+
+        if num_shards == 1:
+            filename = "model.pt"
+        else:
+            filename = "model.{shard_idx}.pt"
+
+        def add_checkpoint_metadata(name: str, path: Path) -> None:
+            cache[name] = {"base": "checkpoint", "checkpoint": str(path)}
+
+        max_step_nr = -1
+
+        scores = []
+
+        try:
+            for step_dir in self._checkpoint_dir.glob("step_*"):
+                if not step_dir.is_dir():
+                    continue
+
+                try:
+                    step_nr = int(step_dir.name[5:])
+                except ValueError:
+                    continue
+
+                add_checkpoint_metadata(
+                    f"checkpoint_step_{step_nr}@", step_dir.joinpath(filename)
+                )
+
+                max_step_nr = max(max_step_nr, step_nr)
+
+                # Load score.
+                score_file = step_dir.joinpath("score.txt")
+                if score_file.exists():
+                    try:
+                        with score_file.open() as fp:
+                            line = fp.readline()
+                    except OSError as ex:
+                        raise RuntimeError(
+                            f"The score of training step {step_nr} cannot be loaded. See nested exception for details."
+                        ) from ex
+
+                    try:
+                        score = float(line)
+                    except ValueError as ex:
+                        raise RuntimeError(
+                            f"The score of training step {step_nr} cannot be loaded. See nested exception for details."
+                        ) from ex
+
+                    scores.append((score, step_nr))
+        except OSError as ex:
+            raise RuntimeError(
+                "The base checkpoint directory cannot be traversed. See nested exception for details."
+            ) from ex
+
+        if max_step_nr >= 0:
+            last_model_file = self._checkpoint_dir.joinpath(
+                f"step_{max_step_nr}/{filename}"
+            )
+
+            add_checkpoint_metadata("last_checkpoint@", last_model_file)
+
+        if self._lower_score_better:
+            scores.sort(key=lambda e: (-e[0], e[1]))
+        else:
+            scores.sort()
+
+        for rank, (_, step_nr) in enumerate(reversed(scores)):
+            model_file = self._checkpoint_dir.joinpath(f"step_{step_nr}/{filename}")
+
+            add_checkpoint_metadata(f"checkpoint_best_{rank}@", model_file)
+
+        return cache

--- a/src/fairseq2/datasets/instruction.py
+++ b/src/fairseq2/datasets/instruction.py
@@ -182,9 +182,10 @@ class GenericInstructionDataset(InstructionDataset):
         manifest_file = path.joinpath("MANIFEST")
 
         try:
-            fp = manifest_file.open()
+            with manifest_file.open() as fp:
+                content = list(fp)
         except FileNotFoundError:
-            fp = None
+            content = None
         except OSError as ex:
             raise RuntimeError(
                 f"{manifest_file} cannot be read. See nested exception for details."
@@ -192,7 +193,7 @@ class GenericInstructionDataset(InstructionDataset):
 
         # If the directory does not contain a MANIFEST file, treat all JSONL
         # files as part of the dataset with equal weight.
-        if fp is None:
+        if content is None:
             try:
                 files = list(path.glob("**/*.jsonl"))
             except OSError as ex:
@@ -203,15 +204,6 @@ class GenericInstructionDataset(InstructionDataset):
             weights = [1.0 for _ in range(len(files))]
 
             return GenericInstructionDataset(files, weights=weights)
-
-        try:
-            content = list(fp)
-        except OSError as ex:
-            raise RuntimeError(
-                f"{manifest_file} cannot be read. See nested exception for details."
-            ) from ex
-        finally:
-            fp.close()
 
         # Sort the JSONL files in alphabetical order.
         content.sort()

--- a/src/fairseq2/datasets/parallel_text.py
+++ b/src/fairseq2/datasets/parallel_text.py
@@ -196,20 +196,12 @@ class GenericParallelTextDataset(ParallelTextDataset):
             manifest_file = path.joinpath(split).joinpath("MANIFEST")
 
             try:
-                fp = manifest_file.open()
+                with manifest_file.open() as fp:
+                    content = list(fp)
             except OSError as ex:
                 raise RuntimeError(
                     f"{manifest_file} cannot be read. See nested exception for details."
                 ) from ex
-
-            try:
-                content = list(fp)
-            except OSError as ex:
-                raise RuntimeError(
-                    f"{manifest_file} cannot be read. See nested exception for details."
-                ) from ex
-            finally:
-                fp.close()
 
             # Sort the directions in alphabetical order.
             content.sort()

--- a/src/fairseq2/recipes/trainer.py
+++ b/src/fairseq2/recipes/trainer.py
@@ -549,7 +549,7 @@ class Trainer(StatefulObjectBag, Generic[BatchT]):
         log.info("Attempting to load the last checkpoint.")
 
         try:
-            step_nr, checkpoint = self._checkpoint_manager.load_last_checkpoint()
+            step_nr, state = self._checkpoint_manager.load_last_checkpoint()
         except CheckpointNotFoundError:
             log.info("No checkpoint found. Starting training.")
 
@@ -559,7 +559,7 @@ class Trainer(StatefulObjectBag, Generic[BatchT]):
 
         self._step_nr = step_nr
 
-        self.load_state_dict(checkpoint)
+        self.load_state_dict(state)
 
         self._root_gang.barrier()
 
@@ -970,29 +970,45 @@ class Trainer(StatefulObjectBag, Generic[BatchT]):
 
         log.info("Saving checkpoint after step {}.", step_nr)
 
-        checkpoint = self.state_dict()
+        log.info("Extracting trainer state.")
 
-        log.info("State dictionary of the trainer extracted.")
+        state = self.state_dict()
+
+        log.info("Trainer state extracted.")
+
+        self._checkpoint_manager.begin_checkpoint(step_nr)
+
+        log.info("Saving trainer state.")
 
         if self._dp_gang.size > 1 and isinstance(self._model, DDP):
             replicated_keys = {"_model", "_optimizer"}
         else:
             replicated_keys = None
 
-        self._checkpoint_manager.save_checkpoint(
-            step_nr, checkpoint, model_key="_model", replicated_keys=replicated_keys
+        self._checkpoint_manager.save_state(
+            state, model_key="_model", replicated_keys=replicated_keys
         )
 
-        log.info("Checkpoint saved.")
+        log.info("Trainer state saved.")
+
+        log.info("Saving validation score.")
+
+        self._checkpoint_manager.save_score(self._valid_score)
+
+        log.info("Validation score saved.")
 
         if isinstance(self._model, FSDP):
-            log.info("Saving consolidated FSDP model after step {}.", step_nr)
+            log.info("Saving consolidated FSDP model.")
 
-            self._checkpoint_manager.save_consolidated_fsdp_model(step_nr, self._model)
+            self._checkpoint_manager.save_consolidated_fsdp_model(self._model)
 
-            log.info("Model saved.")
+            log.info("Consolidated model saved.")
 
-        # Clean up checkpoints.
+        self._checkpoint_manager.commit_checkpoint()
+
+        log.info("Checkpoint complete.")
+
+        # Clean up the checkpoints.
         nc = self._keep_last_n_checkpoints
         nm = self._keep_last_n_models
 
@@ -1003,6 +1019,17 @@ class Trainer(StatefulObjectBag, Generic[BatchT]):
             self._checkpoint_manager.keep_last_n_checkpoints(nc, preserve_model=True)
         elif nc is not None:
             self._checkpoint_manager.keep_last_n_checkpoints(nc)
+
+        nc = self._keep_best_n_checkpoints
+        nm = self._keep_best_n_models
+
+        if nm is not None:
+            assert nc is not None
+
+            self._checkpoint_manager.keep_best_n_checkpoints(nm)
+            self._checkpoint_manager.keep_best_n_checkpoints(nc, preserve_model=True)
+        elif nc is not None:
+            self._checkpoint_manager.keep_best_n_checkpoints(nc)
 
     def _should_do(self, after_n_steps: int, n_steps: int) -> bool:
         if self._eod or self._should_stop:

--- a/src/fairseq2/recipes/wav2vec2/asr/eval.py
+++ b/src/fairseq2/recipes/wav2vec2/asr/eval.py
@@ -102,7 +102,9 @@ def load_wav2vec2_asr_evaluator(
 
     if config.checkpoint_dir is not None:
         default_asset_store.metadata_providers.append(
-            CheckpointModelMetadataProvider(config.checkpoint_dir)
+            CheckpointModelMetadataProvider(
+                config.checkpoint_dir, lower_score_better=True
+            )
         )
 
     gang = setup_root_gang(log)

--- a/src/fairseq2/recipes/wav2vec2/asr/train.py
+++ b/src/fairseq2/recipes/wav2vec2/asr/train.py
@@ -217,11 +217,15 @@ def load_wav2vec2_asr_trainer(
 
     gang = setup_root_gang(log, monitored=config.monitored_gang)
 
-    checkpoint_manager = FileCheckpointManager(output_dir.joinpath("checkpoints"), gang)
+    checkpoint_manager = FileCheckpointManager(
+        output_dir.joinpath("checkpoints"), gang, lower_score_better=True
+    )
 
     if config.resume_checkpoint_dir is not None:
         default_asset_store.metadata_providers.append(
-            CheckpointModelMetadataProvider(config.resume_checkpoint_dir)
+            CheckpointModelMetadataProvider(
+                config.resume_checkpoint_dir, lower_score_better=True
+            )
         )
 
     seed = config.seed

--- a/src/fairseq2/utils/file.py
+++ b/src/fairseq2/utils/file.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import warnings
 from pathlib import Path
-from typing import Any, Callable, Dict, Optional, Protocol, Union
+from typing import Any, Callable, Dict, Mapping, Optional, Protocol, Union
 from warnings import catch_warnings
 
 import torch
@@ -46,7 +46,7 @@ class TensorLoader(Protocol):
 class TensorDumper(Protocol):
     """Dumps tensors to files."""
 
-    def __call__(self, data: Dict[str, Any], path: Path) -> None:
+    def __call__(self, data: Mapping[str, Any], path: Path) -> None:
         """
         :param data:
             The dictionary containing tensors and other auxiliary data.
@@ -72,6 +72,6 @@ def load_tensors(
     return data
 
 
-def dump_tensors(data: Dict[str, Any], path: Path) -> None:
+def dump_tensors(data: Mapping[str, Any], path: Path) -> None:
     """Dump ``data`` to a PyTorch tensor file under ``path``."""
     torch.save(data, path)


### PR DESCRIPTION
This PR revises the implementation of `CheckpointManager` and makes checkpoint saving transactional by having a `begin_checkpoint()`/`commit_checkpoint()` method pair. It also introduces support for keeping the best N checkpoints.