### PR TITLE
Make default device a global dependency

### DIFF
--- a/src/fairseq2/device.py
+++ b/src/fairseq2/device.py
@@ -10,6 +10,7 @@ import os
 
 import torch
 
+from fairseq2.dependency import DependencyContainer
 from fairseq2.logging import get_log_writer
 from fairseq2.typing import CPU, Device
 from fairseq2.utils.env import get_int_from_env
@@ -106,3 +107,7 @@ def _get_device_index(num_devices: int, device_type: str) -> int:
         )
 
     return device_idx
+
+
+def register_objects(container: DependencyContainer) -> None:
+    container.register_factory(Device, lambda _: determine_default_device())

--- a/src/fairseq2/setup.py
+++ b/src/fairseq2/setup.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import os
+from importlib import import_module
 
 from importlib_metadata import entry_points
 
@@ -60,7 +61,16 @@ def setup(container: DependencyContainer) -> None:
 
 
 def _setup_library(container: DependencyContainer) -> None:
-    pass
+    modules = [
+        "fairseq2.device",
+    ]
+
+    for name in modules:
+        module = import_module(name)
+
+        register_objects = getattr(module, "register_objects")
+
+        register_objects(container)
 
 
 def _setup_extensions(container: DependencyContainer) -> None:


### PR DESCRIPTION
This PR registers the default device returned by `determine_default_device()` to the global dependency graph.