### PR TITLE
Clean up preference optimization recipe

### DIFF
--- a/src/fairseq2/models/loader.py
+++ b/src/fairseq2/models/loader.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 
 from pickle import PickleError
-from typing import Any, Generic, Protocol, TypeVar, final
+from typing import Any, Generic, Mapping, Protocol, TypeVar, final
 
 from torch.nn import Module
 from torch.nn.modules.utils import consume_prefix_in_state_dict_if_present
@@ -74,7 +74,7 @@ class ModelLoader(Protocol[ModelT_co]):
         self,
         model_name_or_card: str | AssetCard,
         *,
-        gangs: dict[str, Gang] | None = None,
+        gangs: Mapping[str, Gang] | None = None,
         device: Device | None = None,
         dtype: DataType | None = None,
         force: bool = False,
@@ -177,7 +177,7 @@ class StandardModelLoader(ModelLoader[ModelT], Generic[ModelT, ModelConfigT]):
         self,
         model_name_or_card: str | AssetCard,
         *,
-        gangs: dict[str, Gang] | None = None,
+        gangs: Mapping[str, Gang] | None = None,
         device: Device | None = None,
         dtype: DataType | None = None,
         force: bool = False,
@@ -362,7 +362,7 @@ class DelegatingModelLoader(ModelLoader[ModelT]):
         self,
         model_name_or_card: str | AssetCard,
         *,
-        gangs: dict[str, Gang] | None = None,
+        gangs: Mapping[str, Gang] | None = None,
         device: Device | None = None,
         dtype: DataType | None = None,
         force: bool = False,

--- a/src/fairseq2/recipes/lm/__init__.py
+++ b/src/fairseq2/recipes/lm/__init__.py
@@ -42,6 +42,19 @@ def _setup_lm_cli(cli: Cli) -> None:
         help="instruction-finetune a language model",
     )
 
+    # Preference Finetune
+    preference_finetune_handler = RecipeCommandHandler(
+        loader=load_preference_finetuner,
+        preset_configs=preference_finetune_presets,
+        default_preset="llama3_8b_instruct",
+    )
+
+    group.add_command(
+        name="preference_finetune",
+        handler=preference_finetune_handler,
+        help="preference-finetune a language model (e.g. DPO, SimPO).",
+    )
+
     # Text Generate
     text_generate_handler = RecipeCommandHandler(
         loader=load_text_generator,
@@ -53,17 +66,4 @@ def _setup_lm_cli(cli: Cli) -> None:
         name="generate",
         handler=text_generate_handler,
         help="generate text",
-    )
-
-    # Preference Finetune
-    preference_finetune_handler = RecipeCommandHandler(
-        loader=load_preference_finetuner,
-        preset_configs=preference_finetune_presets,
-        default_preset="llama3_8b_instruct",
-    )
-
-    group.add_command(
-        name="preference_finetune",
-        handler=preference_finetune_handler,
-        help="preference-finetune a language model",
     )

--- a/src/fairseq2/recipes/lm/instruction_finetune.py
+++ b/src/fairseq2/recipes/lm/instruction_finetune.py
@@ -218,6 +218,24 @@ def _llama3_70b_instruct() -> InstructionFinetuneConfig:
     return config
 
 
+@instruction_finetune_preset("llama3_1_8b_instruct")
+def _llama3_1_8b_instruct() -> InstructionFinetuneConfig:
+    config = _llama3_8b_instruct()
+
+    config.model = "llama3_1_8b_instruct"
+
+    return config
+
+
+@instruction_finetune_preset("llama3_1_70b_instruct")
+def _llama3_1_70b_instruct() -> InstructionFinetuneConfig:
+    config = _llama3_70b_instruct()
+
+    config.model = "llama3_1_70b_instruct"
+
+    return config
+
+
 def load_instruction_finetuner(
     config: InstructionFinetuneConfig, output_dir: Path
 ) -> Trainer[SequenceBatch]:
