### PR TITLE
Fix string splitter to return a string when a single index is provided

### DIFF
--- a/native/python/src/fairseq2n/bindings/data/text/converters.cc
+++ b/native/python/src/fairseq2n/bindings/data/text/converters.cc
@@ -65,7 +65,7 @@ def_text_converters(py::module_ &text_module)
                 if (maybe_indices)
                     indices = *std::move(maybe_indices);
 
-                return make_string_splitter(std::move(sep), std::move(maybe_names), std::move(indices), exclude);
+                return make_string_splitter(sep, std::move(maybe_names), std::move(indices), exclude);
             }),
             py::arg("sep") = '\t',
             py::arg("names") = std::nullopt,
@@ -78,7 +78,7 @@ def_text_converters(py::module_ &text_module)
                 std::size_t index,
                 bool exclude)
             {
-                return make_string_splitter(std::move(sep), std::move(maybe_names), index, exclude);
+                return make_string_splitter(sep, std::move(maybe_names), index, exclude);
             }),
             py::arg("sep") = '\t',
             py::arg("names") = std::nullopt,

--- a/native/python/src/fairseq2n/bindings/data/text/converters.cc
+++ b/native/python/src/fairseq2n/bindings/data/text/converters.cc
@@ -60,6 +60,27 @@ def_text_converters(py::module_ &text_module)
             py::arg("names") = std::nullopt,
             py::arg("indices") = std::nullopt,
             py::arg("exclude") = false)
+        .def(
+            py::init([](
+                std::string_view sep,
+                std::optional<std::vector<std::string>> maybe_names,
+                std::size_t index,
+                bool exclude)
+            {
+                if (sep.size() != 1)
+                    throw_<std::invalid_argument>(
+                        "`sep` must be of length 1, but is of length {} instead.", sep.size());
+
+                std::vector<std::string> names{};
+                if (maybe_names)
+                    names = *std::move(maybe_names);
+
+                return std::make_shared<string_splitter>(sep[0], std::move(names), index, exclude);
+            }),
+            py::arg("sep") = '\t',
+            py::arg("names") = std::nullopt,
+            py::arg("indices") = 0,
+            py::arg("exclude") = false)
         .def("__call__", &string_splitter::operator(), py::call_guard<py::gil_scoped_release>{});
 
     // StrToIntConverter

--- a/native/python/src/fairseq2n/bindings/data/text/converters.cc
+++ b/native/python/src/fairseq2n/bindings/data/text/converters.cc
@@ -43,8 +43,12 @@ make_string_splitter(
     if (maybe_names)
         names = *std::move(maybe_names);
 
-    return std::make_shared<string_splitter>(
-        sep[0], std::move(names), std::move(indices), exclude);
+    return std::visit(
+        [&](auto &&idx) {
+            return std::make_shared<string_splitter>(
+                sep[0], std::move(names), std::forward<decltype(idx)>(idx), exclude);
+        },
+        std::move(indices));
 }
 
 void

