### PR TITLE
Compile a matmul + reduction op in vector quantizer to avoid excess memory usage. Fixes #832

### DIFF
--- a/src/fairseq2/models/wav2vec2/vector_quantizer.py
+++ b/src/fairseq2/models/wav2vec2/vector_quantizer.py
@@ -190,7 +190,7 @@ class GumbelVectorQuantizer(VectorQuantizer):
         cb = x
 
         @torch.compile(fullgraph=True)
-        def compute_sum(x):
+        def compute_sum(x: torch.Tensor) -> torch.Tensor:
             return torch.sum(
                 x.view(bsz * tsz, self.num_codebooks, self.num_codebook_entries, 1)
                 * self.entries.view(


### PR DESCRIPTION
Compile a matmul + reduction op in vector quantizer to avoid excess memory usage. Fixes #832

Before | 60.8 Gb peak memory

![373048333-1872cfee-b608-4e20-a7d1-0b6738e2e527](https://github.com/user-attachments/assets/b9800a20-8981-4075-b93f-edef6642e35c)

After | 33.8 Gb peak memory

![Screenshot 2024-10-02 at 6 02 04 PM](https://github.com/user-attachments/assets/bd49e614-d1d4-4258-8230-39f8f12e22fe)


**Does your PR introduce any breaking changes? If yes, please list them:**
List of all backwards-incompatible changes.

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [ x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [ x] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ x] Did you write any **new necessary tests**?
- [ x] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