@@ -358,6 +376,7 @@ def load_instruction_finetuner(
 
     seed += 1
 
+    # Initialize the optimizer.
     try:
         optimizer = create_optimizer(
             config.optimizer, dp_model, config.optimizer_config
@@ -367,6 +386,7 @@ def load_instruction_finetuner(
             "The optimizer cannot be created. See nested exception for details."
         ) from ex
 
+    # Initialize the learning rate scheduler.
     try:
         lr_scheduler = create_lr_scheduler(
             config.lr_scheduler,

--- a/src/fairseq2/recipes/lm/preference_finetune/__init__.py
+++ b/src/fairseq2/recipes/lm/preference_finetune/__init__.py
@@ -1,0 +1,27 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from fairseq2.recipes.lm.preference_finetune.dpo import DpoConfig as DpoConfig
+from fairseq2.recipes.lm.preference_finetune.recipe import (
+    load_preference_finetuner as load_preference_finetuner,
+)
+from fairseq2.recipes.lm.preference_finetune.recipe import (
+    preference_finetune_presets as preference_finetune_presets,
+)
+from fairseq2.recipes.lm.preference_finetune.recipe import (
+    preference_unit_factories as preference_unit_factories,
+)
+from fairseq2.recipes.lm.preference_finetune.recipe import (
+    preference_unit_factory as preference_unit_factory,
+)
+from fairseq2.recipes.lm.preference_finetune.simpo import SimPOConfig as SimPOConfig
+
+# isort: split
+
+import fairseq2.recipes.lm.preference_finetune.dpo
+import fairseq2.recipes.lm.preference_finetune.simpo

--- a/src/fairseq2/recipes/lm/preference_finetune/dpo.py
+++ b/src/fairseq2/recipes/lm/preference_finetune/dpo.py
@@ -1,8 +1,13 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 from __future__ import annotations
 
 from dataclasses import dataclass
-from pathlib import Path
-from typing import cast, final
+from typing import Mapping, cast, final
 
 import torch
 import torch.distributed
@@ -21,37 +26,18 @@ from fairseq2.models.sequence import (
     as_auto_regressive_input,
 )
 from fairseq2.recipes.common_metrics import SequenceMetricBag
+from fairseq2.recipes.lm.preference_finetune.recipe import preference_unit_factory
+from fairseq2.recipes.lm.preference_finetune.utils import _load_reference_model
 from fairseq2.recipes.trainer import AbstractTrainUnit
+from fairseq2.recipes.utils.asset import AssetReference
 from fairseq2.typing import DataType
 
 log = get_log_writer(__name__)
 
 
-@dataclass(kw_only=True)
-class DpoFinetuneConfig:
-    """Holds the DPO-finetuning configuration of a language model."""
-
-    # Hyperparameters
-    dpo_beta: float = 0.1
-    """The coefficient of regularization towards the reference model."""
-
-    nll_scale: float = 0.0
-    """The coefficient of NLL loss added to the DPO loss."""
-
-    # Reference Model
-    reference_model: str | Path = "llama3_8b_instruct"
-    """The name or path to the asset card of the reference model to use."""
-
-    reference_dtype: DataType = torch.bfloat16
-    """The data type of the reference model."""
-
-    reference_tensor_parallel_size: int = 1
-    """The size of tensor parallelism for the reference model."""
-
-
 @final
 class DpoFinetuneUnit(AbstractTrainUnit[PreferenceOptimizationBatch]):
-    """Represents the DPO-finetuning unit of a language model."""
+    """Represents the language model DPO-finetuning unit."""
 
     _reference_model: Module
     _beta: float
@@ -73,7 +59,6 @@ class DpoFinetuneUnit(AbstractTrainUnit[PreferenceOptimizationBatch]):
         self._nll_scale = nll_scale
 
         self._metric_bag = DpoFinetuneMetricBag(gang)
-        self._gang = gang
 
     @override
     def __call__(self, batch: PreferenceOptimizationBatch) -> tuple[Tensor, int]:
@@ -120,6 +105,7 @@ class DpoFinetuneUnit(AbstractTrainUnit[PreferenceOptimizationBatch]):
         )
 
         self._metric_bag.update_nll_loss(chosen_batch, nll_loss)
+
         self._metric_bag.update_dpo_loss(chosen_batch, dpo_loss)
 
         self._metric_bag.update_batch_metrics(chosen_batch)
@@ -149,14 +135,14 @@ class DpoFinetuneUnit(AbstractTrainUnit[PreferenceOptimizationBatch]):
         )
         return logp_ratio_chosen, logp_ratio_rejected, dpo_loss.sum()
 
+    @override
+    def set_step_nr(self, step_nr: int) -> None:
+        self._step_nr = step_nr
+
     @property
     @override
     def metric_bag(self) -> DpoFinetuneMetricBag:
         return self._metric_bag
-
-    def set_step_nr(self, step_nr: int) -> None:
-        """Set the current training step number."""
-        self._step_nr = step_nr
 
 
 register_metric_formatter("dpo_loss", "DPO Loss", 0, format_as_float)
@@ -172,8 +158,50 @@ class DpoFinetuneMetricBag(SequenceMetricBag):
 
     @torch.inference_mode()
     def update_dpo_loss(self, batch: SequenceBatch, loss: Tensor) -> None:
-        batch_size = torch.tensor(batch.batch_size)
+        self._dpo_loss.update(loss / batch.batch_size, weight=batch.batch_size)
 
-        normalized_loss = loss.cpu() / batch_size
 
-        self._dpo_loss.update(normalized_loss, weight=batch_size)
+@dataclass(kw_only=True)
+class DpoConfig:
+    """Holds the DPO configuration of a language model preference-finetuning task."""
+
+    # Reference Model
+    reference_model: AssetReference = "llama3_8b_instruct"
+    """The name, path, or path to the asset card of the reference model."""
+
+    reference_dtype: DataType = torch.bfloat16
+    """The data type of the reference model."""
+
+    reference_tensor_parallel_size: int = 1
+    """The size of tensor parallelism for the reference model."""
+
+    # Loss
+    beta: float = 0.1
+    """The coefficient of regularization towards the reference model."""
+
+    nll_scale: float = 0.0
+    """The coefficient of NLL loss added to the DPO loss."""
+
+
+@preference_unit_factory("dpo")
+def create_dpo_unit(
+    config: DpoConfig, model: Module, root_gang: Gang, gangs: Mapping[str, Gang]
+) -> DpoFinetuneUnit:
+    reference_model = _load_reference_model(
+        config.reference_model,
+        config.reference_dtype,
+        root_gang,
+        gangs,
+        config.reference_tensor_parallel_size,
+        log,
+    )
+
+    dp_gang = gangs["dp"]  # data
+
+    return DpoFinetuneUnit(
+        model,
+        reference_model,
+        dp_gang,
+        config.beta,
+        config.nll_scale,
+    )

--- a/src/fairseq2/recipes/lm/preference_finetune/simpo.py
+++ b/src/fairseq2/recipes/lm/preference_finetune/simpo.py
@@ -1,7 +1,13 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import cast, final
+from typing import Mapping, cast, final
 
 import torch
 import torch.distributed
@@ -20,29 +26,15 @@ from fairseq2.models.sequence import (
     as_auto_regressive_input,
 )
 from fairseq2.recipes.common_metrics import SequenceMetricBag
+from fairseq2.recipes.lm.preference_finetune.recipe import preference_unit_factory
 from fairseq2.recipes.trainer import AbstractTrainUnit
 
 log = get_log_writer(__name__)
 
 
-@dataclass(kw_only=True)
-class SimpoFinetuneConfig:
-    """Holds the SimPO-finetuning configuration of a language model."""
-
-    # Hyperparameters
-    simpo_beta: float = 1
-    """The coefficient of KL-divergence regularization."""
-
-    simpo_gamma: float = 0.5
-    """Target reward margin between positive and negative completions."""
-
-    nll_scale: float = 0.0
-    """The coefficient of NLL loss added to the SimPO loss."""
-
-
 @final
-class SimpoFinetuneUnit(AbstractTrainUnit[PreferenceOptimizationBatch]):
-    """Represents the DPO-finetuning unit of a language model."""
+class SimPOFinetuneUnit(AbstractTrainUnit[PreferenceOptimizationBatch]):
+    """Represents the language model SimPO-finetuning unit."""
 
     _beta: float
     _gamma: float
@@ -64,7 +56,6 @@ class SimpoFinetuneUnit(AbstractTrainUnit[PreferenceOptimizationBatch]):
         self._nll_scale = nll_scale
 
         self._metric_bag = SimpoFinetuneMetricBag(gang)
-        self._gang = gang
 
     @override
     def __call__(self, batch: PreferenceOptimizationBatch) -> tuple[Tensor, int]:
@@ -101,6 +92,7 @@ class SimpoFinetuneUnit(AbstractTrainUnit[PreferenceOptimizationBatch]):
         )
 
         self._metric_bag.update_nll_loss(chosen_batch, nll_loss)
