### PR TITLE
Allow unstricted model loading

### DIFF
--- a/src/fairseq2/models/loader.py
+++ b/src/fairseq2/models/loader.py
@@ -128,7 +128,8 @@ class ModelSharder(Protocol[ModelT_contra, ModelConfigT_contra]):
         model: ModelT_contra,
         config: ModelConfigT_contra,
         gangs: Mapping[str, Gang],
-    ) -> None: ...
+    ) -> None:
+        ...
 
 
 @final

--- a/src/fairseq2/models/loader.py
+++ b/src/fairseq2/models/loader.py
@@ -206,7 +206,7 @@ class StandardModelLoader(ModelLoader[ModelT], Generic[ModelT, ModelConfigT]):
         force: bool = False,
         progress: bool = True,
         strict_state_dict: bool = True,
-        
+
     ) -> ModelT:
         if isinstance(model_name_or_card, AssetCard):
             card = model_name_or_card

--- a/src/fairseq2/models/loader.py
+++ b/src/fairseq2/models/loader.py
@@ -128,8 +128,7 @@ class ModelSharder(Protocol[ModelT_contra, ModelConfigT_contra]):
         model: ModelT_contra,
         config: ModelConfigT_contra,
         gangs: Mapping[str, Gang],
-    ) -> None:
-        ...
+    ) -> None: ...
 
 
 @final
@@ -206,7 +205,6 @@ class StandardModelLoader(ModelLoader[ModelT], Generic[ModelT, ModelConfigT]):
         force: bool = False,
         progress: bool = True,
         strict_state_dict: bool = True,
-
     ) -> ModelT:
         if isinstance(model_name_or_card, AssetCard):
             card = model_name_or_card

--- a/src/fairseq2/models/loader.py
+++ b/src/fairseq2/models/loader.py
@@ -82,6 +82,7 @@ class ModelLoader(Protocol[ModelT_co]):
         dtype: DataType | None = None,
         force: bool = False,
         progress: bool = True,
+        strict_state_dict: bool = True,
     ) -> ModelT_co:
         """
         :param model_name_or_card:
@@ -98,6 +99,9 @@ class ModelLoader(Protocol[ModelT_co]):
             cache.
         :param progress:
             If ``True``, displays a progress bar to stderr.
+        :param strict_state_dict:
+            If ``True``, checkpoint' parameters and layers must be identical to
+            the model state dict)
 
         :returns:
             A model loaded from the checkpoint of ``model_name_or_card``.
@@ -201,6 +205,8 @@ class StandardModelLoader(ModelLoader[ModelT], Generic[ModelT, ModelConfigT]):
         dtype: DataType | None = None,
         force: bool = False,
         progress: bool = True,
+        strict_state_dict: bool = True,
+        
     ) -> ModelT:
         if isinstance(model_name_or_card, AssetCard):
             card = model_name_or_card
@@ -355,7 +361,7 @@ class StandardModelLoader(ModelLoader[ModelT], Generic[ModelT, ModelConfigT]):
         consume_prefix_in_state_dict_if_present(state_dict, prefix="module.")
 
         try:
-            load_state_dict(model, state_dict)
+            load_state_dict(model, state_dict, strict=strict_state_dict)
         except (KeyError, ValueError) as ex:
             raise AssetError(
                 f"{card.name} cannot be loaded. See nested exception for details."
@@ -396,6 +402,7 @@ class DelegatingModelLoader(ModelLoader[ModelT]):
         dtype: DataType | None = None,
         force: bool = False,
         progress: bool = True,
+        strict_state_dict: bool = True,
     ) -> ModelT:
         if isinstance(model_name_or_card, AssetCard):
             card = model_name_or_card
@@ -419,6 +426,7 @@ class DelegatingModelLoader(ModelLoader[ModelT]):
             dtype=dtype,
             force=force,
             progress=progress,
+            strict_state_dict=strict_state_dict,
         )
 
     def register(self, family: str, loader: ModelLoader[ModelT]) -> None:

--- a/src/fairseq2/nn/utils/module.py
+++ b/src/fairseq2/nn/utils/module.py
@@ -431,7 +431,9 @@ def broadcast_module(
     _broadcast_coalesced(pg, tensors, bucket_size, source_rank)
 
 
-def load_state_dict(module: Module, state_dict: Mapping[str, object], strict: bool = True) -> None:
+def load_state_dict(
+    module: Module, state_dict: Mapping[str, object], strict: bool = True
+) -> None:
     """Copy parameters and buffers from ``state_dict`` into ``module`` and its
     descendant modules.
 

--- a/src/fairseq2/nn/utils/module.py
+++ b/src/fairseq2/nn/utils/module.py
@@ -431,16 +431,15 @@ def broadcast_module(
     _broadcast_coalesced(pg, tensors, bucket_size, source_rank)
 
 
-def load_state_dict(module: Module, state_dict: Mapping[str, object]) -> None:
+def load_state_dict(module: Module, state_dict: Mapping[str, object], strict: bool = True) -> None:
     """Copy parameters and buffers from ``state_dict`` into ``module`` and its
     descendant modules.
 
-    This implementation internally calls :meth:`Module.load_state_dict()` with
-    ``strict`` set to ``True``, and also enforces that ``state_dict`` does not
-    contain any keys corresponding to descendants that are set to ``None`` via
-    :meth:`Module.register_module()`.
+    This implementation internally calls :meth:`Module.load_state_dict()`, and also enforces that
+    ``state_dict`` does not contain any keys corresponding to descendants that are set to ``None``
+    via :meth:`Module.register_module()`.
     """
-    module.load_state_dict(state_dict, strict=True)
+    module.load_state_dict(state_dict, strict=strict)
 
     unexpected_keys = []
 


### PR DESCRIPTION
We want to extend the ModelLoader API by allowing load checkpoints with incomplete parameters to a registered model. This is useful where different model blocks are delivered in different checkpoints (for example, to save spaces), as in the cases with the V-JEPA checkpoints (https://github.com/facebookresearch/jepa)

Fixes #{issue number}

**Does your PR introduce any breaking changes? If yes, please list them:**
List of all backwards-incompatible changes.

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [ ] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
