### PR TITLE
Fix batch size metric when grad accumulation is enabled

### DIFF
--- a/src/fairseq2/metrics/aggregation.py
+++ b/src/fairseq2/metrics/aggregation.py
@@ -6,18 +6,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
-
 import torch
 from torch import Tensor
 from torcheval.metrics import Max as MaxBase
 from torcheval.metrics import Mean as MeanBase
-from torcheval.metrics import Metric
 from torcheval.metrics import Min as MinBase
 from torcheval.metrics import Sum as SumBase
 from typing_extensions import Self, override
-
-from fairseq2.typing import Device
 
 
 class Min(MinBase):
@@ -78,39 +73,5 @@ class Sum(SumBase):
             input_ = torch.tensor(input_)
 
         super().update(input_, weight=weight)
-
-        return self
-
-
-class MaxSum(Metric[Tensor]):
-    """Calculate the sum of all elements in all the input tensors locally and
-    take the maximum value when merged with other metrics."""
-
-    sum_: Tensor
-
-    def __init__(self, *, device: Device | None = None) -> None:
-        super().__init__(device=device)
-
-        sum_ = torch.zeros((), device=device, dtype=torch.int64)
-
-        self._add_state("sum_", sum_)
-
-    @override
-    @torch.inference_mode()
-    def update(self, input_: int | Tensor) -> Self:
-        self.sum_ += input_
-
-        return self
-
-    @override
-    @torch.inference_mode()
-    def compute(self) -> Tensor:
-        return self.sum_
-
-    @override
-    @torch.inference_mode()
-    def merge_state(self, metrics: Iterable[MaxSum]) -> Self:
-        for metric in metrics:
-            self.sum_ = torch.max(self.sum_, metric.sum_.to(self.device))
 
         return self

--- a/src/fairseq2/recipes/common_metrics.py
+++ b/src/fairseq2/recipes/common_metrics.py
@@ -6,26 +6,22 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 import torch
 from torch import Tensor
 from torcheval.metrics import Throughput
-from typing_extensions import override
 
 from fairseq2.gang import Gang
 from fairseq2.generation import Seq2SeqGeneratorOutput, SequenceGeneratorOutput
 from fairseq2.metrics import MetricBag
-from fairseq2.metrics.aggregation import Max, MaxSum, Mean, Sum
+from fairseq2.metrics.aggregation import Max, Mean, Sum
 from fairseq2.models.seq2seq import Seq2SeqBatch
 from fairseq2.models.sequence import SequenceBatch
 
 
-class TaskMetricBag(MetricBag):
-    """Holds the metrics of a machine learning task."""
+class BaseMetricBag(MetricBag):
+    """Holds the base metrics of a machine learning task."""
 
     _train: bool
-    _num_batches: MaxSum
     _num_examples: Sum
     _num_elements: Sum
     _total_num_examples: Sum | None
@@ -33,7 +29,7 @@ class TaskMetricBag(MetricBag):
 
     def __init__(self, gang: Gang, train: bool) -> None:
         """
-        :para train:
+        :param train:
             If ``True``, indicates that this bag is used in a training task.
         """
         super().__init__(gang)
@@ -41,8 +37,6 @@ class TaskMetricBag(MetricBag):
         d = gang.device
 
         self._train = train
-
-        self.register_metric("_num_batches", MaxSum(device=d), persistent=False)
 
         self.register_metric("_num_examples", Sum(device=d), persistent=False)
         self.register_metric("_num_elements", Sum(device=d), persistent=False)
@@ -54,27 +48,8 @@ class TaskMetricBag(MetricBag):
             self._total_num_examples = None
             self._total_num_elements = None
 
-    @override
-    def process_metric_values(self, values: dict[str, Any]) -> None:
-        super().process_metric_values(values)
 
-        num_batches = values.pop("num_batches")
-
-        num_examples = values["num_examples"]
-        num_elements = values["num_elements"]
-
-        if num_batches > 0:
-            values["batch_size"] = num_examples // num_batches
-        else:
-            values["batch_size"] = 0
-
-        if num_batches > 0:
-            values["elements_per_batch"] = num_elements // num_batches
-        else:
-            values["elements_per_batch"] = 0
-
-
-class SequenceMetricBag(TaskMetricBag):
+class SequenceMetricBag(BaseMetricBag):
     """Holds the metrics of a sequence model training or evaluation task."""
 
     _nll_loss: Mean
@@ -98,21 +73,18 @@ class SequenceMetricBag(TaskMetricBag):
     @torch.inference_mode()
     def update_nll_loss(self, batch: SequenceBatch, loss: Tensor) -> None:
         """Update the NLL loss metric."""
-        num_target_elements = batch.num_target_elements()
+        n = batch.num_target_elements()
 
-        self._nll_loss.update(
-            loss.detach() / num_target_elements, weight=num_target_elements
-        )
+        self._nll_loss.update(loss.detach() / n, weight=n)
 
     @torch.inference_mode()
     def update_batch_metrics(self, batch: SequenceBatch) -> None:
         """Update the batch metrics."""
         num_examples = batch.batch_size
-        num_elements = batch.num_elements()
 
         num_target_elements = batch.num_target_elements()
 
-        self._num_batches.update(1)
+        num_elements = batch.num_elements()
 
         self._num_examples.update(num_examples)
         self._num_elements.update(num_elements)
@@ -122,6 +94,7 @@ class SequenceMetricBag(TaskMetricBag):
         if self._train:
             assert self._total_num_examples is not None
             assert self._total_num_elements is not None
+
             assert self._total_num_target_elements is not None
 
             self._total_num_examples.update(num_examples)
