### PR TITLE
Dynamic bucket creation customization options

### DIFF
--- a/native/python/src/fairseq2n/bindings/data/data_pipeline.cc
+++ b/native/python/src/fairseq2n/bindings/data/data_pipeline.cc
@@ -484,6 +484,8 @@ def_data_pipeline(py::module_ &data_module)
                 data_pipeline_builder &self,
                 float64 threshold,
                 cost_fn fn,
+                std::optional<bucket_creation_fn> maybe_bucket_fn,
+                std::optional<postprocess_remainder_fn> maybe_remainder_fn,
                 std::optional<std::size_t> maybe_min_num_examples,
                 std::optional<std::size_t> maybe_max_num_examples,
                 bool drop_remainder) -> data_pipeline_builder &
@@ -491,6 +493,8 @@ def_data_pipeline(py::module_ &data_module)
                 self = std::move(self).dynamic_bucket(
                     threshold,
                     std::move(fn),
+                    std::move(maybe_bucket_fn),
+                    std::move(maybe_remainder_fn),
                     maybe_min_num_examples,
                     maybe_max_num_examples,
                     drop_remainder);
@@ -499,6 +503,8 @@ def_data_pipeline(py::module_ &data_module)
             },
             py::arg("threshold"),
             py::arg("fn"),
+            py::arg("bucket_creation_fn") = std::nullopt,
+            py::arg("postprocess_remainder_fn") = std::nullopt,
             py::arg("min_num_examples") = std::nullopt,
             py::arg("max_num_examples") = std::nullopt,
             py::arg("drop_remainder") = false)

--- a/native/python/src/fairseq2n/bindings/data/data_pipeline.cc
+++ b/native/python/src/fairseq2n/bindings/data/data_pipeline.cc
@@ -485,7 +485,6 @@ def_data_pipeline(py::module_ &data_module)
                 float64 threshold,
                 cost_fn fn,
                 std::optional<bucket_creation_fn> maybe_bucket_fn,
-                std::optional<postprocess_remainder_fn> maybe_remainder_fn,
                 std::optional<std::size_t> maybe_min_num_examples,
                 std::optional<std::size_t> maybe_max_num_examples,
                 bool drop_remainder) -> data_pipeline_builder &
@@ -494,7 +493,6 @@ def_data_pipeline(py::module_ &data_module)
                     threshold,
                     std::move(fn),
                     std::move(maybe_bucket_fn),
-                    std::move(maybe_remainder_fn),
                     maybe_min_num_examples,
                     maybe_max_num_examples,
                     drop_remainder);
@@ -504,7 +502,6 @@ def_data_pipeline(py::module_ &data_module)
             py::arg("threshold"),
             py::arg("fn"),
             py::arg("bucket_creation_fn") = std::nullopt,
-            py::arg("postprocess_remainder_fn") = std::nullopt,
             py::arg("min_num_examples") = std::nullopt,
             py::arg("max_num_examples") = std::nullopt,
             py::arg("drop_remainder") = false)

--- a/native/src/fairseq2n/data/data_pipeline.cc
+++ b/native/src/fairseq2n/data/data_pipeline.cc
@@ -408,7 +408,6 @@ data_pipeline_builder::dynamic_bucket(
     float64 threshold,
     cost_fn fn,
     std::optional<bucket_creation_fn> maybe_bucket_fn,
-    std::optional<postprocess_remainder_fn> maybe_remainder_fn,
     std::optional<std::size_t> maybe_min_num_examples,
     std::optional<std::size_t> maybe_max_num_examples,
     bool drop_remainder) &&
