### PR TITLE
Introduce sync_mode to datasets

### DIFF
--- a/src/fairseq2/datasets/asr.py
+++ b/src/fairseq2/datasets/asr.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any, cast, final
+from typing import Any, Literal, cast, final
 
 import torch
 from torch import Tensor
@@ -57,6 +57,7 @@ class AsrDataset(ABC):
         batch_shuffle_window: int = 1,
         drop_remainder: bool = False,
         sync_batches: bool = True,
+        sync_mode: Literal["until_first", "until_last"] = "until_first",
         max_num_batches: int | None = None,
         num_accumulate: int = 1,
         num_prefetch: int = 1,
@@ -100,6 +101,11 @@ class AsrDataset(ABC):
             can vary per process (e.g. due to unbalanced sharding or non-static
             batching) and it is critical for each process to iterate over the
             same number of batches (e.g. during training).
+        :param sync_mode:
+            If ``until_first``, stops iteration when the first rank reaches end
+            of data. If ``until_last``, stops iteration when the last rank
+            reaches end of data; ranks that have already reached their end of
+            data will return an empty list of batches.
         :param max_num_batches:
             The maximum number of batches to return.
         :param num_accumulate:
@@ -176,6 +182,7 @@ class GenericAsrDataset(AsrDataset):
         batch_shuffle_window: int = 1,
         drop_remainder: bool = False,
         sync_batches: bool = True,
+        sync_mode: Literal["until_first", "until_last"] = "until_first",
         max_num_batches: int | None = None,
         num_accumulate: int = 1,
         num_prefetch: int = 1,
@@ -316,6 +323,7 @@ class GenericAsrDataset(AsrDataset):
             num_accumulate=num_accumulate,
             drop_remainder=drop_remainder,
             sync_batches=sync_batches,
+            sync_mode=sync_mode,
         )
 
     def _retrieve_data_directory(self, split: str) -> Path:

--- a/src/fairseq2/datasets/data_reader.py
+++ b/src/fairseq2/datasets/data_reader.py
@@ -8,12 +8,12 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Iterator, Mapping
-from typing import Any, TypeVar, final
+from typing import Any, Literal, TypeVar, final
 
 from typing_extensions import Self, override
 
 from fairseq2.data import DataPipeline
-from fairseq2.datasets.utils import _reduce_num_batches
+from fairseq2.datasets.utils import _min_num_batches, _sum_num_batches
 from fairseq2.gang import Gang
 from fairseq2.logging import get_log_writer
 
@@ -73,6 +73,7 @@ class DataPipelineReader(DataReader[BatchT]):
         num_accumulate: int = 1,
         drop_remainder: bool = True,
         sync_batches: bool = True,
+        sync_mode: Literal["until_first", "until_last"] = "until_first",
     ) -> None:
         """
         :param pipeline:
@@ -90,6 +91,11 @@ class DataPipelineReader(DataReader[BatchT]):
             across all processes in the gang. Typically used when the amount of
             data to be read can vary per process (e.g. due to bucketing) and it
             is critical for each process to iterate over same number of batches.
+        :param sync_mode:
+            If ``until_first``, stops iteration when the first rank reaches end
+            of data. If ``until_last``, stops iteration when the last rank
+            reaches end of data; ranks that have already reached their end of
+            data will return an empty list of batches.
         """
         self._pipeline = pipeline
         self._pipeline_iter = iter(pipeline)
@@ -97,6 +103,7 @@ class DataPipelineReader(DataReader[BatchT]):
         self._num_accumulate = num_accumulate
         self._drop_remainder = drop_remainder
         self._sync_batches = sync_batches
+        self._sync_until_last = sync_mode == "until_last"
         self._eod = False
 
     @override
@@ -126,10 +133,13 @@ class DataPipelineReader(DataReader[BatchT]):
         local_num_batches = len(batches)
 
         if self._sync_batches and self._gang.size > 1:
-            num_batches = _reduce_num_batches(local_num_batches, self._gang, log)
+            if self._sync_until_last:
+                num_batches = _sum_num_batches(local_num_batches, self._gang)
+            else:
+                num_batches = _min_num_batches(local_num_batches, self._gang, log)
 
-            if num_batches != local_num_batches:
-                batches = batches[:num_batches]
+                if num_batches != local_num_batches:
+                    batches = batches[:num_batches]
         else:
             num_batches = local_num_batches
 

--- a/src/fairseq2/datasets/parallel_text.py
+++ b/src/fairseq2/datasets/parallel_text.py
@@ -10,7 +10,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from functools import partial
 from pathlib import Path
-from typing import Any, NoReturn, cast, final
+from typing import Any, Literal, NoReturn, cast, final
 
 from typing_extensions import override
 
