### PR TITLE
adding run name option for wandb, adding resume allow

### DIFF
--- a/src/fairseq2/metrics/recorder.py
+++ b/src/fairseq2/metrics/recorder.py
@@ -489,7 +489,7 @@ else:
 class WandbRecorder(MetricRecorder):
     """Records metric values to Weights & Biases."""
 
-    def __init__(self, project: str, output_dir: Path) -> None:
+    def __init__(self, project: str, name: str, output_dir: Path) -> None:
         """
         :param project: The W&B project name.
         :param output_dir: The base directory under which to store the W&B files.
@@ -502,7 +502,9 @@ class WandbRecorder(MetricRecorder):
 
             self._run = None
         else:
-            self._run = wandb.init(project=project, dir=output_dir.parent)
+            self._run = wandb.init(
+                project=project, name=name, dir=output_dir.parent, resume="allow"
+            )
 
     @override
     def record_metrics(

--- a/src/fairseq2/recipes/legacy_config.py
+++ b/src/fairseq2/recipes/legacy_config.py
@@ -40,10 +40,11 @@ def _set_legacy_config(resolver: DependencyResolver, config: DataClass) -> None:
 
     def set_metric_recorders_config() -> None:
         wandb_project = getattr(config, "wandb_project", None)
+        wandb_run_name = getattr(config, "wandb_run_name", None)
 
         if wandb_project is not None:
             config_dict["metric_recorders"] = MetricRecordersConfig(
-                wandb=True, wandb_project=wandb_project
+                wandb=True, wandb_project=wandb_project, wandb_run_name=wandb_run_name
             )
 
     set_gang_config()

--- a/src/fairseq2/recipes/lm/instruction_finetune.py
+++ b/src/fairseq2/recipes/lm/instruction_finetune.py
@@ -212,6 +212,9 @@ class InstructionFinetuneConfig:
     wandb_project: str | None = None
     """If not ``None``, sets the project name for W&B logging."""
 
+    wandb_run_name: str | None = None
+    """If not ``None``, sets the run name for W&B logging. If None, then W&B creates a random name."""
+
 
 instruction_finetune_presets = ConfigRegistry[InstructionFinetuneConfig]()
 

--- a/src/fairseq2/recipes/lm/preference_finetune/recipe.py
+++ b/src/fairseq2/recipes/lm/preference_finetune/recipe.py
@@ -200,6 +200,9 @@ class PreferenceFinetuneConfig:
     wandb_project: str | None = None
     """If not ``None``, sets the project name for W&B logging."""
 
+    wandb_run_name: str | None = None
+    """If not ``None``, sets the run name for W&B logging. If None, then W&B creates a random name."""
+
 
 preference_finetune_presets = ConfigRegistry[PreferenceFinetuneConfig]()
 

--- a/src/fairseq2/recipes/metrics.py
+++ b/src/fairseq2/recipes/metrics.py
@@ -32,6 +32,7 @@ class MetricRecordersConfig:
     tensorboard: bool = True
     wandb: bool = False
     wandb_project: str | None = None
+    wandb_run_name: str | None = None
 
 
 def register_metric_recorders(container: DependencyContainer) -> None:
@@ -113,4 +114,4 @@ def _create_wandb_recorder(resolver: DependencyResolver) -> MetricRecorder | Non
 
     output_dir = config_manager.get_config("output_dir", Path).joinpath("wandb")
 
-    return WandbRecorder(config.wandb_project, output_dir)
+    return WandbRecorder(config.wandb_project, config.wandb_run_name, output_dir)


### PR DESCRIPTION
* wandb was not taking any run name before, that makes it harder to group runs within e.g. the sweep.
* currently wandb_run_name is another config name that is parsed by the legacy config parser.
* wandb init resume allow was added so that interrupted runs can resume logging as long as the project and name are the same.