@@ -130,7 +103,7 @@ class SequenceMetricBag(TaskMetricBag):
             self._total_num_target_elements.update(num_target_elements)
 
 
-class Seq2SeqMetricBag(TaskMetricBag):
+class Seq2SeqMetricBag(BaseMetricBag):
     """Holds the metrics of a sequence-to-sequence model training or evaluation task."""
 
     _nll_loss: Mean
@@ -175,8 +148,6 @@ class Seq2SeqMetricBag(TaskMetricBag):
 
         num_elements = num_source_elements + num_target_elements
 
-        self._num_batches.update(1)
-
         self._num_examples.update(num_examples)
         self._num_elements.update(num_elements)
 
@@ -197,7 +168,7 @@ class Seq2SeqMetricBag(TaskMetricBag):
             self._total_num_target_elements.update(num_target_elements)
 
 
-class SequenceGenerationMetricBag(TaskMetricBag):
+class SequenceGenerationMetricBag(BaseMetricBag):
     """Holds the metrics of a sequence generation task."""
 
     _generator_prefill_size: Sum
@@ -232,8 +203,6 @@ class SequenceGenerationMetricBag(TaskMetricBag):
 
         num_elements = prefill_size + num_generated_elements
 
-        self._num_batches.update(1)
-
         self._num_examples.update(num_examples)
         self._num_elements.update(num_elements)
 
@@ -250,7 +219,7 @@ class SequenceGenerationMetricBag(TaskMetricBag):
         self._generator_cache_capacity.update(output.counters.cache_capacity)
 
 
-class Seq2SeqGenerationMetricBag(TaskMetricBag):
+class Seq2SeqGenerationMetricBag(BaseMetricBag):
     """Holds the metrics of a sequence-to-sequence generation task."""
 
     _num_source_elements: Sum
@@ -290,8 +259,6 @@ class Seq2SeqGenerationMetricBag(TaskMetricBag):
 
         num_elements = num_source_elements + prefill_size + num_generated_elements
 
-        self._num_batches.update(1)
-
         self._num_examples.update(num_examples)
         self._num_elements.update(num_elements)
 
@@ -310,17 +277,35 @@ class Seq2SeqGenerationMetricBag(TaskMetricBag):
         self._generator_cache_capacity.update(output.counters.cache_capacity)
 
 
-def set_throughput_value(metric_values: dict[str, Any], elapsed_time: float) -> None:
-    """Set the throughput value in ``metric_values``."""
-    try:
-        num_elements = metric_values["num_elements"]
-    except KeyError:
-        return
+def extend_batch_metrics(
+    metric_values: dict[str, object], num_batches: int, elapsed_time: float
+) -> None:
+    def get_value(name: str) -> int | float | Tensor | None:
+        try:
+            value = metric_values[name]
+        except KeyError:
+            return None
 
-    if not isinstance(num_elements, (int, float, Tensor)):
-        return
+        if not isinstance(value, (int, float, Tensor)):
+            return None
 
-    if elapsed_time == 0.0:
-        metric_values["elements_per_second"] = 0.0
-    else:
-        metric_values["elements_per_second"] = num_elements / elapsed_time
+        return value
+
+    num_examples = get_value("num_examples")
+    if num_examples is not None:
+        if num_batches > 0:
+            metric_values["batch_size"] = num_examples // num_batches
+        else:
+            metric_values["batch_size"] = 0
+
+    num_elements = get_value("num_elements")
+    if num_elements is not None:
+        if num_batches > 0:
+            metric_values["elements_per_batch"] = num_elements // num_batches
+        else:
+            metric_values["elements_per_batch"] = 0
+
+        if elapsed_time > 0.0:
+            metric_values["elements_per_second"] = num_elements / elapsed_time
+        else:
+            metric_values["elements_per_second"] = 0.0

--- a/src/fairseq2/recipes/wav2vec2/asr/common.py
+++ b/src/fairseq2/recipes/wav2vec2/asr/common.py
@@ -14,10 +14,10 @@ from torch import Tensor
 from fairseq2.gang import Gang
 from fairseq2.metrics.aggregation import Mean
 from fairseq2.models.seq2seq import Seq2SeqBatch
-from fairseq2.recipes.common_metrics import TaskMetricBag
+from fairseq2.recipes.common_metrics import BaseMetricBag
 
 
-class Wav2Vec2AsrMetricBag(TaskMetricBag):
+class Wav2Vec2AsrMetricBag(BaseMetricBag):
     """Holds the metrics of a wav2vec 2.0 ASR model training or evaluation task."""
 
     _ctc_loss: Mean
@@ -32,17 +32,16 @@ class Wav2Vec2AsrMetricBag(TaskMetricBag):
     @torch.inference_mode()
     def update_ctc_loss(self, batch: Seq2SeqBatch, loss: Tensor) -> None:
         """Update the CTC loss metric."""
-        normalized_loss = loss.detach() / batch.batch_size / math.log(2)
+        n = batch.batch_size
 
-        self._ctc_loss.update(normalized_loss, weight=batch.batch_size)
+        self._ctc_loss.update(loss.detach() / n / math.log(2), weight=n)
 
     @torch.inference_mode()
     def update_batch_metrics(self, batch: Seq2SeqBatch) -> None:
         """Update the batch metrics."""
         num_examples = batch.batch_size
-        num_elements = batch.num_source_elements()
 
-        self._num_batches.update(1)
+        num_elements = batch.num_source_elements()
 
         self._num_examples.update(num_examples)
         self._num_elements.update(num_elements)


### PR DESCRIPTION
This PR fixes the bug that causes the batch size metric to report the size of a single batch instead of the effective batch when grad accumulation is enabled.