### PR TITLE
Refactor wav2vec2 masker

### DIFF
--- a/src/fairseq2/error.py
+++ b/src/fairseq2/error.py
@@ -9,3 +9,7 @@ from __future__ import annotations
 
 class AlreadyExistsError(RuntimeError):
     """Raised when an item already exists."""
+
+
+class NotSupportedError(RuntimeError):
+    pass

--- a/src/fairseq2/models/feature_extractor.py
+++ b/src/fairseq2/models/feature_extractor.py
@@ -43,9 +43,9 @@ class SequenceFeatureExtractor(Module, ABC):
             is the batch size and :math:`S` is the sequence length.
 
         :returns:
-            - The extracted features. *Shape:* :math:`(N,S_{out},F)`, where
+            - The extracted features. *Shape:* :math:`(N,S_{out},E)`, where
               :math:`N` is the batch size, :math:`S_{out}` is the output
-              sequence length, and :math:`F` is the dimensionality of the
+              sequence length, and :math:`E` is the dimensionality of the
               features.
             - The padding mask of the extracted features. *Shape:*
               :math:`(N,S_{out})`, where :math:`N` is the batch size and

--- a/src/fairseq2/models/wav2vec2/asr/factory.py
+++ b/src/fairseq2/models/wav2vec2/asr/factory.py
@@ -17,7 +17,7 @@ from fairseq2.models.wav2vec2.factory import (
     Wav2Vec2EncoderBuilder,
     Wav2Vec2EncoderConfig,
 )
-from fairseq2.models.wav2vec2.masker import Wav2Vec2Masker
+from fairseq2.models.wav2vec2.masker import StandardWav2Vec2Masker, Wav2Vec2Masker
 from fairseq2.typing import DataType, Device
 
 WAV2VEC2_ASR_FAMILY: Final = "wav2vec2_asr"
@@ -150,7 +150,7 @@ class Wav2Vec2AsrBuilder:
         if not self._config.use_masking:
             return None
 