@@ -427,7 +426,6 @@ data_pipeline_builder::dynamic_bucket(
         =, 
         fn = std::move(fn), 
         maybe_bucket_fn = std::move(maybe_bucket_fn), 
-        maybe_remainder_fn = std::move(maybe_remainder_fn), 
         inner = std::move(factory_)]() mutable
     {
         return std::make_unique<dynamic_bucket_data_source>(
@@ -435,7 +433,6 @@ data_pipeline_builder::dynamic_bucket(
             threshold, 
             std::move(fn), 
             std::move(maybe_bucket_fn),
-            std::move(maybe_remainder_fn),
             maybe_min_num_examples, 
             maybe_max_num_examples, 
             drop_remainder);

--- a/native/src/fairseq2n/data/data_pipeline.cc
+++ b/native/src/fairseq2n/data/data_pipeline.cc
@@ -407,6 +407,8 @@ data_pipeline_builder
 data_pipeline_builder::dynamic_bucket(
     float64 threshold,
     cost_fn fn,
+    std::optional<bucket_creation_fn> maybe_bucket_fn,
+    std::optional<postprocess_remainder_fn> maybe_remainder_fn,
     std::optional<std::size_t> maybe_min_num_examples,
     std::optional<std::size_t> maybe_max_num_examples,
     bool drop_remainder) &&
@@ -421,12 +423,19 @@ data_pipeline_builder::dynamic_bucket(
         throw_<std::invalid_argument>("`max_num_examples` must be greater than or equal to `min_num_examples`.");
     }
 
-    factory_ = [=, fn = std::move(fn), inner = std::move(factory_)]() mutable
+    factory_ = [
+        =, 
+        fn = std::move(fn), 
+        maybe_bucket_fn = std::move(maybe_bucket_fn), 
+        maybe_remainder_fn = std::move(maybe_remainder_fn), 
+        inner = std::move(factory_)]() mutable
     {
         return std::make_unique<dynamic_bucket_data_source>(
             inner(), 
             threshold, 
             std::move(fn), 
+            std::move(maybe_bucket_fn),
+            std::move(maybe_remainder_fn),
             maybe_min_num_examples, 
             maybe_max_num_examples, 
             drop_remainder);

--- a/native/src/fairseq2n/data/data_pipeline.h
+++ b/native/src/fairseq2n/data/data_pipeline.h
@@ -8,6 +8,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <deque>
 #include <filesystem>
 #include <functional>
 #include <memory>
@@ -111,15 +112,13 @@ private:
     mutable bool is_broken_ = false;
 };
 
-using bucket_creation_fn = std::function<std::pair<data_list, data_list>(data_list &&)>;
+using bucket_creation_fn = std::function<std::pair<std::deque<data_list>, data_list>(data_list &&)>;
 
 using cost_fn = std::function<float64(const data &)>;
 
 using data_length_fn = std::function<std::size_t(const data &)>;
 
 using map_fn = std::function<data(data &&)>;
-
-using postprocess_remainder_fn = std::function<data_list(data_list &&)>;
 
 using predicate_fn = std::function<bool(const data &)>;
 
@@ -157,7 +156,6 @@ public:
         float64 threshold,
         cost_fn fn,
         std::optional<bucket_creation_fn> maybe_bucket_fn = std::nullopt,
-        std::optional<postprocess_remainder_fn> maybe_remainder_fn = std::nullopt,
         std::optional<std::size_t> maybe_min_num_examples = std::nullopt,
         std::optional<std::size_t> maybe_max_num_examples = std::nullopt,
         bool drop_remainder = false) &&;

--- a/native/src/fairseq2n/data/data_pipeline.h
+++ b/native/src/fairseq2n/data/data_pipeline.h
@@ -112,7 +112,7 @@ private:
     mutable bool is_broken_ = false;
 };
 
-using bucket_creation_fn = std::function<std::pair<std::deque<data_list>, data_list>(data_list &&)>;
+using bucket_creation_fn = std::function<std::pair<std::deque<data>, data_list>(data_list &&)>;
 
 using cost_fn = std::function<float64(const data &)>;
 

--- a/native/src/fairseq2n/data/data_pipeline.h
+++ b/native/src/fairseq2n/data/data_pipeline.h
@@ -111,13 +111,17 @@ private:
     mutable bool is_broken_ = false;
 };
 
+using bucket_creation_fn = std::function<std::pair<data_list, data_list>(data_list &&)>;
+
+using cost_fn = std::function<float64(const data &)>;
+
 using data_length_fn = std::function<std::size_t(const data &)>;
 
 using map_fn = std::function<data(data &&)>;
 
-using predicate_fn = std::function<bool(const data &)>;
+using postprocess_remainder_fn = std::function<data_list(data_list &&)>;
 
-using cost_fn = std::function<float64(const data &)>;
+using predicate_fn = std::function<bool(const data &)>;
 
 using yield_fn = std::function<data_pipeline(const data &)>;
 
@@ -152,6 +156,8 @@ public:
     dynamic_bucket(
         float64 threshold,
         cost_fn fn,
+        std::optional<bucket_creation_fn> maybe_bucket_fn = std::nullopt,
+        std::optional<postprocess_remainder_fn> maybe_remainder_fn = std::nullopt,
         std::optional<std::size_t> maybe_min_num_examples = std::nullopt,
         std::optional<std::size_t> maybe_max_num_examples = std::nullopt,
         bool drop_remainder = false) &&;