--- a/native/python/src/fairseq2n/bindings/data/text/converters.cc
+++ b/native/python/src/fairseq2n/bindings/data/text/converters.cc
@@ -31,8 +31,8 @@ namespace fairseq2n {
 static std::shared_ptr<string_splitter>
 make_string_splitter(
     std::string_view sep,
-    std::optional<std::vector<std::string>> maybe_names,
-    std::variant<std::size_t, std::vector<std::size_t>> indices,
+    std::optional<std::vector<std::string>> &&maybe_names,
+    std::variant<std::size_t, std::vector<std::size_t>> &&indices,
     bool exclude)
 {
     if (sep.size() != 1)

--- a/native/src/fairseq2n/data/text/string_splitter.cc
+++ b/native/src/fairseq2n/data/text/string_splitter.cc
@@ -18,13 +18,11 @@ using namespace fairseq2n::detail;
 namespace fairseq2n {
 
 static std::vector<std::size_t>
-wrapIndices(std::variant<std::size_t, std::vector<std::size_t>> indices) {
+wrapIndices(std::variant<std::size_t, std::vector<std::size_t>> &&indices) {
     if (std::holds_alternative<std::size_t>(indices)) {
-        // Wrap the size_t value in a new vector
-        return {std::get<std::size_t>(indices)};
+        return {std::get<std::size_t>(std::move(indices))};
     } else {
-        // Move the existing vector
-        return std::move(std::get<std::vector<std::size_t>>(indices));
+        return std::get<std::vector<std::size_t>>(std::move(indices));
     }
 }
 

--- a/native/src/fairseq2n/data/text/string_splitter.cc
+++ b/native/src/fairseq2n/data/text/string_splitter.cc
@@ -76,9 +76,13 @@ string_splitter::operator()(data &&d) const
         throw_<std::invalid_argument>(
             "The input string must have at least {} field(s), but has {} instead.", indices_.back(), idx);
 
-    // If no names specified, return as list.
-    if (names_.empty())
+    // If no names specified, return a list, or a string if a single non-excluding index is specified.
+    if (names_.empty()) {
+        if (!exclude_ && indices_.size() == 1)
+            return data{std::move(fields[0])};
+
         return fields;
+    }
 
     // Otherwise, as dictionary.
     if (names_.size() != fields.size())

--- a/native/src/fairseq2n/data/text/string_splitter.cc
+++ b/native/src/fairseq2n/data/text/string_splitter.cc
@@ -18,7 +18,7 @@ using namespace fairseq2n::detail;
 namespace fairseq2n {
 
 static std::vector<std::size_t>
-wrapIndices(std::variant<std::size_t, std::vector<std::size_t>> &&indices) {
+wrap_indices(std::variant<std::size_t, std::vector<std::size_t>> &&indices) {
     if (std::holds_alternative<std::size_t>(indices)) {
         return {std::get<std::size_t>(std::move(indices))};
     } else {
@@ -31,7 +31,7 @@ string_splitter::string_splitter(
     std::vector<std::string> names,
     std::variant<std::size_t, std::vector<std::size_t>> indices,
     bool exclude)
-  : separator_{separator}, names_(std::move(names)), indices_{wrapIndices(std::move(indices))}, exclude_{exclude}, single_column_{std::holds_alternative<std::size_t>(indices)}
+  : separator_{separator}, names_(std::move(names)), indices_{wrap_indices(std::move(indices))}, exclude_{exclude}, single_column_{std::holds_alternative<std::size_t>(indices)}
 {
     if (indices_.empty())
         return;

--- a/native/src/fairseq2n/data/text/string_splitter.cc
+++ b/native/src/fairseq2n/data/text/string_splitter.cc
@@ -17,22 +17,36 @@ using namespace fairseq2n::detail;
 
 namespace fairseq2n {
 
-static std::vector<std::size_t>
-wrap_indices(std::variant<std::size_t, std::vector<std::size_t>> &&indices) {
-    if (std::holds_alternative<std::size_t>(indices)) {
-        return {std::get<std::size_t>(std::move(indices))};
-    } else {
-        return std::get<std::vector<std::size_t>>(std::move(indices));
-    }
+string_splitter::string_splitter(
+    char separator,
+    std::vector<std::string> names,
+    std::vector<std::size_t> indices,
+    bool exclude)
+  : separator_{separator},
+    names_{std::move(names)},
+    indices_{std::move(indices)},
+    exclude_{exclude},
+    single_column_{false}
+{
+    finalize_indices();
 }
 
 string_splitter::string_splitter(
     char separator,
     std::vector<std::string> names,
-    std::variant<std::size_t, std::vector<std::size_t>> indices,
+    std::size_t index,
     bool exclude)
-  : separator_{separator}, names_(std::move(names)), indices_{wrap_indices(std::move(indices))}, exclude_{exclude}, single_column_{std::holds_alternative<std::size_t>(indices)}
+  : separator_{separator},
+    names_{std::move(names)},
+    indices_{index},
+    exclude_{exclude},
+    single_column_{true}
 {
+    finalize_indices();
+}
+
+void
+string_splitter::finalize_indices() {
     if (indices_.empty())
         return;
 

--- a/native/src/fairseq2n/data/text/string_splitter.cc
+++ b/native/src/fairseq2n/data/text/string_splitter.cc
@@ -17,12 +17,23 @@ using namespace fairseq2n::detail;
 
 namespace fairseq2n {
 
+static std::vector<std::size_t>
+wrapIndices(std::variant<std::size_t, std::vector<std::size_t>> indices) {
+    if (std::holds_alternative<std::size_t>(indices)) {
+        // Wrap the size_t value in a new vector
+        return {std::get<std::size_t>(indices)};
+    } else {
+        // Move the existing vector
+        return std::move(std::get<std::vector<std::size_t>>(indices));
+    }
+}
+
 string_splitter::string_splitter(
     char separator,
     std::vector<std::string> names,
     std::variant<std::size_t, std::vector<std::size_t>> indices,
     bool exclude)
-  : separator_{separator}, names_(std::move(names)), indices_{wrapIndices(indices)}, exclude_{exclude}, single_column_{std::holds_alternative<std::size_t>(indices)}
+  : separator_{separator}, names_(std::move(names)), indices_{wrapIndices(std::move(indices))}, exclude_{exclude}, single_column_{std::holds_alternative<std::size_t>(indices)}
 {
     if (indices_.empty())
         return;
@@ -95,17 +106,6 @@ string_splitter::operator()(data &&d) const
         dict.emplace(names_[i], std::move(fields[i]));
 
     return dict;
-}
-
-std::vector<std::size_t>
-string_splitter::wrapIndices(std::variant<std::size_t, std::vector<std::size_t>> indices) {
-    if (std::holds_alternative<std::size_t>(indices)) {
-        // Wrap the size_t value in a new vector
-        return {std::get<std::size_t>(indices)};
-    } else {
-        // Move the existing vector
-        return std::move(std::get<std::vector<std::size_t>>(indices));
-    }
 }
 
 }  // namespace fairseq2n

--- a/native/src/fairseq2n/data/text/string_splitter.cc
+++ b/native/src/fairseq2n/data/text/string_splitter.cc
@@ -20,25 +20,10 @@ namespace fairseq2n {
 string_splitter::string_splitter(
     char separator,
     std::vector<std::string> names,
-    std::vector<std::size_t> indices,
+    std::variant<std::size_t, std::vector<std::size_t>> indices,
     bool exclude)
-  : separator_{separator}, names_(std::move(names)), indices_{std::move(indices)}, exclude_{exclude}, single_column_{false}
+  : separator_{separator}, names_(std::move(names)), indices_{wrapIndices(indices)}, exclude_{exclude}, single_column_{std::holds_alternative<std::size_t>(indices)}
 {
-    finalizeConstructor();
-}
-
-string_splitter::string_splitter(
-    char separator,
-    std::vector<std::string> names,
-    std::size_t index,
-    bool exclude)
-  : separator_{separator}, names_(std::move(names)), indices_{index}, exclude_{exclude}, single_column_{true}
-{
-    finalizeConstructor();
-}
-
-void
-string_splitter::finalizeConstructor() {
     if (indices_.empty())
         return;
 
@@ -112,15 +97,15 @@ string_splitter::operator()(data &&d) const
     return dict;
 }
 
-// std::vector<std::size_t>
-// string_splitter::wrapIndices(std::variant<std::size_t, std::vector<std::size_t>> indices) {
-//     if (std::holds_alternative<std::size_t>(indices)) {
-//         // Wrap the size_t value in a new vector
-//         return {std::get<std::size_t>(indices)};
-//     } else {
-//         // Move the existing vector
-//         return std::move(std::get<std::vector<std::size_t>>(indices));
-//     }
-// }
+std::vector<std::size_t>
+string_splitter::wrapIndices(std::variant<std::size_t, std::vector<std::size_t>> indices) {
+    if (std::holds_alternative<std::size_t>(indices)) {
+        // Wrap the size_t value in a new vector
+        return {std::get<std::size_t>(indices)};
+    } else {
+        // Move the existing vector
+        return std::move(std::get<std::vector<std::size_t>>(indices));
+    }
+}
 
 }  // namespace fairseq2n

--- a/native/src/fairseq2n/data/text/string_splitter.h
+++ b/native/src/fairseq2n/data/text/string_splitter.h
@@ -36,7 +36,6 @@ private:
     bool exclude_;
     bool single_column_;
 
-    std::vector<std::size_t> wrapIndices(std::variant<std::size_t, std::vector<std::size_t>> indices);
 };
 
 }  // namespace fairseq2n

--- a/native/src/fairseq2n/data/text/string_splitter.h
+++ b/native/src/fairseq2n/data/text/string_splitter.h
@@ -25,6 +25,13 @@ public:
         std::vector<std::size_t> indices = {},
         bool exclude = false);
 
+    explicit
+    string_splitter(
+        char separator = '\t',
+        std::vector<std::string> names = {},
+        std::size_t index = 0,
+        bool exclude = false);
+
     data
     operator()(data &&d) const;
 
@@ -33,6 +40,9 @@ private:
     std::vector<std::string> names_;
     std::vector<std::size_t> indices_;
     bool exclude_;
+    bool single_column_;
+
+    void finalizeConstructor();
 };
 
 }  // namespace fairseq2n

--- a/native/src/fairseq2n/data/text/string_splitter.h
+++ b/native/src/fairseq2n/data/text/string_splitter.h
@@ -23,7 +23,14 @@ public:
     string_splitter(
         char separator = '\t',
         std::vector<std::string> names = {},
-        std::variant<std::size_t, std::vector<std::size_t>> indices = {},
+        std::vector<std::size_t> indices = {},
+        bool exclude = false);
+
+    explicit
+    string_splitter(
+        char separator = '\t',
+        std::vector<std::string> names = {},
+        std::size_t index = 0,
         bool exclude = false);
 
     data
@@ -36,6 +43,7 @@ private:
     bool exclude_;
     bool single_column_;
 
+    void finalize_indices();
 };
 
 }  // namespace fairseq2n

--- a/native/src/fairseq2n/data/text/string_splitter.h
+++ b/native/src/fairseq2n/data/text/string_splitter.h
@@ -9,6 +9,7 @@
 #include <cstddef>
 #include <optional>
 #include <string>
+#include <variant>
 #include <vector>
 
 #include "fairseq2n/api.h"
@@ -22,14 +23,7 @@ public:
     string_splitter(
         char separator = '\t',
         std::vector<std::string> names = {},
-        std::vector<std::size_t> indices = {},
-        bool exclude = false);
-
-    explicit
-    string_splitter(
-        char separator = '\t',
-        std::vector<std::string> names = {},
-        std::size_t index = 0,
+        std::variant<std::size_t, std::vector<std::size_t>> indices = {},
         bool exclude = false);
 
     data
@@ -42,7 +36,7 @@ private:
     bool exclude_;
     bool single_column_;
 
-    void finalizeConstructor();
+    std::vector<std::size_t> wrapIndices(std::variant<std::size_t, std::vector<std::size_t>> indices);
 };
 
 }  // namespace fairseq2n

--- a/src/fairseq2/data/text/converters.py
+++ b/src/fairseq2/data/text/converters.py
@@ -29,13 +29,18 @@ if TYPE_CHECKING or DOC_MODE:
 
         :param indices:
             The indices of the column to keep.
+            If a single index is provided and exclude is False, the output will be a string.
+
+        :param exclude:
+            If True, the indices will be excluded from the output, instead of kept.
+            Default to False.
 
         Example usage::
 
             # read all columns: ["Go.", "Va !", "CC-BY 2.0 (France)"]
             dataloader = read_text("tatoeba.tsv").map(StrSplitter()).and_return()
-            # keep only the second column and convert to string: "Va !"
-            dataloader = read_text("tatoeba.tsv").map(StrSplitter(indices=[1])).map(lambda x: x[0]).and_return()
+            # keep only the second column, directly yielding a string: "Va !"
+            dataloader = read_text("tatoeba.tsv").map(StrSplitter(indices=[1])).and_return()
             # keep only the first and second column and convert to dict: {"en": "Go.", "fr": "Va !"}
             dataloader = read_text("tatoeba.tsv").map(StrSplitter(names=["en", "fr"], indices=[0, 1])).and_return()
 
@@ -50,7 +55,7 @@ if TYPE_CHECKING or DOC_MODE:
         ) -> None:
             ...
 
-        def __call__(self, s: str) -> list[str] | dict[str, str]:
+        def __call__(self, s: str) -> str | list[str] | dict[str, str]:
             ...
 
     @final

--- a/src/fairseq2/data/text/converters.py
+++ b/src/fairseq2/data/text/converters.py
@@ -29,12 +29,12 @@ if TYPE_CHECKING or DOC_MODE:
 
         :param indices:
             A list of indices of the column to keep, or a single index.
-            If a single index is provided and exclude is False,
+            If a single index is provided and ``exclude`` is ``False``,
             the output is a string.
 
         :param exclude:
-            If True, the indices will be excluded from the output,
-            instead of kept. Default to False.
+            If ``True``, the indices will be excluded from the output,
+            instead of kept. Default to ``False``.
 
         Example usage::
 

--- a/src/fairseq2/data/text/converters.py
+++ b/src/fairseq2/data/text/converters.py
@@ -28,19 +28,22 @@ if TYPE_CHECKING or DOC_MODE:
             Will create dictionaries object with one entry per column
 
         :param indices:
-            The indices of the column to keep.
-            If a single index is provided and exclude is False, the output will be a string.
+            A list of indices of the column to keep, or a single index.
+            If a single index is provided and exclude is False,
+            the output is a string.
 
         :param exclude:
-            If True, the indices will be excluded from the output, instead of kept.
-            Default to False.
+            If True, the indices will be excluded from the output,
+            instead of kept. Default to False.
 
         Example usage::
 
             # read all columns: ["Go.", "Va !", "CC-BY 2.0 (France)"]
             dataloader = read_text("tatoeba.tsv").map(StrSplitter()).and_return()
+            # keep first and second columns, yielding the list: ["Go.", "Va !"]
+            dataloader = read_text("tatoeba.tsv").map(StrSplitter(indices=[0, 1])).and_return()
             # keep only the second column, directly yielding a string: "Va !"
-            dataloader = read_text("tatoeba.tsv").map(StrSplitter(indices=[1])).and_return()
+            dataloader = read_text("tatoeba.tsv").map(StrSplitter(indices=1)).and_return()
             # keep only the first and second column and convert to dict: {"en": "Go.", "fr": "Va !"}
             dataloader = read_text("tatoeba.tsv").map(StrSplitter(names=["en", "fr"], indices=[0, 1])).and_return()
 
@@ -50,7 +53,7 @@ if TYPE_CHECKING or DOC_MODE:
             self,
             sep: str = "\t",
             names: Sequence[str] | None = None,
-            indices: Sequence[int] | None = None,
+            indices: int | Sequence[int] | None = None,
             exclude: bool = False,
         ) -> None:
             ...

--- a/tests/unit/data/text/test_str_splitter.py
+++ b/tests/unit/data/text/test_str_splitter.py
@@ -58,18 +58,17 @@ class TestStrSplitter:
 
         assert splitter(s) == {"a": "1", "b": "2", "c": "3"}
 
-    @pytest.mark.parametrize("indices", [[0], [1], [4]])
+    @pytest.mark.parametrize("indices", [0, 1, 4])
     def test_call_works_when_single_index_is_specified(
-        self, indices: Sequence[int]
+        self, indices: int
     ) -> None:
         s = "0,1,2,3,4"
 
         splitter = StrSplitter(sep=",", indices=indices)
 
-        assert len(indices) == 1
-        assert splitter(s) == str(indices[0])
+        assert splitter(s) == str(indices)
 
-    @pytest.mark.parametrize("indices", [[2, 3], [1, 2, 4]])
+    @pytest.mark.parametrize("indices", [[0], [1], [4], [2, 3], [1, 2, 4]])
     def test_call_works_when_multiple_indices_are_specified(
         self, indices: Sequence[int]
     ) -> None:
@@ -83,7 +82,9 @@ class TestStrSplitter:
         "indices,expected",
         [
             ([0], [1, 2, 3, 4]),
+            (0, [1, 2, 3, 4]),
             ([4], [0, 1, 2, 3]),
+            (4, [0, 1, 2, 3]),
             ([2, 3], [0, 1, 4]),
             ([1, 2, 4], [0, 3]),
             ([1, 2, 3, 4], [0]),

--- a/tests/unit/data/text/test_str_splitter.py
+++ b/tests/unit/data/text/test_str_splitter.py
@@ -58,8 +58,19 @@ class TestStrSplitter:
 
         assert splitter(s) == {"a": "1", "b": "2", "c": "3"}
 
-    @pytest.mark.parametrize("indices", [[0], [1], [4], [2, 3], [1, 2, 4]])
-    def test_call_works_when_indices_are_specified(
+    @pytest.mark.parametrize("indices", [[0], [1], [4]])
+    def test_call_works_when_single_index_is_specified(
+        self, indices: Sequence[int]
+    ) -> None:
+        s = "0,1,2,3,4"
+
+        splitter = StrSplitter(sep=",", indices=indices)
+
+        assert len(indices) == 1
+        assert splitter(s) == str(indices[0])
+
+    @pytest.mark.parametrize("indices", [[2, 3], [1, 2, 4]])
+    def test_call_works_when_multiple_indices_are_specified(
         self, indices: Sequence[int]
     ) -> None:
         s = "0,1,2,3,4"
@@ -75,6 +86,7 @@ class TestStrSplitter:
             ([4], [0, 1, 2, 3]),
             ([2, 3], [0, 1, 4]),
             ([1, 2, 4], [0, 3]),
+            ([1, 2, 3, 4], [0]),
         ],
     )
     def test_call_works_when_exclude_indices_are_specified(

--- a/tests/unit/data/text/test_str_splitter.py
+++ b/tests/unit/data/text/test_str_splitter.py
@@ -59,9 +59,7 @@ class TestStrSplitter:
         assert splitter(s) == {"a": "1", "b": "2", "c": "3"}
 
     @pytest.mark.parametrize("indices", [0, 1, 4])
-    def test_call_works_when_single_index_is_specified(
-        self, indices: int
-    ) -> None:
+    def test_call_works_when_single_index_is_specified(self, indices: int) -> None:
         s = "0,1,2,3,4"
 
         splitter = StrSplitter(sep=",", indices=indices)


### PR DESCRIPTION
**What does this PR do? Please describe:**
String splitter now returns a string when a single index is provided as argument.
This relieves the user from unpacking the previous returned singleton list.

Fixes #{issue number}

**Does your PR introduce any breaking changes? If yes, please list them:**
No

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**?
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