-        return Wav2Vec2Masker(
+        return StandardWav2Vec2Masker(
             self._config.encoder_config.model_dim,
             self._config.temporal_mask_span_len,
             self._config.max_temporal_mask_prob,

--- a/src/fairseq2/models/wav2vec2/factory.py
+++ b/src/fairseq2/models/wav2vec2/factory.py
@@ -20,7 +20,7 @@ from fairseq2.models.wav2vec2.feature_extractor import (
     Wav2Vec2FeatureExtractor,
 )
 from fairseq2.models.wav2vec2.frontend import Wav2Vec2Frontend
-from fairseq2.models.wav2vec2.masker import Wav2Vec2Masker
+from fairseq2.models.wav2vec2.masker import StandardWav2Vec2Masker, Wav2Vec2Masker
 from fairseq2.models.wav2vec2.model import Wav2Vec2Model
 from fairseq2.models.wav2vec2.position_encoder import (
     Wav2Vec2PositionEncoder,
@@ -305,7 +305,7 @@ class Wav2Vec2Builder:
 
     def build_masker(self) -> Wav2Vec2Masker:
         """Build a feature masker."""
-        return Wav2Vec2Masker(
+        return StandardWav2Vec2Masker(
             self._config.encoder_config.model_dim,
             self._config.temporal_mask_span_len,
             self._config.max_temporal_mask_prob,

--- a/src/fairseq2/models/wav2vec2/frontend.py
+++ b/src/fairseq2/models/wav2vec2/frontend.py
@@ -12,6 +12,7 @@ from torch import Tensor
 from torch.nn import Dropout
 from typing_extensions import override
 
+from fairseq2.error import NotSupportedError
 from fairseq2.models.feature_extractor import SequenceFeatureExtractor
 from fairseq2.models.transformer import TransformerFrontend
 from fairseq2.models.wav2vec2.masker import Wav2Vec2Masker
@@ -72,9 +73,9 @@ class Wav2Vec2Frontend(TransformerFrontend):
         self.feature_dim = feature_dim
 
         if feature_extractor is not None:
-            if feature_dim != feature_extractor.feature_dim:
+            if feature_extractor.feature_dim != feature_dim:
                 raise ValueError(
-                    f"`feature_dim` of `feature_extractor` must be equal to `feature_dim` ({feature_dim}), but is {feature_extractor.feature_dim} instead."
+                    f"`feature_extractor.feature_dim` must be equal to `feature_dim` ({feature_dim}), but is {feature_extractor.feature_dim} instead."
                 )
 
             self.feature_extractor = feature_extractor
@@ -100,7 +101,7 @@ class Wav2Vec2Frontend(TransformerFrontend):
         if pos_encoder is not None:
             if pos_encoder.encoding_dim != model_dim:
                 raise ValueError(
-                    f"`encoding_dim` of `pos_encoder` must be equal to `model_dim` ({model_dim}), but is {pos_encoder.encoding_dim} instead."
+                    f"`pos_encoder.encoding_dim` must be equal to `model_dim` ({model_dim}), but is {pos_encoder.encoding_dim} instead."
                 )
 
             self.pos_encoder = pos_encoder
@@ -128,8 +129,8 @@ class Wav2Vec2Frontend(TransformerFrontend):
         state_bag: IncrementalStateBag | None = None,
     ) -> tuple[Tensor, PaddingMask | None]:
         if state_bag is not None:
-            raise ValueError(
-                "`Wav2Vec2Frontend` does not support incremental decoding."
+            raise NotSupportedError(
+                f"`{type(self)}` does not support incremental decoding."
             )
 
         seqs, padding_mask, _ = self.extract_features(seqs, padding_mask)
@@ -153,9 +154,9 @@ class Wav2Vec2Frontend(TransformerFrontend):
             is the batch size and :math:`S` is the sequence length.
 
         :returns:
-            - The normalized features. *Shape:* :math:`(N,S_{out},F)`, where
+            - The normalized features. *Shape:* :math:`(N,S_{out},E)`, where
               :math:`N` is the batch size, :math:`S_{out}` is the output
-              sequence length, and :math:`F` is the dimensionality of the
+              sequence length, and :math:`E` is the dimensionality of the
               extracted features.
             - The padding mask of the extracted features. *Shape:*
               :math:`(N,S_{out})`, where :math:`N` is the batch size and
@@ -181,8 +182,8 @@ class Wav2Vec2Frontend(TransformerFrontend):
         """Process extracted features.
 
         :param seqs:
-            The features to process. *Shape:* :math:`(N,S,F)`, where :math:`N`
-            is the batch size, :math:`S` is the sequence length, and :math:`F`
+            The features to process. *Shape:* :math:`(N,S,E)`, where :math:`N`
+            is the batch size, :math:`S` is the sequence length, and :math:`E`
             is the dimensionality of the features.
         :param padding_mask:
             The padding mask of ``seqs``. *Shape:* :math:`(N,S)`, where :math:`N`

--- a/src/fairseq2/models/wav2vec2/masker.py
+++ b/src/fairseq2/models/wav2vec2/masker.py
@@ -6,23 +6,51 @@
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from typing import final
 
 import torch
 import torch.nn as nn
 from torch import Tensor
 from torch.nn import Module, Parameter
+from typing_extensions import override
 
 from fairseq2.nn.padding import PaddingMask
-from fairseq2.nn.utils.mask import compute_row_mask
+from fairseq2.nn.utils.mask import RowMaskFactory, compute_row_mask
 from fairseq2.typing import DataType, Device
 
 
+class Wav2Vec2Masker(Module, ABC):
+    """Masks extracted wav2vec 2.0 features."""
+
+    @abstractmethod
+    def forward(
+        self, seqs: Tensor, padding_mask: PaddingMask | None
+    ) -> tuple[Tensor, Tensor]:
+        """
+        :param seqs:
+            The sequences to mask. *Shape:* :math:`(N,S,M)`, where :math:`N` is
+            the batch size, :math:`S` is the sequence length, and :math:`M` is
+            the dimensionality of the model.
+        :param seq_lens:
+            An array where each element represents the length of the sequence at
+            the same index in ``seqs``. *Shape:* :math:`(N)`, where :math:`N` is
+            the batch size.
+
+        :returns:
+            - The input sequences with mask applied. *Shape:* Same as ``seqs``.
+            - The temporal mask that has been applied to ``seqs``. *Shape:*
+              :math:`(N,S)`, where :math:`N` is the batch size and :math`S` is
+              the sequence length.
+        """
+
+
 @final
-class Wav2Vec2Masker(Module):
-    """Masks extracted features as described in Section 3.1 of
+class StandardWav2Vec2Masker(Wav2Vec2Masker):
+    """Masks extracted wav2vec 2.0 features as described in Section 3.1 of
     :cite:t:`https://doi.org/10.48550/arxiv.2006.11477`."""
 
+    mask_factory: RowMaskFactory
     temporal_span_len: int
     max_temporal_mask_prob: float
     temporal_mask_embed: Parameter
@@ -39,6 +67,7 @@ class Wav2Vec2Masker(Module):
         max_spatial_mask_prob: float = 0.0,
         min_num_spatial_mask_spans: int = 2,
         *,
+        mask_factory: RowMaskFactory | None = None,
         device: Device | None = None,
         dtype: DataType | None = None,
     ) -> None:
@@ -56,8 +85,13 @@ class Wav2Vec2Masker(Module):
         :param max_spatial_mask_prob:
             The maximum probability of masking a feature. Note that, due to mask
             span overlap, the effective probability will be lower.
+        :param mask_factory:
+            The row mask factory. If ``None``, :func:`compute_row_mask` will be
+            used.
         """
         super().__init__()
+
+        self.mask_factory = mask_factory or compute_row_mask
 
         if max_temporal_mask_prob == 0.0:
             raise ValueError("`max_temporal_mask_prob` must be greater than 0.")
@@ -80,29 +114,14 @@ class Wav2Vec2Masker(Module):
         """Reset the parameters and buffers of the module."""
         nn.init.uniform_(self.temporal_mask_embed)
 
+    @override
     def forward(
         self, seqs: Tensor, padding_mask: PaddingMask | None
     ) -> tuple[Tensor, Tensor]:
-        """
-        :param seqs:
-            The sequences to mask. *Shape:* :math:`(N,S,M)`, where :math:`N` is
-            the batch size, :math:`S` is the sequence length, and :math:`M` is
-            the dimensionality of the model.
-        :param seq_lens:
-            An array where each element represents the length of the sequence at
-            the same index in ``seqs``. *Shape:* :math:`(N)`, where :math:`N` is
-            the batch size.
-
-        :returns:
-            - The input sequences with mask applied. *Shape:* Same as ``seqs``.
-            - The temporal mask that has been applied to ``seqs``. *Shape:*
-              :math:`(N,S)`, where :math:`N` is the batch size and :math`S` is
-              the sequence length.
-        """
         batch_size, seq_len, model_dim = seqs.shape
 
         # Temporal mask over time steps.
-        temporal_mask = compute_row_mask(
+        temporal_mask = self.mask_factory(
             shape=(batch_size, seq_len),
             span_len=self.temporal_span_len,
             max_mask_prob=self.max_temporal_mask_prob,
@@ -118,7 +137,7 @@ class Wav2Vec2Masker(Module):
         if self.max_spatial_mask_prob > 0.0:
             # Spatial mask over features.
             # (N, M)
-            spatial_mask = compute_row_mask(
+            spatial_mask = self.mask_factory(
                 shape=(batch_size, model_dim),
                 span_len=self.spatial_span_len,
                 max_mask_prob=self.max_spatial_mask_prob,
@@ -137,7 +156,7 @@ class Wav2Vec2Masker(Module):
 
     def extra_repr(self) -> str:
         """:meta private:"""
-        return (
+        s = (
             f"temporal_span_len={self.temporal_span_len}, "
             f"max_temporal_mask_prob={self.max_temporal_mask_prob}, "
             f"min_num_temporal_mask_spans={self.min_num_temporal_mask_spans}, "
@@ -145,6 +164,13 @@ class Wav2Vec2Masker(Module):
             f"max_spatial_mask_prob={self.max_spatial_mask_prob}, "
             f"min_num_spatial_mask_spans={self.min_num_spatial_mask_spans}"
         )
+
+        if self.mask_factory is not compute_row_mask:
+            mask_factory = getattr(self.mask_factory, "__name__", self.mask_factory)
+
+            s = f"{s}, mask_factory={mask_factory}"
+
+        return s
 
 
 def extract_masked_elements(seqs: Tensor, temporal_mask: Tensor) -> Tensor:

--- a/src/fairseq2/models/wav2vec2/vector_quantizer.py
+++ b/src/fairseq2/models/wav2vec2/vector_quantizer.py
@@ -62,7 +62,6 @@ class VectorQuantizerOutput(ABC):
         pass
 
 
-@final
 class GumbelVectorQuantizer(VectorQuantizer):
     """Quantizes incoming data using Gumbel-Softmax."""
 
@@ -144,7 +143,7 @@ class GumbelVectorQuantizer(VectorQuantizer):
         self.num_updates.zero_()
 
     @override
-    def forward(self, x: Tensor) -> "GumbelVectorQuantizerOutput":
+    def forward(self, x: Tensor) -> GumbelVectorQuantizerOutput:
         current_temp = self._compute_current_temp()
 
         bsz, tsz, fsz = x.shape
@@ -228,7 +227,6 @@ def init_entry_projection(proj: Linear) -> None:
     nn.init.zeros_(proj.bias)
 
 
-@final
 @dataclass
 class GumbelVectorQuantizerOutput(VectorQuantizerOutput):
     cb: Tensor

--- a/src/fairseq2/models/wav2vec2/vector_quantizer.py
+++ b/src/fairseq2/models/wav2vec2/vector_quantizer.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import final
 
 import torch
 import torch.nn as nn

--- a/src/fairseq2/nn/utils/mask.py
+++ b/src/fairseq2/nn/utils/mask.py
@@ -181,15 +181,15 @@ def _generate_mask(indices: Tensor, max_row_len: int) -> Tensor:
     # We randomly pick `min_num_masked` masked elements from each row, which
     # effectively unmasks the remaining elements.
     #
-    # We first make a tensor of random values and 0.001 to it to ensure
-    # the min value > 0. Then we multiply it with the float_mask so that
-    # all the 0 values in the float_mask are still 0 but the non-zero
-    # values have a random value assigned to them. Then we select the
-    # topk values (which would be basically a subset of non-zero values
-    # in the float_mask
-
+    # We first make a tensor of random values and 0.001 to it to ensure the
+    # minimum value is larger than 0. Then we multiply it with the float_mask so
+    # that all the 0 values in `float_mask` are still 0 but the non-zero values
+    # have a random value assigned to them. Then we select the top-k values,
+    #  which would be basically a subset of non-zero values `float_mask`.
     random_values = torch.rand_like(float_mask) + 0.001
+
     random_values = random_values * float_mask
+
     _, indices = torch.topk(random_values, k=min_num_masked, dim=1, sorted=False)
 
     # (N, S)


### PR DESCRIPTION
This PR:

- Introduces a new `RowMaskFactory` protocol which `compute_row_mask` follows.
- Converts `Wav2Vec2Masker` into an interface and moves its existing implementation to a new `StandardWav2Vec2Masker`.
- Introduces a new `mask_factory` parameter in `StandardWav2Vec2Masker` to optionally override the standard `compute_row_mask` implementation.
- Removes the `final` annotation from `GumbelVectorQuantizer` and `GumbelVectorQuantizerOutput`.