### PR TITLE
Add flatten method to AssetCard

### DIFF
--- a/src/fairseq2/assets/card.py
+++ b/src/fairseq2/assets/card.py
@@ -125,6 +125,24 @@ class AssetCard:
 
         metadata[path[-1]] = value
 
+    def flatten(self) -> AssetCard:
+        """
+        Flattens the metadata of this card and all its bases into a single one.
+        """
+        all_metadata = []
+
+        card: AssetCard | None = self
+
+        while card is not None:
+            all_metadata.append(card._metadata)
+
+            card = card._base_card
+
+        for metadata in all_metadata[-2::-1]:
+            all_metadata[-1].update(metadata)
+
+        return AssetCard(self._name, all_metadata[-1])
+
     def __repr__(self) -> str:
         return repr(self._metadata)
 

--- a/tests/unit/assets/test_card.py
+++ b/tests/unit/assets/test_card.py
@@ -213,3 +213,24 @@ class TestAssetCard:
             AssetCardError, match=r"^The 'test-card' asset card cannot have a field named 'field1.field2' due to path conflict at 'field1'\.$",  # fmt: skip
         ):
             self.card.field("field1").field("field2").set("foo")
+
+    def test_flatten_works(self) -> None:
+        card = self.card.flatten()
+
+        expected_metadata = {
+            "name": "test-card",
+            "field1": "foo1",
+            "field2": {
+                "sub-field2": "sub-foo2",
+            },
+            "field3": 3,
+            "field4": "",
+            "field5": [],
+            "field6": "invalid/filename",
+            "field7": [1, 3, 2],
+            "field8": [1, "b", 3],
+            "field9": "http://foo.com",
+            "field10": None,
+        }
+
+        assert card.metadata == expected_metadata


### PR DESCRIPTION
This PR adds a `flatten()` method to `AssetCard` that will later be used for improved `resume_checkpoint_dir` handling in recipes.