### PR TITLE
Add support for CLI tab completions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,10 +7,6 @@
 from __future__ import annotations
 
 from setuptools import find_namespace_packages, setup
-from setuptools.command.install import install
-from setuptools.command.develop import develop
-import subprocess
-import os
 
 version = "0.3.0.dev0"
 
@@ -20,36 +16,6 @@ if version.endswith(".dev0"):
     fairseq2n_version_spec = f">={version},<={version[:-5]}"
 else:
     fairseq2n_version_spec = f"=={version}"
-
-class PostInstallCommand:
-    """Base class for post-installation commands."""
-    def _post_install(self):
-        completion_scripts = {
-            'bash': '/etc/bash_completion.d/fairseq2.sh',
-            'zsh': '/usr/share/zsh/site-functions/_fairseq2',
-            'tcsh': '/etc/profile.d/fairseq2.csh',
-        }
-        for shell, path in completion_scripts.items():
-            try:
-                output = subprocess.check_output(['my_cli', '--print-completions', shell], text=True)
-                with open(path, 'w') as f:
-                    f.write(output)
-                print(f"Installed completion for {shell} in {path}")
-            except Exception as e:
-                print(f"Could not install completion for {shell}: {e}")
-
-class DevelopCommand(develop, PostInstallCommand):
-    """Post-installation for development mode."""
-    def run(self):
-        print("Running develop command")
-        develop.run(self)
-        self._post_install()
-
-class InstallCommand(install, PostInstallCommand):
-    """Post-installation for installation mode."""
-    def run(self):
-        install.run(self)
-        self._post_install()
 
 setup(
     name="fairseq2",
@@ -102,8 +68,4 @@ setup(
         "arrow": ["pyarrow>=13.0.0", "pandas~=2.0.0"],
     },
     entry_points={"console_scripts": ["fairseq2=fairseq2.recipes:main"]},
-    cmdclass={
-        'install': InstallCommand,
-        'develop': DevelopCommand,
-    },
 )

--- a/src/fairseq2/recipes/cli.py
+++ b/src/fairseq2/recipes/cli.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import sys
+import shtab  # for completion magic
 from abc import ABC, abstractmethod
 from argparse import OPTIONAL, ArgumentParser, Namespace
 from copy import deepcopy
@@ -146,6 +147,7 @@ class Cli:
 
     def _run_command(self) -> None:
         parser = ArgumentParser(self._name, description=self._description)
+        shtab.add_argument_to(parser, ["-s", "--print-completion"])
 
         self.init_parser(parser)
 

--- a/src/fairseq2/recipes/cli.py
+++ b/src/fairseq2/recipes/cli.py
@@ -493,7 +493,7 @@ class RecipeCommandHandler(CliCommandHandler, Generic[RecipeConfigT]):
             type=Path,
             nargs="*",
             help="yaml configuration file(s)",
-        )
+        ).complete = shtab.FILE
 
         parser.add_argument(
             "--config",
@@ -536,7 +536,7 @@ class RecipeCommandHandler(CliCommandHandler, Generic[RecipeConfigT]):
             type=Path,
             nargs=OPTIONAL,
             help="directory to store recipe artifacts",
-        )
+        ).complete = shtab.DIRECTORY
 
     @override
     def __call__(self, args: Namespace) -> None:

--- a/src/fairseq2/recipes/llama/convert_checkpoint.py
+++ b/src/fairseq2/recipes/llama/convert_checkpoint.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import final
 from warnings import catch_warnings
 
+import shtab
 from typing_extensions import override
 
 from fairseq2.console import get_error_console
@@ -43,13 +44,13 @@ class ConvertCheckpointCommandHandler(CliCommandHandler):
             "input_dir",
             type=Path,
             help="checkpoint directory",
-        )
+        ).complete = shtab.DIRECTORY
 
         parser.add_argument(
             "output_dir",
             type=Path,
             help="output directory to store reference checkpoint",
-        )
+        ).complete = shtab.DIRECTORY
 
     @override
     def __call__(self, args: Namespace) -> None:


### PR DESCRIPTION
**What does this PR do? Please describe:**
This PR extends the CLI with support for tab completions. Initially, I tried using argcomplete, but it was slow and ran a Fairseq2 process each time I pressed tab, which was far from ideal.

I then discovered shtab, a package that generates shell tab completion scripts efficiently. According to its [README](https://github.com/iterative/shtab?tab=readme-ov-file#shtab):
> - What: Automatically generate shell tab completion scripts for Python CLI apps
> - Why: Speed & correctness. Alternatives like argcomplete and pyzshcomplete are slow and have side-effects
> - How: shtab processes an argparse.ArgumentParser object to generate a tab completion script for your shell

After implementing `shtab`, tab completion works beautifully. Here are some examples:
```
$ fairseq2 [TAB]
assets        llama         lm            mt            wav2vec2_asr  
```
```
$ fairseq2 ll[TAB]
$ fairseq2 llama
```

It’s especially useful for things like presets. Instead of listing presets and copying them manually, you can now use tab completion:
```
$ fairseq2 lm [TAB]
chatbot               generate              instruction_finetune  preference_finetune   
$ fairseq2 lm c[TAB]
$ fairseq2 lm chatbot
```

It also works with arguments:
```
$ fairseq2 lm chatbot --[TAB]
--cluster               --help                  --model                 --temperature           --top-p                 
--dtype                 --max-gen-len           --seed                  --tensor-parallel-size  
```

Tab completions are specific to each shell and require the installation of corresponding scripts in the shell's directory.

Initially, I intended to extend the project by adding post-install scripts to automatically set up tab completion scripts (b63af9842eaba1521c00dd3f42ec3169b40a9f02). However, I discovered that this approach only worked with zip and tarball distributions, while fairseq2 uses wheel builds. As a result, I reverted that change.

Currently, you can enable tab completions manually by using `--print-completions {bash|zsh|tcsh}`. The output of this command can be saved to the shell's completion scripts directory for persistence or evaluated directly for the current session.

For example:
```
eval "$(fairseq2 --print-completion bash)"
```

Please note: each time the CLI interfaces are modified, the shell completion scripts need to be updated.