### PR TITLE
Fix wav2vec2 target grad bug

### DIFF
--- a/src/fairseq2/models/wav2vec2/model.py
+++ b/src/fairseq2/models/wav2vec2/model.py
@@ -169,7 +169,7 @@ class Wav2Vec2Model(Model):
 
         # We use the extracted features as context network targets after masking
         # and quantization.
-        targets = seqs.detach().clone()
+        targets = seqs.clone()
 
         if frontend.first_pass_dropout is not None:
             targets = frontend.first_pass_dropout(targets)


### PR DESCRIPTION
This PR fixes a subtle, but important bug in wav2vec2 pretraining. We wrongfully detach `target` tensor from autograd although it is still needed for learning the quantizer codebook entries. Thanks to @vineelpratap and @kauterry for finding out and fixing this bug. Full credit goes to them.