### PR TITLE
llama3.3 instruct 70b asset added

### DIFF
--- a/src/fairseq2/assets/cards/models/llama.yaml
+++ b/src/fairseq2/assets/cards/models/llama.yaml
@@ -126,6 +126,13 @@ num_shards: 8
 
 ---
 
+name: llama3_3_70b_instruct
+base: llama3
+model_arch: llama3_1_70b
+num_shards: 8
+
+---
+
 name: llama3_1_70b_instruct
 base: llama3_instruct
 model_arch: llama3_1_70b


### PR DESCRIPTION
**What does this PR do? Please describe:**

added the llama3.3 instruct 70b asset. the model uses the same arch as 3.1 following HF: https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct

so we follow that and use 3.1 arch as is