+
         self._metric_bag.update_simpo_loss(chosen_batch, simpo_loss)
 
         self._metric_bag.update_batch_metrics(chosen_batch)
@@ -123,23 +115,21 @@ class SimpoFinetuneUnit(AbstractTrainUnit[PreferenceOptimizationBatch]):
         return total_logps, average_logps
 
     def _compute_simpo_loss(
-        self,
-        average_chosen_logps: Tensor,
-        average_rejected_logps: Tensor,
+        self, average_chosen_logps: Tensor, average_rejected_logps: Tensor
     ) -> Tensor:
         simpo_loss = -torch.nn.functional.logsigmoid(
             self._beta * (average_chosen_logps - average_rejected_logps) - self._gamma
         )
         return simpo_loss.sum()
 
+    @override
+    def set_step_nr(self, step_nr: int) -> None:
+        self._step_nr = step_nr
+
     @property
     @override
     def metric_bag(self) -> SimpoFinetuneMetricBag:
         return self._metric_bag
-
-    def set_step_nr(self, step_nr: int) -> None:
-        """Set the current training step number."""
-        self._step_nr = step_nr
 
 
 register_metric_formatter("simpo_loss", "SimPO Loss", 0, format_as_float)
@@ -155,8 +145,29 @@ class SimpoFinetuneMetricBag(SequenceMetricBag):
 
     @torch.inference_mode()
     def update_simpo_loss(self, batch: SequenceBatch, loss: Tensor) -> None:
