### PR TITLE
Revise GenericModelFactory

### DIFF
--- a/src/fairseq2/models/__init__.py
+++ b/src/fairseq2/models/__init__.py
@@ -15,7 +15,9 @@ from fairseq2.models.config_loader import (
 )
 from fairseq2.models.config_loader import get_model_family as get_model_family
 from fairseq2.models.config_loader import is_model_card as is_model_card
-from fairseq2.models.factory import DelegatingModelFactory as DelegatingModelFactory
+from fairseq2.models.factory import (
+    DelegatingGenericModelFactory as DelegatingGenericModelFactory,
+)
 from fairseq2.models.factory import ModelFactory as ModelFactory
 from fairseq2.models.factory import create_model as create_model
 from fairseq2.models.loader import CheckpointConverter as CheckpointConverter

--- a/src/fairseq2/models/factory.py
+++ b/src/fairseq2/models/factory.py
@@ -6,14 +6,25 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional, Protocol, Tuple, Type, TypeVar, final
+from typing import (
+    Any,
+    Dict,
+    Generic,
+    Mapping,
+    Optional,
+    Protocol,
+    Tuple,
+    Type,
+    TypeVar,
+    final,
+)
 
 from torch.nn import Module
 
 from fairseq2.config_registry import ConfigRegistry
 from fairseq2.typing import DataClass, DataType, Device
 from fairseq2.utils.dataclass import FieldError, update_dataclass
-from fairseq2.utils.value_converter import ValueConverter
+from fairseq2.utils.value_converter import ValueConverter, default_value_converter
 
 ModelT = TypeVar("ModelT", bound=Module)
 
@@ -46,31 +57,14 @@ class ModelFactory(Protocol[ModelConfigT_contra, ModelT_co]):
         """
 
 
-class _GenericModelFactory(Protocol):
-    def __call__(
-        self,
-        arch: Optional[str],
-        config: Optional[Dict[str, Any]],
-        device: Optional[Device],
-        dtype: Optional[DataType],
-    ) -> Tuple[Module, DataClass]:
-        ...
-
-
-@final
-class DelegatingModelFactory:
-    """Constructs models using registered factories."""
-
-    _factories: Dict[str, _GenericModelFactory]
-
-    def __init__(self) -> None:
-        self._factories = {}
+class GenericModelFactory(Protocol):
+    """Constructs models."""
 
     def __call__(
         self,
         family: str,
         arch: Optional[str],
-        config: Optional[Dict[str, Any]],
+        config: Any,
         *,
         device: Optional[Device] = None,
         dtype: Optional[DataType] = None,
@@ -82,18 +76,139 @@ class DelegatingModelFactory:
             The architecture of the model. If ``None``, uses the default model
             configuration.
         :param config:
-            The weakly-typed model configuration. Keys within ``config`` will
-            override corresponding fields in model configuration object. Keys
-            that are not present in ``config`` will have their default values
-            set based on ``arch``.
+            The model configuration object or a dictionary where keys will
+            override corresponding fields in the model configuration of ``arch``.
         """
 
+
+@final
+class StandardGenericModelFactory(GenericModelFactory, Generic[ModelT, ModelConfigT]):
+    """Constructs models."""
+
+    _family: str
+    _factory: ModelFactory[ModelConfigT, ModelT]
+    _config_kls: Type[ModelConfigT]
+    _arch_configs: Optional[ConfigRegistry[ModelConfigT]]
+    _value_converter: ValueConverter
+
+    def __init__(
+        self,
+        *,
+        family: str,
+        factory: ModelFactory[ModelConfigT, ModelT],
+        config_kls: Type[ModelConfigT],
+        arch_configs: Optional[ConfigRegistry[ModelConfigT]],
+        value_converter: Optional[ValueConverter] = None,
+    ) -> None:
+        """
+        :param family:
+            The model family.
+        :param factory:
+            The factory to construct models.
+        :param config_kls:
+            The type of the model configuration.
+        :param arch_configs:
+            The registry containing all supported model architectures.
+        :param value_converter:
+            The :class:`ValueConverter` instance to use. If ``None``, the
+            default instance will be used.
+        """
+        self._family = family
+        self._factory = factory
+        self._config_kls = config_kls
+        self._arch_configs = arch_configs
+        self._value_converter = value_converter or default_value_converter
+
+    def __call__(
+        self,
+        family: str,
+        arch: Optional[str],
+        config: Any,
+        *,
+        device: Optional[Device] = None,
+        dtype: Optional[DataType] = None,
+    ) -> Tuple[Module, DataClass]:
+        if family != self._family:
+            raise ValueError(
+                f"`family` must be '{self._family}', but is '{family}' instead."
+            )
+
+        if isinstance(config, self._config_kls):
+            model = self._factory(config, device=device, dtype=dtype)
+
+            return model, config
+
+        if arch is None:
+            try:
+                config_ = self._config_kls()
+            except TypeError as ex:
+                raise RuntimeError(
+                    f"The '{family}' model family has not default configuration."
+                ) from ex
+        else:
+            if self._arch_configs is None:
+                raise ValueError(
+                    f"`arch` must be a registered architecture, but the '{family}' model family has no architecture named '{arch}'."
+                )
+
+            try:
+                config_ = self._arch_configs.get(arch)
+            except ValueError:
+                raise ValueError(
+                    f"`arch` must be a registered architecture, but the '{family}' model family has no architecture named '{arch}'."
+                ) from None
+
+        if config is not None:
+            if not isinstance(config, Mapping):
+                raise ValueError(
+                    f"`config` must be of type `{self._config_kls}` or `{Mapping}`, but is of type `{type(config)}` instead."
+                )
+
+            try:
+                unknown_fields = update_dataclass(
+                    config_, config, value_converter=self._value_converter
+                )
+            except FieldError as ex:
+                raise ValueError(
+                    f"`config` must be a valid model configuration, but the value of the configuration field '{ex.field_name}' is invalid. See nested exception for details."
+                ) from ex
+
+            if unknown_fields:
+                raise ValueError(
+                    f"`config` must be a valid model configuration, but the following configuration fields are unknown: {', '.join(unknown_fields)}"
+                )
+
+        model = self._factory(config_, device=device, dtype=dtype)
+
+        return model, config_
+
+
+@final
+class DelegatingGenericModelFactory(GenericModelFactory):
+    """Constructs models using registered factories."""
+
+    _factories: Dict[str, GenericModelFactory]
+
+    def __init__(self) -> None:
+        self._factories = {}
+
+    def __call__(
+        self,
+        family: str,
+        arch: Optional[str],
+        config: Any,
+        *,
+        device: Optional[Device] = None,
+        dtype: Optional[DataType] = None,
+    ) -> Tuple[Module, DataClass]:
         try:
             factory = self._factories[family]
         except KeyError:
