### PR TITLE
nll normalization improvements for dpo.py, simpo.py

### DIFF
--- a/src/fairseq2/recipes/lm/preference_finetune/simpo.py
+++ b/src/fairseq2/recipes/lm/preference_finetune/simpo.py
@@ -17,7 +17,7 @@ from torcheval.metrics import Mean
 from typing_extensions import override
 
 from fairseq2.datasets.preference import PreferenceOptimizationBatch
-from fairseq2.gang import Gang, get_rank
+from fairseq2.gang import Gang
 from fairseq2.logging import get_log_writer
 from fairseq2.metrics.recorder import format_as_float, register_metric_formatter
 from fairseq2.models.sequence import (
@@ -84,18 +84,19 @@ class SimPOFinetuneUnit(AbstractTrainUnit[PreferenceOptimizationBatch]):
             chosen_target_batch.seqs, loss_mask=chosen_target_batch.target_mask
         )
 
-        # adding NLL loss to the total loss for now!
-        loss = simpo_loss + self._nll_scale * nll_loss
-
-        log.info(
-            f"Step:{self._step_nr} Rank:{get_rank()} IDs:{[str(idx) for idx in batch.chosen.example['id']]}, SimPO loss: {simpo_loss.item()}"
-        )
+        self._metric_bag.update_simpo_loss(chosen_batch, simpo_loss)
 
         self._metric_bag.update_nll_loss(chosen_batch, nll_loss)
 
-        self._metric_bag.update_simpo_loss(chosen_batch, simpo_loss)
-
         self._metric_bag.update_batch_metrics(chosen_batch)
+
+        loss = (
+            simpo_loss
+            + self._nll_scale
+            * nll_loss
+            * chosen_target_batch.batch_size
+            / chosen_target_batch.num_target_elements()
+        )  # nll normalization applied locally per-rank
 
         return loss, chosen_target_batch.batch_size
 


### PR DESCRIPTION
**What does this PR do? Please describe:**
Fixes NLL normalization for DPO and SimPO by approximating the scaling needed to reflect them effectively. NLL scale no longer dependent on batch size or sequence length. 

**Does your PR introduce any breaking changes? If yes, please list them:**
List of all backwards-incompatible changes.

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [ ] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
