### PR TITLE
Change checksum field to tokenizer_checksum

### DIFF
--- a/src/fairseq2/data/text/text_tokenizer.py
+++ b/src/fairseq2/data/text/text_tokenizer.py
@@ -223,7 +223,7 @@ class AbstractTextTokenizerLoader(ABC, TextTokenizerLoader[TextTokenizerT]):
             return self(tokenizer_ref, force=force, progress=progress)
 
         tokenizer_uri = card.field("tokenizer").as_uri()
-        tokenizer_checksum = card.field("checksum").get_as_(str)
+        tokenizer_checksum = card.field("tokenizer_checksum").get_as_(str)
 
         try:
             path = self._download_manager.download_tokenizer(


### PR DESCRIPTION
**What does this PR do? Please describe:**
This PR fixes a small bug with [text_tokenizer.py](https://github.com/facebookresearch/fairseq2/blob/2ab824540c366925df447f5fc95377b698b41e08/src/fairseq2/data/text/text_tokenizer.py#L226) where it would pull the tokenizer checksum from the ``checksum`` field in the asset card which is instead used for the model checksum. Now, models and tokenizers don't share the same checksum field and can therefore be validated separately as expected.

Fixes #865

**Does your PR introduce any breaking changes? If yes, please list them:**
None

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
