### PR TITLE
yaoj/add gsm8k data

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.jsonl filter=lfs diff=lfs merge=lfs -text

--- a/data/gsm8k/dpo/train.jsonl
+++ b/data/gsm8k/dpo/train.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fc96e7f131ba8901f447a8cca51f7f17e831957525e46ef07e4afc52d174ac2e
+size 279914182

--- a/data/gsm8k/sft/train.jsonl
+++ b/data/gsm8k/sft/train.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:12ae92e014cb33ecf8e8f2d8309c663cb816de42d728f38decd06c2239c06f83
+size 4623988

--- a/src/fairseq2/assets/cards/datasets/gsm8k.yaml
+++ b/src/fairseq2/assets/cards/datasets/gsm8k.yaml
@@ -1,0 +1,9 @@
+name: gsm8k_sft
+dataset_family: generic_instruction
+data: "../../../../../data/gsm8k/sft"
+
+---
+
+name: gsm8k_dpo
+dataset_family: generic_preference_optimization
+data: "../../../../../data/gsm8k/dpo"


### PR DESCRIPTION
**What does this PR do? Please describe:**
Add GSM8K dataset as git lfs and add them as datasets

Fixes #848 

**Does your PR introduce any breaking changes? If yes, please list them:**
N/A

**Check list:**
- [x] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)

**Example**

```
$ conda run -n fairseq2_pt2_4_dev_no_apex --live-stream fairseq2 assets show gsm8k_sft
gsm8k_sft
  source          : 'package:fairseq2.assets.cards'
  dataset_family  : 'generic_instruction'
  data            : '../../../../../data/gsm8k/sft'
```

Also tested with SFT recipe on FAIR Clusters with success.