### PR TITLE
Introduce unsorted_map op

### DIFF
--- a/native/python/src/fairseq2n/bindings/data/data_pipeline.cc
+++ b/native/python/src/fairseq2n/bindings/data/data_pipeline.cc
@@ -616,8 +616,9 @@ def_data_pipeline(py::module_ &data_module)
             [](
                 data_pipeline_builder &self,
                 std::variant<map_fn, std::vector<map_fn>> fn,
-                std::optional<std::string> maybe_selector,
-                std::size_t num_parallel_calls) -> data_pipeline_builder &
+                std::size_t buffer_size,
+                std::size_t num_threads,
+                std::optional<std::string> maybe_selector) -> data_pipeline_builder &
             {
                 map_fn f{};
 
@@ -636,13 +637,14 @@ def_data_pipeline(py::module_ &data_module)
 
                 element_mapper mapper{std::move(f), std::move(maybe_selector)};
 
-                self = std::move(self).map(mapper, num_parallel_calls);
+                self = std::move(self).unsorted_map(mapper, buffer_size, num_threads);
 
                 return self;
             },
             py::arg("fn"),
-            py::arg("selector") = std::nullopt,
-            py::arg("num_parallel_calls") = 1)
+            py::arg("buffer_size"),
+            py::arg("num_threads"),
+            py::arg("selector") = std::nullopt)
         .def(
             "yield_from",
             [](data_pipeline_builder &self, yield_fn fn) -> data_pipeline_builder &

--- a/native/src/fairseq2n/CMakeLists.txt
+++ b/native/src/fairseq2n/CMakeLists.txt
@@ -47,6 +47,7 @@ target_sources(fairseq2n
         data/skip_data_source.cc
         data/take_data_source.cc
         data/tape.cc
+        data/unsorted_map_data_source.cc
         data/yield_from_data_source.cc
         data/zip_data_source.cc
         data/zip_file_data_source.cc

--- a/native/src/fairseq2n/data/data_pipeline.cc
+++ b/native/src/fairseq2n/data/data_pipeline.cc
@@ -539,17 +539,21 @@ data_pipeline_builder::take(std::size_t num_examples) &&
 }
 
 data_pipeline_builder
-data_pipeline_builder::unsorted_map(const map_fn &fn, std::size_t num_parallel_calls) &&
+data_pipeline_builder::unsorted_map(
+    const map_fn &fn, 
+    std::size_t buffer_size, 
+    std::size_t num_threads) &&
 {
-    if (num_parallel_calls == 0)
+    if (num_threads == 0)
         throw_<std::invalid_argument>(
-            "`num_parallel_calls` must be greater than zero.");
+            "`num_threads` must be greater than zero.");
 
-    std::vector<map_fn> fns(num_parallel_calls, fn);
+    std::vector<map_fn> fns(num_threads, fn);
 
     factory_ = [=, fns = std::move(fns), inner = std::move(factory_)]() mutable
     {
-        return std::make_unique<unsorted_map_data_source>(inner(), std::move(fns), num_parallel_calls);
+        return std::make_unique<unsorted_map_data_source>(
+            inner(), std::move(fns), buffer_size, num_threads);
     };
 
     return std::move(*this);

--- a/native/src/fairseq2n/data/data_pipeline.h
+++ b/native/src/fairseq2n/data/data_pipeline.h
@@ -181,6 +181,9 @@ public:
     take(std::size_t num_examples) &&;
 
     data_pipeline_builder
+    unsorted_map(const map_fn &fn, std::size_t num_parallel_calls = 1) &&;
+
+    data_pipeline_builder
     yield_from(yield_fn fn) &&;
 
     data_pipeline

--- a/native/src/fairseq2n/data/data_pipeline.h
+++ b/native/src/fairseq2n/data/data_pipeline.h
@@ -181,7 +181,7 @@ public:
     take(std::size_t num_examples) &&;
 
     data_pipeline_builder
-    unsorted_map(const map_fn &fn, std::size_t num_parallel_calls = 1) &&;
+    unsorted_map(const map_fn &fn, std::size_t buffer_size, std::size_t num_threads) &&;
 
     data_pipeline_builder
     yield_from(yield_fn fn) &&;

--- a/native/src/fairseq2n/data/unsorted_map_data_source.cc
+++ b/native/src/fairseq2n/data/unsorted_map_data_source.cc
@@ -1,0 +1,278 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "fairseq2n/data/unsorted_map_data_source.h"
+
+#include <exception>
+
+#include "fairseq2n/data/data_pipeline.h"
+#include "fairseq2n/data/detail/exception.h"
+#include "fairseq2n/detail/parallel.h"
+
+namespace fairseq2n::detail {
+
+unsorted_map_data_source::unsorted_map_data_source(
+    std::unique_ptr<data_source> &&inner, std::vector<map_fn> &&fns, std::size_t num_parallel_calls)
+  : inner_{std::move(inner)},
+    map_fns_{std::move(fns)},
+    num_parallel_calls_{num_parallel_calls},
+    thread_pool_{num_parallel_calls},
+    buffer_{std::vector(num_parallel_calls)}
+{}
+
+std::optional<data>
+unsorted_map_data_source::next()
+{
+    if (num_parallel_calls_ <= 1) {
+        while (std::optional<data> maybe_example = inner_->next()) {
+            maybe_example = invoke_function(*std::move(maybe_example), 0);
+            if (maybe_example)
+                return maybe_example;
+        }
+
+        return std::nullopt;
+    }
+    
+    if (faulted_) {
+        std::rethrow_exception(exception_ptr_);
+    }
+
+    ensure_thread_pool_running();
+
+    return fill_buffer();
+}
+
+void
+unsorted_map_data_source::reset(bool reset_rng)
+{
+    faulted_ = false;
+
+    for (auto& element : buffer_) {
+        element.store(std::nullopt);
+    }
+
+    inner_->reset(reset_rng);
+}
+
+void
+unsorted_map_data_source::record_position(tape &t, bool strict) const
+{
+    stop_thread_pool();
+
+    if (faulted_) {
+        std::rethrow_exception(exception_ptr_);
+    }
+
+    if (strict) {
+        data_list result_queue_buffer;
+        result_queue_buffer.reserve(result_queue_.size());
+        for (auto& result : result_queue_) {
+            if (std::holds_alternative<std::exception_ptr>(result)) {
+                faulted_ = true;
+                exception_ptr_ = std::get<std::exception_ptr>(result);
+                std::rethrow_exception(exception_ptr_);
+            }
+            result_queue_buffer.push_back(std::get<data>(result));
+        }
+
+        t.record(result_queue_buffer);
+
+        std::vector<std::size_t> task_queue_buffer;
+        task_queue_buffer.reserve(task_queue_.size());
+        for (auto& it : task_queue_) {
+            task_queue_buffer.push_back(it - task_queue_.begin());
+        }
+
+        t.record(task_queue_buffer);
+
+        std::vector<std::optional<data>> buffer;
+        buffer.reserve(buffer_.size());
+        for (auto& element : buffer_) {
+            buffer.push_back(element.load());
+        }
+
+        t.record(buffer);
+    }
+
+    inner_->record_position(t, strict);
+}
+
+void
+unsorted_map_data_source::reload_position(tape &t, bool strict)
+{
+    stop_thread_pool();
+
+    result_queue_.clear();
+    task_queue_.clear();
+
+    if (strict) {
+
+        for (const data& result : t.read<data_list>()) {
+            result_queue_.push(result);
+        }
+
+        for (const auto& index : t.read<std::vector<std::size_t>>()) {
+            task_queue_.push(buffer_.begin() + index);
+        }
+
+        std::vector<std::optional<data>> buffer{
+            t.read<std::vector<std::optional<data>>>()
+        };
+        for (std::size_t i = 0; i < num_parallel_calls_; ++i) {
+            buffer_[i].store(buffer[i]);
+        }
+    } else {
+        buffer_.clear();
+    }
+
+    inner_->reload_position(t, strict);
+}
+
+data_source_finitude_type
+unsorted_map_data_source::finitude_type() const noexcept
+{
+    return inner_->finitude_type();
+}
+
+std::optional<data>
+unsorted_map_data_source::fill_buffer()
+{
+    bool empty_buffer = true;
+    for (auto it = buffer_.begin(); it != buffer_.end(); ++it) {
+        if (*it) { 
+            empty_buffer = false;
+            continue;
+        }
+
+        std::optional<data> maybe_example;
+        try {
+            maybe_example = inner_->next();
+        } catch (const std::exception &) {
+            stop_thread_pool();
+            faulted_ = true;
+            exception_ptr_ = std::current_exception();
+            std::rethrow_exception(std::current_exception());
+        }
+        if (!maybe_example)
+            break;
+
+        {
+            std::unique_lock<std::mutex> queue_lock{task_queue_mutex_};
+            task_queue_.push(it);
+        }
+        task_queue_condition_.notify_one();
+    }
+
+    if (empty_buffer)
+        return std::nullopt;
+
+    
+    std::unique_lock<std::mutex> queue_lock{result_queue_mutex_};
+
+    result_queue_condition_.wait(queue_lock, [this]
+    {
+        return !fill_queue_.empty();
+    });
+
+    auto result = result_queue_.front()->load();
+    if (std::holds_alternative<std::exception_ptr>(result)) {
+        stop_thread_pool();
+        faulted_ = true;
+        exception_ptr_ = std::get<std::exception_ptr>(result);
+        std::rethrow_exception(exception_ptr_);
+    }
+    result_queue_.pop();
+    return std::get<data>(result);
+}
+
+std::optional<data>
+unsorted_map_data_source::invoke_function(data &&example, std::size_t fn_idx)
+{
+    return map_fns_[fn_idx](std::move(example));
+}
+
+void
+unsorted_map_data_source::run_map()
+{
+    while (true) {
+        std::optional<data> maybe_example;
+        std::exception_ptr exception_ptr;
+        std::vector<std::atomic<std::optional<data>>>::iterator buffer_iterator;
+        {
+            std::unique_lock<std::mutex> queue_lock{task_queue_mutex_};
+
+            task_queue_condition_.wait(queue_lock, [this]
+            {
+                return should_stop_map_ || !task_queue_.empty();
+            });
+
+            if (should_stop_map_) {
+                break;
+            }
+            
+            buffer_iterator = task_queue_.front();
+            maybe_example = buffer_iterator->load();
+            task_queue_.pop();
+        }
+
+        if (!maybe_example) {
+            //Should never happen
+            break;
+        }
+
+        std::size_t buffer_pos = buffer_iterator - buffer_.begin();
+        try {
+            maybe_example = invoke_function(*std::move(maybe_example), buffer_pos);
+        } catch (const std::exception&) {
+            exception_ptr = std::current_exception();
+        }
+
+        {
+            std::unique_lock<std::mutex> queue_lock{result_queue_mutex_};
+            if (maybe_example) {
+                result_queue_.push(*std::move(maybe_example));
+            } else {
+                result_queue_.push(exception_ptr);
+            }
+        }
+
+        buffer_iterator->store(std::nullopt);
+
+        result_queue_condition_.notify_one();
+    }
+}
+
+void
+unsorted_map_data_source::ensure_thread_pool_running()
+{
+    for (auto& thread : thread_pool_) {
+        if (prefetch_thread_.joinable())
+            continue;
+        thread = start_thread(&unsorted_map_data_source::run_map, this);
+    }
+}
+
+void
+stop_thread_pool()
+{
+    {
+        std::unique_lock<std::mutex> task_queue_lock{task_queue_mutex_};
+        std::unique_lock<std::mutex> result_queue_lock{result_queue_mutex_};
+
+        should_stop_map_ = true;
+    }
+
+    task_queue_condition_.notify_all();
+    result_queue_condition_.notify_all();
+
+    for (auto& thread : thread_pool_) {
+        thread.join();
+    }
+
+    should_stop_map_ = false;
+}
+
+}  // namespace fairseq2n::detail

--- a/native/src/fairseq2n/data/unsorted_map_data_source.h
+++ b/native/src/fairseq2n/data/unsorted_map_data_source.h
@@ -33,7 +33,7 @@ public:
       : inner_{std::move(inner)}, 
         map_fns_{std::move(fns)},
         buffer_size_{buffer_size}, 
-        prefetch_threads_(num_threads)
+        thread_pool_(num_threads)
     {}
 
     unsorted_map_data_source(const unsorted_map_data_source &) = delete;
@@ -61,13 +61,13 @@ public:
 
 private:
     void
-    ensure_prefetch_thread_running();
+    ensure_thread_pool_running();
 
     void
-    prefetch(std::size_t thread_idx);
+    fetch_and_map(std::size_t thread_idx);
 
     void
-    stop_prefetch_threads() const noexcept;
+    stop_thread_pool() const noexcept;
 
     void
     join_all_threads() const noexcept;
@@ -77,8 +77,8 @@ private:
     std::vector<map_fn> map_fns_;
     std::size_t buffer_size_;
     unsorted_map_state state_ = unsorted_map_state::not_running;
-    mutable std::vector<std::thread> prefetch_threads_{};
-    mutable bool should_stop_prefetch_ = false;
+    mutable std::vector<std::thread> thread_pool_{};
+    mutable bool should_stop_pool_ = false;
     mutable std::mutex queue_mutex_{};
     mutable std::mutex pipeline_mutex_{};
     mutable std::condition_variable fill_queue_condition_{};

--- a/native/src/fairseq2n/data/unsorted_map_data_source.h
+++ b/native/src/fairseq2n/data/unsorted_map_data_source.h
@@ -1,0 +1,89 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <utility>
+#include <vector>
+#include <atomic>
+
+#include "fairseq2n/data/data_pipeline.h"
+#include "fairseq2n/data/data_source.h"
+
+namespace fairseq2n::detail {
+
+class unsorted_map_data_source final : public data_source {
+public:
+    explicit
+    unsorted_map_data_source(
+        std::unique_ptr<data_source> &&inner,
+        std::vector<map_fn> &&fns,
+        std::size_t num_parallel_calls) 
+    : inner_{std::move(inner)},
+      map_fns_{std::move(fns)},
+      num_parallel_calls_{num_parallel_calls}
+    {
+        for (std::size_t i = 0; i < num_parallel_calls; ++i) {
+            buffer_.emplace_back(std::nullopt);
+        }
+    }
+
+    std::optional<data>
+    next() override;
+
+    void
+    reset(bool reset_rng) override;
+
+    void
+    record_position(tape &t, bool strict) const override;
+
+    void
+    reload_position(tape &t, bool strict) override;
+
+    data_source_finitude_type
+    finitude_type() const noexcept override;
+
+private:
+    bool
+    fill_buffer();
+
+    std::optional<data>
+    invoke_function(data &&example, std::size_t fn_idx);
+
+    void
+    run_map();
+
+    void
+    ensure_thread_pool_running();
+
+    void
+    stop_thread_pool();
+
+private:
+    std::unique_ptr<data_source> inner_;
+    std::vector<map_fn> map_fns_;
+    std::size_t num_parallel_calls_;
+    std::vector<std::thread> thread_pool_;
+    std::vector<std::atomic<std::optional<data>>> buffer_{};
+
+    bool faulted_{false};
+    bool should_stop_map_{false};
+
+    mutable std::mutex task_queue_mutex_{};
+    mutable std::condition_variable task_queue_condition_{};
+    std::deque<std::vector<std::atomic<std::optional<data>>>::iterator> task_queue_;
+
+    mutable std::mutex result_queue_mutex_{};
+    mutable std::condition_variable result_queue_condition_{};
+    std::deque<std::variant<data, std::exception_ptr>> result_queue_{};
+
+    std::exception_ptr exception_ptr_{};
+};
+
+}  // namespace fairseq2n::detail

--- a/src/fairseq2/data/data_pipeline.py
+++ b/src/fairseq2/data/data_pipeline.py
@@ -346,10 +346,10 @@ if TYPE_CHECKING or DOC_MODE:
 
         def unsorted_map(
             self,
-            fn: Union[Callable[[Any], Any], Sequence[Callable[[Any], Any]]],
+            fn: Callable[[Any], Any] | Sequence[Callable[[Any], Any]],
             buffer_size: int,
             num_threads: int,
-            selector: Optional[str] = None,
+            selector: str | None = None,
         ) -> Self:
             """Start thread pool of size ``num_threads`` that continuously fetches
             and applies ``fn`` to examples.

--- a/src/fairseq2/data/data_pipeline.py
+++ b/src/fairseq2/data/data_pipeline.py
@@ -347,12 +347,24 @@ if TYPE_CHECKING or DOC_MODE:
         def unsorted_map(
             self,
             fn: Union[Callable[[Any], Any], Sequence[Callable[[Any], Any]]],
+            buffer_size: int,
+            num_threads: int,
             selector: Optional[str] = None,
-            num_parallel_calls: int = 1,
         ) -> Self:
-            """John 3:16 says that God so loved the world that he gave his only
-            begotten son, that whoever believed in him would never die but have
-            eternal life.
+            """Start thread pool of size ``num_threads`` that continuously fetches
+            and applies ``fn`` to examples.
+
+            :param fn:
+                The function to apply.
+                If it's a list of function, they will be automatically chained.
+                ``.map([f1, f2])`` is the more efficient version of ``.map(f1).map(f2)``
+            :param buffer_size:
+                Maximum number of examples to buffer.
+            :param num_threads:
+                Number of threads in thread pool.
+            :param selector:
+                The column to apply the function to. Several columns can be specified by separating them with a ",".
+                See :ref:`reference/data:column syntax` for more details.
             """
 
         def yield_from(self, fn: Callable[[Any], DataPipeline]) -> Self:

--- a/src/fairseq2/data/data_pipeline.py
+++ b/src/fairseq2/data/data_pipeline.py
@@ -344,6 +344,17 @@ if TYPE_CHECKING or DOC_MODE:
         def take(self, num_examples: int) -> Self:
             """Return at most ``num_examples`` examples."""
 
+        def unsorted_map(
+            self,
+            fn: Union[Callable[[Any], Any], Sequence[Callable[[Any], Any]]],
+            selector: Optional[str] = None,
+            num_parallel_calls: int = 1,
+        ) -> Self:
+            """John 3:16 says that God so loved the world that he gave his only
+            begotten son, that whoever believed in him would never die but have
+            eternal life.
+            """
+
         def yield_from(self, fn: Callable[[Any], DataPipeline]) -> Self:
             """
             Map every example to a data pipeline and yield the examples returned

--- a/tests/unit/data/data_pipeline/test_unsorted_map.py
+++ b/tests/unit/data/data_pipeline/test_unsorted_map.py
@@ -1,0 +1,164 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import time
+from itertools import islice
+
+import pytest
+
+from fairseq2.data import read_sequence
+
+
+class TestUnsortedMapOp:
+    @pytest.mark.parametrize("buffer_size,num_threads", [(0, 1), (1, 1), (4, 4)])
+    def test_op_works(self, buffer_size: int, num_threads: int) -> None:
+        def double_fn(d: int) -> int:
+            return d * 2
+
+        seq = list(range(1, 5))
+        result_seq = list(range(2, 10, 2))
+
+        pipeline = (
+            read_sequence(seq)
+            .unsorted_map(double_fn, buffer_size=buffer_size, num_threads=num_threads)
+            .and_return()
+        )
+
+        for _ in range(2):
+            assert set(pipeline) == set(result_seq)
+
+            pipeline.reset()
+
+    def test_op_yields_shortest_job_first(self) -> None:
+        def sleep_fn(d: int) -> int:
+            time.sleep(d / 100)
+            return d
+
+        seq = [3, 2, 1]
+        result_seq = [1, 2, 3]
+
+        pipeline = (
+            read_sequence(seq)
+            .unsorted_map(sleep_fn, buffer_size=3, num_threads=3)
+            .and_return()
+        )
+
+        for _ in range(2):
+            assert list(pipeline) == result_seq
+
+            pipeline.reset()
+
+    @pytest.mark.parametrize("buffer_size,num_threads", [(0, 1), (1, 1), (4, 4)])
+    def test_op_works_after_reset(self, buffer_size: int, num_threads: int) -> None:
+        def double_fn(d: int) -> int:
+            time.sleep(d / 100)
+            return d * 2
+
+        seq = list(range(1, 10))
+        result_seq = list(range(2, 20, 2))
+
+        pipeline = (
+            read_sequence(seq)
+            .unsorted_map(double_fn, buffer_size=buffer_size, num_threads=num_threads)
+            .and_return()
+        )
+
+        for _ in range(2):
+            assert list(islice(pipeline, 5)) == result_seq[:5]
+
+            pipeline.reset()
+
+    @pytest.mark.parametrize("buffer_size,num_threads", [(0, 1), (1, 1), (4, 4)])
+    def test_op_works_when_no_data_is_specified(
+        self, buffer_size: int, num_threads: int
+    ) -> None:
+        pipeline = (
+            read_sequence([])
+            .unsorted_map(lambda x: x, buffer_size=buffer_size, num_threads=num_threads)
+            .and_return()
+        )
+
+        for _ in range(2):
+            assert list(pipeline) == []
+
+            pipeline.reset()
+
+    @pytest.mark.parametrize("buffer_size,num_threads", [(0, 1), (1, 1), (4, 4)])
+    def test_op_propagates_errors(self, buffer_size: int, num_threads: int) -> None:
+        def fn(d: int) -> int:
+            if d == 6:
+                raise ValueError("map error")
+
+            return d
+
+        seq = list(range(1, 10))
+
+        pipeline = (
+            read_sequence(seq)
+            .unsorted_map(fn, buffer_size=buffer_size, num_threads=num_threads)
+            .and_return()
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            for d in pipeline:
+                pass
+
+        assert str(exc_info.value) == "map error"
+
+    @pytest.mark.parametrize("buffer_size,num_threads", [(0, 1), (1, 1), (4, 4)])
+    def test_op_saves_and_restores_its_state(
+        self, buffer_size: int, num_threads: int
+    ) -> None:
+        def sleep_fn(d: int) -> int:
+            time.sleep(d / 100)
+            return d
+
+        seq = list(range(1, 10))
+
+        pipeline = (
+            read_sequence(seq)
+            .unsorted_map(sleep_fn, buffer_size=buffer_size, num_threads=num_threads)
+            .and_return()
+        )
+
+        d = None
+
+        it = iter(pipeline)
+
+        # Move to the second example.
+        for _ in range(2):
+            d = next(it)
+
+        assert d == 2
+
+        state_dict = pipeline.state_dict()
+
+        # Read a few examples before we roll back.
+        for _ in range(4):
+            d = next(it)
+
+        assert d == 6
+
+        # Expected to roll back to the second example.
+        pipeline.load_state_dict(state_dict)
+
+        # Move to EOD.
+        for _ in range(7):
+            d = next(it)
+
+        assert d == 9
+
+        state_dict = pipeline.state_dict()
+
+        pipeline.reset()
+
+        # Expected to be EOD.
+        pipeline.load_state_dict(state_dict)
+
+        with pytest.raises(StopIteration):
+            next(iter(pipeline))

--- a/tests/unit/data/data_pipeline/test_unsorted_map.py
+++ b/tests/unit/data/data_pipeline/test_unsorted_map.py
@@ -34,25 +34,6 @@ class TestUnsortedMapOp:
 
             pipeline.reset()
 
-    def test_op_yields_shortest_job_first(self) -> None:
-        def sleep_fn(d: int) -> int:
-            time.sleep(d / 10)
-            return d
-
-        seq = [3, 2, 1]
-        result_seq = [1, 2, 3]
-
-        pipeline = (
-            read_sequence(seq)
-            .unsorted_map(sleep_fn, buffer_size=3, num_threads=3)
-            .and_return()
-        )
-
-        for _ in range(2):
-            assert list(pipeline) == result_seq
-
-            pipeline.reset()
-
     @pytest.mark.parametrize("buffer_size,num_threads", [(0, 1), (1, 1), (4, 4)])
     def test_op_works_after_reset(self, buffer_size: int, num_threads: int) -> None:
         def double_fn(d: int) -> int:

--- a/tests/unit/data/data_pipeline/test_unsorted_map.py
+++ b/tests/unit/data/data_pipeline/test_unsorted_map.py
@@ -6,7 +6,6 @@
 
 from __future__ import annotations
 
-import time
 from itertools import islice
 
 import pytest


### PR DESCRIPTION
**What does this PR do? Please describe:**
This PR introduces an unsorted_map op; it launches a thread pool that fetches and maps examples in the background.

**Does your PR introduce any breaking changes? If yes, please list them:**
List of all backwards-incompatible changes.
N/A

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [ ] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
