### PR TITLE
Fix config_kls bug in SamplerHandlers

### DIFF
--- a/src/fairseq2/generation/sampling/sampler.py
+++ b/src/fairseq2/generation/sampling/sampler.py
@@ -150,7 +150,7 @@ class TopPSamplerHandler(SamplerHandler):
     @property
     @override
     def config_kls(self) -> type:
-        return TopPSamplerHandler
+        return TopPSamplerConfig
 
 
 TOP_K_SAMPLER: Final = "top-k"
@@ -172,4 +172,4 @@ class TopKSamplerHandler(SamplerHandler):
     @property
     @override
     def config_kls(self) -> type:
-        return TopKSamplerHandler
+        return TopKSamplerConfig


### PR DESCRIPTION
Fixes the bug where we accidentally return the handler instead of the dataclass in `config_kls` in `SamplerHandler`.