### PR TITLE
Update PyTorch THPVariable_Wrap to use const ref

### DIFF
--- a/native/python/src/fairseq2n/bindings/type_casters/torch.cc
+++ b/native/python/src/fairseq2n/bindings/type_casters/torch.cc
@@ -20,7 +20,7 @@ struct THPVariable {
 
 extern PyObject *THPVariableClass;
 
-PyObject *THPVariable_Wrap(at::TensorBase var);
+PyObject *THPVariable_Wrap(const at::TensorBase& var);
 
 // Taken from <torch/bindings/Device.h>
 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)


### PR DESCRIPTION
**What does this PR do? Please describe:**
This comes from a change from PyTorch https://github.com/pytorch/pytorch/pull/138880 in which the signature of `THPVariable_Wrap` changes to 

```
TORCH_PYTHON_API PyObject * THPVariable_Wrap(const at::TensorBase& var);
```

A build failure happens when importing the change to fbcode D65031075 for one project that is using `fairseq2`

**Does your PR introduce any breaking changes? If yes, please list them:**
This makes fairseq2 compatible with latest PyTorch, so I don't think there is any breaking change here.

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
