### PR TITLE
keep prompts indices in the example

### DIFF
--- a/src/fairseq2/datasets/preference.py
+++ b/src/fairseq2/datasets/preference.py
@@ -235,6 +235,7 @@ class GenericPreferenceOptimizationDataset(PreferenceOptimizationDataset):
 
             return {
                 "id": id_,
+                "indices_prompt": prompt_indices,
                 "indices_chosen": indices_chosen,
                 "indices_rejected": indices_rejected,
                 "target_mask_chosen": target_mask_chosen,


### PR DESCRIPTION
**What does this PR do? Please describe:**

In preference dataset we now keep prompt indices in the example so that we can access it for generation during online preference training.
