### PR TITLE
Fix error wrongly triggered on 'model' key absence in Llama checkpoint conversion

### DIFF
--- a/src/fairseq2/recipes/llama/convert_checkpoint.py
+++ b/src/fairseq2/recipes/llama/convert_checkpoint.py
@@ -122,8 +122,8 @@ class ConvertCheckpointCommandHandler(CliCommandHandler):
 
                     sys.exit(1)
 
-                if "model" not in checkpoint:
-                    log.error("Checkpoint file {} does not contain a 'model' entry.", input_file.name)  # fmt: skip
+                if all(key not in checkpoint for key in ["model_key", "model"]):
+                    log.error("Checkpoint file {} does not contain a 'model_key' nor 'model' entry.", input_file.name)  # fmt: skip
 
                     sys.exit(1)
 


### PR DESCRIPTION
**What does this PR do? Please describe:**
Fixes a `Checkpoint file does not contain a 'model' entry` error triggered wrongly while "model_key" (the preferred more general way to define the model key) is indeed present in the checkpoint.
No change necessary in documentation (following the process described in the current doc yields this error).

**Does your PR introduce any breaking changes? If yes, please list them:**
No

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [ ] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
