### PR TITLE
Training DPO with pre-computed reference scores

### DIFF
--- a/src/fairseq2/recipes/lm/preference_finetune/dpo.py
+++ b/src/fairseq2/recipes/lm/preference_finetune/dpo.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Mapping, cast, final
+from typing import Mapping, cast, final
 
 import torch
 import torch.distributed
@@ -76,6 +76,11 @@ class DpoFinetuneUnit(AbstractTrainUnit[PreferenceOptimizationBatch]):
         rejected_input_batch, rejected_target_batch = as_auto_regressive_input(
             rejected_batch
         )
+        if (
+            chosen_target_batch.target_mask is None
+            or rejected_target_batch.target_mask is None
+        ):
+            raise RuntimeError("target_mask attributes must exist for DPO loss")
 
         chosen_output = cast(SequenceModelOutput, self._model(chosen_input_batch))
         rejected_output = cast(SequenceModelOutput, self._model(rejected_input_batch))
@@ -116,7 +121,7 @@ class DpoFinetuneUnit(AbstractTrainUnit[PreferenceOptimizationBatch]):
             )
         else:
             raise RuntimeError(
-                f"Reference model is not initialized and data batch does not provide reference score, but at least one must exist."
+                "Reference model is not initialized and data batch does not provide reference score, but at least one must exist."
             )
 
         if self._length_normalization:


### PR DESCRIPTION
**What does this PR do? Please describe:**

For large model finetuning it is beneficial to be able to precompute reference scores offline and avoid using 2nd LLM online to extract the same scores for training data every epoch.

We implement this by allowing to set DPO reference model to null. If this is the case, then finetune unit will try to use scores from the data batch. If the data batch scores are not available, training will crash. We could add some error handling here. 

TODOs:
* Error handling when reference model is not set, and scores do not exist in the batch.
* Improve the docstring around reference model in DPO config to highlight this feature.

## How scores look like in the data

we add 2 columns to json that contain floats:
* reference_score_rejected
* reference_score_chosen

## How to test

Example config:
```yaml
dataset: dpo_offline_score
optimizer_config:
  lr: 1e-7
max_num_data_epochs: 100
max_num_steps: 500
max_num_tokens: 8192
max_seq_len: 8192
publish_metrics_every_n_steps: 1
keep_last_n_models: 20
checkpoint_every_n_steps: 50
batch_size: 1
model: llama3_3_70b_instruct
tensor_parallel_size: 8
criterion: dpo
_add_:
  criterion_config:
      reference_model: null  # to use offline scores
      beta: 0.1
      nll_scale: 0.0
wandb_project: dpo_offline_score
wandb_run_name: weizhe_run
```

Example run command on h100-2:

`FAIRSEQ2_USER_ASSET_DIR=/opt/hpcaas/.mounts/fs-0df31b178aa4037ac/home/kulikov/code/RAM/fairseq2_ram/src/fairseq2_ram/cards srun fairseq2 lm preference_finetune $(realpath .)/run --no-sweep-dir --config-file ./train_config.yaml`

Note there is `FAIRSEQ2_USER_ASSET_DIR` variable pointing to the dataset card