--- a/native/src/fairseq2n/data/dynamic_bucket_data_source.cc
+++ b/native/src/fairseq2n/data/dynamic_bucket_data_source.cc
@@ -31,7 +31,7 @@ std::optional<data>
 dynamic_bucket_data_source::next()
 {
     if (!return_buffer_.empty()) {
-        data_list output{return_buffer_.front()};
+        data output{return_buffer_.front()};
         return_buffer_.pop_front();
         return output;
     }
@@ -75,7 +75,7 @@ dynamic_bucket_data_source::next()
 
             buffer_ = std::move(new_buffer);
 
-            data_list output{return_buffer.front()};
+            data output{return_buffer.front()};
             return_buffer.pop_front();
 
             return_buffer_ = std::move(return_buffer);

--- a/native/src/fairseq2n/data/dynamic_bucket_data_source.h
+++ b/native/src/fairseq2n/data/dynamic_bucket_data_source.h
@@ -23,7 +23,6 @@ public:
         float64 threshold,
         cost_fn &&fn,
         std::optional<bucket_creation_fn> &&maybe_bucket_fn,
-        std::optional<postprocess_remainder_fn> &&maybe_remainder_fn,
         std::optional<std::size_t> maybe_min_num_examples,
         std::optional<std::size_t> maybe_max_num_examples,
         bool drop_remainder) noexcept;
@@ -48,12 +47,13 @@ private:
     float64 threshold_;
     cost_fn cost_fn_;
     std::optional<bucket_creation_fn> maybe_bucket_creation_fn_;
-    std::optional<postprocess_remainder_fn> maybe_postprocess_remainder_fn_;
     std::optional<std::size_t> maybe_min_num_examples_;
     std::optional<std::size_t> maybe_max_num_examples_;
     bool drop_remainder_;
 
     data_list buffer_{};
+    std::deque<data_list> return_buffer_{};
+
 };
 
 }  // namespace fairseq2n::detail

--- a/native/src/fairseq2n/data/dynamic_bucket_data_source.h
+++ b/native/src/fairseq2n/data/dynamic_bucket_data_source.h
@@ -52,7 +52,7 @@ private:
     bool drop_remainder_;
 
     data_list buffer_{};
-    std::deque<data_list> return_buffer_{};
+    std::deque<data> return_buffer_{};
 
 };
 

--- a/native/src/fairseq2n/data/dynamic_bucket_data_source.h
+++ b/native/src/fairseq2n/data/dynamic_bucket_data_source.h
@@ -22,6 +22,8 @@ public:
         std::unique_ptr<data_source> &&inner,
         float64 threshold,
         cost_fn &&fn,
+        std::optional<bucket_creation_fn> &&maybe_bucket_fn,
+        std::optional<postprocess_remainder_fn> &&maybe_remainder_fn,
         std::optional<std::size_t> maybe_min_num_examples,
         std::optional<std::size_t> maybe_max_num_examples,
         bool drop_remainder) noexcept;
@@ -45,9 +47,13 @@ private:
     std::unique_ptr<data_source> inner_;
     float64 threshold_;
     cost_fn cost_fn_;
+    std::optional<bucket_creation_fn> maybe_bucket_creation_fn_;
+    std::optional<postprocess_remainder_fn> maybe_postprocess_remainder_fn_;
     std::optional<std::size_t> maybe_min_num_examples_;
     std::optional<std::size_t> maybe_max_num_examples_;
     bool drop_remainder_;
+
+    data_list buffer_{};
 };
 
 }  // namespace fairseq2n::detail

--- a/src/fairseq2/data/data_pipeline.py
+++ b/src/fairseq2/data/data_pipeline.py
@@ -232,10 +232,8 @@ if TYPE_CHECKING or DOC_MODE:
             threshold: float,
             cost_fn: Callable[[Any], float],
             bucket_creation_fn: Callable[
-                [Sequence[Any]], tuple[Sequence[Any], Sequence[Any]]
+                [Sequence[Any]], tuple[Sequence[Sequence[Any]], Sequence[Any]]
             ]
-            | None = None,
-            postprocess_remainder_fn: Callable[[Sequence[Any]], Sequence[Any]]
             | None = None,
             min_num_examples: int | None = None,
             max_num_examples: int | None = None,
@@ -255,13 +253,10 @@ if TYPE_CHECKING or DOC_MODE:
             :param bucket_creation_fn:
                 Function for customizing bucket creation. Called with the bucket of
                 examples that caused the cost threshold to be exceeded.
-                Expected to return a tuple of ``(new_bucket, remainder)``, where
-                the internal buffer is set to ``remainder`` and ``new_bucket`` is
-                the final bucket to be yielded. If ``None``, defaults to the
+                Expected to return a tuple of ``(new_buckets, remainder)``, where
+                the internal buffer is set to ``remainder`` and ``new_buckets`` is
+                a list of buckets to be yielded. If ``None``, defaults to the
                 identity function.
