### PR TITLE
Introduce type inferred dependency injection

### DIFF
--- a/doc/reference/fairseq2.dependency.rst
+++ b/doc/reference/fairseq2.dependency.rst
@@ -11,20 +11,23 @@ fairseq2.dependency
 
 **ABCs**
 
-* :class:`DependencyContainer`
-* :class:`DependencyResolver`
+:class:`DependencyContainer`, :class:`DependencyResolver`
 
 **Classes**
 
-* :class:`StandardDependencyContainer`
+:class:`StandardDependencyContainer`
 
 **Protocols**
 
-* :class:`DependencyFactory`
+:class:`DependencyFactory`
+
+**Exceptions**
+
+:class:`DependencyError`, :class:`DependencyNotFoundError`
 
 **Functions**
 
-* :func:`get_container`
+:func:`get_container`
 
 ABCs
 ====
@@ -43,6 +46,13 @@ Protocols
 
 .. autoclass:: DependencyFactory()
     :special-members: __call__
+
+Exceptions
+==========
+
+.. autoclass:: DependencyError
+
+.. autoclass:: DependencyNotFoundError
 
 Functions
 =========

--- a/doc/topics/design_philosophy.rst
+++ b/doc/topics/design_philosophy.rst
@@ -160,7 +160,7 @@ passed to :meth:`~DependencyResolver.resolve`::
 
     assert isinstance(obj, Foo)
 
-:meth:`~DependencyResolver.resolve` will raise a :class:`LookupError` when an
+:meth:`~DependencyResolver.resolve` will raise a :class:`DependencyError` when an
 object cannot be found. As an alternative, :meth:`~DependencyResolver.resolve_optional`
 can be used which returns ``None`` instead::
 


### PR DESCRIPTION
This PR includes a non-finished implementation of the new `DependencyContainer.register` that uses type annotations to inject dependencies. The remaining work to finish the implementation will follow-up later this week.