### PR TITLE
add no_bos_eos mode in sentencepiece and llama tokenizers

### DIFF
--- a/src/fairseq2/data/text/sentencepiece.py
+++ b/src/fairseq2/data/text/sentencepiece.py
@@ -193,8 +193,8 @@ class BasicSentencePieceTokenizer(SentencePieceTokenizer):
         :param lang:
             Must be ``None``.
         :param mode:
-            Must be 'default', 'prompt', or 'prompt_response'. If ``None``,
-            defaults to 'default'.
+            Must be 'default', 'prompt', 'prompt_response', or 'no_bos_eos'.
+            If ``None``, defaults to 'default'.
         :param device:
             The device on which to construct tensors.
         :param pin_memory:
@@ -217,9 +217,12 @@ class BasicSentencePieceTokenizer(SentencePieceTokenizer):
             case "prompt_response":
                 prefix_tokens = []
                 suffix_tokens = ["</s>"]
+            case "no_bos_eos":
+                prefix_tokens = []
+                suffix_tokens = []
             case _:
                 raise ValueError(
-                    f"`mode` must be 'default' or 'prompt', but is '{mode}' instead."
+                    f"`mode` must be 'default', 'prompt' or 'no_bos_eos', but is '{mode}' instead."
                 )
 
         return SentencePieceEncoder(

--- a/src/fairseq2/models/llama/tokenizer.py
+++ b/src/fairseq2/models/llama/tokenizer.py
@@ -88,9 +88,12 @@ class LLaMA3Tokenizer(TiktokenTokenizer):
             case "prompt_response":
                 prefix_tokens = []
                 suffix_tokens = [self._eos_token]
+            case "no_bos_eos":
+                prefix_tokens = []
+                suffix_tokens = []
             case _:
                 raise ValueError(
-                    f"`mode` must be 'default' or 'prompt', but is '{mode}' instead."
+                    f"`mode` must be 'default', 'prompt' or 'no_bos_eos', but is '{mode}' instead."
                 )
 
         return TiktokenEncoder(


### PR DESCRIPTION
**What does this PR do? Please describe:**
Add no_bos_eos mode in sentencepiece tokenizer and llama tokenizer.

Fixes #{issue number}

**Does your PR introduce any breaking changes? If yes, please list them:**
List of all backwards-incompatible changes.

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
