### PR TITLE
Add src/tgt encode options for inst finetuning

### DIFF
--- a/src/fairseq2/datasets/preference.py
+++ b/src/fairseq2/datasets/preference.py
@@ -64,6 +64,8 @@ class PreferenceOptimizationDataset(ABC):
         num_accumulate: int = 1,
         num_prefetch: int = 1,
         mask_source_tokens: bool = True,
+        src_encode_mode: str = "prompt",
+        tgt_encode_mode: str = "prompt_response",
         seed: int = 2,
         **extras: Any,
     ) -> DataPipelineReader[PreferenceOptimizationBatch]:
@@ -107,6 +109,10 @@ class PreferenceOptimizationDataset(ABC):
             The number of batches to prefetch in background.
         :param mask_source_tokens:
             If ``False``, calculates loss on the `src` tokens as well as the `tgt` tokens.
+        :param src_encode_mode:
+            The mode to encode the prompt
+        :param tgt_encode_mode:
+            The mode to encode the target
         :param seed:
             The seed to initialize the random number generators used internally.
         :param extras:
@@ -168,6 +174,8 @@ class GenericPreferenceOptimizationDataset(PreferenceOptimizationDataset):
         num_accumulate: int = 1,
         num_prefetch: int = 1,
         mask_source_tokens: bool = True,
+        src_encode_mode: str = "prompt",
+        tgt_encode_mode: str = "prompt_response",
         seed: int = 2,
         **extras: Any,
     ) -> DataPipelineReader[PreferenceOptimizationBatch]:
@@ -202,8 +210,8 @@ class GenericPreferenceOptimizationDataset(PreferenceOptimizationDataset):
         seed += gang.rank
 
         # Encode prompt and target texts.
-        prompt_encoder = tokenizer.create_encoder(mode="prompt")
-        target_encoder = tokenizer.create_encoder(mode="prompt_response")
+        prompt_encoder = tokenizer.create_encoder(mode=src_encode_mode)
+        target_encoder = tokenizer.create_encoder(mode=tgt_encode_mode)
 
         builder.map(prompt_encoder, selector="src", num_parallel_calls=npc)
         builder.map(target_encoder, selector="tgt_chosen", num_parallel_calls=npc)

--- a/src/fairseq2/models/llama/tokenizer.py
+++ b/src/fairseq2/models/llama/tokenizer.py
@@ -88,9 +88,13 @@ class LLaMA3Tokenizer(TiktokenTokenizer):
             case "prompt_response":
                 prefix_tokens = []
                 suffix_tokens = [self._eos_token]
+            case "as_is":
+                prefix_tokens = []
+                suffix_tokens = []
             case _:
                 raise ValueError(
-                    f"`mode` must be 'default' or 'prompt', but is '{mode}' instead."
+                    f"`mode` must be in `['default', 'prompt', 'prompt_response', "
+                    f"'as_is']` but is '{mode}' instead."
                 )
 
         return TiktokenEncoder(

--- a/src/fairseq2/recipes/lm/instruction_finetune.py
+++ b/src/fairseq2/recipes/lm/instruction_finetune.py
@@ -93,6 +93,12 @@ class InstructionFinetuneConfig:
     num_prefetch: int = 4
     """The number of batches to prefetch in background."""
 
+    src_encode_mode: str = "prompt"
+    """The encode mode for the prompt, determines what special tokens to add."""
+
+    tgt_encode_mode: str = "prompt_response"
+    """The encode mode for the target, determines what special tokens to add."""
+
     # Model
     model: AssetReference = "llama3_1_8b_instruct"
     """The name or path to the asset card of the language model to finetune."""
@@ -424,6 +430,8 @@ def load_instruction_finetuner(
             batch_shuffle_window=config.batch_shuffle_window,
             num_accumulate=config.gradient_accumulation,
             num_prefetch=config.num_prefetch,
+            src_encode_mode=config.src_encode_mode,
+            tgt_encode_mode=config.tgt_encode_mode,
             seed=seed,
         )
     except ValueError as ex:
@@ -474,6 +482,8 @@ def load_instruction_finetuner(
                 sync_mode="until_last",
                 num_accumulate=config.gradient_accumulation,
                 num_prefetch=config.num_prefetch,
+                src_encode_mode=config.src_encode_mode,
+                tgt_encode_mode=config.tgt_encode_mode,
                 seed=seed,
             )
         except ValueError as ex:

--- a/src/fairseq2/recipes/lm/preference_finetune/recipe.py
+++ b/src/fairseq2/recipes/lm/preference_finetune/recipe.py
@@ -80,6 +80,12 @@ class PreferenceFinetuneConfig:
     mask_source_tokens: bool = True
     """If ``False``, calculates loss on the `src` tokens as well as the `tgt` tokens."""
 
+    src_encode_mode: str = "prompt"
+    """The encode mode for the prompt, determines what special tokens to add."""
+
+    tgt_encode_mode: str = "prompt_response"
+    """The encode mode for the target, determines what special tokens to add."""
+
     # Model
     model: AssetReference = "llama3_1_8b_instruct"
     """The name or path to the asset card of the language model to finetune."""
@@ -402,6 +408,8 @@ def load_preference_finetuner(
             num_accumulate=config.gradient_accumulation,
             num_prefetch=config.num_prefetch,
             mask_source_tokens=config.mask_source_tokens,
+            src_encode_mode=config.src_encode_mode,
+            tgt_encode_mode=config.tgt_encode_mode,
             seed=config.seed,
         )
     except ValueError as ex:


### PR DESCRIPTION
**What does this PR do? Please describe:**
Add options in instruction finetuning to select the tokenizer encode mode for src and tgt sequences, which allows you to control what special tokens are added.

For certain use cases (e.g., multi-turn conversations), we would like to add our own special tokens, so I also added an option `as_is` to not add any special tokens, and this can be set in the `instruction_finetune` recipe.

Since this is a small change, no tests are written, but I have tried with the following config using the `instruction_finetune` recipe and the training seems to be starting just fine:
```
...
src_encode_mode: as_is
tgt_encode_mode: prompt_response
...
```