### PR TITLE
Introduce support for Safetensors

### DIFF
--- a/src/fairseq2/checkpoint/manager.py
+++ b/src/fairseq2/checkpoint/manager.py
@@ -24,7 +24,12 @@ from typing_extensions import override
 from fairseq2.gang import Gang
 from fairseq2.logging import get_log_writer
 from fairseq2.typing import CPU, DataClass
-from fairseq2.utils.file import TensorDumper, TensorLoader, dump_tensors, load_tensors
+from fairseq2.utils.file import (
+    TensorDumper,
+    TensorLoader,
+    dump_pt_tensors,
+    load_pt_tensors,
+)
 from fairseq2.utils.value_converter import default_value_converter
 
 log = get_log_writer(__name__)
@@ -207,8 +212,8 @@ class FileCheckpointManager(CheckpointManager):
         elif dp_gang is not None or tp_gang is not None:
             raise ValueError("`dp_gang` and `tp_gang` must be both specified.")
 
-        self._tensor_loader = tensor_loader or load_tensors
-        self._tensor_dumper = tensor_dumper or dump_tensors
+        self._tensor_loader = tensor_loader or load_pt_tensors
+        self._tensor_dumper = tensor_dumper or dump_pt_tensors
 
         self._lower_score_better = lower_score_better
 

--- a/src/fairseq2/models/llama/loader.py
+++ b/src/fairseq2/models/llama/loader.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, final
 
+from torch import Tensor
 from typing_extensions import override
 
 from fairseq2.assets import AssetCard
