### PR TITLE
Introduce DependencyContainer

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -9,6 +9,11 @@ to train custom models for translation, summarization, language modeling, and
 other content generation tasks.
 
 .. toctree::
+    :maxdepth: 2
+
+    reference/index
+
+.. toctree::
    :caption: fairseq2 Reference
    :maxdepth: 1
 

--- a/doc/reference/fairseq2.dependency.rst
+++ b/doc/reference/fairseq2.dependency.rst
@@ -1,0 +1,133 @@
+===================
+fairseq2.dependency
+===================
+
+.. module:: fairseq2.dependency
+    :synopsis: A lightweight dependency injection API
+
+    fairseq2 relies on the `dependency inversion principle`_ to maintain a clean,
+    well-tested, and extensible code base.
+
+    This module contains the abstract classes :class:`DependencyResolver` and
+    :class:`DependencyContainer`, as well as the
+    :class:`StandardDependencyContainer` class, as a lightweight `dependency
+    injection`_ API.
+
+.. _`dependency inversion principle`: https://en.wikipedia.org/wiki/Dependency_inversion_principle
+.. _`dependency injection`: https://en.wikipedia.org/wiki/Dependency_injection
+
+.. class:: DependencyResolver()
+
+    extends :class:`~abc.ABC`
+
+    .. method:: resolve[T](kls: type[T], key: str | None = None) -> T
+        :abstractmethod:
+
+        Return the singleton dependency of type ``T``. If ``key`` is not ``None``,
+        the singleton dependency with the specified key will be returned.
+
+        If a dependency of type ``T``, or a dependency of type ``T`` with ``key``
+        cannot be found, a :class:`LookupError` is raised.
+
+    .. method:: resolve_optional(kls: type[T], key: str | None = None) -> T | None
+        :abstractmethod:
+
+        Return the singleton dependency of type ``T`` similar to :meth:`resolve`,
+        but return ``None`` instead of raising a :class:`LookupError` if the
+        dependency is not found.
+
+    .. method:: resolve_all(kls: type[T]) -> Iterable[T]:
+        :abstractmethod:
+
+        Return all singleton dependencies of type ``T`` that have no associated
+        key.
+
+        If multiple singleton dependencies of type ``T`` are registered,
+        :meth:`resolve` only returns the last registered one. In contrast,
+        :meth:`resolve_all` returns them all, in the order that they were
+        registered.
+
+        If no dependency can be found, an empty iterable will be returned.
+
+    .. method:: resolve_all_keyed(kls: type[T]) -> Iterable[tuple[str, T]]
+        :abstractmethod:
+
+        Return all singleton dependencies of type ``T`` that have an associated
+        key.
+
+        This method behaves similar to :meth:`resolve_all`, but returns an
+        iterable of key-dependency pairs instead.
+
+.. class:: DependencyContainer()
+
+    extends :class:`DependencyResolver`
+
+    .. method:: register[T](kls: type[T], factory: DependencyFactory[T], key: str | None = None) -> None
+        :abstractmethod:
+
+        Register a singleton dependency of type ``T``.
+
+        ``factory`` is expected to return an instance of type ``T``, or ``None``
+        if the instance cannot be created. It should follow the protocol::
+
+            class DependencyFactory(Protocol[T]):
+                def __call__(self, resolver: DependencyResolver) -> T | None:
+                    ...
+
+        ``resolver`` passed to ``factory`` can be used to resolve the
+        dependencies needed to construct the instance itself.
+
+        Optionally ``key`` can be specified. In this case, the same key must
+        be passed to :meth:`~DependencyResolver.resolve` to return the
+        dependency.
+
+        If multiple singleton dependencies of type ``T``, optionally with the
+        same key, are registered, :meth:`~DependencyResolver.resolve` will
+        return the last registered one.
+
+    .. method:: register_instance[T](kls: type[T], obj: T, key: str | None = None) -> None
+        :abstractmethod:
+
+        Register an existing singleton dependency of type ``T``.
+
+        Other than registering ``obj`` instead of a factory, the method behaves
+        the same as :meth:`register`.
+
+.. class:: StandardDependencyContainer()
+    :final:
+
+    implements :class:`DependencyContainer`
+
+    This is the standard implementation of :class:`DependencyContainer` and
+    transitively of :class:`DependencyResolver`.
+
+    ::
+
+        from abc import ABC, abstractmethod
+
+        from fairseq2.dependency import DependencyResolver, StandardDependencyContainer
+
+        container = StandardDependencyContainer()
+
+        # The interface
+        class Foo(ABC):
+            @abstractmethod
+            def foo(self) -> None:
+                ...
+
+        # The implementation
+        class FooImpl(Foo):
+            def foo(self) -> None:
+                pass
+
+        # The factory
+        def create_foo(resolver: DependencyResolver) -> Foo:
+            assert resolver is container
+
+            return FooImpl()
+
+        container.register(Foo, create_foo)
+
+        foo = container.resolve(Foo)
+
+        assert isinstance(foo, FooImpl)

