### PR TITLE
Introduce interpolated position encoders

### DIFF
--- a/src/fairseq2/nn/__init__.py
+++ b/src/fairseq2/nn/__init__.py
@@ -17,10 +17,22 @@ from fairseq2.nn.normalization import LayerNorm as LayerNorm
 from fairseq2.nn.normalization import RMSNorm as RMSNorm
 from fairseq2.nn.normalization import StandardLayerNorm as StandardLayerNorm
 from fairseq2.nn.position_encoder import (
+    InterpolatedPositionEncoder as InterpolatedPositionEncoder,
+)
+from fairseq2.nn.position_encoder import (
     LearnedPositionEncoder as LearnedPositionEncoder,
 )
 from fairseq2.nn.position_encoder import PositionEncoder as PositionEncoder
 from fairseq2.nn.position_encoder import RotaryEncoder as RotaryEncoder
+from fairseq2.nn.position_encoder import (
+    Sinusoidal2dPositionEncoder as Sinusoidal2dPositionEncoder,
+)
+from fairseq2.nn.position_encoder import (
+    Sinusoidal3dPositionEncoder as Sinusoidal3dPositionEncoder,
+)
+from fairseq2.nn.position_encoder import (
+    SinusoidalNdPositionEncoder as SinusoidalNdPositionEncoder,
+)
 from fairseq2.nn.position_encoder import (
     SinusoidalPositionEncoder as SinusoidalPositionEncoder,
 )

--- a/src/fairseq2/nn/position_encoder.py
+++ b/src/fairseq2/nn/position_encoder.py
@@ -15,7 +15,7 @@ import torch
 import torch.nn as nn
 from torch import Tensor
 from torch.nn import Module
-from torch.nn.functional import embedding
+from torch.nn.functional import embedding, interpolate
 from torch.nn.parameter import Parameter
 from typing_extensions import override
 
@@ -32,9 +32,9 @@ class PositionEncoder(Module, ABC):
 
     def __init__(self, encoding_dim: int, max_seq_len: int | None) -> None:
         """
-        :param encoding_dim: The dimensionality of positional encodings. Input
-            sequences are expected to have the same dimensionality.
-
+        :param encoding_dim: The dimensionality of positional encodings. The
+            last dimension of input sequences is expected to have the same
+            dimensionality.
         :param max_seq_len: The maximum allowed length for input sequences.
             Sequences longer than ``max_seq_len`` will cause a :class:`ValueError`.
             Typically it is set to the context length of the underlying model.
@@ -59,11 +59,9 @@ class PositionEncoder(Module, ABC):
             where :math:`*` is any number of batch dimensions including none,
             :math:`S` is the sequence length, and :math:`E` is the dimensionality
             of the positional encodings.
-
         :param padding_mask: The padding mask of ``seqs``. *Shape:* :math:`(*,S)`,
             where :math:`*` is any number of batch dimensions including none and
             :math:`S` is the sequence length.
-
         :param state_bag: If not ``None``, the encoder will operate in
             incremental decoding mode. This means that the first step in ``seqs``
             will be considered to be at position :attr:`state_bag.step_nr
@@ -127,9 +125,9 @@ class SinusoidalPositionEncoder(PositionEncoder):
         device: Device | None = None,
     ) -> None:
         """
-        :param encoding_dim: The dimensionality of positional encodings. Input
-            sequences are expected to have the same dimensionality.
-
+        :param encoding_dim: The dimensionality of positional encodings. The
+            last dimension of input sequences is expected to have the same
+            dimensionality.
         :param max_seq_len: The maximum allowed length for input sequences.
             Sequences longer than ``max_seq_len`` will cause a :class:`ValueError`.
 
@@ -142,18 +140,18 @@ class SinusoidalPositionEncoder(PositionEncoder):
                 f"`encoding_dim` must be even, but is {encoding_dim} instead."
             )
 
