### PR TITLE
Support feature penalty in wav2vec2 loss

### DIFF
--- a/src/fairseq2/models/wav2vec2/asr/factory.py
+++ b/src/fairseq2/models/wav2vec2/asr/factory.py
@@ -58,7 +58,7 @@ class Wav2Vec2AsrConfig:
     temporal_mask_span_len: int = 10
     """The length of each temporal mask span that is applied over time steps."""
 
-    max_temporal_mask_prob: float = 0.70
+    max_temporal_mask_prob: float = 0.69
     """The maximum probability of masking a time step. Note that, due to mask
     span overlap, the effective probability will be lower."""
 

--- a/src/fairseq2/models/wav2vec2/asr/model.py
+++ b/src/fairseq2/models/wav2vec2/asr/model.py
@@ -91,7 +91,7 @@ class Wav2Vec2AsrModel(Model):
         :param batch:
             The batch of sequences to process.
         """
-        seqs, padding_mask = self.encoder_frontend.extract_features(
+        seqs, padding_mask, _ = self.encoder_frontend.extract_features(
             batch.seqs, batch.padding_mask
         )
 

--- a/src/fairseq2/models/wav2vec2/factory.py
+++ b/src/fairseq2/models/wav2vec2/factory.py
@@ -76,7 +76,7 @@ class Wav2Vec2Config:
     temporal_mask_span_len: int = 10
     """The length of each temporal mask span that is applied over time steps."""
 
-    max_temporal_mask_prob: float = 0.70
+    max_temporal_mask_prob: float = 0.69
     """The maximum probability of masking a time step. Note that, due to mask
     span overlap, the effective probability will be lower."""
 

--- a/src/fairseq2/models/wav2vec2/factory.py
+++ b/src/fairseq2/models/wav2vec2/factory.py
@@ -76,7 +76,7 @@ class Wav2Vec2Config:
     temporal_mask_span_len: int = 10
     """The length of each temporal mask span that is applied over time steps."""
 
-    max_temporal_mask_prob: float = 0.65
+    max_temporal_mask_prob: float = 0.70
     """The maximum probability of masking a time step. Note that, due to mask
     span overlap, the effective probability will be lower."""
 

--- a/src/fairseq2/models/wav2vec2/frontend.py
+++ b/src/fairseq2/models/wav2vec2/frontend.py
@@ -166,7 +166,7 @@ class Wav2Vec2Frontend(TransformerFrontend):
         if self.feature_extractor is not None:
             seqs, padding_mask = self.feature_extractor(seqs, padding_mask)
 
-        raw_features = seqs
+        raw_features = seqs.clone()
 
         seqs = self.post_extract_layer_norm(seqs)
 

--- a/src/fairseq2/models/wav2vec2/frontend.py
+++ b/src/fairseq2/models/wav2vec2/frontend.py
@@ -132,7 +132,7 @@ class Wav2Vec2Frontend(TransformerFrontend):
                 "`Wav2Vec2Frontend` does not support incremental decoding."
             )
 
-        seqs, padding_mask = self.extract_features(seqs, padding_mask)
+        seqs, padding_mask, _ = self.extract_features(seqs, padding_mask)
 
         seqs, padding_mask, _ = self.process_features(seqs, padding_mask)
 
@@ -140,7 +140,7 @@ class Wav2Vec2Frontend(TransformerFrontend):
 
     def extract_features(
         self, seqs: Tensor, padding_mask: PaddingMask | None
-    ) -> tuple[Tensor, PaddingMask | None]:
+    ) -> tuple[Tensor, PaddingMask | None, Tensor]:
         """Extract features from the specified sequences.
 
         :param seqs:
@@ -153,27 +153,31 @@ class Wav2Vec2Frontend(TransformerFrontend):
             is the batch size and :math:`S` is the sequence length.
 
         :returns:
-            - The extracted features. *Shape:* :math:`(N,S_{out},F)`, where
+            - The normalized features. *Shape:* :math:`(N,S_{out},F)`, where
               :math:`N` is the batch size, :math:`S_{out}` is the output
               sequence length, and :math:`F` is the dimensionality of the
               extracted features.
             - The padding mask of the extracted features. *Shape:*
               :math:`(N,S_{out})`, where :math:`N` is the batch size and
               :math:`S_{out}` is the output sequence length.