-            raise ValueError("`family` must have a registered model factory.") from None
+            raise ValueError(
+                f"`family` must be a supported model family, but '{family}' has no registered factory."
+            ) from None
 
-        return factory(arch, config, device, dtype)
+        return factory(family, arch, config, device=device, dtype=dtype)
 
     def register(
         self,
@@ -109,7 +224,7 @@ class DelegatingModelFactory:
         :param family:
             The model family supported by ``factory``.
         :param factory:
-            The model factory.
+            The factory to construct models.
         :param config_kls:
             The type of the model configuration.
         :param arch_configs:
@@ -123,52 +238,15 @@ class DelegatingModelFactory:
                 f"`family` must be a unique model family name, but '{family}' has already a registered factory."
             )
 
-        def create_model(
-            arch: Optional[str],
-            config: Optional[Dict[str, Any]],
-            device: Optional[Device],
-            dtype: Optional[DataType],
-        ) -> Tuple[Module, DataClass]:
-            if arch is None:
-                try:
-                    config_ = config_kls()
-                except TypeError as ex:
-                    raise RuntimeError(
-                        f"The {family} model family has not default configuration."
-                    ) from ex
-            else:
-                if arch_configs is None:
-                    raise ValueError(
-                        f"`arch` must be a registered architecture, but the '{family}' model family has no architecture named '{arch}'."
-                    )
+        generic_factory = StandardGenericModelFactory(
+            family=family,
+            factory=factory,
+            config_kls=config_kls,
+            arch_configs=arch_configs,
+            value_converter=value_converter,
+        )
 
-                try:
-                    config_ = arch_configs.get(arch)
-                except ValueError:
-                    raise ValueError(
-                        f"`arch` must be a registered architecture, but the '{family}' model family has no architecture named '{arch}'."
-                    ) from None
-
-            if config is not None:
-                try:
-                    unknown_fields = update_dataclass(
-                        config_, config, value_converter=value_converter
-                    )
-                except FieldError as ex:
-                    raise ValueError(
-                        f"`config` must be a valid model configuration, but the value of the configuration field '{ex.field_name}' is invalid. See nested exception for details."
-                    ) from ex
-
-                if unknown_fields:
-                    raise ValueError(
-                        f"`config` must be a valid model configuration, but the following configuration fields are unknown: {', '.join(unknown_fields)}"
-                    )
-
-            model = factory(config_, device=device, dtype=dtype)
-
-            return model, config_
-
-        self._factories[family] = create_model
+        self._factories[family] = generic_factory
 
 
-create_model = DelegatingModelFactory()
+create_model = DelegatingGenericModelFactory()

--- a/src/fairseq2/recipes/mt/train.py
+++ b/src/fairseq2/recipes/mt/train.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Literal, Optional, Tuple, final
+from typing import Any, List, Literal, Optional, Tuple, final
 
 import torch
 from torch import Tensor
@@ -100,8 +100,8 @@ class MTTrainConfig:
     model_arch: Optional[str] = "nllb_dense_600m"
     """The architecture of the model."""
 
-    model_config: Optional[Dict[str, Any]] = None
-    """The model configuration overrides."""
+    model_config: Any = None
+    """The model configuration."""
 
     dtype: DataType = torch.float16
     """The data type of the model."""

--- a/src/fairseq2/recipes/wav2vec2/asr/train.py
+++ b/src/fairseq2/recipes/wav2vec2/asr/train.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Literal, Optional, Tuple, final
+from typing import Any, Literal, Optional, Tuple, final
 
 import torch
 from torch import Tensor
@@ -103,8 +103,8 @@ class Wav2Vec2AsrTrainConfig:
     model_arch: Optional[str] = "base_10h"
     """The architecture of the model."""
 
-    model_config: Optional[Dict[str, Any]] = None
-    """The model configuration overrides."""
+    model_config: Any = None
+    """The model configuration."""
 
     dtype: DataType = torch.float16
     """The data type of the model."""


### PR DESCRIPTION
This PR revises the implementation of `GenericModelFactory` and makes it a bit more flexible by allowing the user to pass a model configuration instance instead of a regular `dict`. 