### PR TITLE
Expose weight initialization bounds for LayerNorm, Projection, Conv2D, Conv3D

### DIFF
--- a/src/fairseq2/models/jepa/factory.py
+++ b/src/fairseq2/models/jepa/factory.py
@@ -11,14 +11,8 @@ from dataclasses import dataclass, field
 from functools import partial
 from typing import Final, cast
 
-<<<<<<< HEAD
-import torch
-from torch.nn import GELU
-=======
-from torch import Tensor
 import torch
 from torch.nn import GELU, Module
->>>>>>> a09ad4fe (Can's comments)
 
 from fairseq2.config_registry import ConfigRegistry
 from fairseq2.models.jepa.model import JepaModel

--- a/src/fairseq2/models/jepa/factory.py
+++ b/src/fairseq2/models/jepa/factory.py
@@ -374,7 +374,7 @@ class JepaEncoderBuilder:
         proj = ffn.output_proj
         assert isinstance(proj, Linear), f"Invalid projection type: {type(proj)}"
         proj.weight.data.div_(math.sqrt(2.0 * (layer_idx + 1)))
-        
+
         return ffn
 
     def build_layer_norm(
@@ -407,7 +407,7 @@ def create_jepa_model(
     dtype: DataType | None = None,
 ) -> JepaModel:
     return JepaBuilder(config, device=device, dtype=dtype).build_model()
-        
+
 
 def init_truncated_uniforma_weights_and_bias(
     m: Module,
@@ -419,7 +419,7 @@ def init_truncated_uniforma_weights_and_bias(
 ) -> None:
     if not hasattr(m, "weight") or not hasattr(m, "bias"):
         raise ValueError(f"Cannot initialize weights and bias of a {type(m)}")
-    
+
     with torch.no_grad():
         torch.nn.init.trunc_normal_(m.weight, mean=mean, std=std, a=a, b=b)
         if m.bias is not None:

--- a/src/fairseq2/models/jepa/factory.py
+++ b/src/fairseq2/models/jepa/factory.py
@@ -355,7 +355,7 @@ class JepaEncoderBuilder:
             init_truncated_uniforma_weights_and_bias(proj, std=init_std)
 
             with torch.no_grad():
-                proj.weight.div_(math.sqrt(2.0 * layer_idx))
+                proj.weight.div_(math.sqrt(2.0 * (layer_idx + 1)))
 
         inner_dim = int(config.model_dim * config.ffn_inner_dim_ratio)
 

--- a/src/fairseq2/models/jepa/factory.py
+++ b/src/fairseq2/models/jepa/factory.py
@@ -388,7 +388,9 @@ class JepaEncoderBuilder:
 
         init_std = config.init_std
 
-        init_layer_norm = partial(init_truncated_uniforma_weights_and_bias, std=init_std)
+        init_layer_norm = partial(
+            init_truncated_uniforma_weights_and_bias, std=init_std
+        )
 
         return StandardLayerNorm(
             model_dim,

--- a/src/fairseq2/models/jepa/factory.py
+++ b/src/fairseq2/models/jepa/factory.py
@@ -6,10 +6,14 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
+from functools import partial
+import math
 from typing import Final, cast
 
-from torch.nn import GELU
+import torch
+from torch.nn import GELU, Module
 
 from fairseq2.config_registry import ConfigRegistry
 from fairseq2.models.jepa.model import JepaModel
@@ -23,6 +27,7 @@ from fairseq2.models.vit import (
 from fairseq2.nn import (
     InterpolatedPositionEncoder,
     LayerNorm,
+    Linear,
     Sinusoidal2dPositionEncoder,
     Sinusoidal3dPositionEncoder,
     StandardLayerNorm,
@@ -39,6 +44,7 @@ from fairseq2.nn.transformer import (
     TransformerNormOrder,
     create_default_sdpa,
 )
+from fairseq2.nn.transformer.residual import DropPathResidualConnect
 from fairseq2.typing import DataType, Device
 
 JEPA_FAMILY: Final = "jepa"
@@ -96,9 +102,15 @@ class JepaEncoderConfig:
     The ratio of the dimensionality of the inner projection layers in
     feed-forward networks to :attr:`model_dim`.
     """
+    
+    init_std: float = 0.02
+    """std to initialize the weights and bias for linear and LayerNorm layers"""
 
     dropout_p: float = 0.0
     """The dropout probability on outputs of Transformer layers."""
+
+    droppath_p: float = 0.0
+    """The probability of output sequence drop."""
 
     uniform_power: bool = False
     """
@@ -181,6 +193,8 @@ class JepaEncoderBuilder:
 
     def build_feature_extractor(self) -> PatchFeatureExtractor:
         config = self._config
+        
+        conv_init_fn = partial(init_with_explicit_bounds, std=config.init_std)
 
         num_patch_dims = len(config.patch_dims)
 
@@ -191,6 +205,7 @@ class JepaEncoderBuilder:
                 config.num_input_channels,
                 config.model_dim,
                 patch_3d_dims,
+                init_fn=conv_init_fn,
                 device=self._device,
                 dtype=self._dtype,
             )
@@ -201,6 +216,7 @@ class JepaEncoderBuilder:
                 config.num_input_channels,
                 config.model_dim,
                 patch_2d_dims,
+                init_fn=conv_init_fn,
                 device=self._device,
                 dtype=self._dtype,
             )
@@ -255,7 +271,7 @@ class JepaEncoderBuilder:
 
         num_layers = config.num_encoder_layers
 
-        layers = [self.build_encoder_layer() for _ in range(num_layers)]
+        layers = [self.build_encoder_layer(i) for i in range(num_layers)]
 
         return StandardTransformerEncoder(
             layers,
@@ -265,12 +281,14 @@ class JepaEncoderBuilder:
             dtype=self._dtype,
         )
 
-    def build_encoder_layer(self) -> TransformerEncoderLayer:
+    def build_encoder_layer(self, layer_id: int) -> TransformerEncoderLayer:
         config = self._config
 
-        self_attn = self.build_attention()
+        self_attn = self.build_attention(layer_id)
 
-        ffn = self.build_ffn()
+        ffn = self.build_ffn(layer_id)
+        
+        drop_path = DropPathResidualConnect(drop_p=config.droppath_p)
 
         return StandardTransformerEncoderLayer(
             self_attn,
@@ -278,47 +296,87 @@ class JepaEncoderBuilder:
             dropout_p=config.dropout_p,
             norm_order=TransformerNormOrder.PRE,
             layer_norm_factory=self.build_layer_norm,
+            self_attn_residual=drop_path,
+            ffn_residual=drop_path,
             device=self._device,
             dtype=self._dtype,
         )
 
-    def build_attention(self) -> MultiheadAttention:
+    def build_attention(self, layer_id: int) -> MultiheadAttention:
         config = self._config
 
         sdpa = create_default_sdpa(attn_dropout_p=config.attn_dropout_p)
+
+        proj = self.build_projection(layer_id)
 
         return StandardMultiheadAttention(
             config.model_dim,
             config.num_encoder_attn_heads,
             sdpa=sdpa,
             bias=config.qkv_bias,
+            output_proj=proj,
             output_proj_bias=True,
             device=self._device,
             dtype=self._dtype,
         )
 
-    def build_ffn(self) -> FeedForwardNetwork:
+    def build_projection(self, layer_id: int) -> Linear:
         config = self._config
 
-        return StandardFeedForwardNetwork(
+        proj_init_fn: Callable[[Linear], None] = partial(
+            init_with_explicit_bounds, std=config.init_std
+        )
+
+        proj = Linear(
+            config.model_dim,
+            config.model_dim,
+            bias=True,
+            init_fn=proj_init_fn,
+            device=self._device,
+            dtype=self._dtype,
+        )
+
+        # rescale the linear layer
+        proj.weight.data.div_(math.sqrt(2.0 * layer_id))
+
+        return proj
+
+    def build_ffn(self, layer_id: int) -> FeedForwardNetwork:
+        config = self._config
+
+        proj_init_fn = partial(init_with_explicit_bounds, std=config.init_std)
+
+        ffn = StandardFeedForwardNetwork(
             config.model_dim,
             int(config.model_dim * config.ffn_inner_dim_ratio),
             bias=True,
             inner_activation=GELU(),
+            proj_init_fn=proj_init_fn,
             norm_order=TransformerNormOrder.PRE,
             device=self._device,
             dtype=self._dtype,
         )
 
-    @staticmethod
+        # rescale the last layer
+        proj = ffn.output_proj
+        assert isinstance(proj, Linear), f"Invalid projection type: {type(proj)}"
+        proj.weight.data.div_(math.sqrt(2.0 * layer_id))
+        
+        return ffn
+
     def build_layer_norm(
+        self,
         model_dim: int,
         *,
         device: Device | None = None,
         dtype: DataType | None = None,
     ) -> LayerNorm:
+        config = self._config
+        
+        layer_norm_init_fn = partial(init_with_explicit_bounds, std=config.init_std)
+        
         return StandardLayerNorm(
-            model_dim, bias=True, eps=1e-6, device=device, dtype=dtype
+            model_dim, bias=True, eps=1e-6, init_fn=layer_norm_init_fn, device=device, dtype=dtype
         )
 
 
@@ -329,3 +387,46 @@ def create_jepa_model(
     dtype: DataType | None = None,
 ) -> JepaModel:
     return JepaBuilder(config, device=device, dtype=dtype).build_model()
+
+
+def _norm_cdf(x):
+    # Computes standard normal cumulative distribution function
+    return (1.0 + math.erf(x / math.sqrt(2.0))) / 2.0
+    
+
+def normalize_truncate(
+    tensor: torch.Tensor,
+    *,
+    mean: float = 0.0,
+    std: float = 1.0,
+    a: float = -2.0,
+    b: float = 2.0,
+) -> None:
+
+    lower = _norm_cdf((a - mean) / std)
+    upper = _norm_cdf((b - mean) / std)
+    
+    tensor.uniform_(2 * lower - 1, 2 * upper - 1)
+    tensor.erfinv_()
+    
+    tensor.mul_(std * math.sqrt(2.0))
+    tensor.add_(mean)
+    
+    tensor.clamp_(min=a, max=b)
+        
+
+def init_with_explicit_bounds(
+    m: Module,
+    *,
+    mean: float = 0.0,
+    std: float = 1.0,
+    a: float = -2.0,
+    b: float = 2.0,
+):
+    if not hasattr(m, "weight") or not hasattr(m, "bias"):
+        raise ValueError(f"Cannot initialize weights and bias of a {type(m)}")
+    
+    with torch.no_grad():
+        normalize_truncate(m.weight, mean=mean, std=std, a=a, b=b)
+        if m.bias is not None:
+            torch.nn.init.zeros_(m.bias)

--- a/src/fairseq2/models/jepa/model.py
+++ b/src/fairseq2/models/jepa/model.py
@@ -44,9 +44,7 @@ class JepaModel(Module):
 
     def forward(self, batch: SequenceBatch) -> SequenceBatch:
         seqs, padding_mask = self.encoder_frontend(batch.seqs, batch.padding_mask)
-        out_seqs, out_mask = self.encoder(seqs, padding_mask)  # type: ignore[no-any-return]
-        
-        return SequenceBatch(
-            seqs=out_seqs,
-            padding_mask=out_mask,
-        )
+
+        seqs, padding_mask = self.encoder(seqs, padding_mask)
+
+        return SequenceBatch(seqs, padding_mask)

--- a/src/fairseq2/models/jepa/model.py
+++ b/src/fairseq2/models/jepa/model.py
@@ -6,7 +6,6 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import final
 
 from torch.nn import Module
@@ -43,11 +42,11 @@ class JepaModel(Module):
         self.encoder_frontend = encoder_frontend
         self.encoder = encoder
 
-    def forward(self, batch: SequenceBatch) -> JepaOutput:
-        raise NotImplementedError()
-
-
-@final
-@dataclass
-class JepaOutput:
-    pass
+    def forward(self, batch: SequenceBatch) -> SequenceBatch:
+        seqs, padding_mask = self.encoder_frontend(batch.seqs, batch.padding_mask)
+        out_seqs, out_mask = self.encoder(seqs, padding_mask)  # type: ignore[no-any-return]
+        
+        return SequenceBatch(
+            seqs=out_seqs,
+            padding_mask=out_mask,
+        )

--- a/src/fairseq2/models/vit/feature_extractor.py
+++ b/src/fairseq2/models/vit/feature_extractor.py
@@ -95,7 +95,6 @@ class Conv2dPatchFeatureExtractor(PatchFeatureExtractor):
         else:
             self.conv.reset_parameters()
 
-
     @override
     def forward(self, x: Tensor) -> Tensor:
         # (N, C, H_inp, W_inp) -> (N, H_out, W_out, E)
@@ -115,7 +114,7 @@ class Conv3dPatchFeatureExtractor(PatchFeatureExtractor):
         feature_dim: int,
         patch_dims: tuple[int, int, int],
         *,
-        init_fn: Callable[[Conv2d], None] | None = None,
+        init_fn: Callable[[Conv3d], None] | None = None,
         device: Device | None = None,
         dtype: DataType | None = None,
     ) -> None:
@@ -135,7 +134,7 @@ class Conv3dPatchFeatureExtractor(PatchFeatureExtractor):
             device=device,
             dtype=dtype,
         )
-        
+
         self.init_fn = init_fn
 
         self.reset_parameters()
@@ -146,7 +145,6 @@ class Conv3dPatchFeatureExtractor(PatchFeatureExtractor):
             self.init_fn(self.conv)
         else:
             self.conv.reset_parameters()
-
 
     @override
     def forward(self, x: Tensor) -> Tensor:

--- a/src/fairseq2/models/vit/feature_extractor.py
+++ b/src/fairseq2/models/vit/feature_extractor.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from typing import final
 
 from torch import Tensor
@@ -54,6 +55,7 @@ class Conv2dPatchFeatureExtractor(PatchFeatureExtractor):
     """Extracts patch features from 2-dimensional inputs using convolution."""
 
     conv: Conv2d
+    init_fn: Callable[[Conv2d], None] | None
 
     def __init__(
         self,
@@ -61,6 +63,7 @@ class Conv2dPatchFeatureExtractor(PatchFeatureExtractor):
         feature_dim: int,
         patch_dims: tuple[int, int],
         *,
+        init_fn: Callable[[Conv2d], None] | None = None,
         device: Device | None = None,
         dtype: DataType | None = None,
     ) -> None:
@@ -81,6 +84,18 @@ class Conv2dPatchFeatureExtractor(PatchFeatureExtractor):
             dtype=dtype,
         )
 
+        self.init_fn = init_fn
+
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        """Reset the parameters and buffers of the module."""
+        if self.init_fn is not None:
+            self.init_fn(self.conv)
+        else:
+            self.conv.reset_parameters()
+
+
     @override
     def forward(self, x: Tensor) -> Tensor:
         # (N, C, H_inp, W_inp) -> (N, H_out, W_out, E)
@@ -92,6 +107,7 @@ class Conv3dPatchFeatureExtractor(PatchFeatureExtractor):
     """Extracts patch features from 3-dimensional inputs using convolution."""
 
     conv: Conv3d
+    init_fn: Callable[[Conv3d], None] | None
 
     def __init__(
         self,
@@ -99,6 +115,7 @@ class Conv3dPatchFeatureExtractor(PatchFeatureExtractor):
         feature_dim: int,
         patch_dims: tuple[int, int, int],
         *,
+        init_fn: Callable[[Conv2d], None] | None = None,
         device: Device | None = None,
         dtype: DataType | None = None,
     ) -> None:
@@ -118,6 +135,18 @@ class Conv3dPatchFeatureExtractor(PatchFeatureExtractor):
             device=device,
             dtype=dtype,
         )
+        
+        self.init_fn = init_fn
+
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        """Reset the parameters and buffers of the module."""
+        if self.init_fn is not None:
+            self.init_fn(self.conv)
+        else:
+            self.conv.reset_parameters()
+
 
     @override
     def forward(self, x: Tensor) -> Tensor:

--- a/src/fairseq2/nn/normalization.py
+++ b/src/fairseq2/nn/normalization.py
@@ -41,7 +41,6 @@ class LayerNorm(Module, ABC):
     bias: Parameter | None
     init_fn: Callable[[LayerNorm], None] | None
 
-
     def __init__(
         self,
         normalized_shape: int | Sequence[int] | Size,
@@ -90,7 +89,7 @@ class LayerNorm(Module, ABC):
             )
         else:
             self.register_parameter("bias", None)
-        
+
         self.init_fn = init_fn
 
         self.reset_parameters()

--- a/src/fairseq2/nn/utils/module.py
+++ b/src/fairseq2/nn/utils/module.py
@@ -581,22 +581,21 @@ def normalize_truncate(
     a: float = -2.0,
     b: float = 2.0,
 ) -> None:
-    
-    def _norm_cdf(x):
+    def _norm_cdf(x: float) -> float:
         # Computes standard normal cumulative distribution function
         return (1.0 + math.erf(x / math.sqrt(2.0))) / 2.0
 
     lower = _norm_cdf((a - mean) / std)
     upper = _norm_cdf((b - mean) / std)
-    
+
     tensor.uniform_(2 * lower - 1, 2 * upper - 1)
     tensor.erfinv_()
-    
+
     tensor.mul_(std * math.sqrt(2.0))
     tensor.add_(mean)
-    
+
     tensor.clamp_(min=a, max=b)
-        
+
 
 def init_truncated_uniforma_weights_and_bias(
     m: Module,
@@ -605,10 +604,10 @@ def init_truncated_uniforma_weights_and_bias(
     std: float = 1.0,
     a: float = -2.0,
     b: float = 2.0,
-):
+) -> None:
     if not hasattr(m, "weight") or not hasattr(m, "bias"):
         raise ValueError(f"Cannot initialize weights and bias of a {type(m)}")
-    
+
     with torch.no_grad():
         normalize_truncate(m.weight, mean=mean, std=std, a=a, b=b)
         if m.bias is not None:

--- a/src/fairseq2/nn/utils/module.py
+++ b/src/fairseq2/nn/utils/module.py
@@ -570,20 +570,3 @@ def get_module_size(module: Module) -> ModuleSizeInfo:
         info.total_size_bytes += size_bytes
 
     return info
-
-
-def init_truncated_uniforma_weights_and_bias(
-    m: Module,
-    *,
-    mean: float = 0.0,
-    std: float = 1.0,
-    a: float = -2.0,
-    b: float = 2.0,
-) -> None:
-    if not hasattr(m, "weight") or not hasattr(m, "bias"):
-        raise ValueError(f"Cannot initialize weights and bias of a {type(m)}")
-
-    with torch.no_grad():
-        torch.nn.init.trunc_normal_(m.weight, mean=mean, std=std, a=a, b=b)
-        if m.bias is not None:
-            torch.nn.init.zeros_(m.bias)

--- a/src/fairseq2/nn/utils/module.py
+++ b/src/fairseq2/nn/utils/module.py
@@ -570,31 +570,6 @@ def get_module_size(module: Module) -> ModuleSizeInfo:
         info.total_size_bytes += size_bytes
 
     return info
-<<<<<<< HEAD
-
-
-def normalize_truncate(
-    tensor: Tensor,
-    *,
-    mean: float = 0.0,
-    std: float = 1.0,
-    a: float = -2.0,
-    b: float = 2.0,
-) -> None:
-    def _norm_cdf(x: float) -> float:
-        # Computes standard normal cumulative distribution function
-        return (1.0 + math.erf(x / math.sqrt(2.0))) / 2.0
-
-    lower = _norm_cdf((a - mean) / std)
-    upper = _norm_cdf((b - mean) / std)
-
-    tensor.uniform_(2 * lower - 1, 2 * upper - 1)
-    tensor.erfinv_()
-
-    tensor.mul_(std * math.sqrt(2.0))
-    tensor.add_(mean)
-
-    tensor.clamp_(min=a, max=b)
 
 
 def init_truncated_uniforma_weights_and_bias(
@@ -609,8 +584,6 @@ def init_truncated_uniforma_weights_and_bias(
         raise ValueError(f"Cannot initialize weights and bias of a {type(m)}")
 
     with torch.no_grad():
-        normalize_truncate(m.weight, mean=mean, std=std, a=a, b=b)
+        torch.nn.init.trunc_normal_(m.weight, mean=mean, std=std, a=a, b=b)
         if m.bias is not None:
             torch.nn.init.zeros_(m.bias)
-=======
->>>>>>> a09ad4fe (Can's comments)

--- a/src/fairseq2/nn/utils/module.py
+++ b/src/fairseq2/nn/utils/module.py
@@ -6,7 +6,6 @@
 
 from __future__ import annotations
 
-import math
 import re
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
@@ -571,6 +570,7 @@ def get_module_size(module: Module) -> ModuleSizeInfo:
         info.total_size_bytes += size_bytes
 
     return info
+<<<<<<< HEAD
 
 
 def normalize_truncate(
@@ -612,3 +612,5 @@ def init_truncated_uniforma_weights_and_bias(
         normalize_truncate(m.weight, mean=mean, std=std, a=a, b=b)
         if m.bias is not None:
             torch.nn.init.zeros_(m.bias)
+=======
+>>>>>>> a09ad4fe (Can's comments)


### PR DESCRIPTION
**What does this PR do? Please describe:**

Most of fairseq2 Modules runs the standard (Xavier) initialization function, or uniform / constant weights initialization. 

Sometimes users want to experiment with different algorithms too, for example when they want to manually set the boundaries of the weights. This was the case for the JEPA model.

This PR add parameters `init_fn` to the common Module (Projection, TransfomerEncoderLayer, LayerNorm)

Fixes #{issue number}

**Does your PR introduce any breaking changes? If yes, please list them:**
List of all backwards-incompatible changes.

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [ ] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
