### PR TITLE
allow_unpickleable flag added

### DIFF
--- a/native/python/src/fairseq2n/bindings/data/data_pipeline.cc
+++ b/native/python/src/fairseq2n/bindings/data/data_pipeline.cc
@@ -656,8 +656,8 @@ def_data_pipeline(py::module_ &data_module)
     m.def("read_zipped_records", &read_zipped_records, py::arg("path"));
 
     m.def("read_iterator",
-            [](py::iterator iterator, reset_fn fn, bool infinite, bool allow_unpickleable) {
-                if (!allow_unpickleable) {
+            [](py::iterator iterator, reset_fn fn, bool infinite, bool skip_pickling_check) {
+                if (!skip_pickling_check) {
                     py::gil_scoped_acquire acquire;
                     py::function pickle_dump_fn = py::module::import("pickle").attr("dumps");
                     try { 
@@ -665,7 +665,8 @@ def_data_pipeline(py::module_ &data_module)
                     } catch (const py::error_already_set &e) {
                         if (e.matches(PyExc_TypeError))
                             throw py::type_error(
-                                "`allow_unpickleable` is False, but `iterator` is not pickleable.");
+                                "`iterator` is not pickleable; set `skip_pickling_check` to True to bypass"
+                                " (see `read_iterator` documentation for details).");
                         else
                             throw;
                     }
@@ -680,7 +681,7 @@ def_data_pipeline(py::module_ &data_module)
             py::arg("iterator"),
             py::arg("reset_fn"),
             py::arg("infinite"),
-            py::arg("allow_unpickleable") = false);
+            py::arg("skip_pickling_check") = false);
 
     // Collater
     py::class_<collate_options_override>(m, "CollateOptionsOverride")

--- a/native/python/src/fairseq2n/bindings/data/data_pipeline.cc
+++ b/native/python/src/fairseq2n/bindings/data/data_pipeline.cc
@@ -660,7 +660,15 @@ def_data_pipeline(py::module_ &data_module)
                 if (!allow_unpickleable) {
                     py::gil_scoped_acquire acquire;
                     py::function pickle_dump_fn = py::module::import("pickle").attr("dumps");
-                    pickle_dump_fn(iterator);
+                    try { 
+                        pickle_dump_fn(iterator);
+                    } catch (const py::error_already_set &e) {
+                        if (e.matches(PyExc_TypeError))
+                            throw py::type_error(
+                                "`allow_unpickleable` is False, but `iterator` is not pickleable.");
+                        else
+                            throw;
+                    }
                 }
                 auto factory = [iterator = std::move(iterator), fn = std::move(fn), infinite]() mutable
                 {

--- a/src/fairseq2/data/data_pipeline.py
+++ b/src/fairseq2/data/data_pipeline.py
@@ -402,6 +402,7 @@ if TYPE_CHECKING or DOC_MODE:
         iterator: T,
         reset_fn: Callable[[T], T],
         infinite: bool,
+        allow_unpickleable: bool = False,
     ) -> DataPipelineBuilder:
         """Read each element of ``iterator``.
 

--- a/src/fairseq2/data/data_pipeline.py
+++ b/src/fairseq2/data/data_pipeline.py
@@ -402,9 +402,17 @@ if TYPE_CHECKING or DOC_MODE:
         iterator: T,
         reset_fn: Callable[[T], T],
         infinite: bool,
-        allow_unpickleable: bool = False,
+        skip_pickling_check: bool = False,
     ) -> DataPipelineBuilder:
         """Read each element of ``iterator``.
+
+        Iterators must be pickleable in order for ``state_dict`` saving/reloading to
+        work. To avoid surprises, by default, upon creation, ``read_iterator`` will
+        perform a test pickle of ``iterator`` to ensure pickleability and will raise
+        an error if pickling fails. To skip this pickling check performed upon
+        creation (if, for example, you do not need to save/reload the ``state_dict``
+        or want to avoid incurring the cost of pickling on creation), set
+        ``skip_pickling_check`` to ``True``.
 
         :param iterator:
             The iterator to read.
@@ -412,6 +420,8 @@ if TYPE_CHECKING or DOC_MODE:
             Function to reset iterator.
         :param infinite:
             Whether iterator is infinite or not.
+        :param skip_pickling_check:
+            Whether to skip the pickling check or not.
         """
 
     class CollateOptionsOverride:

--- a/tests/unit/data/data_pipeline/test_read_iterator.py
+++ b/tests/unit/data/data_pipeline/test_read_iterator.py
@@ -85,7 +85,10 @@ class TestReadIteratorOp:
                 yield i
                 i += 1
 
-        with pytest.raises(TypeError, match=r"^cannot pickle 'generator' object$"):
+        with pytest.raises(
+            TypeError,
+            match=r"^`allow_unpickleable` is False, but `iterator` is not pickleable.$",
+        ):
             pipeline = read_iterator(
                 generator_fn(), lambda x: generator_fn(), infinite=True
             ).and_return()

--- a/tests/unit/data/data_pipeline/test_read_iterator.py
+++ b/tests/unit/data/data_pipeline/test_read_iterator.py
@@ -87,7 +87,8 @@ class TestReadIteratorOp:
 
         with pytest.raises(
             TypeError,
-            match=r"^`allow_unpickleable` is False, but `iterator` is not pickleable.$",
+            match=r"^`iterator` is not pickleable; set `skip_pickling_check` to True"
+            r" to bypass \(see `read_iterator` documentation for details\)\.$",
         ):
             pipeline = read_iterator(
                 generator_fn(), lambda x: generator_fn(), infinite=True
@@ -97,7 +98,7 @@ class TestReadIteratorOp:
             generator_fn(),
             lambda x: generator_fn(),
             infinite=True,
-            allow_unpickleable=True,
+            skip_pickling_check=True,
         ).and_return()
 
         it = iter(pipeline)

--- a/tests/unit/data/data_pipeline/test_read_iterator.py
+++ b/tests/unit/data/data_pipeline/test_read_iterator.py
@@ -78,6 +78,37 @@ class TestReadIteratorOp:
 
         assert list(pipeline) == [*range(5)]
 
+    def test_op_works_with_generator(self) -> None:
+        def generator_fn() -> Iterator[int]:
+            i = 0
+            while True:
+                yield i
+                i += 1
+
+        with pytest.raises(TypeError, match=r"^cannot pickle 'generator' object$"):
+            pipeline = read_iterator(
+                generator_fn(), lambda x: generator_fn(), infinite=True
+            ).and_return()
+
+        pipeline = read_iterator(
+            generator_fn(),
+            lambda x: generator_fn(),
+            infinite=True,
+            allow_unpickleable=True,
+        ).and_return()
+
+        it = iter(pipeline)
+
+        for _ in range(2):
+            assert next(it) == 0
+            assert next(it) == 1
+            assert next(it) == 2
+
+            pipeline.reset()
+
+        with pytest.raises(TypeError, match=r"^cannot pickle 'generator' object$"):
+            pipeline.state_dict()
+
     def test_op_stops(self) -> None:
         pipeline = read_iterator(
             EarlyStopIterator(3), reset_fn, infinite=False


### PR DESCRIPTION
**What does this PR do? Please describe:**
Adds an allow_unpickleable boolean flag to read_iterator, False by default. 
If False, raises error on creation when iterator is not pickleable. If True, only raises error if/when state_dict() is called.

**Does your PR introduce any breaking changes? If yes, please list them:**
N/A

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [ ] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