-        batch_size = torch.tensor(batch.batch_size)
+        self._simpo_loss.update(loss / batch.batch_size, weight=batch.batch_size)
 
-        normalized_loss = loss.cpu() / batch_size
 
-        self._simpo_loss.update(normalized_loss, weight=batch_size)
+@dataclass(kw_only=True)
+class SimPOConfig:
+    """Holds the SimPO configuration of a language model preference-finetuning task."""
+
+    beta: float = 1
+    """The coefficient of KL-divergence regularization."""
+
+    gamma: float = 0.5
+    """The target reward margin between positive and negative completions."""
+
+    nll_scale: float = 0.0
+    """The coefficient of NLL loss added to the SimPO loss."""
+
+
+@preference_unit_factory("simpo")
+def create_simpo_unit(
+    config: SimPOConfig, model: Module, root_gang: Gang, gangs: Mapping[str, Gang]
+) -> SimPOFinetuneUnit:
+    dp_gang = gangs["dp"]  # data
+
+    return SimPOFinetuneUnit(
+        model, dp_gang, config.beta, config.gamma, config.nll_scale
+    )

--- a/src/fairseq2/recipes/lm/preference_finetune/utils.py
+++ b/src/fairseq2/recipes/lm/preference_finetune/utils.py
@@ -1,0 +1,56 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from typing import Mapping
+
+from torch.nn import Module
+
+from fairseq2.gang import Gang
+from fairseq2.logging import LogWriter
+from fairseq2.models import load_model
+from fairseq2.nn.utils.module import freeze_parameters
+from fairseq2.recipes.utils.asset import AssetReference, retrieve_asset_card
+from fairseq2.recipes.utils.setup import broadcast_model
+from fairseq2.typing import META, DataType
+
+
+def _load_reference_model(
+    model_name_or_card: AssetReference,
+    dtype: DataType,
+    root_gang: Gang,
+    gangs: Mapping[str, Gang],
+    tensor_parallel_size: int,
+    log: LogWriter,
+) -> Module:
+    dp_gang = gangs["dp"]
+
+    card = retrieve_asset_card(model_name_or_card)
+
+    log.info("Loading {} reference model on data parallel rank 0 (per shard).", card.name)  # fmt: skip
+
+    if dp_gang.rank == 0:
+        init_device = root_gang.device
+    else:
+        init_device = META
+
+    # TODO: figure out how to load the reference model onto its own gangs
+    model = load_model(card, gangs=gangs, device=init_device, dtype=dtype)
+
+    root_gang.barrier()
+
+    log.info("Reference model loaded on data parallel rank 0.")
+
+    model.eval()
+
+    freeze_parameters(model)
+
+    # Distribute the model to all processes in the gang.
+    if dp_gang.size != 1:
+        broadcast_model(model, dp_gang, log)
+
+    return model