@@ -74,6 +74,7 @@ class ParallelTextDataset(ABC):
         batch_shuffle_window: int = 1,
         drop_remainder: bool = False,
         sync_batches: bool = True,
+        sync_mode: Literal["until_first", "until_last"] = "until_first",
         max_num_batches: int | None = None,
         num_accumulate: int = 1,
         num_prefetch: int = 1,
@@ -117,6 +118,11 @@ class ParallelTextDataset(ABC):
             can vary per process (e.g. due to unbalanced sharding or non-static
             batching) and it is critical for each process to iterate over the
             same number of batches (e.g. during training).
+        :param sync_mode:
+            If ``until_first``, stops iteration when the first rank reaches end
+            of data. If ``until_last``, stops iteration when the last rank
+            reaches end of data; ranks that have already reached their end of
+            data will return an empty list of batches.
         :param max_num_batches:
             The maximum number of batches to return.
         :param num_accumulate:
@@ -289,6 +295,7 @@ class GenericParallelTextDataset(ParallelTextDataset):
         batch_shuffle_window: int = 1,
         drop_remainder: bool = False,
         sync_batches: bool = True,
+        sync_mode: Literal["until_first", "until_last"] = "until_first",
         max_num_batches: int | None = None,
         num_accumulate: int = 1,
         num_prefetch: int = 1,
@@ -432,6 +439,7 @@ class GenericParallelTextDataset(ParallelTextDataset):
             num_accumulate=num_accumulate,
             drop_remainder=drop_remainder,
             sync_batches=sync_batches,
+            sync_mode=sync_mode,
         )
 
     def _read_direction(self, split: str, direction: Direction) -> DataPipelineBuilder:

--- a/src/fairseq2/datasets/speech.py
+++ b/src/fairseq2/datasets/speech.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any, final
+from typing import Any, Literal, final
 
 import torch
 from typing_extensions import override
@@ -40,6 +40,7 @@ class SpeechDataset(ABC):
         batch_shuffle_window: int = 1,
         drop_remainder: bool = False,
         sync_batches: bool = True,
+        sync_mode: Literal["until_first", "until_last"] = "until_first",
         max_num_batches: int | None = None,
         num_accumulate: int = 1,
         num_prefetch: int = 1,
@@ -81,6 +82,11 @@ class SpeechDataset(ABC):
             can vary per process (e.g. due to unbalanced sharding or non-static
             batching) and it is critical for each process to iterate over the
             same number of batches (e.g. during training).
+        :param sync_mode:
+            If ``until_first``, stops iteration when the first rank reaches end
+            of data. If ``until_last``, stops iteration when the last rank
+            reaches end of data; ranks that have already reached their end of
+            data will return an empty list of batches.
         :param max_num_batches:
             The maximum number of batches to return.
         :param num_accumulate:
@@ -129,6 +135,7 @@ class GenericSpeechDataset(SpeechDataset):
         batch_shuffle_window: int = 1,
         drop_remainder: bool = False,
         sync_batches: bool = True,
+        sync_mode: Literal["until_first", "until_last"] = "until_first",
         max_num_batches: int | None = None,
         num_accumulate: int = 1,
         num_prefetch: int = 1,

--- a/src/fairseq2/datasets/text.py
+++ b/src/fairseq2/datasets/text.py
@@ -10,7 +10,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from functools import partial
 from pathlib import Path
-from typing import Any, cast, final
+from typing import Any, Literal, cast, final
 
 from typing_extensions import override
 
@@ -49,6 +49,7 @@ class TextDataset(ABC):
         batch_shuffle_window: int = 1,
         drop_remainder: bool = False,
         sync_batches: bool = True,
+        sync_mode: Literal["until_first", "until_last"] = "until_first",
         max_num_batches: int | None = None,
         num_accumulate: int = 1,
         num_prefetch: int = 1,
@@ -88,6 +89,11 @@ class TextDataset(ABC):
             can vary per process (e.g. due to unbalanced sharding or non-static
             batching) and it is critical for each process to iterate over the
             same number of batches (e.g. during training).
+        :param sync_mode:
+            If ``until_first``, stops iteration when the first rank reaches end
+            of data. If ``until_last``, stops iteration when the last rank
+            reaches end of data; ranks that have already reached their end of
+            data will return an empty list of batches.
         :param max_num_batches:
             The maximum number of batches to return.
         :param num_accumulate:
@@ -155,6 +161,7 @@ class GenericTextDataset(TextDataset):
         batch_shuffle_window: int = 1,
         drop_remainder: bool = False,
         sync_batches: bool = True,
+        sync_mode: Literal["until_first", "until_last"] = "until_first",
         max_num_batches: int | None = None,
         num_accumulate: int = 1,
         num_prefetch: int = 1,
