### PR TITLE
add mask_src_tokens parameter to preference finetuning

### DIFF
--- a/src/fairseq2/datasets/preference.py
+++ b/src/fairseq2/datasets/preference.py
@@ -63,6 +63,7 @@ class PreferenceOptimizationDataset(ABC):
         max_num_batches: int | None = None,
         num_accumulate: int = 1,
         num_prefetch: int = 1,
+        mask_src_tokens: bool = True,
         seed: int = 2,
         **extras: Any,
     ) -> DataPipelineReader[PreferenceOptimizationBatch]:
@@ -164,6 +165,7 @@ class GenericPreferenceOptimizationDataset(PreferenceOptimizationDataset):
         max_num_batches: int | None = None,
         num_accumulate: int = 1,
         num_prefetch: int = 1,
+        mask_src_tokens: bool = True,
         seed: int = 2,
         **extras: Any,
     ) -> DataPipelineReader[PreferenceOptimizationBatch]:
@@ -215,7 +217,9 @@ class GenericPreferenceOptimizationDataset(PreferenceOptimizationDataset):
             indices_chosen = torch.cat([prompt_indices, target_indices_chosen])
             indices_rejected = torch.cat([prompt_indices, target_indices_rejected])
 
-            prompt_len = len(prompt_indices)
+            prompt_len = 0
+            if mask_src_tokens:
+                prompt_len = len(prompt_indices)
 
             target_mask_chosen = torch.arange(len(indices_chosen)) >= prompt_len
             target_mask_rejected = torch.arange(len(indices_rejected)) >= prompt_len

--- a/src/fairseq2/datasets/preference.py
+++ b/src/fairseq2/datasets/preference.py
@@ -63,7 +63,7 @@ class PreferenceOptimizationDataset(ABC):
         max_num_batches: int | None = None,
         num_accumulate: int = 1,
         num_prefetch: int = 1,
-        mask_src_tokens: bool = True,
+        mask_source_tokens: bool = True,
         seed: int = 2,
         **extras: Any,
     ) -> DataPipelineReader[PreferenceOptimizationBatch]:
@@ -105,6 +105,8 @@ class PreferenceOptimizationDataset(ABC):
             used with gradient accumulation during training.
         :param num_prefetch:
             The number of batches to prefetch in background.
+        :param mask_source_tokens:
+            If ``False``, calculates loss on the `src` tokens as well as the `tgt` tokens.
         :param seed:
             The seed to initialize the random number generators used internally.
         :param extras:
@@ -165,7 +167,7 @@ class GenericPreferenceOptimizationDataset(PreferenceOptimizationDataset):
         max_num_batches: int | None = None,
         num_accumulate: int = 1,
         num_prefetch: int = 1,
-        mask_src_tokens: bool = True,
+        mask_source_tokens: bool = True,
         seed: int = 2,
         **extras: Any,
     ) -> DataPipelineReader[PreferenceOptimizationBatch]:
@@ -217,12 +219,13 @@ class GenericPreferenceOptimizationDataset(PreferenceOptimizationDataset):
             indices_chosen = torch.cat([prompt_indices, target_indices_chosen])
             indices_rejected = torch.cat([prompt_indices, target_indices_rejected])
 
-            prompt_len = 0
-            if mask_src_tokens:
+            if mask_source_tokens:
                 prompt_len = len(prompt_indices)
-
-            target_mask_chosen = torch.arange(len(indices_chosen)) >= prompt_len
-            target_mask_rejected = torch.arange(len(indices_rejected)) >= prompt_len
+                target_mask_chosen = torch.arange(len(indices_chosen)) >= prompt_len
+                target_mask_rejected = torch.arange(len(indices_rejected)) >= prompt_len
+            else:
+                target_mask_chosen = torch.full([len(indices_chosen)], True)
+                target_mask_rejected = torch.full([len(indices_rejected)], True)
 
             return {
                 "id": id_,

--- a/src/fairseq2/recipes/lm/preference_finetune/recipe.py
+++ b/src/fairseq2/recipes/lm/preference_finetune/recipe.py
@@ -70,7 +70,7 @@ class PreferenceOptimizationConfig:
     num_prefetch: int = 4
     """The number of batches to prefetch in background."""
 
-    mask_src_tokens: bool = True
+    mask_source_tokens: bool = True
     """If ``False``, calculates loss on the `src` tokens as well as the `tgt` tokens."""
 
     # Model
@@ -354,7 +354,7 @@ def load_preference_finetuner(
             batch_shuffle_window=config.batch_shuffle_window,
             num_accumulate=config.gradient_accumulation,
             num_prefetch=config.num_prefetch,
-            mask_src_tokens=config.mask_src_tokens,
+            mask_source_tokens=config.mask_source_tokens,
             seed=config.seed,
         )
     except ValueError as ex:

--- a/src/fairseq2/recipes/lm/preference_finetune/recipe.py
+++ b/src/fairseq2/recipes/lm/preference_finetune/recipe.py
@@ -70,6 +70,9 @@ class PreferenceOptimizationConfig:
     num_prefetch: int = 4
     """The number of batches to prefetch in background."""
 
+    mask_src_tokens: bool = True
+    """If ``False``, calculates loss on the `src` tokens as well as the `tgt` tokens."""
+
     # Model
     model: AssetReference = "llama3_8b_instruct"
     """The name or path to the asset card of the language model to finetune."""
@@ -351,6 +354,7 @@ def load_preference_finetuner(
             batch_shuffle_window=config.batch_shuffle_window,
             num_accumulate=config.gradient_accumulation,
             num_prefetch=config.num_prefetch,
+            mask_src_tokens=config.mask_src_tokens,
             seed=config.seed,
         )
     except ValueError as ex:


### PR DESCRIPTION
**What does this PR do? Please describe:**
Allows src tokens to be used in the loss calculation for preference finetuning recipes, which may be beneficial when dropout is used as shown by Ilia. 

Fixes #{issue number}

**Does your PR introduce any breaking changes? If yes, please list them:**
None

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [ ] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
