### PR TITLE
Introduce ResidualConnect and DropPath

### DIFF
--- a/src/fairseq2/nn/transformer/encoder_layer.py
+++ b/src/fairseq2/nn/transformer/encoder_layer.py
@@ -9,11 +9,8 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import final
 
-import torch
-import torch.nn as nn
 from torch import Tensor
 from torch.nn import Dropout, Module
-from torch.nn.parameter import Parameter
 from typing_extensions import override
 
 from fairseq2.nn.normalization import LayerNorm
@@ -26,6 +23,7 @@ from fairseq2.nn.transformer.layer_norm import (
 )
 from fairseq2.nn.transformer.multihead_attention import MultiheadAttention
 from fairseq2.nn.transformer.norm_order import TransformerNormOrder
+from fairseq2.nn.transformer.residual import ResidualConnect, StandardResidualConnect
 from fairseq2.typing import DataType, Device
 
 
@@ -83,10 +81,11 @@ class StandardTransformerEncoderLayer(TransformerEncoderLayer):
     self_attn: MultiheadAttention
     self_attn_norm: LayerNorm | None
     self_attn_dropout: Dropout | None
+    self_attn_residual: ResidualConnect
     self_attn_layer_norm: LayerNorm
     ffn: FeedForwardNetwork
     ffn_dropout: Dropout | None
-    residual_scale: Parameter | None
+    ffn_residual: ResidualConnect
     ffn_layer_norm: LayerNorm
     norm_order: TransformerNormOrder
 
@@ -95,10 +94,11 @@ class StandardTransformerEncoderLayer(TransformerEncoderLayer):
         self_attn: MultiheadAttention,
         ffn: FeedForwardNetwork,
         *,
-        scale_residual: bool = False,
         dropout_p: float = 0.0,
         norm_order: TransformerNormOrder = TransformerNormOrder.POST,
         layer_norm_factory: LayerNormFactory | None = None,
+        self_attn_residual: ResidualConnect | None = None,
+        ffn_residual: ResidualConnect | None = None,
         device: Device | None = None,
         dtype: DataType | None = None,
     ) -> None:
@@ -107,10 +107,6 @@ class StandardTransformerEncoderLayer(TransformerEncoderLayer):
             The self attention layer.
         :param ffn:
             The feed-forward network.
-        :param scale_residual:
-            If ``True``, scales residuals before adding them to the output of
-            the feed-forward network as described in
-            :cite:t:`https://doi.org/10.48550/arxiv.2110.09456`.
         :param dropout_p:
             The dropout probability on outputs of the self attention layer and
             the feed-forward network.
@@ -118,6 +114,12 @@ class StandardTransformerEncoderLayer(TransformerEncoderLayer):
             The Layer Normalization order.
         :param layer_norm_factory:
             The factory to construct the Layer Normalization modules.
