### PR TITLE
Revise model sharder API

### DIFF
--- a/src/fairseq2/assets/cards/models/llama.yaml
+++ b/src/fairseq2/assets/cards/models/llama.yaml
@@ -97,7 +97,6 @@ name: llama3_70b
 base: llama3
 model_arch: llama3_70b
 num_shards: 8
-shard_embed_dim: false
 
 ---
 
@@ -105,7 +104,6 @@ name: llama3_70b_instruct
 base: llama3_instruct
 model_arch: llama3_70b
 num_shards: 8
-shard_embed_dim: false
 
 ---
 
@@ -125,7 +123,6 @@ name: llama3_1_70b
 base: llama3
 model_arch: llama3_1_70b
 num_shards: 8
-shard_embed_dim: false
 
 ---
 
@@ -133,4 +130,3 @@ name: llama3_1_70b_instruct
 base: llama3_instruct
 model_arch: llama3_1_70b
 num_shards: 8
-shard_embed_dim: false


### PR DESCRIPTION
This PR revises the sharder API to make `StandardModelLoader` more reusable.