### PR TITLE
preference optimization lengthbatching max_num_tokens calculation by chosen + rejected

### DIFF
--- a/src/fairseq2/datasets/preference.py
+++ b/src/fairseq2/datasets/preference.py
@@ -228,7 +228,7 @@ class GenericPreferenceOptimizationDataset(PreferenceOptimizationDataset):
                 target_mask_rejected = torch.full([len(indices_rejected)], True)
 
             total_tokens = (
-                len(prompt_indices)
+                2 * len(prompt_indices)
                 + len(target_indices_chosen)
                 + len(target_indices_rejected)
             )

--- a/src/fairseq2/datasets/preference.py
+++ b/src/fairseq2/datasets/preference.py
@@ -227,12 +227,19 @@ class GenericPreferenceOptimizationDataset(PreferenceOptimizationDataset):
                 target_mask_chosen = torch.full([len(indices_chosen)], True)
                 target_mask_rejected = torch.full([len(indices_rejected)], True)
 
+            total_tokens = (
+                len(prompt_indices)
+                + len(target_indices_chosen)
+                + len(target_indices_rejected)
+            )
+
             return {
                 "id": id_,
                 "indices_chosen": indices_chosen,
                 "indices_rejected": indices_rejected,
                 "target_mask_chosen": target_mask_chosen,
                 "target_mask_rejected": target_mask_rejected,
+                "total_tokens": total_tokens,
             }
 
         builder.map(cat_source_and_target, num_parallel_calls=npc)
@@ -245,7 +252,7 @@ class GenericPreferenceOptimizationDataset(PreferenceOptimizationDataset):
             # Bucket by the sequence length.
             builder.bucket_by_length(
                 bucket_sizes,
-                selector="indices_chosen,indices_rejected",
+                selector="total_tokens",
                 skip_above_max_examples=True,
                 drop_remainder=drop_remainder,
             )

--- a/src/fairseq2/recipes/lm/preference_finetune/recipe.py
+++ b/src/fairseq2/recipes/lm/preference_finetune/recipe.py
@@ -56,10 +56,10 @@ class PreferenceOptimizationConfig:
     """The name, path, or path to the asset card of the preference optimization dataset."""
 
     max_seq_len: int = 8192
-    """The maximum sequence length."""
+    """The maximum `src` + `tgt_chosen` and `src` + `tgt_rejected` sequence length. Longer sequences will be dropped."""
 
     max_num_tokens: int = 8192 * 2
-    """The maximum number of tokens per batch."""
+    """The maximum number of total `src`, `tgt_chosen`, and `tgt_rejected` tokens per batch."""
 
     example_shuffle_window: int = 10_000
     """The size of the sliding window for shuffling examples."""


### PR DESCRIPTION
**What does this PR do? Please describe:**
Change preference optimization lengthbatching to count max_num_tokens by src + tgt_chosen + tgt_rejected rather than max(src + tgt_chosen, src + tgt_rejected) to improve batch memory consistency and prevent surprise OOMs.

![Screenshot 2024-08-23 at 2 46 08 PM](https://github.com/user-attachments/assets/f488ecff-e6f9-4c37-90ae-8a4d38af7365)

![Screenshot 2024-08-23 at 4 20 15 PM](https://github.com/user-attachments/assets/9ac86058-bcdc-47e3-8cdf-47d2b6965464)


**Does your PR introduce any breaking changes? If yes, please list them:**
List of all backwards-incompatible changes.

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [ ] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
