### PR TITLE
add blobfile in setup as required package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
         "torcheval~=0.0.6",
         "tqdm~=4.62",
         "typing_extensions~=4.12",
+        "blobfile~=3.0.0",  # This dependency is required for tiktoken.load.read_file, but it's listed as optional in tiktoken's pyproject.toml (https://github.com/openai/tiktoken/blob/main/pyproject.toml#L9)  # fmt: skip
     ],
     extras_require={
         "arrow": ["pyarrow>=13.0.0", "pandas~=2.0.0"],

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,10 @@ setup(
         "torcheval~=0.0.6",
         "tqdm~=4.62",
         "typing_extensions~=4.12",
-        "blobfile~=3.0.0",  # This dependency is required for tiktoken.load.read_file, but it's listed as optional in tiktoken's pyproject.toml (https://github.com/openai/tiktoken/blob/main/pyproject.toml#L9)  # fmt: skip
+        # This dependency is required for tiktoken.load.read_file, but it's
+        # listed as optional in tiktoken's pyproject.toml
+        # (https://github.com/openai/tiktoken/blob/main/pyproject.toml#L9)
+        "blobfile~=3.0.0",
     ],
     extras_require={
         "arrow": ["pyarrow>=13.0.0", "pandas~=2.0.0"],


### PR DESCRIPTION
**What does this PR do? Please describe:**
When running lm instruct_finetune recipe like `fairseq2 lm instruction_finetune --config-file <$TEST_NAME>.yaml -- <$OUTPUT_DIR>` after fresh installation of fairseq2, we start to see error like:


```
"/.../conda/lib/python3.10/site-packages/tiktoken/load.py", line 18, in read_file
                                 raise ImportError(
                             ImportError: blobfile is not installed. Please install it by running
                             `pip install blobfile`.
```

This is because of dependency of `blobfile` from `tiktoken`, yet `blobfile` is listed as an optional package in `tiktoken` (https://github.com/openai/tiktoken/blob/main/pyproject.toml#L9). This PR aims to fix this import error.

Fixes #{issue number}

**Does your PR introduce any breaking changes? If yes, please list them:**
List of all backwards-incompatible changes.

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
