### PR TITLE
Rename librispeech_asr to char_tokenizer

### DIFF
--- a/src/fairseq2/assets/cards/datasets/librispeech.yaml
+++ b/src/fairseq2/assets/cards/datasets/librispeech.yaml
@@ -7,7 +7,7 @@
 name: librispeech_asr
 dataset_family: generic_asr
 tokenizer: "https://dl.fbaipublicfiles.com/fairseq/wav2vec/librispeech_asr.model"
-tokenizer_family: librispeech_asr
+tokenizer_family: char_tokenizer
 
 ---
 

--- a/src/fairseq2/data/text/__init__.py
+++ b/src/fairseq2/data/text/__init__.py
@@ -31,6 +31,7 @@ from fairseq2.data.text.sentencepiece import (
 from fairseq2.data.text.sentencepiece import (
     default_raw_sentencepiece_tokenizer_loader as default_raw_sentencepiece_tokenizer_loader,
 )
+from fairseq2.data.text.sentencepiece import load_char_tokenizer as load_char_tokenizer
 from fairseq2.data.text.sentencepiece import (
     vocab_info_from_sentencepiece as vocab_info_from_sentencepiece,
 )

--- a/src/fairseq2/data/text/sentencepiece.py
+++ b/src/fairseq2/data/text/sentencepiece.py
@@ -20,6 +20,7 @@ from fairseq2.data.text.text_tokenizer import (
     AbstractTextTokenizerLoader,
     TextTokenDecoder,
     TextTokenEncoder,
+    load_text_tokenizer,
 )
 from fairseq2.data.vocabulary_info import VocabularyInfo
 from fairseq2.typing import Device
@@ -314,3 +315,8 @@ def vocab_info_from_sentencepiece(model: SentencePieceModel) -> VocabularyInfo:
         model.eos_idx,
         model.pad_idx,
     )
+
+
+load_char_tokenizer = default_raw_sentencepiece_tokenizer_loader
+
+load_text_tokenizer.register("char_tokenizer", load_char_tokenizer)

--- a/src/fairseq2/datasets/asr.py
+++ b/src/fairseq2/datasets/asr.py
@@ -27,13 +27,7 @@ from fairseq2.data import (
     read_sequence,
 )
 from fairseq2.data.audio import AudioDecoder
-from fairseq2.data.text import (
-    StrSplitter,
-    TextTokenizer,
-    default_raw_sentencepiece_tokenizer_loader,
-    load_text_tokenizer,
-    read_text,
-)
+from fairseq2.data.text import StrSplitter, TextTokenizer, read_text
 from fairseq2.datasets.batching import Batching, LengthBatching, StaticBatching
 from fairseq2.datasets.data_reader import DataPipelineReader, DataReader
 from fairseq2.datasets.error import DatasetError
@@ -394,7 +388,3 @@ class GenericAsrDatasetLoader(AbstractDatasetLoader[GenericAsrDataset]):
 load_generic_asr_dataset = GenericAsrDatasetLoader()
 
 load_asr_dataset.register("generic_asr", load_generic_asr_dataset)
-
-load_librispeech_asr_tokenizer = default_raw_sentencepiece_tokenizer_loader
-
-load_text_tokenizer.register("librispeech_asr", load_librispeech_asr_tokenizer)

--- a/src/fairseq2/recipes/wav2vec2/__init__.py
+++ b/src/fairseq2/recipes/wav2vec2/__init__.py
@@ -20,10 +20,7 @@ from fairseq2.recipes.wav2vec2.train import (
 
 def _setup_wav2vec2_cli(cli: Cli) -> None:
     default_sweep_tagger.extend_allow_set(
-        "max_audio_len",
-        "min_audio_len",
-        "normalize_audio",
-        "finetune_from_model",
+        "max_audio_len", "min_audio_len", "normalize_audio"
     )
 
     group = cli.add_group("wav2vec2", help="wav2vec 2.0 pretraining recipes")

--- a/src/fairseq2/recipes/wav2vec2/asr/eval.py
+++ b/src/fairseq2/recipes/wav2vec2/asr/eval.py
@@ -17,7 +17,7 @@ from typing_extensions import override
 from fairseq2.assets import AssetNotFoundError, default_asset_store
 from fairseq2.checkpoint import CheckpointModelMetadataProvider
 from fairseq2.config_registry import ConfigRegistry
-from fairseq2.data.text import TextTokenDecoder, TextTokenizer, load_text_tokenizer
+from fairseq2.data.text import TextTokenDecoder, TextTokenizer, load_char_tokenizer
 from fairseq2.datasets import LengthBatching
 from fairseq2.datasets.asr import GenericAsrDataset, load_asr_dataset
 from fairseq2.gang import Gang
@@ -119,7 +119,7 @@ def load_wav2vec2_asr_evaluator(
     # Load the tokenizer.
     log.info("Loading {} tokenizer.", model_card.name)
 
-    tokenizer = load_text_tokenizer(model_card)
+    tokenizer = load_char_tokenizer(model_card)
 
     log.info("Tokenizer loaded.")
 

--- a/src/fairseq2/recipes/wav2vec2/asr/train.py
+++ b/src/fairseq2/recipes/wav2vec2/asr/train.py
@@ -18,7 +18,7 @@ from typing_extensions import override
 from fairseq2.assets import AssetNotFoundError, default_asset_store
 from fairseq2.checkpoint import CheckpointModelMetadataProvider, FileCheckpointManager
 from fairseq2.config_registry import ConfigRegistry
-from fairseq2.data.text import load_text_tokenizer
+from fairseq2.data.text import load_char_tokenizer
 from fairseq2.datasets import LengthBatching
 from fairseq2.datasets.asr import GenericAsrDataset, load_asr_dataset
 from fairseq2.gang import Gang
@@ -298,7 +298,7 @@ def load_wav2vec2_asr_trainer(
     # Load the tokenizer.
     log.info("Loading {} tokenizer.", tokenizer_card.name)
 
-    tokenizer = load_text_tokenizer(tokenizer_card)
+    tokenizer = load_char_tokenizer(tokenizer_card)
 
     log.info("Tokenizer loaded.")
 


### PR DESCRIPTION
This PR renames `librispeech_asr` to `char_tokenizer` to make it more generic and usable with other char-based sentencepiece models.