@@ -247,6 +254,7 @@ class GenericTextDataset(TextDataset):
             num_accumulate=num_accumulate,
             drop_remainder=drop_remainder,
             sync_batches=sync_batches,
+            sync_mode=sync_mode,
         )
 
     @staticmethod

--- a/src/fairseq2/recipes/evaluator.py
+++ b/src/fairseq2/recipes/evaluator.py
@@ -17,7 +17,7 @@ from torch.nn import Module
 from typing_extensions import override
 
 from fairseq2.datasets import DataReader
-from fairseq2.gang import FakeGang, Gang, all_sum
+from fairseq2.gang import FakeGang, Gang
 from fairseq2.logging import get_log_writer
 from fairseq2.metrics import (
     JsonFileMetricRecorder,
@@ -236,22 +236,14 @@ class Evaluator(Generic[BatchT]):
                 try:
                     batches = next(data_reader)
                 except StopIteration:
-                    batches = []
+                    break
 
                 for batch in batches:
                     unit(batch)
 
-                if self._is_eod(batches):
-                    break
-
                 num_effective_batches += 1
 
         self._publish_metrics(unit, num_effective_batches, watch.get_elapsed_time())
-
-    def _is_eod(self, batches: list[BatchT]) -> bool:
-        total_num_batches = all_sum(self._dp_gang, len(batches))
-
-        return bool(total_num_batches == 0)
 
     def _publish_metrics(
         self, unit: EvalUnit[BatchT], num_batches: int, elapsed_time: float

--- a/src/fairseq2/recipes/lm/text_generate.py
+++ b/src/fairseq2/recipes/lm/text_generate.py
@@ -278,7 +278,7 @@ def load_text_generator(
             dp_gang,
             config.max_seq_len,
             batching=StaticBatching(config.batch_size),
-            sync_batches=False,
+            sync_mode="until_last",
             num_prefetch=config.num_prefetch,
             seed=seed,
         )

--- a/src/fairseq2/recipes/mt/eval.py
+++ b/src/fairseq2/recipes/mt/eval.py
@@ -222,7 +222,7 @@ def load_mt_evaluator(
                 config.max_seq_len,
                 batching=LengthBatching(config.max_num_tokens),
                 direction=direction,
-                sync_batches=False,
+                sync_mode="until_last",
                 num_prefetch=config.num_prefetch,
                 seed=seed,
             )
@@ -296,7 +296,7 @@ def load_mt_evaluator(
                 config.max_seq_len,
                 batching=StaticBatching(config.generator_batch_size),
                 direction=direction,
-                sync_batches=False,
+                sync_mode="until_last",
                 num_prefetch=config.num_prefetch,
                 seed=seed,
             )

--- a/src/fairseq2/recipes/mt/train.py
+++ b/src/fairseq2/recipes/mt/train.py
@@ -398,7 +398,7 @@ def load_mt_trainer(config: MTTrainConfig, output_dir: Path) -> Trainer[Seq2SeqB
                 config.max_seq_len,
                 batching=LengthBatching(config.max_num_tokens),
                 direction=direction,
-                sync_batches=False,
+                sync_mode="until_last",
                 num_prefetch=config.num_prefetch,
                 seed=seed,
             )
@@ -427,7 +427,7 @@ def load_mt_trainer(config: MTTrainConfig, output_dir: Path) -> Trainer[Seq2SeqB
                     config.max_seq_len,
                     batching=StaticBatching(config.generator_batch_size),
                     direction=direction,
-                    sync_batches=False,
+                    sync_mode="until_last",
                     num_prefetch=config.num_prefetch,
                     seed=seed,
                 )

--- a/src/fairseq2/recipes/mt/translate.py
+++ b/src/fairseq2/recipes/mt/translate.py
@@ -228,7 +228,7 @@ def load_text_translator(
             gang,
             config.max_seq_len,
             batching=StaticBatching(config.batch_size),
-            sync_batches=False,
+            sync_mode="until_last",
             num_prefetch=config.num_prefetch,
             seed=seed,
         )

--- a/src/fairseq2/recipes/wav2vec2/asr/eval.py
+++ b/src/fairseq2/recipes/wav2vec2/asr/eval.py
@@ -217,7 +217,7 @@ def load_wav2vec2_asr_evaluator(
             min_audio_len=config.min_audio_len,
             max_audio_len=config.max_audio_len,
             normalize_audio=config.normalize_audio,
-            sync_batches=False,
+            sync_mode="until_last",
             num_prefetch=config.num_prefetch,
             seed=seed,
         )


### PR DESCRIPTION
This PR introduces a new `sync_mode` parameter to `DataReader`. If ``until_first``, stops iteration when the first rank reaches end of data. If ``until_last``, stops iteration when the last rank reaches end of data; ranks that have already reached their end of data will return an empty list of batches.