### PR TITLE
Use weights_only for load

### DIFF
--- a/tests/integration/models/test_s2t_transformer.py
+++ b/tests/integration/models/test_s2t_transformer.py
@@ -66,7 +66,7 @@ def test_load_s2t_conformer_rel_pos_covost_st_en_de() -> None:
 def assert_translation(
     model: TransformerModel, tokenizer: S2TTransformerTokenizer, expected: str
 ) -> None:
-    fbank = torch.load(TEST_FBANK_PATH).to(device)
+    fbank = torch.load(TEST_FBANK_PATH, weights_only=True).to(device)
 
     generator = BeamSearchSeq2SeqGenerator(model)
 


### PR DESCRIPTION
`torch.load` without `weights_only` parameter is unsafe. Explicitly set `weights_only` to False only if you trust the data you load and full pickle functionality is needed, otherwise set `weights_only=True`.

If `weights_only=True` doesn't work for some cases, then explicit `weights_only=False` should be used.

Found with https://github.com/pytorch-labs/torchfix/