--- a/doc/reference/index.rst
+++ b/doc/reference/index.rst
@@ -1,0 +1,8 @@
+=============
+API Reference
+=============
+
+.. toctree::
+    :maxdepth: 1
+
+    fairseq2.dependency

--- a/src/fairseq2/dependency.py
+++ b/src/fairseq2/dependency.py
@@ -1,0 +1,232 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Iterable
+from typing import Final, Protocol, TypeVar, final
+
+from typing_extensions import override
+
+T = TypeVar("T")
+
+T_co = TypeVar("T_co", covariant=True)
+
+
+class DependencyResolver(ABC):
+    @abstractmethod
+    def resolve(self, kls: type[T], key: str | None = None) -> T:
+        ...
+
+    @abstractmethod
+    def resolve_optional(self, kls: type[T], key: str | None = None) -> T | None:
+        ...
+
+    @abstractmethod
+    def resolve_all(self, kls: type[T]) -> Iterable[T]:
+        ...
+
+    @abstractmethod
+    def resolve_all_keyed(self, kls: type[T]) -> Iterable[tuple[str, T]]:
+        ...
+
+
+class DependencyFactory(Protocol[T_co]):
+    def __call__(self, resolver: DependencyResolver) -> T_co | None:
+        ...
+
+
+class DependencyContainer(DependencyResolver):
+    @abstractmethod
+    def register(
+        self, kls: type[T], factory: DependencyFactory[T], key: str | None = None
+    ) -> None:
+        ...
+
+    @abstractmethod
+    def register_instance(self, kls: type[T], obj: T, key: str | None = None) -> None:
+        ...
+
+
+@final
+class StandardDependencyContainer(DependencyContainer):
+    _registrations: dict[type, list[_Registration]]
+    _keyed_registrations: dict[type, dict[str, _Registration]]
+
+    def __init__(self) -> None:
+        self._registrations = {}
+        self._keyed_registrations = {}
+
+    @override
+    def register(
+        self, kls: type[T], factory: DependencyFactory[T], key: str | None = None
+    ) -> None:
+        self._register(kls, key, _Registration(factory=factory))
+
+    @override
+    def register_instance(self, kls: type[T], obj: T, key: str | None = None) -> None:
+        self._register(kls, key, _Registration(obj=obj))
+
+    def _register(
+        self, kls: type, key: str | None, registration: _Registration
+    ) -> None:
+        if key is None:
+            registrations = self._registrations.get(kls)
+            if registrations is None:
+                registrations = []
+
+                self._registrations[kls] = registrations
+
+            registrations.append(registration)
+        else:
+            keyed_registrations = self._keyed_registrations.get(kls)
+            if keyed_registrations is None:
+                keyed_registrations = {}
+
+                self._keyed_registrations[kls] = keyed_registrations
+
+            keyed_registrations[key] = registration
+
+    @override
+    def resolve(self, kls: type[T], key: str | None = None) -> T:
+        if key is None:
+            try:
+                registration = self._registrations[kls][-1]
+            except (KeyError, IndexError):
+                raise LookupError(
+                    f"No registered factory or instance found for `{kls}`."
+                ) from None
+
+            obj = self._get_object(kls, registration)
+            if obj is None:
+                raise LookupError(
+                    f"The registered factory for `{kls}` returned `None`."
+                )
+        else:
+            try:
+                registration = self._keyed_registrations[kls][key]
+            except KeyError:
+                raise LookupError(
+                    f"No registered factory or instance found for `{kls}` with the key '{key}'."
+                ) from None
+
+            obj = self._get_object(kls, registration)
+            if obj is None:
+                raise LookupError(
+                    f"The registered factory for `{kls}` with the key '{key}' returned `None`."
+                )
+
+        return obj
+
+    @override
+    def resolve_optional(self, kls: type[T], key: str | None = None) -> T | None:
+        try:
+            return self.resolve(kls, key)
+        except LookupError:
+            return None
+
+    @override
+    def resolve_all(self, kls: type[T]) -> Iterable[T]:
+        objs: list[T] = []
+
+        registrations = self._registrations.get(kls)
+        if registrations is None:
+            return objs
+
+        for registration in registrations:
+            obj = self._get_object(kls, registration)
+            if obj is not None:
+                objs.append(obj)
+
+        return objs
+
+    @override
+    def resolve_all_keyed(self, kls: type[T]) -> Iterable[tuple[str, T]]:
+        objs: list[tuple[str, T]] = []
+
+        keyed_registrations = self._keyed_registrations.get(kls)
+        if keyed_registrations is None:
+            return objs
+
+        for key, registration in keyed_registrations.items():
+            obj = self._get_object(kls, registration)
+            if obj is not None:
+                objs.append((key, obj))
+
+        return objs
+
+    def _get_object(self, kls: type[T], registration: _Registration) -> T | None:
+        if registration.obj is _NOT_SET:
+            obj = registration.factory(self)
+
+            if not registration.transient:
+                registration.obj = obj
+        else:
+            obj = registration.obj
+
+        if obj is not None and not isinstance(obj, kls):
+            raise TypeError(
+                f"The object in the container is expected to be of type `{kls}`, but is of type `{type(obj)}` instead. Please file a bug report."
+            )
+
+        return obj
+
+
+_NOT_SET: Final = object()
+
+
+class _Registration:
+    obj: object
+    factory: DependencyFactory[object]
+    transient: bool
+
+    def __init__(
+        self,
+        *,
+        obj: object = _NOT_SET,
+        factory: DependencyFactory[object] | None = None,
+        transient: bool = False,
+    ) -> None:
+        if obj is _NOT_SET and factory is None:
+            raise RuntimeError(
+                "Neither `obj` nor `factory` is specified. Please file a bug report."
+            )
+
+        if factory is None:
+            factory = lambda _: obj
+
+        self.obj = obj
+        self.factory = factory
+        self.transient = transient
+
+
+_container: DependencyContainer | None = None
+
+
+def get_default_container() -> DependencyContainer:
+    global _container
+
+    if _container is None:
+        raise RuntimeError(
+            "fairseq2 is not initialized. Make sure to call `fairseq2.setup_fairseq2()`."
+        )
+
+    return _container
+
+
+def set_default_container(container: DependencyContainer) -> None:
+    global _container
+
+    _container = container
+
+
+def get_default_resolver() -> DependencyResolver:
+    return get_default_container()
+
+
+def resolve(kls: type[T], key: str | None = None) -> T:
+    return get_default_resolver().resolve(kls, key)

