### PR TITLE
base fix for llama 3.3 to use correct eos token

### DIFF
--- a/src/fairseq2/assets/cards/models/llama.yaml
+++ b/src/fairseq2/assets/cards/models/llama.yaml
@@ -127,7 +127,7 @@ num_shards: 8
 ---
 
 name: llama3_3_70b_instruct
-base: llama3
+base: llama3_instruct
 model_arch: llama3_1_70b
 num_shards: 8
 


### PR DESCRIPTION
**What does this PR do? Please describe:**

we need to use llama3_instruct so that the correct eot token in used during training