### PR TITLE
Introduce AssetReference alias

### DIFF
--- a/src/fairseq2/recipes/lm/instruction_finetune.py
+++ b/src/fairseq2/recipes/lm/instruction_finetune.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal, Optional, Tuple, Union, final
+from typing import Literal, Optional, Tuple, final
 
 import torch
 import torch.distributed
@@ -39,7 +39,11 @@ from fairseq2.optim import AdamW
 from fairseq2.optim.lr_scheduler import CosineAnnealingLR
 from fairseq2.recipes.common_metrics import SequenceMetricBag
 from fairseq2.recipes.trainer import AbstractTrainUnit, Trainer
-from fairseq2.recipes.utils.asset import asset_as_path, retrieve_asset_card
+from fairseq2.recipes.utils.asset import (
+    AssetReference,
+    asset_as_path,
+    retrieve_asset_card,
+)
 from fairseq2.recipes.utils.log import log_model
 from fairseq2.recipes.utils.setup import (
     check_model_type,
@@ -58,7 +62,7 @@ class InstructionFinetuneConfig:
     """Holds the configuration of a language model instruction-finetuning task."""
 
     # Data
-    dataset: Union[str, Path] = "foo"  # TODO: change!
+    dataset: AssetReference = "foo"  # TODO: change!
     """The name, path, or path to the asset card of the instruction dataset."""
 
     max_seq_len: int = 8192
@@ -77,7 +81,7 @@ class InstructionFinetuneConfig:
     """The number of batches to prefetch in background."""
 
     # Model
-    model: Union[str, Path] = "llama3_8b_instruct"
+    model: AssetReference = "llama3_8b_instruct"
     """The name or path to the asset card of the language model to finetune."""
 
     dtype: DataType = torch.bfloat16

--- a/src/fairseq2/recipes/lm/text_generate.py
+++ b/src/fairseq2/recipes/lm/text_generate.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Literal, Optional, TextIO, Union, final
+from typing import Literal, Optional, TextIO, final
 
 import torch
 
@@ -38,7 +38,11 @@ from fairseq2.models.decoder import DecoderModel
 from fairseq2.models.sequence import SequenceBatch
 from fairseq2.recipes.common_metrics import SequenceGenerationMetricBag
 from fairseq2.recipes.generator import AbstractGeneratorUnit, Generator
-from fairseq2.recipes.utils.asset import asset_as_path, retrieve_asset_card
+from fairseq2.recipes.utils.asset import (
+    AssetReference,
+    asset_as_path,
+    retrieve_asset_card,
+)
 from fairseq2.recipes.utils.log import log_model
 from fairseq2.recipes.utils.setup import broadcast_model, check_model_type, setup_gangs
 from fairseq2.typing import META, DataType, override
@@ -52,7 +56,7 @@ class TextGenerateConfig:
     """Holds the configuration of a text generation task."""
 
     # Data
-    dataset: Union[str, Path] = "foo"  # TODO: change!
+    dataset: AssetReference = "foo"  # TODO: change!
     """The name, path, or path to the asset card of the instruction dataset."""
 
     max_seq_len: int = 8192
@@ -65,7 +69,7 @@ class TextGenerateConfig:
     """The number of batches to prefetch in background."""
 
     # Model
-    model: Union[str, Path] = "llama3_8b_instruct"
+    model: AssetReference = "llama3_8b_instruct"
     """The name of the model to generate with."""
 
     checkpoint_dir: Optional[Path] = None

--- a/src/fairseq2/recipes/mt/eval.py
+++ b/src/fairseq2/recipes/mt/eval.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import List, Literal, Optional, TextIO, Union, final
+from typing import List, Literal, Optional, TextIO, final
 
 import torch
 from torch.nn import Module
@@ -39,7 +39,11 @@ from fairseq2.recipes.mt.translate import (
     SamplingConfig,
     _create_sequence_generator,
 )
-from fairseq2.recipes.utils.asset import asset_as_path, retrieve_asset_card
+from fairseq2.recipes.utils.asset import (
+    AssetReference,
+    asset_as_path,
+    retrieve_asset_card,
+)
 from fairseq2.recipes.utils.log import log_model
 from fairseq2.recipes.utils.setup import (
     broadcast_model,
@@ -57,7 +61,7 @@ class MTEvalConfig:
     """Holds the configuration of a machine translation evaluation task."""
 
     # Data
-    dataset: Union[str, Path] = "foo"  # TODO: change!
+    dataset: AssetReference = "foo"  # TODO: change!
     """The name, path, or path to the asset card of the parallel text dataset."""
 
     split: str = "test"
@@ -73,7 +77,7 @@ class MTEvalConfig:
     """The number of batches to prefetch in background."""
 
     # Model
-    model: Union[str, Path] = "nllb-200_dense_distill_600m"
+    model: AssetReference = "nllb-200_dense_distill_600m"
     """The name of the model to evaluate."""
 
     checkpoint_dir: Optional[Path] = None

--- a/src/fairseq2/recipes/mt/train.py
+++ b/src/fairseq2/recipes/mt/train.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Literal, Optional, Tuple, Union, final
+from typing import Any, Dict, List, Literal, Optional, Tuple, final
 
 import torch
 from torch import Tensor
@@ -40,7 +40,11 @@ from fairseq2.recipes.mt.translate import (
     _create_sequence_generator,
 )
 from fairseq2.recipes.trainer import AbstractTrainUnit, Trainer
-from fairseq2.recipes.utils.asset import asset_as_path, retrieve_asset_card
+from fairseq2.recipes.utils.asset import (
+    AssetReference,
+    asset_as_path,
+    retrieve_asset_card,
+)
 from fairseq2.recipes.utils.log import log_model, log_model_config
 from fairseq2.recipes.utils.setup import (
     check_model_type,
@@ -62,7 +66,7 @@ class MTTrainConfig:
     """
 
     # Data
-    dataset: Union[str, Path] = "foo"  # TODO: change!
+    dataset: AssetReference = "foo"  # TODO: change!
     """The name, path, or path to the asset card of the parallel text dataset."""
 
     split: str = "train"
@@ -86,7 +90,7 @@ class MTTrainConfig:
     num_prefetch: int = 4
     """The number of batches to prefetch in background."""
 
-    tokenizer: Union[str, Path] = "nllb-200"
+    tokenizer: AssetReference = "nllb-200"
     """The name or path to the asset card of the tokenizer to use."""
 
     # Model

--- a/src/fairseq2/recipes/mt/translate.py
+++ b/src/fairseq2/recipes/mt/translate.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Literal, Optional, TextIO, Tuple, Union, final
+from typing import Literal, Optional, TextIO, Tuple, final
 
 import torch
 
@@ -35,7 +35,11 @@ from fairseq2.models.encoder_decoder import EncoderDecoderModel
 from fairseq2.models.sequence import SequenceBatch
 from fairseq2.recipes.common_metrics import Seq2SeqGenerationMetricBag
 from fairseq2.recipes.generator import AbstractGeneratorUnit, Generator
-from fairseq2.recipes.utils.asset import asset_as_path, retrieve_asset_card
+from fairseq2.recipes.utils.asset import (
+    AssetReference,
+    asset_as_path,
+    retrieve_asset_card,
+)
 from fairseq2.recipes.utils.log import log_model
 from fairseq2.recipes.utils.setup import (
     broadcast_model,
@@ -53,7 +57,7 @@ class TextTranslateConfig:
     """Holds the configuration of a text translation task."""
 
     # Data
-    dataset: Union[str, Path] = "foo"  # TODO: change!
+    dataset: AssetReference = "foo"  # TODO: change!
     """The name, path, or path to the asset card of the text dataset."""
 
     source_lang: str = "eng_Latn"
@@ -72,7 +76,7 @@ class TextTranslateConfig:
     """The number of batches to prefetch in background."""
 
     # Model
-    model: Union[str, Path] = "nllb-200_dense_distill_600m"
+    model: AssetReference = "nllb-200_dense_distill_600m"
     """The name of the model to translate with."""
 
     checkpoint_dir: Optional[Path] = None

--- a/src/fairseq2/recipes/utils/asset.py
+++ b/src/fairseq2/recipes/utils/asset.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Union
 
+from typing_extensions import TypeAlias
+
 from fairseq2.assets import (
     AssetCard,
     AssetMetadataError,
@@ -18,8 +20,10 @@ from fairseq2.assets import (
     load_metadata_file,
 )
 
+AssetReference: TypeAlias = Union[str, AssetCard, Path]
 
-def retrieve_asset_card(name_or_card: Union[str, AssetCard, Path]) -> AssetCard:
+
+def retrieve_asset_card(name_or_card: AssetReference) -> AssetCard:
     """Retrieve the specified asset.
 
     :param name_or_card:
@@ -30,7 +34,9 @@ def retrieve_asset_card(name_or_card: Union[str, AssetCard, Path]) -> AssetCard:
 
     if isinstance(name_or_card, Path):
         if name_or_card.is_dir():
-            raise AssetNotFoundError(f"{name_or_card}", "The asset cannot be found.")
+            raise AssetNotFoundError(
+                f"{name_or_card}", f"An asset metadata file cannot be found at {name_or_card}."  # fmt: skip
+            )
 
         return _card_from_file(name_or_card)
 
@@ -73,9 +79,14 @@ def _card_from_file(file: Path) -> AssetCard:
     return default_asset_store.retrieve_card(name, extra_provider=metadata_provider)
 
 
-def asset_as_path(name_or_card: Union[str, Path]) -> Path:
+def asset_as_path(name_or_card: AssetReference) -> Path:
     if isinstance(name_or_card, Path):
         return name_or_card
+
+    if isinstance(name_or_card, AssetCard):
+        raise ValueError(
+            f"`name_or_card` must be of type `{str}` or `{Path}`, but is of type `{AssetCard}` instead."
+        )
 
     try:
         path = Path(name_or_card)

--- a/src/fairseq2/recipes/wav2vec2/asr/eval.py
+++ b/src/fairseq2/recipes/wav2vec2/asr/eval.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Optional, TextIO, Union, final
+from typing import Any, Dict, Optional, TextIO, final
 
 import torch
 from torch.nn import Module
@@ -29,7 +29,11 @@ from fairseq2.models.wav2vec2.asr import Wav2Vec2AsrModel
 from fairseq2.models.wav2vec2.asr.model import Wav2Vec2AsrOutput
 from fairseq2.nn.utils.module import remove_parametrizations
 from fairseq2.recipes.evaluator import AbstractEvalUnit, Evaluator
-from fairseq2.recipes.utils.asset import asset_as_path, retrieve_asset_card
+from fairseq2.recipes.utils.asset import (
+    AssetReference,
+    asset_as_path,
+    retrieve_asset_card,
+)
 from fairseq2.recipes.utils.log import log_model
 from fairseq2.recipes.utils.setup import (
     broadcast_model,
@@ -48,7 +52,7 @@ class Wav2Vec2AsrEvalConfig:
     """Holds the configuration of a wav2vec 2.0 ASR model evaluation task."""
 
     # Data
-    dataset: Union[str, Path] = "librilight_asr_10h"
+    dataset: AssetReference = "librilight_asr_10h"
     """The name, path, or path to the asset card of the ASR dataset."""
 
     split: str = "test_other"
@@ -70,7 +74,7 @@ class Wav2Vec2AsrEvalConfig:
     """The number of batches to prefetch in background."""
 
     # Model
-    model: Union[str, Path] = "wav2vec2_asr_base_10h"
+    model: AssetReference = "wav2vec2_asr_base_10h"
     """The name or path to the asset card of the wav2vec 2.0 ASR model to evaluate."""
 
     checkpoint_dir: Optional[Path] = None

--- a/src/fairseq2/recipes/wav2vec2/asr/train.py
+++ b/src/fairseq2/recipes/wav2vec2/asr/train.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Literal, Optional, Tuple, Union, final
+from typing import Any, Dict, Literal, Optional, Tuple, final
 
 import torch
 from torch import Tensor
@@ -31,7 +31,11 @@ from fairseq2.nn.utils.module import freeze_parameters, share_parameters, to_dev
 from fairseq2.optim import AdamW
 from fairseq2.optim.lr_scheduler import TriStageLR
 from fairseq2.recipes.trainer import AbstractTrainUnit, Trainer
-from fairseq2.recipes.utils.asset import asset_as_path, retrieve_asset_card
+from fairseq2.recipes.utils.asset import (
+    AssetReference,
+    asset_as_path,
+    retrieve_asset_card,
+)
 from fairseq2.recipes.utils.log import log_model, log_model_config
 from fairseq2.recipes.utils.setup import (
     check_model_type,
@@ -56,7 +60,7 @@ class Wav2Vec2AsrTrainConfig:
     """
 
     # Data
-    dataset: Union[str, Path] = "librilight_asr_10h"
+    dataset: AssetReference = "librilight_asr_10h"
     """The name, path, or path to the asset card of the ASR dataset."""
 
     train_split: str = "train"
@@ -86,11 +90,11 @@ class Wav2Vec2AsrTrainConfig:
     num_prefetch: int = 4
     """The number of batches to prefetch in background."""
 
-    tokenizer: Union[str, Path] = "librispeech_asr"
+    tokenizer: AssetReference = "librispeech_asr"
     """The name or path to the asset card of the tokenizer to use."""
 
     # Model
-    pretrained_model: Union[str, Path] = "wav2vec2_base"
+    pretrained_model: AssetReference = "wav2vec2_base"
     """The name or path to the asset card of the wav2vec 2.0 model to finetune."""
 
     model_family: str = "wav2vec2_asr"


### PR DESCRIPTION
This PR introduces the `AssetReference` type alias to replace the uses of long `Union[str, AssetCard, Path]` annotations.