### PR TITLE
Introduce ConfigBoundFactoryRegistry

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
         "fairseq2n" + fairseq2n_version_spec,
         "importlib_metadata~=7.0",
         "importlib_resources~=6.4",
+        "mypy-extensions~=1.0",
         "numpy~=1.23",
         "packaging~=23.1",
         "psutil~=5.9",
@@ -62,7 +63,7 @@ setup(
         "tiktoken~=0.7",
         "torcheval~=0.0.6",
         "tqdm~=4.62",
-        "typing_extensions~=4.3;python_version<'3.10'",
+        "typing_extensions~=4.12;python_version<'3.10'",
     ],
     extras_require={
         "arrow": ["pyarrow>=13.0.0", "pandas~=2.0.0"],

--- a/src/fairseq2/config_registry.py
+++ b/src/fairseq2/config_registry.py
@@ -61,7 +61,7 @@ class ConfigRegistry(Generic[ConfigT]):
             config = self._configs[name]()
         except KeyError:
             raise ValueError(
-                f"`name` must be a registered name, but is '{name}' instead."
+                f"`name` must be a registered configuration name, but is '{name}' instead."
             ) from None
 
         if overwrite is not None:
@@ -82,7 +82,7 @@ class ConfigRegistry(Generic[ConfigT]):
         """
         if name in self._configs:
             raise ValueError(
-                f"`name` must be a unique name, but '{name}' is already registered."
+                f"`name` must be a unique configuration name, but '{name}' is already registered."
             )
 
         self._configs[name] = config_factory

--- a/src/fairseq2/factory_registry.py
+++ b/src/fairseq2/factory_registry.py
@@ -1,0 +1,126 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from functools import partial
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Generic,
+    Optional,
+    Protocol,
+    Tuple,
+    Type,
+    TypeVar,
+    cast,
+    final,
+)
+
+from typing_extensions import Concatenate, ParamSpec
+
+from fairseq2.config_registry import ConfigRegistry
+from fairseq2.typing import DataClass
+
+ConfigT = TypeVar("ConfigT", bound=DataClass)
+
+P = ParamSpec("P")
+
+R = TypeVar("R")
+
+R_co = TypeVar("R_co", covariant=True)
+
+
+class ConfigBoundFactory(Protocol[P, R_co]):
+    """Constructs instances of ``R`` using :attr:`config`."""
+
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R_co:
+        ...
+
+    @property
+    def config(self) -> DataClass:
+        """The configuration bound to the factory."""
+
+
+@final
+class ConfigBoundFactoryRegistry(Generic[P, R]):
+    """Holds factories with parameter(s) ``P`` and return type ``R``."""
+
+    _factories: Dict[
+        str, Tuple[Callable[..., R], Type[DataClass], Optional[ConfigRegistry[Any]]]
+    ]
+
+    def __init__(self) -> None:
+        self._factories = {}
+
+    def get(
+        self,
+        name: str,
+        config: Optional[DataClass] = None,
+        base_config_name: Optional[str] = None,
+    ) -> ConfigBoundFactory[P, R]:
+        """Return the factory with ``name``.
+
+        :param config:
+            The configuration to bind to the factory.
+        :param base_config_name:
+            The name of the configuration on which ``config`` will be based.
+        """
+        try:
+            factory, config_kls, config_registry = self._factories[name]
+        except KeyError:
+            raise ValueError(
+                f"`name` must be a registered name, but is '{name}' instead."
+            ) from None
+
+        if config is not None:
+            if not isinstance(config, config_kls):
+                raise ValueError(
+                    f"`config` must be of type `{config}` for '{name}', but is of type `{type(config)}` instead."
+                )
+
+        if base_config_name is None:
+            if config is None:
+                try:
+                    config = config_kls()
+                except TypeError as ex:
+                    raise RuntimeError(
+                        f"'{name}' has no default configuration."
+                    ) from ex
+        else:
+            if config_registry is None:
+                raise ValueError(
+                    f"`base_config_name` must be a registered configuration name, but is '{base_config_name}' instead."
+                )
+
+            try:
+                config = config_registry.get(base_config_name, overwrite=config)
+            except ValueError:
+                raise ValueError(
+                    f"`base_config_name` must be a registered configuration name, but is '{base_config_name}' instead."
+                ) from None
+
+        f = partial(factory, config)
+
+        f.config = config  # type: ignore[attr-defined]
+
+        return cast(ConfigBoundFactory[P, R], f)
+
+    def register(
+        self,
+        name: str,
+        factory: Callable[Concatenate[ConfigT, P], R],
+        config_kls: Type[ConfigT],
+        config_registry: Optional[ConfigRegistry[ConfigT]] = None,
+    ) -> None:
+        """Register ``factory`` with ``name``."""
+        if name in self._factories:
+            raise ValueError(
+                f"`name` must be a unique name, but '{name}' is already registered."
+            )
+
+        self._factories[name] = (factory, config_kls, config_registry)

--- a/src/fairseq2/recipes/utils/environment.py
+++ b/src/fairseq2/recipes/utils/environment.py
@@ -158,7 +158,7 @@ class EnvironmentSetterRegistry:
         """
         if cluster in self._factories:
             raise ValueError(
-                f"`cluster` must be a unique cluster name, but '{cluster}' has already a registered environment setter."
+                f"`cluster` must be a unique cluster name, but '{cluster}' is already registered."
             )
 
         self._factories[cluster] = factory

--- a/src/fairseq2/registry.py
+++ b/src/fairseq2/registry.py
@@ -1,0 +1,38 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from typing import Dict, Generic, TypeVar
+
+T = TypeVar("T")
+
+
+class Registry(Generic[T]):
+    """Holds objects of type ``T``."""
+
+    _objects: Dict[str, T]
+
+    def __init__(self) -> None:
+        self._objects = {}
+
+    def get(self, name: str) -> T:
+        """Return the object registered with ``name``."""
+        try:
+            return self._objects[name]
+        except KeyError:
+            raise ValueError(
+                f"`name` must be a registered name, but is '{name}' instead."
+            ) from None
+
+    def register(self, name: str, obj: T) -> None:
+        """Register ``obj`` with ``name``."""
+        if name in self._objects:
+            raise ValueError(
+                f"`name` must be a unique name, but '{name}' is already registered."
+            )
+
+        self._objects[name] = obj

--- a/tests/unit/test_config_registry.py
+++ b/tests/unit/test_config_registry.py
@@ -50,7 +50,7 @@ class TestConfigRegistry:
 
         with pytest.raises(
             ValueError,
-            match=r"^`name` must be a unique name, but 'name' is already registered\.$",
+            match=r"^`name` must be a unique configuration name, but 'name' is already registered\.$",
         ):
             registry.register("name", lambda: Foo("config"))
 
@@ -59,6 +59,6 @@ class TestConfigRegistry:
 
         with pytest.raises(
             ValueError,
-            match=r"^`name` must be a registered name, but is 'foo' instead\.$",
+            match=r"^`name` must be a registered configuration name, but is 'foo' instead\.$",
         ):
             registry.get("foo")


### PR DESCRIPTION
This PR introduces `ConfigBoundFactoryRegistry` that will be used throughout the code base to dynamically expose certain APIs in first-party recipes.