### PR TITLE
update `create_hf_reader` to correctly pad sequences of variable lengths

### DIFF
--- a/src/fairseq2/datasets/huggingface.py
+++ b/src/fairseq2/datasets/huggingface.py
@@ -37,6 +37,7 @@ def create_hf_reader(
     seq_len_col: Optional[str] = None,
     num_accumulate: int = 1,
     num_prefetch: int = 1,
+    pad_value: Optional[int] = None,
     **extra: Any,
 ) -> DataPipelineReader[BatchT]:
     """
@@ -95,7 +96,7 @@ def create_hf_reader(
     if batching is None:
         data = dataset.data.to_batches()  # list of RecordBatch
     else:
-        data = dataset.to_list()
+        data = dataset
     builder = read_sequence(data)
 
     # Shard.
@@ -135,7 +136,7 @@ def create_hf_reader(
             )
 
         # collate to python dict
-        builder.map(Collater())
+        builder.map(Collater(pad_value=pad_value))
     else:
         # Convert RecordBatch to python dictionary
         builder = builder.map(lambda batch: batch.to_pydict())


### PR DESCRIPTION
**What does this PR do? Please describe:**
This PR extends `create_hf_reader` to pad sequences of variable lengths.

Changes:
- Changed `data = dataset.to_list()` to `data = dataset` because the collater doesn't pad python lists.
- Updated `builder.map(Collater())` to `builder.map(Collater(pad_value=pad_value))` because the collater will only stack sequences unless a pad_value is specified (default is None).
- Add `pad_value` argument to the function

**Does your PR introduce any breaking changes? If yes, please list them:**
None.

**Check list:**
- [X] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [X] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [X] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [X] Did you make sure to **update the documentation** with your changes? (if necessary)
- [X] Did you write any **new necessary tests**?
- [X] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
