### PR TITLE
Introduce Vision Transformer front-end

### DIFF
--- a/src/fairseq2/models/vit/__init__.py
+++ b/src/fairseq2/models/vit/__init__.py
@@ -1,0 +1,18 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from fairseq2.models.vit.feature_extractor import (
+    Conv2dPatchFeatureExtractor as Conv2dPatchFeatureExtractor,
+)
+from fairseq2.models.vit.feature_extractor import (
+    Conv3dPatchFeatureExtractor as Conv3dPatchFeatureExtractor,
+)
+from fairseq2.models.vit.feature_extractor import (
+    PatchFeatureExtractor as PatchFeatureExtractor,
+)
+from fairseq2.models.vit.frontend import StandardViTFrontend as StandardViTFrontend

--- a/src/fairseq2/models/vit/feature_extractor.py
+++ b/src/fairseq2/models/vit/feature_extractor.py
@@ -1,0 +1,125 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import final
+
+from torch import Tensor
+from torch.nn import Conv2d, Conv3d, Module
+from typing_extensions import override
+
+from fairseq2.typing import DataType, Device
+
+
+class PatchFeatureExtractor(Module, ABC):
+    """
+    Extracts patch features from N-dimensional inputs and embeds them in a
+    latent space.
+    """
+
+    feature_dim: int
+
+    def __init__(self, feature_dim: int) -> None:
+        """
+        :param feature_dim:
+            The dimensionality of extracted patch features.
+        """
+        super().__init__()
+
+        self.feature_dim = feature_dim
+
+    @abstractmethod
+    def forward(self, x: Tensor) -> Tensor:
+        """
+        :param x: The inputs from which to extract patch features. *Shape:*
+            :math:`(N,C,*)`, where :math:`N` is the batch size, :math:`C` is the
+            number of channels, and :math:`*` is any number of input-specific
+            dimensions.
+
+        :returns: The extracted patch features. *Shape:* :math:`(N,*,E)`, where
+              :math:`N` is the batch size, :math:`*` is the same number of
+              dimensions as in input, but potentially with different
+              dimensionality, and :math:`E` is the dimensionality of the patch
+              features.
+        """
+
+
+@final
+class Conv2dPatchFeatureExtractor(PatchFeatureExtractor):
+    """Extracts patch features from 2-dimensional inputs using convolution."""
+
+    conv: Conv2d
+
+    def __init__(
+        self,
+        num_channels: int,
+        feature_dim: int,
+        patch_dims: tuple[int, int],
+        *,
+        device: Device | None = None,
+        dtype: DataType | None = None,
+    ) -> None:
+        """
+        :param num_channels: The number of input channels.
+        :param feature_dim: The dimensionality of extracted patch features.
+        :param patch_dims: The dimensionality of height and width patch
+            dimensions.
+        """
+        super().__init__(feature_dim)
+
+        self.conv = Conv2d(
+            num_channels,
+            feature_dim,
+            kernel_size=patch_dims,
+            stride=patch_dims,
+            device=device,
+            dtype=dtype,
+        )
+
+    @override
+    def forward(self, x: Tensor) -> Tensor:
+        # (N, C, H_inp, W_inp) -> (N, H_out, W_out, E)
+        return self.conv(x).permute(0, 2, 3, 1)  # type: ignore[no-any-return]
+
+
+@final
+class Conv3dPatchFeatureExtractor(PatchFeatureExtractor):
+    """Extracts patch features from 3-dimensional inputs using convolution."""
+
+    conv: Conv3d
+
+    def __init__(
+        self,
+        num_channels: int,
+        feature_dim: int,
+        patch_dims: tuple[int, int, int],
+        *,
+        device: Device | None = None,
+        dtype: DataType | None = None,
+    ) -> None:
+        """
+        :param num_channels: The number of input channels.
+        :param feature_dim: The dimensionality of extracted patch features.
+        :param patch_dims: The dimensionality of depth, height, and width patch
+            dimensions.
+        """
+        super().__init__(feature_dim)
+
+        self.conv = Conv3d(
+            num_channels,
+            feature_dim,
+            kernel_size=patch_dims,
+            stride=patch_dims,
+            device=device,
+            dtype=dtype,
+        )
+
+    @override
+    def forward(self, x: Tensor) -> Tensor:
+        # (N, C, D_inp, H_inp, W_inp) -> (N, D_out, H_out, W_out, E)
+        return self.conv(x).permute(0, 2, 3, 4, 1)  # type: ignore[no-any-return]

--- a/src/fairseq2/models/vit/frontend.py
+++ b/src/fairseq2/models/vit/frontend.py
@@ -1,0 +1,82 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from typing import final
+
+from torch import Tensor
+from torch.nn import Dropout
+from typing_extensions import override
+
+from fairseq2.models.transformer import TransformerFrontend
+from fairseq2.models.vit.feature_extractor import PatchFeatureExtractor
+from fairseq2.nn import InterpolatedPositionEncoder
+from fairseq2.nn.incremental_state import IncrementalStateBag
+from fairseq2.nn.padding import PaddingMask
+
+
+@final
+class StandardViTFrontend(TransformerFrontend):
+    """Represents a standard Vision Transformer front-end as described in
+    :cite:t:`https://doi.org/10.48550/arXiv.2010.11929`."""
+
+    feature_extractor: PatchFeatureExtractor
+    pos_encoder: InterpolatedPositionEncoder
+    dropout: Dropout | None
+
+    def __init__(
+        self,
+        feature_extractor: PatchFeatureExtractor,
+        pos_encoder: InterpolatedPositionEncoder,
+        *,
+        dropout_p: float = 0.0,
+    ) -> None:
+        """
+        :param feature_extractor: The feature extractor.
+        :param pos_encoder: The interpolated position encoder.
+        :param dropout_p: The dropout probability on extracted patch features.
+        """
+        feature_dim = feature_extractor.feature_dim
+
+        super().__init__(feature_dim)
+
+        self.feature_extractor = feature_extractor
+
+        if pos_encoder.encoding_dim != feature_dim:
+            raise ValueError(
+                f"`pos_encoder.encoding_dim` must be equal to `feature_extractor.feature_dim` ({feature_dim}), but is {pos_encoder.encoding_dim} instead."
+            )
+
+        self.pos_encoder = pos_encoder
+
+        if dropout_p > 0.0:
+            self.dropout = Dropout(dropout_p)
+        else:
+            self.register_module("dropout", None)
+
+    @override
+    def forward(
+        self,
+        seqs: Tensor,
+        padding_mask: PaddingMask | None,
+        *,
+        state_bag: IncrementalStateBag | None = None,
+    ) -> tuple[Tensor, PaddingMask | None]:
+        if padding_mask is not None:
+            raise ValueError(f"`{type(self)}` does not support padding mask.")
+
+        if state_bag is not None:
+            raise ValueError(f"`{type(self)}` does not support incremental decoding.")
+
+        seqs = self.feature_extractor(seqs)
+
+        seqs = self.pos_encoder(seqs)
+
+        # (N, *, E) -> (N, S, E)
+        seqs = seqs.flatten(1, -2)
+
+        return seqs, None


### PR DESCRIPTION
This PR introduces a front-end for vanilla Vision Transformer architecture along with two basic convolutional patch feature/embedding extractors.