+            - The raw features. *Shape*: Same as the normalized features (i.e.
+              first element of the returned tuple).
         """
         if self.feature_extractor is not None:
             seqs, padding_mask = self.feature_extractor(seqs, padding_mask)
 
+        raw_features = seqs
+
         seqs = self.post_extract_layer_norm(seqs)
 
-        return seqs, padding_mask
+        return seqs, padding_mask, raw_features
 
     def process_features(
         self,
         seqs: Tensor,
         padding_mask: PaddingMask | None,
         masker: Wav2Vec2Masker | None = None,
-    ) -> tuple[Tensor, PaddingMask | None, Tensor]:
+    ) -> tuple[Tensor, PaddingMask | None, Tensor | None]:
         """Process extracted features.
 
         :param seqs:

--- a/src/fairseq2/models/wav2vec2/model.py
+++ b/src/fairseq2/models/wav2vec2/model.py
@@ -124,19 +124,17 @@ class Wav2Vec2Model(Model):
         :param batch:
             The batch of sequences to process.
         """
-        seqs, padding_mask, targets, temporal_mask = self.run_frontend(
-            batch.seqs, batch.padding_mask
+        features = self.run_frontend(batch.seqs, batch.padding_mask)
+
+        features.seqs, features.padding_mask = self.encoder(
+            features.seqs, features.padding_mask
         )
 
-        encoder_output, encoder_padding_mask = self.encoder(seqs, padding_mask)
-
-        return Wav2Vec2Features(
-            encoder_output, encoder_padding_mask, targets, temporal_mask
-        )
+        return features
 
     def run_frontend(
         self, seqs: Tensor, padding_mask: PaddingMask | None
-    ) -> tuple[Tensor, PaddingMask | None, Tensor, Tensor]:
+    ) -> Wav2Vec2Features:
         """Run the encoder frontend in pretraining mode.
 
         :param seqs:
@@ -146,26 +144,10 @@ class Wav2Vec2Model(Model):
         :param padding_mask:
             The padding mask of ``seqs``. *Shape:* :math:`(N,S)`, where :math:`N`
             is the batch size and :math:`S` is the sequence length.
-
-        :returns:
-            - The processed features to pass to the context network.
-              *Shape:* :math:`(N,S_{out},M)`, where :math:`N` is the batch size,
-              :math:`S_{out}` is the output sequence length, and :math:`M` is
-              the dimensionality of the model.
-            - The padding mask of the processed features. *Shape:*
-              :math:`(N,S_{out})`, where :math:`N` is the batch size and
-              :math:`S_{out}` is the output sequence length.
-            - The non-quantized context network targets that have been extracted
-              from the input sequences. *Shape:* :math:`(N,S_{msk},M)`, where
-              :math:`N` is the batch size, :math:`S_{msk}` is the masked
-              sequence length, and :math:`M` is the dimensionality of the model.
-            - The temporal mask that has been applied to extract the context
-              network targets. *Shape:* :math:`(N,S_{out})`, where :math:`N` is
-              the batch size and :math`S_{out}` is the output sequence length.
         """
         frontend = self.encoder_frontend
 
-        seqs, padding_mask = frontend.extract_features(seqs, padding_mask)
+        seqs, padding_mask, raw_features = frontend.extract_features(seqs, padding_mask)
 
         # We use the extracted features as context network targets after masking
         # and quantization.
@@ -182,7 +164,9 @@ class Wav2Vec2Model(Model):
 
         targets = extract_masked_elements(targets, temporal_mask)
 
-        return seqs, padding_mask, targets, temporal_mask
+        return Wav2Vec2Features(
+            seqs, padding_mask, targets, temporal_mask, raw_features
+        )
 
     def quantize_and_contrast(self, features: Wav2Vec2Features) -> Wav2Vec2Output:
         """Quantize targets and produce logits for contrastive prediction.
@@ -191,8 +175,8 @@ class Wav2Vec2Model(Model):
             The extracted features from the encoder.
         """
         encoder_output, encoder_padding_mask, targets, temporal_mask = (
-            features.encoder_output,
-            features.encoder_padding_mask,
+            features.seqs,
+            features.padding_mask,
             features.targets,
             features.temporal_mask,
         )
@@ -216,6 +200,7 @@ class Wav2Vec2Model(Model):
             quantizer_output,
             encoder_output,
             encoder_padding_mask,
+            features.raw,
         )
 
     def _sample_distractors(self, targets: Tensor) -> Tensor:
@@ -286,7 +271,7 @@ class Wav2Vec2Model(Model):
         if distractor_is_target.any():
             logits[:, :, 1:][distractor_is_target] = -torch.inf
 
-        return logits.type_as(seqs)
+        return logits
 
     def extra_repr(self) -> str:
         """:meta private:"""
@@ -302,15 +287,15 @@ class Wav2Vec2Model(Model):
 class Wav2Vec2Features:
     """Holds the extracted features of a wav2vec 2.0 model."""
 
-    encoder_output: Tensor
-    """The context network output. *Shape:* :math:`(N,S_{enc},M)`, where
-    :math:`N` is the batch size, :math:`S_{enc}` is the encoder output sequence
-    length, and :math:`M` is the dimensionality of the model."""
+    seqs: Tensor
+    """The features. *Shape:* :math:`(N,S_{enc},M)`, where :math:`N` is the
+    batch size, :math:`S_{out}` is the output sequence length, and :math:`M` is
+    the dimensionality of the model."""
 
-    encoder_padding_mask: PaddingMask | None
-    """The padding mask of :attr:`encoder_output`. *Shape:* :math:`(N,S_{enc})`,
-    where :math:`N` is the batch size and :math:`S_{enc}` is the encoder output
-    sequence length."""
+    padding_mask: PaddingMask | None
+    """The padding mask of :attr:`seqs`. *Shape:* :math:`(N,S_{out})`, where
+    :math:`N` is the batch size and :math:`S_{out}` is the output sequence
+    length."""
 
     targets: Tensor
     """The non-quantized context network targets that have been extracted from