+        :param self_attn_residual:
+            The residual connection between the input and output of the self
+            attention layer.
+        :param ffn_residual:
+            The residual connection between the input and output of the
+            feed-forward network.
         """
         model_dim = self_attn.model_dim
 
@@ -145,6 +147,11 @@ class StandardTransformerEncoderLayer(TransformerEncoderLayer):
         else:
             self.register_module("self_attn_dropout", None)
 
+        if self_attn_residual is None:
+            self_attn_residual = StandardResidualConnect()
+
+        self.self_attn_residual = self_attn_residual
+
         if norm_order == TransformerNormOrder.POST:
             self.self_attn_layer_norm = self_attn_layer_norm
 
@@ -160,24 +167,15 @@ class StandardTransformerEncoderLayer(TransformerEncoderLayer):
         else:
             self.register_module("ffn_dropout", None)
 
-        if scale_residual:
-            self.residual_scale = Parameter(
-                torch.empty((model_dim,), device=device, dtype=dtype)
-            )
-        else:
-            self.register_parameter("residual_scale", None)
+        if ffn_residual is None:
+            ffn_residual = StandardResidualConnect()
+
+        self.ffn_residual = ffn_residual
 
         if norm_order == TransformerNormOrder.POST:
             self.ffn_layer_norm = ffn_layer_norm
 
         self.norm_order = norm_order
-
-        self.reset_parameters()
-
-    def reset_parameters(self) -> None:
-        """Reset the parameters and buffers of the module."""
-        if self.residual_scale is not None:
-            nn.init.ones_(self.residual_scale)
 
     @override
     def forward(
@@ -218,7 +216,7 @@ class StandardTransformerEncoderLayer(TransformerEncoderLayer):
         if self.self_attn_dropout is not None:
             seqs = self.self_attn_dropout(seqs)
 
-        seqs = seqs + residual
+        seqs = self.self_attn_residual(seqs, residual)
 
         if self.norm_order == TransformerNormOrder.POST:
             seqs = self.self_attn_layer_norm(seqs)
@@ -236,10 +234,7 @@ class StandardTransformerEncoderLayer(TransformerEncoderLayer):
         if self.ffn_dropout is not None:
             seqs = self.ffn_dropout(seqs)
 
-        if self.residual_scale is not None:
-            residual = self.residual_scale * residual
-
-        seqs = seqs + residual
+        seqs = self.ffn_residual(seqs, residual)
 
         if self.norm_order == TransformerNormOrder.POST:
             seqs = self.ffn_layer_norm(seqs)

--- a/src/fairseq2/nn/transformer/residual.py
+++ b/src/fairseq2/nn/transformer/residual.py
@@ -1,0 +1,131 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import final
+
+import torch
+import torch.nn as nn
+from torch import Tensor
+from torch.nn import Module, Parameter
+from typing_extensions import override
+
+from fairseq2.typing import DataType, Device
+
+
+class ResidualConnect(Module, ABC):
+    """Represents a residual connection within a Transformer layer."""
+
+    @abstractmethod
+    def forward(self, seqs: Tensor, residual: Tensor) -> Tensor:
+        """
+        :param seqs: The sequences output by a module such as a multi-head
+            attention layer or a feed-forward network. *Shape:* :math:`(N,S,M)`,
+            where :math:`N` is the batch size, :math:`S` is the sequence length,
+            and :math:`M` is the dimensionality of the model.
+        :param residual: The input sequences to the module. *Shape:* Same as
+            ``seqs``.
+
+        :returns: The output sequences with residuals applied. *Shape:* Same as
+            ``seqs``.
+        """
+
+
+@final
+class StandardResidualConnect(ResidualConnect):
+    """Sums inputs and outputs of a Transformer module."""
+
+    @override
+    def forward(self, seqs: Tensor, residual: Tensor) -> Tensor:
+        return seqs + residual
+
+
+@final
+class ScaledResidualConnect(ResidualConnect):
+    """
+    Scales residuals before adding them to the output of a feed-forward
+    network as described in :cite:t:`https://doi.org/10.48550/arxiv.2110.09456`.
+    """
+
+    scale_proj: Parameter
+
+    def __init__(
+        self,
+        model_dim: int,
+        *,
+        device: Device | None = None,
+        dtype: DataType | None = None,
+    ) -> None:
+        """
+        :param model_dim: The dimensionality of the model.
+        """
+        super().__init__()
+
+        self.scale_proj = Parameter(
+            torch.empty((model_dim,), device=device, dtype=dtype)
+        )
+
+    def reset_parameters(self) -> None:
+        """Reset the parameters and buffers of the module."""
+        nn.init.ones_(self.scale_proj)
+
+    @override
+    def forward(self, seqs: Tensor, residual: Tensor) -> Tensor:
+        residual = self.scale_proj * residual
+
+        return seqs + residual
+
+
+@final
+class DropPathResidualConnect(ResidualConnect):
+    """
+    Drops entire sequences from module outputs before adding residuals which
+    effectively results in stochastic depth as described in section 3 of
+    :cite:t:`https://doi.org/10.48550/arxiv.1603.09382`.
+
+    .. note::
+
+        This implementation is mostly adapted from Ross Wightman's ``drop_path``
+        function in timm.
+    """
+
+    drop_p: float
+    scale_by_keep: bool
+
+    def __init__(self, drop_p: float, scale_by_keep: bool = True) -> None:
+        """
+        :param drop_p: The probability of dropping sequences from module outputs.
+        :param scale_by_keep: If ``True``, non-dropped sequences will be scaled
+            by the keep probability (i.e. ``1 - drop_p``) as in EfficientNet.
+        """
+        super().__init__()
+
+        self.drop_p = drop_p
+        self.scale_by_keep = scale_by_keep
+
+    @override
+    def forward(self, seqs: Tensor, residual: Tensor) -> Tensor:
+        if not self.training or self.drop_p == 0.0:
+            return seqs + residual
+
+        shape = [seqs.size(0)] + [1] * (seqs.ndim - 1)
+
+        keep_p = 1.0 - self.drop_p
+
+        # (N)
+        drop_mask = torch.rand(shape, device=seqs.device, dtype=seqs.dtype) + keep_p
+
+        drop_mask.floor_()  # binarize
+
+        if self.scale_by_keep:
+            seqs = seqs / keep_p
+
+        return (seqs * drop_mask) + residual
+
+    def extra_repr(self) -> str:
+        return f"drop_p={self.drop_p}, scale_by_keep={self.scale_by_keep}"


### PR DESCRIPTION
This PR introduces the new `ResidualConnect` interface along with `StandardResidualConnect`, `ScaledResidualConnect` (from NormFormer paper), and `DropPathResidualConnect` (from EfficientNet) implementations. `StandardEncoderLayer` and `StandardDecoderLayer` classes are also extended with optional `ResidualConnect` parameters for MHA and FFN modules. If the provided argument to the layers is `None`, a `StandardResidualConnect` instance will be used which effectively means summing module outputs with their residuals.