### PR TITLE
Annotate recipe entrypoints with inference_mode

### DIFF
--- a/src/fairseq2/recipes/lm/chatbot.py
+++ b/src/fairseq2/recipes/lm/chatbot.py
@@ -108,6 +108,7 @@ class ChatbotCommandHandler(CliCommandHandler):
         )
 
     @override
+    @torch.inference_mode()
     def __call__(self, args: Namespace, container: DependencyContainer) -> None:
         setup_basic_logging()
 

--- a/src/fairseq2/recipes/lm/text_generate.py
+++ b/src/fairseq2/recipes/lm/text_generate.py
@@ -144,6 +144,7 @@ def _llama3_1_70b_instruct() -> TextGenerateConfig:
     return config
 
 
+@torch.inference_mode()
 def load_text_generator(
     config: TextGenerateConfig, output_dir: Path
 ) -> Generator[SequenceBatch]:

--- a/src/fairseq2/recipes/mt/eval.py
+++ b/src/fairseq2/recipes/mt/eval.py
@@ -112,6 +112,7 @@ def _nllb_dense_600m() -> MTEvalConfig:
     return MTEvalConfig()
 
 
+@torch.inference_mode()
 def load_mt_evaluator(
     config: MTEvalConfig, output_dir: Path
 ) -> Evaluator[Seq2SeqBatch]:

--- a/src/fairseq2/recipes/mt/translate.py
+++ b/src/fairseq2/recipes/mt/translate.py
@@ -102,6 +102,7 @@ def _nllb_dense_600m() -> TextTranslateConfig:
     return TextTranslateConfig()
 
 
+@torch.inference_mode()
 def load_text_translator(
     config: TextTranslateConfig, output_dir: Path
 ) -> Generator[SequenceBatch]:

--- a/src/fairseq2/recipes/wav2vec2/asr/eval.py
+++ b/src/fairseq2/recipes/wav2vec2/asr/eval.py
@@ -95,6 +95,7 @@ def _base_10h() -> Wav2Vec2AsrEvalConfig:
     return Wav2Vec2AsrEvalConfig()
 
 
+@torch.inference_mode()
 def load_wav2vec2_asr_evaluator(
     config: Wav2Vec2AsrEvalConfig, output_dir: Path
 ) -> Evaluator[Seq2SeqBatch]:

--- a/src/fairseq2/recipes/wav2vec2/eval.py
+++ b/src/fairseq2/recipes/wav2vec2/eval.py
@@ -97,6 +97,7 @@ def _base_ls960h() -> Wav2Vec2EvalConfig:
     return Wav2Vec2EvalConfig()
 
 
+@torch.inference_mode()
 def load_wav2vec2_evaluator(
     config: Wav2Vec2EvalConfig, output_dir: Path
 ) -> Evaluator[SequenceBatch]:


### PR DESCRIPTION
`Evaluator` and `Generator` already run in inference mode, but these entrypoint annotations make sure that the models themselves are also initialized without any autograd payload.