@@ -322,6 +307,9 @@ class Wav2Vec2Features:
     """The temporal mask that has been used to extract the context network
     targets. *Shape:* :math:`(N,S_{enc})`, where :math:`N` is the batch size and
     :math`S_{enc}` is the encoder output sequence length."""
+
+    raw: Tensor
+    """The raw features returned by the frontend. *Shape*: Same as :attr:`seqs`."""
 
 
 @final
@@ -359,19 +347,33 @@ class Wav2Vec2Output:
     where :math:`N` is the batch size and :math:`S_{enc}` is the encoder output
     sequence length."""
 
-    def compute_loss(self, *, diversity_loss_weight: float = 0.1) -> Wav2Vec2Loss:
+    raw_features: Tensor
+    """The raw features returned by the frontend. *Shape*: Same as
+    :attr:`encoder_output`."""
+
+    def compute_loss(
+        self, *, diversity_loss_weight: float = 0.1, penalty_weight: float = 10.0
+    ) -> Wav2Vec2Loss:
         """Compute the loss.
 
         :param diversity_loss_weight:
             The weight of diversity in loss computation.
+        :param penalty_weight:
+            The weight of the feature penalty in loss computation.
         """
         contrastive_loss = self.compute_contrastive_loss()
 
         diversity_loss = self.compute_diversity_loss()
 
-        total_loss = contrastive_loss + diversity_loss_weight * diversity_loss
+        penalty = self.compute_penalty()
 
-        return Wav2Vec2Loss(total_loss, contrastive_loss, diversity_loss)
+        weighted_diversity_loss = diversity_loss_weight * diversity_loss
+
+        weighted_penalty = penalty_weight * penalty
+
+        loss = contrastive_loss + weighted_diversity_loss + weighted_penalty
+
+        return Wav2Vec2Loss(loss, contrastive_loss, diversity_loss, penalty)
 
     def compute_contrastive_loss(self) -> Tensor:
         """Compute the contrastive loss."""
@@ -379,6 +381,9 @@ class Wav2Vec2Output:
 
         # (N, S, L) -> (S x N, L)
         logits = self.logits.transpose(0, 1).reshape(-1, num_logits)
+
+        # For numerical stability in low-precision.
+        logits = logits.float()
 
         # The target is always at index 0 in the candidate list.
         target_indices = logits.new_zeros((batch_size * seq_len,), dtype=torch.int64)
@@ -390,6 +395,12 @@ class Wav2Vec2Output:
         batch_size, seq_len = self.logits.shape[:2]
 
         return self.quantizer_output.compute_loss() * batch_size * seq_len
+
+    def compute_penalty(self) -> Tensor:
+        """Compute the feature penalty."""
+        batch_size, seq_len = self.logits.shape[:2]
+
+        return self.raw_features.float().pow(2).mean() * batch_size * seq_len
 
 
 @final
@@ -406,8 +417,5 @@ class Wav2Vec2Loss:
     diversity: Tensor
     """The diversity loss. *Shape:* :math:`()`."""
 
-    def detach(self) -> Wav2Vec2Loss:
-        """Return a copy detached from the autograd graph."""
-        return Wav2Vec2Loss(
-            self.total.detach(), self.contrastive.detach(), self.diversity.detach()
-        )
+    penalty: Tensor
+    """The feature penalty. *Shape:* :math:`()`."""


### PR DESCRIPTION
This PR updates the implementation of wav2vec2 to support feature penalty during pretraining. The majority of the work has been performed by @kauterry in #622. This is mostly a cleaned-up and slightly optimized version of his implementation. The bitwise parity has been verified by a local script that compares loss and model gradients.