-            :param postprocess_remainder_fn:
-                Function for postprocessing remainder when ``drop_remainder`` is
-                ``False``. Never called when ``drop_remainder`` is ``True``.
             :param min_num_examples:
                 Minimum number of examples per bucket.
             :param max_num_examples:

--- a/src/fairseq2/data/data_pipeline.py
+++ b/src/fairseq2/data/data_pipeline.py
@@ -231,6 +231,12 @@ if TYPE_CHECKING or DOC_MODE:
             self,
             threshold: float,
             cost_fn: Callable[[Any], float],
+            bucket_creation_fn: Callable[
+                [Sequence[Any]], tuple[Sequence[Any], Sequence[Any]]
+            ]
+            | None = None,
+            postprocess_remainder_fn: Callable[[Sequence[Any]], Sequence[Any]]
+            | None = None,
             min_num_examples: int | None = None,
             max_num_examples: int | None = None,
             drop_remainder: bool = False,
@@ -246,6 +252,16 @@ if TYPE_CHECKING or DOC_MODE:
                 Threshold for cumulative cost to trigger bucketing.
             :param cost_fn:
                 Cost function that outputs cost for a particular example.
+            :param bucket_creation_fn:
+                Function for customizing bucket creation. Called with the bucket of
+                examples that caused the cost threshold to be exceeded.
+                Expected to return a tuple of ``(new_bucket, remainder)``, where
+                the internal buffer is set to ``remainder`` and ``new_bucket`` is
+                the final bucket to be yielded. If ``None``, defaults to the
+                identity function.
+            :param postprocess_remainder_fn:
+                Function for postprocessing remainder when ``drop_remainder`` is
+                ``False``. Never called when ``drop_remainder`` is ``True``.
             :param min_num_examples:
                 Minimum number of examples per bucket.
             :param max_num_examples:

--- a/tests/unit/data/data_pipeline/test_dynamic_bucket.py
+++ b/tests/unit/data/data_pipeline/test_dynamic_bucket.py
@@ -225,8 +225,7 @@ class TestDynamicBucketOp:
 
         threshold = 6
         cost_fn = lambda x: x
-        bucket_creation_fn = lambda l: (l[:-1], [l[-1]])
-        postprocess_remainder_fn = lambda l: l
+        bucket_creation_fn = lambda l: ([l[:-1]], [l[-1]])
 
         pipeline = (
             read_sequence(seq)
@@ -234,7 +233,6 @@ class TestDynamicBucketOp:
                 threshold,
                 cost_fn,
                 bucket_creation_fn=bucket_creation_fn,
-                postprocess_remainder_fn=postprocess_remainder_fn,
             )
             .and_return()
         )

--- a/tests/unit/data/data_pipeline/test_dynamic_bucket.py
+++ b/tests/unit/data/data_pipeline/test_dynamic_bucket.py
@@ -220,6 +220,38 @@ class TestDynamicBucketOp:
 
             pipeline.reset()
 
+    def test_op_works_with_bucket_creation_fn_set(self) -> None:
+        seq = list(range(1, 7))
+
+        threshold = 6
+        cost_fn = lambda x: x
+        bucket_creation_fn = lambda l: (l[:-1], [l[-1]])
+        postprocess_remainder_fn = lambda l: l
+
+        pipeline = (
+            read_sequence(seq)
+            .dynamic_bucket(
+                threshold,
+                cost_fn,
+                bucket_creation_fn=bucket_creation_fn,
+                postprocess_remainder_fn=postprocess_remainder_fn,
+            )
+            .and_return()
+        )
+
+        for _ in range(2):
+            it = iter(pipeline)
+
+            assert next(it) == [1, 2]
+            assert next(it) == [3, 4]
+            assert next(it) == [5]
+            assert next(it) == [6]
+
+            with pytest.raises(StopIteration):
+                next(it)
+
+            pipeline.reset()
+
     def test_op_raises_error_when_threshold_is_nonpositive(self) -> None:
         with pytest.raises(
             ValueError, match=r"^`threshold` must be greater than zero\.$"


### PR DESCRIPTION
**What does this PR do? Please describe:**
Add a new optional argument to dynamic_bucket---bucket_creation_fn---to allow the user to customize how buckets are created. 

bucket_creation_fn allows the user to customize what dynamic_bucket yields as a bucket once the cost threshold is met as well as what remains in the subsequent bucket.

**Does your PR introduce any breaking changes? If yes, please list them:**
List of all backwards-incompatible changes.
N/A

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [ ] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
