### PR TITLE
Introduce JepaConfig and a skeleton JEPA model implementation

### DIFF
--- a/bibliography.bib
+++ b/bibliography.bib
@@ -213,15 +213,14 @@
   copyright={arXiv.org perpetual, non-exclusive license}
 }
 
-@misc{https://doi.org/10.48550/arxiv.2207.04672,
-  doi={10.48550/arxiv.2207.04672},
-  url={https://arxiv.org/abs/2207.04672},
-  title={No Language Left Behind: Scaling Human-Centered Machine Translation},
-  author={NLLB Team and Marta R. Costa-jussà and James Cross and Onur Çelebi and Maha Elbayad and Kenneth Heafield and Kevin Heffernan and Elahe Kalbassi and Janice Lam and Daniel Licht and Jean Maillard and Anna Sun and Skyler Wang and Guillaume Wenzek and Al Youngblood and Bapi Akula and Loic Barrault and Gabriel Mejia Gonzalez and Prangthip Hansanti and John Hoffman and Semarley Jarrett and Kaushik Ram Sadagopan and Dirk Rowe and Shannon Spruit and Chau Tran and Pierre Andrews and Necip Fazil Ayan and Shruti Bhosale and Sergey Edunov and Angela Fan and Cynthia Gao and Vedanuj Goswami and Francisco Guzmán and Philipp Koehn and Alexandre Mourachko and Christophe Ropers and Safiyyah Saleem and Holger Schwenk and Jeff Wang},
-  year={2022},
-  eprint={2207.04672},
-  archivePrefix={arXiv},
-  primaryClass={cs.CL}
+@misc{https://doi.org/10.48550/arXiv.2010.11929,
+   title={An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale}, 
+   author={Alexey Dosovitskiy and Lucas Beyer and Alexander Kolesnikov and Dirk Weissenborn and Xiaohua Zhai and Thomas Unterthiner and Mostafa Dehghani and Matthias Minderer and Georg Heigold and Sylvain Gelly and Jakob Uszkoreit and Neil Houlsby},
+   year={2021},
+   eprint={2010.11929},
+   archivePrefix={arXiv},
+   primaryClass={cs.CV},
+   url={https://arxiv.org/abs/2010.11929},
 }
 
 @misc{https://doi.org/10.48550/arxiv.2110.09456,
@@ -233,6 +232,17 @@
   publisher={arXiv},
   year={2021},
   copyright={arXiv.org perpetual, non-exclusive license}
+}
+
+@misc{https://doi.org/10.48550/arxiv.2207.04672,
+  doi={10.48550/arxiv.2207.04672},
+  url={https://arxiv.org/abs/2207.04672},
+  title={No Language Left Behind: Scaling Human-Centered Machine Translation},
+  author={NLLB Team and Marta R. Costa-jussà and James Cross and Onur Çelebi and Maha Elbayad and Kenneth Heafield and Kevin Heffernan and Elahe Kalbassi and Janice Lam and Daniel Licht and Jean Maillard and Anna Sun and Skyler Wang and Guillaume Wenzek and Al Youngblood and Bapi Akula and Loic Barrault and Gabriel Mejia Gonzalez and Prangthip Hansanti and John Hoffman and Semarley Jarrett and Kaushik Ram Sadagopan and Dirk Rowe and Shannon Spruit and Chau Tran and Pierre Andrews and Necip Fazil Ayan and Shruti Bhosale and Sergey Edunov and Angela Fan and Cynthia Gao and Vedanuj Goswami and Francisco Guzmán and Philipp Koehn and Alexandre Mourachko and Christophe Ropers and Safiyyah Saleem and Holger Schwenk and Jeff Wang},
+  year={2022},
+  eprint={2207.04672},
+  archivePrefix={arXiv},
+  primaryClass={cs.CL}
 }
 
 @misc{https://doi.org/10.48550/arxiv.2212.08055,
@@ -278,4 +288,24 @@
    eprint={2310.06825},
    archivePrefix={arXiv},
    primaryClass={cs.CL}
+}
+
+@misc{https://doi.org/10.48550/arXiv.2301.08243,
+   title={Self-Supervised Learning from Images with a Joint-Embedding Predictive Architecture},
+   author={Mahmoud Assran and Quentin Duval and Ishan Misra and Piotr Bojanowski and Pascal Vincent and Michael Rabbat and Yann LeCun and Nicolas Ballas},
+   year={2023},
+   eprint={2301.08243},
+   archivePrefix={arXiv},
+   primaryClass={cs.CV},
+   url={https://arxiv.org/abs/2301.08243},
+}
+
+@misc{https://doi.org/10.48550/arXiv.2404.08471,
+   title={Revisiting Feature Prediction for Learning Visual Representations from Video},
+   author={Adrien Bardes and Quentin Garrido and Jean Ponce and Xinlei Chen and Michael Rabbat and Yann LeCun and Mahmoud Assran and Nicolas Ballas},
+   year={2024},
+   eprint={2404.08471},
+   archivePrefix={arXiv},
+   primaryClass={cs.CV},
+   url={https://arxiv.org/abs/2404.08471},
 }

--- a/src/fairseq2/models/jepa/__init__.py
+++ b/src/fairseq2/models/jepa/__init__.py
@@ -1,0 +1,17 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from fairseq2.models.jepa.factory import JEPA_FAMILY as JEPA_FAMILY
+from fairseq2.models.jepa.factory import JepaConfig as JepaConfig
+from fairseq2.models.jepa.factory import JepaEncoderConfig as JepaEncoderConfig
+from fairseq2.models.jepa.factory import jepa_arch as jepa_arch
+from fairseq2.models.jepa.factory import jepa_archs as jepa_archs
+
+# isort: split
+
+import fairseq2.models.jepa.archs  # Register architectures

--- a/src/fairseq2/models/jepa/archs.py
+++ b/src/fairseq2/models/jepa/archs.py
@@ -1,0 +1,80 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from fairseq2.models.jepa.factory import JepaConfig, jepa_arch
+
+
+@jepa_arch("tiny")
+def tiny() -> JepaConfig:
+    config = base()
+
+    config.encoder_config.model_dim = 192
+    config.encoder_config.num_encoder_attn_heads = 3
+
+    return config
+
+
+@jepa_arch("small")
+def small() -> JepaConfig:
+    config = base()
+
+    config.encoder_config.model_dim = 384
+    config.encoder_config.num_encoder_attn_heads = 6
+
+    return config
+
+
+@jepa_arch("base")
+def base() -> JepaConfig:
+    return JepaConfig()
+
+
+@jepa_arch("large")
+def large() -> JepaConfig:
+    config = base()
+
+    config.encoder_config.model_dim = 1024
+    config.encoder_config.num_encoder_layers = 24
+    config.encoder_config.num_encoder_attn_heads = 16
+
+    return config
+
+
+@jepa_arch("huge")
+def huge() -> JepaConfig:
+    config = base()
+
+    config.encoder_config.model_dim = 1280
+    config.encoder_config.num_encoder_layers = 32
+    config.encoder_config.num_encoder_attn_heads = 16
+
+    return config
+
+
+@jepa_arch("giant")
+def giant() -> JepaConfig:
+    config = base()
+
+    config.encoder_config.model_dim = 1408
+    config.encoder_config.num_encoder_layers = 40
+    config.encoder_config.num_encoder_attn_heads = 16
+    config.encoder_config.ffn_inner_dim_ratio = 48 / 11
+
+    return config
+
+
+@jepa_arch("gigantic")
+def gigantic() -> JepaConfig:
+    config = base()
+
+    config.encoder_config.model_dim = 1664
+    config.encoder_config.num_encoder_layers = 48
+    config.encoder_config.num_encoder_attn_heads = 16
+    config.encoder_config.ffn_inner_dim_ratio = 64 / 13
+
+    return config

--- a/src/fairseq2/models/jepa/factory.py
+++ b/src/fairseq2/models/jepa/factory.py
@@ -1,0 +1,82 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Final
+
+from fairseq2.config_registry import ConfigRegistry
+
+JEPA_FAMILY: Final = "jepa"
+
+
+@dataclass(kw_only=True)
+class JepaConfig:
+    """
+    Holds the configuration of a JEPA model.
+
+    The default values correspond to the 'base' JEPA architecture.
+    """
+
+    encoder_config: JepaEncoderConfig = field(
+        default_factory=lambda: JepaEncoderConfig()
+    )
+    """The configuration of the Vision Transformer encoder."""
+
+
+@dataclass(kw_only=True)
+class JepaEncoderConfig:
+    model_dim: int = 768
+    """The dimensionality of the model."""
+
+    num_input_channels: int = 3
+    """The number of input channels per frame."""
+
+    input_dims: tuple[int, ...] = (224, 224)
+    """
+    The supported native dimensionality of inputs. Expected to be 2-dimensional
+    (height, width) for images and 3-dimensional (depth, height, width) for
+    videos.
+    """
+
+    patch_dims: tuple[int, ...] = (16, 16)
+    """The dimensionality of patches to be extracted from inputs."""
+
+    num_encoder_layers: int = 12
+    """The number of encoder layers."""
+
+    num_encoder_attn_heads: int = 12
+    """The number of attention heads in encoder layers."""
+
+    qkv_bias: bool = True
+    """
+    If ``True``, query, key, and value projections in multi-head attention
+    layers will have an additive bias.
+    """
+
+    attn_dropout_p: float = 0.0
+    """The dropout probability on attention weights."""
+
+    ffn_inner_dim_ratio: float = 4.0
+    """
+    The ratio of the dimensionality of the inner projection layers in
+    feed-forward networks to :attr:`model_dim`.
+    """
+
+    dropout_p: float = 0.0
+    """The dropout probability on outputs of Transformer layers."""
+
+    uniform_power: bool = False
+    """
+    If ``True``, each patch dimension will have equal representation in the
+    produced positional encodings.
+    """
+
+
+jepa_archs = ConfigRegistry[JepaConfig]()
+
+jepa_arch = jepa_archs.decorator

--- a/src/fairseq2/models/jepa/model.py
+++ b/src/fairseq2/models/jepa/model.py
@@ -1,0 +1,53 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import final
+
+from torch.nn import Module
+
+from fairseq2.models.sequence import SequenceBatch
+from fairseq2.models.transformer import TransformerFrontend
+from fairseq2.nn.transformer import TransformerEncoder
+
+# TODO(balioglu): This implementation is not complete. As of this commit, only
+# the encoder and encoder-frontend are available for parity check purposes.
+
+
+@final
+class JepaModel(Module):
+    """
+    Represents a JEPA model as described in:
+        * :cite:t:`https://doi.org/10.48550/arXiv.2301.08243`
+        * :cite:t:`https://doi.org/10.48550/arXiv.2404.08471`
+    """
+
+    model_dim: int
+    encoder_frontend: TransformerFrontend
+    encoder: TransformerEncoder
+
+    def __init__(
+        self,
+        encoder_frontend: TransformerFrontend,
+        encoder: TransformerEncoder,
+    ) -> None:
+        super().__init__()
+
+        self.model_dim = encoder.model_dim
+
+        self.encoder_frontend = encoder_frontend
+        self.encoder = encoder
+
+    def forward(self, batch: SequenceBatch) -> JepaOutput:
+        raise NotImplementedError()
+
+
+@final
+@dataclass
+class JepaOutput:
+    pass


### PR DESCRIPTION
This PR introduces `JepaConfig` dataclass and a partially implemented version of the JEPA model. As of today the model only exposes the encoder for inference parity check purposes. In the near future we will have a full implementation along with pretraining support.