+        freqs = torch.empty(
+            (max_seq_len, encoding_dim), device=device, dtype=torch.float32
+        )
+
+        self.register_buffer("freqs", freqs, persistent=False)
+
         # This is a legacy parameter that should only be set when the encodings
         # must be compatible with fairseq.
         if _legacy_pad_idx is None:
             self._sin_offset = 0
         else:
             self._sin_offset = 1 + _legacy_pad_idx
-
-        freqs = torch.empty(
-            (max_seq_len, encoding_dim), device=device, dtype=torch.float32
-        )
-
-        self.register_buffer("freqs", freqs, persistent=False)
 
         self.reset_parameters()
 
@@ -167,11 +165,6 @@ class SinusoidalPositionEncoder(PositionEncoder):
 
         device, dtype = self.freqs.device, self.freqs.dtype
 
-        num_sin = self.encoding_dim // 2
-
-        l_half = self.freqs[:, :num_sin]
-        r_half = self.freqs[:, num_sin:]
-
         start_step = self._sin_offset
 
         # (S)
@@ -179,19 +172,7 @@ class SinusoidalPositionEncoder(PositionEncoder):
             start_step, start_step + self.max_seq_len, device=device, dtype=dtype
         )
 
-        # (E)
-        indices = torch.arange(num_sin, device=device, dtype=dtype)
-
-        # This is identical to tensor2tensor's implementation.
-        freqs = torch.exp(indices * -math.log(10000.0) / (num_sin - 1))
-
-        # (S) x (E) -> (S, E)
-        torch.outer(steps, freqs, out=l_half)
-
-        r_half.copy_(l_half)
-
-        l_half.sin_()
-        r_half.cos_()
+        _fill_sin_freq_table(self.freqs, self.encoding_dim, steps)
 
     @override
     def _do_forward(
@@ -213,6 +194,35 @@ class SinusoidalPositionEncoder(PositionEncoder):
         return fp32_seqs.type_as(seqs)
 
 
+def _fill_sin_freq_table(
+    freqs: Tensor, encoding_dim: int, steps: Tensor, correction: int = 1
+) -> None:
+    freqs = freqs.flatten(0, -2)
+
+    num_sin = encoding_dim // 2
+
+    l_half = freqs[:, :num_sin]
+    r_half = freqs[:, num_sin:]
+
+    # (E)
+    indices = torch.arange(num_sin, device=steps.device, dtype=steps.dtype)
+
+    # This is identical to tensor2tensor's implementation.
+    freqs = torch.exp(indices * -math.log(10000.0) / (num_sin - correction))
+
+    # (S) x (E) -> (S, E)
+    torch.outer(steps, freqs, out=l_half)
+
+    # The cosine frequencies might be truncated if the table is shorter than the
+    # encoding dimension due to rounding.
+    r_dim = r_half.size(1)
+
+    r_half.copy_(l_half[:, :r_dim])
+
+    l_half.sin_()
+    r_half.cos_()
+
+
 @final
 class LearnedPositionEncoder(PositionEncoder):
     """Encodes sequences with learned positional embeddings."""
@@ -228,9 +238,9 @@ class LearnedPositionEncoder(PositionEncoder):
         dtype: DataType | None = None,
     ) -> None:
         """
-        :param encoding_dim: The dimensionality of positional encodings. Input
-            sequences are expected to have the same dimensionality.
-
+        :param encoding_dim: The dimensionality of positional encodings. The
+            last dimension of input sequences is expected to have the same
+            dimensionality.
         :param max_seq_len: The maximum allowed length for input sequences.
             Sequences longer than ``max_seq_len`` will cause a :class:`ValueError`.
         """