--- a/src/fairseq2/recipes/lm/text_generate.py
+++ b/src/fairseq2/recipes/lm/text_generate.py
@@ -125,6 +125,24 @@ def _llama3_70b_instruct() -> TextGenerateConfig:
     return config
 
 
+@text_generate_preset("llama3_1_8b_instruct")
+def _llama3_1_8b_instruct() -> TextGenerateConfig:
+    config = _llama3_8b_instruct()
+
+    config.model = "llama3_1_8b_instruct"
+
+    return config
+
+
+@text_generate_preset("llama3_1_70b_instruct")
+def _llama3_1_70b_instruct() -> TextGenerateConfig:
+    config = _llama3_70b_instruct()
+
+    config.model = "llama3_1_70b_instruct"
+
+    return config
+
+
 def load_text_generator(
     config: TextGenerateConfig, output_dir: Path
 ) -> Generator[SequenceBatch]:

--- a/src/fairseq2/recipes/mt/train.py
+++ b/src/fairseq2/recipes/mt/train.py
@@ -333,6 +333,7 @@ def load_mt_trainer(config: MTTrainConfig, output_dir: Path) -> Trainer[Seq2SeqB
 
     seed += 1
 
+    # Initialize the optimizer.
     try:
         optimizer = create_optimizer(
             config.optimizer, dp_model, config.optimizer_config
@@ -342,6 +343,7 @@ def load_mt_trainer(config: MTTrainConfig, output_dir: Path) -> Trainer[Seq2SeqB
             "The optimizer cannot be created. See nested exception for details."
         ) from ex
 
+    # Initialize the learning rate scheduler.
     try:
         lr_scheduler = create_lr_scheduler(
             config.lr_scheduler,

--- a/src/fairseq2/recipes/wav2vec2/asr/train.py
+++ b/src/fairseq2/recipes/wav2vec2/asr/train.py
@@ -395,15 +395,17 @@ def load_wav2vec2_asr_trainer(
 
     seed += 1
 
+    # Initialize the optimizer.
     try:
         optimizer = create_optimizer(
             config.optimizer, dp_model, config.optimizer_config
         )
     except ValueError as ex:
         raise ValueError(
-            "The optimizer cannot be initialized. See nested exception for details."
+            "The optimizer cannot be created. See nested exception for details."
         ) from ex
 
+    # Initialize the learning rate scheduler.
     try:
         lr_scheduler = create_lr_scheduler(
             config.lr_scheduler,
@@ -413,7 +415,7 @@ def load_wav2vec2_asr_trainer(
         )
     except ValueError as ex:
         raise ValueError(
-            "The learning rate scheduler cannot be initialized. See nested exception for details."
+            "The learning rate scheduler cannot be created. See nested exception for details."
         ) from ex
 
     # Initialize the validation unit.


### PR DESCRIPTION
This PR cleans up the preference optimization recipe. Now it is possible to dynamically extend the supported preference criterions. As of today DPO and SimPO are supported.