--- a/tests/unit/test_dependency.py
+++ b/tests/unit/test_dependency.py
@@ -1,0 +1,384 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+import pytest
+from typing_extensions import override
+
+from fairseq2.dependency import DependencyResolver, StandardDependencyContainer
+
+
+class Foo(ABC):
+    @abstractmethod
+    def foo(self) -> int:
+        ...
+
+
+class FooImpl1(Foo):
+    @override
+    def foo(self) -> int:
+        return 1
+
+
+class FooImpl2(Foo):
+    @override
+    def foo(self) -> int:
+        return 2
+
+
+class TestStandardDependencyContainer:
+    def test_register_resolve_works(self) -> None:
+        container = StandardDependencyContainer()
+
+        expected_foo = FooImpl1()
+
+        def create_foo(resolver: DependencyResolver) -> Foo:
+            return expected_foo
+
+        container.register(Foo, create_foo)
+
+        foo1 = container.resolve(Foo)
+        foo2 = container.resolve_optional(Foo)
+
+        assert foo1 is expected_foo
+        assert foo2 is expected_foo
+
+    def test_keyed_register_resolve_works(self) -> None:
+        container = StandardDependencyContainer()
+
+        expected_foo = FooImpl1()
+
+        def create_foo(resolver: DependencyResolver) -> Foo:
+            return expected_foo
+
+        container.register(Foo, create_foo, key="foo")
+
+        foo1 = container.resolve(Foo, "foo")
+        foo2 = container.resolve_optional(Foo, "foo")
+
+        assert foo1 is expected_foo
+        assert foo2 is expected_foo
+
+    def test_register_instance_resolve_works(self) -> None:
+        container = StandardDependencyContainer()
+
+        expected_foo = FooImpl1()
+
+        container.register_instance(Foo, expected_foo)
+
+        foo1 = container.resolve(Foo)
+        foo2 = container.resolve_optional(Foo)
+
+        assert foo1 is expected_foo
+        assert foo2 is expected_foo
+
+    def test_keyed_register_instance_resolve_works(self) -> None:
+        container = StandardDependencyContainer()
+
+        expected_foo = FooImpl1()
+
+        container.register_instance(Foo, expected_foo, key="foo")
+
+        foo1 = container.resolve(Foo, "foo")
+        foo2 = container.resolve_optional(Foo, "foo")
+
+        assert foo1 is expected_foo
+        assert foo2 is expected_foo
+
+    def test_repeated_register_resolve_works(self) -> None:
+        container = StandardDependencyContainer()
+
+        expected_foo = FooImpl2()
+
+        def create_foo1(resolver: DependencyResolver) -> Foo:
+            return FooImpl1()
+
+        def create_foo2(resolver: DependencyResolver) -> Foo:
+            return expected_foo
+
+        container.register_instance(Foo, FooImpl1())
+
+        container.register(Foo, create_foo1)
+        container.register(Foo, create_foo2)
+
+        foo1 = container.resolve(Foo)
+        foo2 = container.resolve_optional(Foo)
+
+        assert foo1 is expected_foo
+        assert foo2 is expected_foo
+
+    def test_repeated_keyed_register_resolve_works(self) -> None:
+        container = StandardDependencyContainer()
+
+        expected_foo = FooImpl2()
+
+        def create_foo1(resolver: DependencyResolver) -> Foo:
+            return FooImpl1()
+
+        def create_foo2(resolver: DependencyResolver) -> Foo:
+            return expected_foo
+
+        container.register_instance(Foo, FooImpl1(), key="foo")
+
+        container.register(Foo, create_foo1, key="foo")
+        container.register(Foo, create_foo2, key="foo")
+
+        foo1 = container.resolve(Foo, key="foo")
+        foo2 = container.resolve_optional(Foo, key="foo")
+
+        assert foo1 is expected_foo
+        assert foo2 is expected_foo
+
+    def test_unkeyed_keyed_register_resolve_works(self) -> None:
+        container = StandardDependencyContainer()
+
+        expected_foo1 = FooImpl1()
+        expected_foo2 = FooImpl2()
+
+        def create_foo1(resolver: DependencyResolver) -> Foo:
+            return expected_foo1
+
+        def create_foo2(resolver: DependencyResolver) -> Foo:
+            return expected_foo2
+
+        container.register(Foo, create_foo1)
+        container.register(Foo, create_foo2, key="foo")
+
+        foo1 = container.resolve(Foo)
+        foo2 = container.resolve(Foo, key="foo")
+
+        assert foo1 is expected_foo1
+        assert foo2 is expected_foo2
+
+    def test_resolve_raises_error_when_type_is_invalid(self) -> None:
+        container = StandardDependencyContainer()
+
+        def create_foo(resolver: DependencyResolver) -> str:
+            return "foo"
+
+        container.register(Foo, create_foo)
+
+        with pytest.raises(
+            TypeError, match=rf"^The object in the container is expected to be of type `{Foo}`, but is of type `{str}` instead\. Please file a bug report\.$"  # fmt: skip
+        ):
+            container.resolve(Foo)
+
+    def test_keyed_resolve_raises_error_when_type_is_invalid(self) -> None:
+        container = StandardDependencyContainer()
+
+        def create_foo(resolver: DependencyResolver) -> str:
+            return "foo"
+
+        container.register(Foo, create_foo, key="foo")
+
+        with pytest.raises(
+            TypeError, match=rf"^The object in the container is expected to be of type `{Foo}`, but is of type `{str}` instead\. Please file a bug report\.$"  # fmt: skip
+        ):
+            container.resolve(Foo, "foo")
+
+    def test_resolve_raises_error_when_dependency_is_not_registered(self) -> None:
+        container = StandardDependencyContainer()
+
+        with pytest.raises(
+            LookupError, match=rf"^No registered factory or instance found for `{Foo}`\.$"  # fmt: skip
+        ):
+            container.resolve(Foo)
+
+    def test_keyed_resolve_raises_error_when_dependency_is_not_registered(self) -> None:
+        container = StandardDependencyContainer()
+
+        with pytest.raises(
+            LookupError, match=rf"^No registered factory or instance found for `{Foo}` with the key 'foo'\.$"  # fmt: skip
+        ):
+            container.resolve(Foo, "foo")
+
+    def test_resolve_raises_error_when_dependency_is_none(self) -> None:
+        container = StandardDependencyContainer()
+
+        def create_foo(resolver: DependencyResolver) -> None:
+            return None
+
+        container.register(Foo, create_foo)
+
+        with pytest.raises(
+            LookupError, match=rf"^The registered factory for `{Foo}` returned `None`\.$"  # fmt: skip
+        ):
+            container.resolve(Foo)
+
+    def test_keyed_resolve_raises_error_when_dependency_is_none(self) -> None:
+        container = StandardDependencyContainer()
+
+        def create_foo(resolver: DependencyResolver) -> None:
+            return None
+
+        container.register(Foo, create_foo, key="foo")
+
+        with pytest.raises(
+            LookupError, match=rf"^The registered factory for `{Foo}` with the key 'foo' returned `None`\.$"  # fmt: skip
+        ):
+            container.resolve(Foo, "foo")
+
+    def test_resolve_optional_works_when_dependency_is_not_registered(self) -> None:
+        container = StandardDependencyContainer()
+
+        foo = container.resolve_optional(Foo)
+
+        assert foo is None
+
+    def test_keyed_resolve_optional_works_when_dependency_is_not_registered(
+        self,
+    ) -> None:
+        container = StandardDependencyContainer()
+
+        foo = container.resolve_optional(Foo, "foo")
+
+        assert foo is None
+
+    def test_resolve_optional_works_when_dependency_is_none(self) -> None:
+        container = StandardDependencyContainer()
+
+        def create_foo(resolver: DependencyResolver) -> None:
+            return None
+
+        container.register(Foo, create_foo)
+
+        foo = container.resolve_optional(Foo)
+
+        assert foo is None
+
+    def test_keyed_resolve_optional_works_when_dependency_is_none(self) -> None:
+        container = StandardDependencyContainer()
+
+        def create_foo(resolver: DependencyResolver) -> None:
+            return None
+
+        container.register(Foo, create_foo)
+
+        foo = container.resolve_optional(Foo, "foo")
+
+        assert foo is None
+
+    def test_dependency_factory_works(self) -> None:
+        container = StandardDependencyContainer()
+
+        def create_foo(resolver: DependencyResolver) -> Foo:
+            assert resolver is container
+
+            return FooImpl1()
+
+        container.register(Foo, create_foo)
+
+        container.resolve(Foo)
+
+    def test_register_resolve_all_works(self) -> None:
+        container = StandardDependencyContainer()
+
+        expected_foo1 = FooImpl1()
+        expected_foo2 = FooImpl2()
+
+        def create_foo1(resolver: DependencyResolver) -> Foo:
+            return expected_foo1
+
+        def create_foo2(resolver: DependencyResolver) -> Foo:
+            return expected_foo2
+
+        def create_foo3(resolver: DependencyResolver) -> None:
+            return None
+
+        container.register(Foo, create_foo1)
+        container.register(Foo, create_foo3)
+        container.register(Foo, create_foo2)
+
+        foos = list(container.resolve_all(Foo))
+
+        assert len(foos) == 2
+
+        assert foos[0] is expected_foo1
+        assert foos[1] is expected_foo2
+
+    def test_keyed_register_resolve_all_works(self) -> None:
+        container = StandardDependencyContainer()
+
+        expected_foo1 = FooImpl1()
+        expected_foo2 = FooImpl2()
+
+        def create_foo1(resolver: DependencyResolver) -> Foo:
+            return expected_foo1
+
+        def create_foo2(resolver: DependencyResolver) -> Foo:
+            return expected_foo2
+
+        def create_foo3(resolver: DependencyResolver) -> None:
+            return None
+
+        container.register(Foo, create_foo1, key="foo1")
+        container.register(Foo, create_foo3, key="foo3")
+        container.register(Foo, create_foo2, key="foo2")
+
+        foos = dict(container.resolve_all_keyed(Foo))
+
+        assert len(foos) == 2
+
+        assert foos["foo1"] is expected_foo1
+        assert foos["foo2"] is expected_foo2
+
+    def test_register_resolve_all_works_when_no_dependency_is_registered(self) -> None:
+        container = StandardDependencyContainer()
+
+        foos = list(container.resolve_all(Foo))
+
+        assert len(foos) == 0
+
+    def test_keyed_register_resolve_all_works_when_no_dependency_is_registered(
+        self,
+    ) -> None:
+        container = StandardDependencyContainer()
+
+        foos = dict(container.resolve_all_keyed(Foo))
+
+        assert len(foos) == 0
+
+    def test_unkeyed_keyed_register_resolve_all_works(self) -> None:
+        container = StandardDependencyContainer()
+
+        expected_foo1 = FooImpl1()
+        expected_foo2 = FooImpl2()
+        expected_foo3 = FooImpl1()
+        expected_foo4 = FooImpl2()
+
+        def create_foo1(resolver: DependencyResolver) -> Foo:
+            return expected_foo1
+
+        def create_foo2(resolver: DependencyResolver) -> Foo:
+            return expected_foo2
+
+        def create_foo3(resolver: DependencyResolver) -> Foo:
+            return expected_foo3
+
+        def create_foo4(resolver: DependencyResolver) -> Foo:
+            return expected_foo4
+
+        container.register(Foo, create_foo1)
+        container.register(Foo, create_foo2, key="foo2")
+        container.register(Foo, create_foo3)
+        container.register(Foo, create_foo4, key="foo4")
+
+        list_foos = list(container.resolve_all(Foo))
+
+        assert len(list_foos) == 2
+
+        assert list_foos[0] is expected_foo1
+        assert list_foos[1] is expected_foo3
+
+        dict_foos = dict(container.resolve_all_keyed(Foo))
+
+        assert len(dict_foos) == 2
+
+        assert dict_foos["foo2"] is expected_foo2
+        assert dict_foos["foo4"] is expected_foo4


### PR DESCRIPTION
This PR introduces `DependencyContainer`. Follow-up PRs will gradually migrate individual "registry" types to use `DependencyContainer` instead.