### PR TITLE
Add LoRA-FA support

### DIFF
--- a/src/fairseq2/models/llama/__init__.py
+++ b/src/fairseq2/models/llama/__init__.py
@@ -14,6 +14,9 @@ from fairseq2.models.llama.factory import LLaMABuilder as LLaMABuilder
 from fairseq2.models.llama.factory import LLaMAConfig as LLaMAConfig
 from fairseq2.models.llama.factory import create_llama_model as create_llama_model
 from fairseq2.models.llama.factory import get_llama_lora_config as get_llama_lora_config
+from fairseq2.models.llama.factory import (
+    get_llama_lora_fa_config as get_llama_lora_fa_config,
+)
 from fairseq2.models.llama.factory import llama_arch as llama_arch
 from fairseq2.models.llama.factory import llama_archs as llama_archs
 from fairseq2.models.llama.loader import load_llama_config as load_llama_config

--- a/src/fairseq2/models/llama/factory.py
+++ b/src/fairseq2/models/llama/factory.py
@@ -324,3 +324,10 @@ def get_llama_lora_config() -> LoRAConfig:
         dropout_p=0.05,
         keys=[".*decoder.layers.*.self_attn.*(q_proj|v_proj)$"],
     )
+
+
+def get_llama_lora_fa_config() -> LoRAConfig:
+    config = get_llama_lora_config()
+    config.trainable_A = False
+
+    return config

--- a/src/fairseq2/nn/lora.py
+++ b/src/fairseq2/nn/lora.py
@@ -112,8 +112,8 @@ class LoRAEmbedding(Embedding, LoRALayer):
 
     def reset_lora_parameters(self) -> None:
         """Reset the parameters and buffers of the module."""
-        nn.init.zeros_(self.lora_A)
-        nn.init.normal_(self.lora_B)
+        nn.init.normal_(self.lora_A)
+        nn.init.zeros_(self.lora_B)
 
     @property
     def wrapped_module(self) -> Embedding:


### PR DESCRIPTION
**What does this PR do? Please describe:**
This PR implements LoRA-FA by adding an additional parameter to the LoRAConfig class that can be used to toggle the A matrix used in LoRA as trainable. If toggled off, the A matrix is frozen and LoRA is trained like normal.

Fixes #859 

**Does your PR introduce any breaking changes? If yes, please list them:**
None

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**?
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