@@ -289,15 +299,13 @@ class RotaryEncoder(PositionEncoder):
         device: Device | None = None,
     ) -> None:
         """
-        :param encoding_dim: The dimensionality of positional encodings. Input
-            sequences are expected to have the same dimensionality.
-
+        :param encoding_dim: The dimensionality of positional encodings. The
+            last dimension of input sequences is expected to have the same
+            dimensionality.
         :param max_seq_len: The maximum allowed length for input sequences.
             Sequences longer than ``max_seq_len`` will cause a :class:`ValueError`.
-
         :param theta: The coefficient of the long-term decay as described in
             section 3.3 of the reference paper.
-
         :param freqs_init_fn: A callable to initialize the frequency table. The
             encoder will be passed to the callable as an argument and it is
             expected for the callable to return a :class:`~torch.Tensor` holding
@@ -385,3 +393,316 @@ class RotaryEncoder(PositionEncoder):
         fp32_seqs = torch.view_as_real(complex_seqs).flatten(-2)
 
         return fp32_seqs.type_as(seqs)
+
+
+class InterpolatedPositionEncoder(Module, ABC):
+    """Encodes N-dimensional inputs with interpolated positional information."""
+
+    encoding_dim: int
+
+    def __init__(self, encoding_dim: int) -> None:
+        """
+        :param encoding_dim: The dimensionality of positional encodings. The
+            last dimension of inputs is expected to have the same dimensionality.
+        """
+        super().__init__()
+
+        self.encoding_dim = encoding_dim
+
+    @abstractmethod
+    def forward(self, x: Tensor) -> Tensor:
+        """
+        Returns a copy of ``x`` with positional information encoded.
+
+        :params x: The inputs to encode. *Shape:* :math:`(N,*,E)`, where
+            :math:`N` is the batch size, :math:`*` is any number of
+            implementation-specific dimensions, and :math:`E` is the
+            dimensionality of the positional encodings.
+
+        :returns: The inputs with positional information encoded.  *Shape:* Same
+            as ``x``.
+        """
+        ...
+
+
+class SinusoidalNdPositionEncoder(InterpolatedPositionEncoder):
+    """
+    Provides a skeletal implementation of interpolated sinusoidal position
+    encoders.
+    """
+
+    freqs: Tensor
+    grid_dims: tuple[int, ...]
+
+    def __init__(
+        self,
+        encoding_dim: int,
+        grid_dims: tuple[int, ...],
+        *,
+        device: Device | None = None,
+    ) -> None:
+        """
+        :param encoding_dim: The dimensionality of positional encodings. The
+            last dimension of inputs is expected to have the same dimensionality.
+        :param grid_dims: The dimensionality of the frequency table.
+        """
+        super().__init__(encoding_dim)
+
+        if encoding_dim % 2 != 0:
+            raise ValueError(
+                f"`encoding_dim` must be even, but is {encoding_dim} instead."
+            )
+
+        freqs = torch.empty(
+            grid_dims + (encoding_dim,), device=device, dtype=torch.float32
+        )
+
+        self.grid_dims = grid_dims
+
+        self.register_buffer("freqs", freqs, persistent=False)
+
+    def reset_parameters(self) -> None:
+        """Reset the parameters and buffers of the module."""
+        self.reset_non_persistent_buffers()
+
+    @abstractmethod
+    def reset_non_persistent_buffers(self) -> None:
+        """Reset the non-persistent buffers of the module."""
+
+    @override
+    def forward(self, x: Tensor) -> Tensor:
+        freqs = self._interpolate_freqs_as(x)
+
+        fp32_x = x.float() + freqs
+
+        return fp32_x.type_as(x)
+
+    @abstractmethod
+    def _interpolate_freqs_as(self, x: Tensor) -> Tensor:
+        """
+        Interpolates (or extrapolates) the frequency table to the dimensionality
+        of ``x``.
+
+        :params x: The inputs to encode. *Shape:* :math:`(N,*,E)`, where
+            :math:`N` is the batch size, :math:`*` is the same number of
+            dimensions as :attr:`grid_dims`, but potentially with different
+            dimensionality, and :math:`E` is the dimensionality of the
+            positional encodings.
+
+        :returns: The interpolated (or extrapolated) frequency table. *Shape:*
+            Same as ``x``.
+        """
+
+
+class Sinusoidal2dPositionEncoder(SinusoidalNdPositionEncoder):
+    """Encodes 2-dimensional inputs with sinusoidal positional information.
+
+    .. note::
+        This implementation uses bicubic interpolation. The interpolation
+        technique can be changed by subclassing this type and overriding the
+        :meth:`_interpolate_freqs_as` method.
+    """
+
+    def __init__(
+        self,
+        encoding_dim: int,
+        grid_dims: tuple[int, int],
+        *,
+        device: Device | None = None,
+    ) -> None:
+        """
+        :param encoding_dim: The dimensionality of positional encodings. The
+            last dimension of inputs is expected to have the same dimensionality.
+        :param grid_dims: The dimensionality of the depth, height, and width
+            dimensions.
+        """
+        super().__init__(encoding_dim, grid_dims, device=device)
+
+        self.reset_parameters()
+
+    @override
+    def reset_non_persistent_buffers(self) -> None:
+        freqs = self.freqs
+
+        device, dtype = freqs.device, freqs.dtype
+
+        h, w = freqs.shape[:-1]
+
+        h_steps = torch.arange(h, device=device, dtype=dtype)
+        w_steps = torch.arange(w, device=device, dtype=dtype)
+
+        h_coords, w_coords = torch.meshgrid(h_steps, w_steps, indexing="ij")
+
+        h_coords = h_coords.flatten()
+        w_coords = w_coords.flatten()
+
+        uniform_dim = math.ceil(self.encoding_dim / 4) * 2
+
+        h_dim = uniform_dim
+        w_dim = uniform_dim
+
+        idx = 0
+
+        _fill_sin_freq_table(
+            freqs[..., idx : idx + h_dim], h_dim, h_coords, correction=0
+        )
+
+        idx = h_dim
+
+        _fill_sin_freq_table(
+            freqs[..., idx : idx + w_dim], w_dim, w_coords, correction=0
+        )
+
+    @override
+    def _interpolate_freqs_as(self, x: Tensor) -> Tensor:
+        freqs = self.freqs
+
+        if x.ndim != 4:
+            raise ValueError(
+                f"`x` must be 4 dimensional, but is {x.ndim} dimensional instead."
+            )
+
+        frq_dims, inp_dims = freqs.shape[:-1], x.shape[1:-1]
+
+        if frq_dims == inp_dims:
+            return freqs
+
+        frq_h, frq_w = frq_dims
+        inp_h, inp_w = inp_dims
+
+        scale_factor = math.sqrt((inp_h * inp_w) / (frq_h * frq_w))
+
+        # (H_frq, W_frq, E) -> (1, H_frq, W_frq, E)
+        freqs = freqs.unsqueeze(0)
+
+        # (1, H_frq, W_frq, E) -> (1, E, H_frq, W_frq)
+        freqs = freqs.permute(0, 3, 1, 2)
+
+        # (1, E, H_frq, W_frq) -> (1, E, H_inp, W_inp)
+        freqs = interpolate(freqs, scale_factor=scale_factor, mode="bicubic")
+
+        # (1, E, H_inp, W_inp) -> (1, H_inp, W_inp, E)
+        freqs = freqs.permute(0, 2, 3, 1)
+
+        # (1, H_inp, W_inp, E) -> (H_inp, W_inp, E)
+        return freqs.squeeze(0)
+
+
+class Sinusoidal3dPositionEncoder(SinusoidalNdPositionEncoder):
+    """Encodes 3-dimensional inputs with sinusoidal positional information.
+
+    .. note::
+        This implementation uses trilinear interpolation. The interpolation
+        technique can be changed by subclassing this type and overriding the
+        :meth:`_interpolate_freqs_as` method.
+    """
+
+    uniform_power: bool
+
+    def __init__(
+        self,
+        encoding_dim: int,
+        grid_dims: tuple[int, int, int],
+        *,
+        uniform_power: bool = False,
+        device: Device | None = None,
+    ) -> None:
+        """
+        :param encoding_dim: The dimensionality of positional encodings. The
+            last dimension of inputs is expected to have the same dimensionality.
+        :param grid_dims: The dimensionality of the depth, height, and width
+            dimensions.
+        :param uniform_power: If ``True``, each dimension of ``grid_dims`` will
+            have equal representation in the produced positional encodings. This
+            means, if ``True``, a positional encoding will consists of 1/3 depth,
+            1/3 height, and 1/3 width information; otherwise, 1/2 depth, 1/4
+            height, and 1/4 width information.
+        """
+        super().__init__(encoding_dim, grid_dims, device=device)
+
+        self.uniform_power = uniform_power
+
+        self.reset_parameters()
+
+    @override
+    def reset_non_persistent_buffers(self) -> None:
+        freqs = self.freqs
+
+        device, dtype = freqs.device, freqs.dtype
+
+        d, h, w = freqs.shape[:-1]
+
+        d_steps = torch.arange(d, device=device, dtype=dtype)
+        h_steps = torch.arange(h, device=device, dtype=dtype)
+        w_steps = torch.arange(w, device=device, dtype=dtype)
+
+        d_coords, h_coords, w_coords = torch.meshgrid(
+            d_steps, h_steps, w_steps, indexing="ij"
+        )
+
+        d_coords = d_coords.flatten()
+        h_coords = h_coords.flatten()
+        w_coords = w_coords.flatten()
+
+        if self.uniform_power:
+            uniform_dim = math.ceil(self.encoding_dim / 6) * 2
+
+            d_dim = uniform_dim
+            h_dim = uniform_dim
+            w_dim = uniform_dim
+        else:
+            d_dim = math.ceil(self.encoding_dim / 4) * 2
+            h_dim = math.ceil(self.encoding_dim / 8) * 2
+            w_dim = math.ceil(self.encoding_dim / 8) * 2
+
+        idx = 0
+
+        _fill_sin_freq_table(
+            freqs[..., idx : idx + d_dim], d_dim, d_coords, correction=0
+        )
+
+        idx = d_dim
+
+        _fill_sin_freq_table(
+            freqs[..., idx : idx + h_dim], h_dim, h_coords, correction=0
+        )
+
+        idx = d_dim + h_dim
+
+        _fill_sin_freq_table(
+            freqs[..., idx : idx + w_dim], w_dim, w_coords, correction=0
+        )
+
+    @override
+    def _interpolate_freqs_as(self, x: Tensor) -> Tensor:
+        freqs = self.freqs
+
+        if x.ndim != 5:
+            raise ValueError(
+                f"`x` must be 5 dimensional, but is {x.ndim} dimensional instead."
+            )
+
+        frq_dims, inp_dims = freqs.shape[:-1], x.shape[1:-1]
+
+        if frq_dims == inp_dims:
+            return freqs
+
+        frq_d, frq_h, frq_w = frq_dims
+        inp_d, inp_h, inp_w = inp_dims
+
+        scale_factor = (inp_d / frq_d, inp_h / frq_h, inp_w / frq_w)
+
+        # (D_frq, H_frq, W_frq, E) -> (1, D_frq, H_frq, W_frq, E)
+        freqs = freqs.unsqueeze(0)
+
+        # (1, D_frq, H_frq, W_frq, E) -> (1, E, D_frq, H_frq, W_frq)
+        freqs = freqs.permute(0, 4, 1, 2, 3)
+
+        # (1, E, D_frq, H_frq, W_frq) -> (1, E, D_inp, H_inp, W_inp)
+        freqs = interpolate(freqs, scale_factor=scale_factor, mode="trilinear")
+
+        # (1, E, D_inp, H_inp, W_inp) -> (1, D_inp, H_inp, W_inp, E)
+        freqs = freqs.permute(0, 2, 3, 4, 1)
+
+        # (1, D_inp, H_inp, W_inp, E) -> (D_inp, H_inp, W_inp, E)
+        return freqs.squeeze(0)


### PR DESCRIPTION
This PR introduces the `InterpolatedPositionEncoder` interface along with `Sinusoidal2DPositionEncoder` and `Sinusoidal3DPositionEncoder` that are used by models such as DINOv2 and V-JEPA.