@@ -55,30 +56,74 @@ class LLaMAModelLoader(StandardModelLoader[TransformerDecoderModel, LLaMAConfig]
 def convert_llama_checkpoint(
     checkpoint: dict[str, Any], config: LLaMAConfig
 ) -> dict[str, Any]:
-    """Convert a reference LLaMA checkpoint to fairseq2 format."""
+    """Convert a reference or Hugging Face LLaMA checkpoint to fairseq2 format."""
     # Check if we have a fairseq2 checkpoint.
-    if "output.weight" not in checkpoint:
+    if "final_proj.weight" in checkpoint:
         return checkpoint
 
-    key_map = {
-        # fmt: off
-        r"^layers\.([0-9]+)\.attention\.wq\.":    r"decoder.layers.\1.self_attn.q_proj.",
-        r"^layers\.([0-9]+)\.attention\.wk\.":    r"decoder.layers.\1.self_attn.k_proj.",
-        r"^layers\.([0-9]+)\.attention\.wv\.":    r"decoder.layers.\1.self_attn.v_proj.",
-        r"^layers\.([0-9]+)\.attention\.wo\.":    r"decoder.layers.\1.self_attn.output_proj.",
-        r"^layers\.([0-9]+)\.attention_norm\.":   r"decoder.layers.\1.self_attn_layer_norm.",
-        r"^layers\.([0-9]+)\.feed_forward\.w1\.": r"decoder.layers.\1.ffn.gate_proj.",
-        r"^layers\.([0-9]+)\.feed_forward\.w2\.": r"decoder.layers.\1.ffn.output_proj.",
-        r"^layers\.([0-9]+)\.feed_forward\.w3\.": r"decoder.layers.\1.ffn.inner_proj.",
-        r"^layers\.([0-9]+)\.ffn_norm\.":         r"decoder.layers.\1.ffn_layer_norm.",
-        r"^norm\.":                               r"decoder.layer_norm.",
-        r"^tok_embeddings\.":                     r"decoder_frontend.embed.",
-        r"^output\.":                             r"final_proj.",
-        # fmt: on
-    }
+    # Check if we have a reference or Hugging Face checkpoint.
+    if "lm_head.weight" in checkpoint:  # HG
+        head_dim = config.model_dim // config.num_attn_heads
 
-    # We do not need the pre-computed 'rope.freqs' buffers.
-    checkpoint = {k: v for (k, v) in checkpoint.items() if "rope.freqs" not in k}
+        def permute_rotary(w: Tensor, num_heads: int) -> Tensor:
+            # (H, M) -> (H_d, 2, D / 2, M)
+            w = w.view(num_heads, 2, head_dim // 2, config.model_dim)
+
+            # (H_d, 2, D / 2, M) -> (H_d, D / 2, 2, M)
+            w = w.transpose(1, 2)
+
+            # (H_d, D / 2, 2, M) -> (H, M)
+            return w.reshape(-1, config.model_dim)
+
+        for idx in range(config.num_layers):
+            q_key = f"model.layers.{idx}.self_attn.q_proj.weight"
+            k_key = f"model.layers.{idx}.self_attn.k_proj.weight"
+
+            q_proj = checkpoint[q_key]
+            k_proj = checkpoint[k_key]
+
+            q_proj = permute_rotary(q_proj, config.num_attn_heads)
+            k_proj = permute_rotary(k_proj, config.num_key_value_heads)
+
+            checkpoint[q_key] = q_proj
+            checkpoint[k_key] = k_proj
+
+        key_map = {
+            # fmt: off
+            r"^model\.layers\.([0-9]+)\.self_attn\.q_proj\.":        r"decoder.layers.\1.self_attn.q_proj.",
+            r"^model\.layers\.([0-9]+)\.self_attn\.k_proj\.":        r"decoder.layers.\1.self_attn.k_proj.",
+            r"^model\.layers\.([0-9]+)\.self_attn\.v_proj\.":        r"decoder.layers.\1.self_attn.v_proj.",
+            r"^model\.layers\.([0-9]+)\.self_attn\.o_proj\.":        r"decoder.layers.\1.self_attn.output_proj.",
+            r"^model\.layers\.([0-9]+)\.post_attention_layernorm\.": r"decoder.layers.\1.ffn_layer_norm.",
+            r"^model\.layers\.([0-9]+)\.mlp\.gate_proj\.":           r"decoder.layers.\1.ffn.gate_proj.",
+            r"^model\.layers\.([0-9]+)\.mlp\.down_proj\.":           r"decoder.layers.\1.ffn.output_proj.",
+            r"^model\.layers\.([0-9]+)\.mlp\.up_proj\.":             r"decoder.layers.\1.ffn.inner_proj.",
+            r"^model\.layers\.([0-9]+)\.input_layernorm\.":          r"decoder.layers.\1.self_attn_layer_norm.",
+            r"^model\.norm\.":                                       r"decoder.layer_norm.",
+            r"^model\.embed_tokens\.":                               r"decoder_frontend.embed.",
+            r"^lm_head\.":                                           r"final_proj.",
+            # fmt: on
+        }
+    else:
+        key_map = {
+            # fmt: off
+            r"^layers\.([0-9]+)\.attention\.wq\.":    r"decoder.layers.\1.self_attn.q_proj.",
+            r"^layers\.([0-9]+)\.attention\.wk\.":    r"decoder.layers.\1.self_attn.k_proj.",
+            r"^layers\.([0-9]+)\.attention\.wv\.":    r"decoder.layers.\1.self_attn.v_proj.",
+            r"^layers\.([0-9]+)\.attention\.wo\.":    r"decoder.layers.\1.self_attn.output_proj.",
+            r"^layers\.([0-9]+)\.attention_norm\.":   r"decoder.layers.\1.self_attn_layer_norm.",
+            r"^layers\.([0-9]+)\.feed_forward\.w1\.": r"decoder.layers.\1.ffn.gate_proj.",
+            r"^layers\.([0-9]+)\.feed_forward\.w2\.": r"decoder.layers.\1.ffn.output_proj.",
+            r"^layers\.([0-9]+)\.feed_forward\.w3\.": r"decoder.layers.\1.ffn.inner_proj.",
+            r"^layers\.([0-9]+)\.ffn_norm\.":         r"decoder.layers.\1.ffn_layer_norm.",
+            r"^norm\.":                               r"decoder.layer_norm.",
+            r"^tok_embeddings\.":                     r"decoder_frontend.embed.",
+            r"^output\.":                             r"final_proj.",
+            # fmt: on
+        }
+
+        # We do not need the pre-computed 'rope.freqs' buffers.
+        checkpoint = {k: v for (k, v) in checkpoint.items() if "rope.freqs" not in k}
 
     checkpoint = convert_model_state_dict(checkpoint, key_map)
 

--- a/src/fairseq2/models/mistral/loader.py
+++ b/src/fairseq2/models/mistral/loader.py
@@ -31,7 +31,8 @@ def convert_mistral_checkpoint(
     checkpoint: dict[str, Any], config: MistralConfig
 ) -> dict[str, Any]:
     """Convert a reference Mistral checkpoint to fairseq2 format."""
-    if "output.weight" not in checkpoint:
+    # Check if we have a fairseq2 checkpoint.
+    if "final_proj.weight" in checkpoint:
         return checkpoint
 
     key_map = {

--- a/src/fairseq2/models/s2t_transformer/loader.py
+++ b/src/fairseq2/models/s2t_transformer/loader.py
@@ -38,7 +38,8 @@ def convert_s2t_transformer_checkpoint(
     except KeyError:
         return checkpoint
 
-    if "decoder.output_projection.weight" not in state_dict:
+    # Check if we have a fairseq2 checkpoint.
+    if "final_proj.weight" in state_dict:
         return checkpoint
 
     key_map = {

--- a/src/fairseq2/models/transformer/loader.py
+++ b/src/fairseq2/models/transformer/loader.py
@@ -34,7 +34,8 @@ def convert_transformer_checkpoint(
     except KeyError:
         return checkpoint
 
-    if "decoder.output_projection.weight" not in state_dict:
+    # Check if we have a fairseq2 checkpoint.
+    if "final_proj.weight" in state_dict:
         return checkpoint
 
     key_map = {

--- a/src/fairseq2/models/w2vbert/loader.py
+++ b/src/fairseq2/models/w2vbert/loader.py
@@ -35,7 +35,8 @@ def convert_w2vbert_checkpoint(
     except KeyError:
         return checkpoint
 
-    if "mlm_proj.weight" not in state_dict:
+    # Check if we have a fairseq2 checkpoint.
+    if "final_bert_proj.weight" in state_dict:
         return checkpoint
 
     state_dict["w2v2_model.quantizer.num_updates"] = torch.zeros((), device="cpu")

--- a/src/fairseq2/models/wav2vec2/asr/loader.py
+++ b/src/fairseq2/models/wav2vec2/asr/loader.py
@@ -33,7 +33,8 @@ def convert_wav2vec2_asr_checkpoint(
     except KeyError:
         return checkpoint
 
-    if "w2v_encoder.proj.weight" not in state_dict:
+    # Check if we have a fairseq2 checkpoint.
+    if "final_proj.weight" in state_dict:
         return checkpoint
 
     if config.encoder_config.norm_order == TransformerNormOrder.POST:

--- a/src/fairseq2/models/wav2vec2/loader.py
+++ b/src/fairseq2/models/wav2vec2/loader.py
@@ -35,7 +35,8 @@ def convert_wav2vec2_checkpoint(
     except KeyError:
         return checkpoint
 
-    if "project_q.weight" not in state_dict:
+    # Check if we have a fairseq2 checkpoint.
+    if "final_target_proj.weight" in state_dict:
         return checkpoint
 
     if config.encoder_config.norm_order == TransformerNormOrder.POST:

--- a/src/fairseq2/recipes/llama/convert_checkpoint.py
+++ b/src/fairseq2/recipes/llama/convert_checkpoint.py
@@ -22,7 +22,7 @@ from fairseq2.logging import get_log_writer
 from fairseq2.models.llama import load_llama_config
 from fairseq2.models.llama.integ import convert_to_reference_checkpoint
 from fairseq2.recipes.cli import CliCommandHandler
-from fairseq2.utils.file import dump_tensors, load_tensors
+from fairseq2.utils.file import dump_pt_tensors, load_pt_tensors
 
 log = get_log_writer(__name__)
 
@@ -106,7 +106,7 @@ class ConvertCheckpointCommandHandler(CliCommandHandler):
                     with catch_warnings():
                         warnings.simplefilter("ignore")
 
-                        checkpoint = load_tensors(input_file, restrict=True)
+                        checkpoint = load_pt_tensors(input_file, restrict=True)
                 except RuntimeError:
                     log.exception(
                         "Checkpoint file {} cannot be loaded.", input_file.name
@@ -126,7 +126,7 @@ class ConvertCheckpointCommandHandler(CliCommandHandler):
                 ref_state_dict = convert_to_reference_checkpoint(checkpoint)
 
                 try:
-                    dump_tensors(ref_state_dict, output_file)
+                    dump_pt_tensors(ref_state_dict, output_file)
                 except RuntimeError:
                     log.exception(
                         "Checkpoint file {} cannot be saved.", output_file.name

--- a/src/fairseq2/utils/file.py
+++ b/src/fairseq2/utils/file.py
@@ -55,7 +55,7 @@ class TensorDumper(Protocol):
         """
 
 
-def load_tensors(
+def load_pt_tensors(
     path: Path,
     *,
     map_location: MapLocation = None,
@@ -72,6 +72,83 @@ def load_tensors(
     return data
 
 
-def dump_tensors(data: Mapping[str, Any], path: Path) -> None:
+def dump_pt_tensors(data: Mapping[str, Any], path: Path) -> None:
     """Dump ``data`` to a PyTorch tensor file under ``path``."""
     torch.save(data, path)
+
+
+def load_safetensors(
+    path: Path,
+    *,
+    map_location: MapLocation = None,
+    restrict: bool = False,
+) -> dict[str, Any]:
+    """Load the Hugging Face Safetensors file(s) stored under ``path``."""
+    try:
+        from safetensors import safe_open  # type: ignore[import-not-found]
+    except ImportError:
+        raise RuntimeError(
+            "Safetensors not found in your Python environment. Use `pip install safetensors`."
+        )
+
+    if map_location is not None:
+        if not isinstance(map_location, (Device, str)):
+            raise RuntimeError(
+                "Safetensors only supports `torch.device` and `str` for the `map_location` parameter."
+            )
+
+    if path.is_dir():
+        files = _get_files(path, ".safetensors")
+        if not files:
+            raise RuntimeError(
+                f"No Safetensors file found under the directory '{path}'."
+            )
+    else:
+        files = [path]
+
+    tensors = {}
+
+    for file in files:
+        with safe_open(file, framework="pt", device=str(map_location)) as f:  # type: ignore[attr-defined]
+            for k in f.keys():
+                if k in tensors:
+                    raise RuntimeError(
+                        f"The '{k}' key exists in more than one Safetensors file under the directory '{path}'."
+                    )
+
+                tensors[k] = f.get_tensor(k)
+
+    return tensors
+
+
+def load_tensors(
+    path: Path,
+    *,
+    map_location: MapLocation = None,
+    restrict: bool = False,
+) -> dict[str, Any]:
+    """Load the tensors stored under ``path``."""
+    loader = load_pt_tensors
+
+    if path.is_dir():
+        if not _has_files(path, ".safetensors"):
+            raise RuntimeError(f"'{path}' is a directory with no known tensor files.")
+
+        loader = load_safetensors
+    elif path.suffix == ".safetensors":
+        loader = load_safetensors
+
+    return loader(path, map_location=map_location, restrict=restrict)
+
+
+def _get_files(path: Path, extension: str) -> list[Path]:
+    return list(path.glob("*" + extension))
+
+
+def _has_files(path: Path, extension: str) -> bool:
+    try:
+        next(iter(path.glob("*" + extension)))
+    except StopIteration:
+        return False
+
+    return True


### PR DESCRIPTION
This PR contains two new features: (1) we now support loading checkpoints based on HuggingFace Safetensors besides regular PyTorch tensor files (2) we can now load Hugging Face LLaMA checkpoints directly into fairseq2 LLaMA models and use them everywhere just like regular reference LLaMA models.