### PR TITLE
Load sharded llama checkpoint

### DIFF
--- a/src/fairseq2/models/llama/loader.py
+++ b/src/fairseq2/models/llama/loader.py
@@ -46,6 +46,10 @@ def convert_llama_checkpoint(
     if "model" in checkpoint:
         return checkpoint
 
+    # Check if we have a sharded checkpoint.
+    if "weights" in checkpoint and len(checkpoint) < 3:
+        checkpoint = checkpoint["weights"]
+
     # Check if we have a reference or Hugging Face checkpoint.
     if "lm_head.weight" in checkpoint:  # HG
         head_dim = config.model_dim // config.num_attn_heads


### PR DESCRIPTION
**What does this PR do? Please describe:**
This PR modifies the `convert_llama_checkpoint` function to be able to load (single) sharded llama checkpoints, where the state dict contains a single "weights" field `{"weight": {...}`.

Fixes #{issue number}

**Does your PR introduce any breaking changes? If yes, please list them:**
List of all backwards-incompatible changes.

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
