### PR TITLE
Introduce GLU FFN implementation based on Dauphin's paper

### DIFF
--- a/bibliography.bib
+++ b/bibliography.bib
@@ -1,10 +1,11 @@
-@misc{https://doi.org/10.48550/arxiv.1608.03983,
-  title={SGDR: Stochastic Gradient Descent with Warm Restarts},
-  author={Ilya Loshchilov and Frank Hutter},
-  year={2017},
-  eprint={1608.03983},
+@misc{https://doi.org/10.48550/arxiv.1603.09382,
+  title={Deep Networks with Stochastic Depth},
+  author={Gao Huang and Yu Sun and Zhuang Liu and Daniel Sedra and Kilian Weinberger},
+  year={2016},
+  eprint={1603.09382},
   archivePrefix={arXiv},
-  primaryClass={cs.LG}
+  primaryClass={cs.LG},
+  url={https://arxiv.org/abs/1603.09382},
 }
 
 @misc{https://doi.org/10.48550/arxiv.1607.06450,
@@ -23,6 +24,25 @@
   eprint={1609.03499},
   archivePrefix={arXiv},
   primaryClass={cs.SD}
+}
+
+@misc{https://doi.org/10.48550/arxiv.1608.03983,
+  title={SGDR: Stochastic Gradient Descent with Warm Restarts},
+  author={Ilya Loshchilov and Frank Hutter},
+  year={2017},
+  eprint={1608.03983},
+  archivePrefix={arXiv},
+  primaryClass={cs.LG}
+}
+
+@misc{https://doi.org/10.48550/arXiv.1612.08083,
+  title={Language Modeling with Gated Convolutional Networks},
+  author={Yann N. Dauphin and Angela Fan and Michael Auli and David Grangier},
+  year={2017},
+  eprint={1612.08083},
+  archivePrefix={arXiv},
+  primaryClass={cs.CL},
+  url={https://arxiv.org/abs/1612.08083},
 }
 
 @misc{https://doi.org/10.48550/arxiv.1706.03762,


### PR DESCRIPTION
This PR introduces the GLU FFN variant described in Yann Dauphin's paper. This is also the predecessor of the GLU FFNs described in Shazeer's paper. Since Shazeer's work already exists as `GLUFeedForwardNetwork` in fairseq2, this new implementation is named `DauphinFeedForwardNetwork`.