### PR TITLE
Move batching strategy to DataReadConfig

### DIFF
--- a/src/fairseq2/data/text/tokenizers/llama.py
+++ b/src/fairseq2/data/text/tokenizers/llama.py
@@ -34,6 +34,8 @@ class LLaMA3Tokenizer(TiktokenTokenizer):
         :param instruct:
             If ``True``, uses EOT (end-of-turn) token in-place of EOS token.
         """
+        self._eos_token = "<|eot_id|>" if instruct else "<|end_of_text|>"
+
         special_tokens = [
             "<|begin_of_text|>",
             "<|end_of_text|>",
@@ -52,8 +54,6 @@ class LLaMA3Tokenizer(TiktokenTokenizer):
 
         for i in range(num_reserved_special_tokens - len(special_tokens)):
             special_tokens.append(f"<|reserved_special_token_{2 + i}|>")
-
-        self._eos_token = "<|eot_id|>" if instruct else "<|end_of_text|>"
 
         super().__init__(
             path,

--- a/src/fairseq2/data/text/tokenizers/s2t_transformer.py
+++ b/src/fairseq2/data/text/tokenizers/s2t_transformer.py
@@ -30,11 +30,7 @@ class S2TTransformerTokenizer(SentencePieceTokenizer):
     _default_target_lang: str
 
     def __init__(
-        self,
-        path: Path,
-        task: str,
-        target_langs: set[str],
-        default_target_lang: str,
+        self, path: Path, task: str, target_langs: set[str], default_target_lang: str
     ) -> None:
         """
         :param path:

--- a/src/fairseq2/datasets/__init__.py
+++ b/src/fairseq2/datasets/__init__.py
@@ -10,9 +10,9 @@ from fairseq2.datasets.config import Batching as Batching
 from fairseq2.datasets.config import DataReadOptions as DataReadOptions
 from fairseq2.datasets.config import LengthBatching as LengthBatching
 from fairseq2.datasets.config import StaticBatching as StaticBatching
+from fairseq2.datasets.config import SyncMode as SyncMode
 from fairseq2.datasets.data_reader import DataPipelineReader as DataPipelineReader
 from fairseq2.datasets.data_reader import DataReader as DataReader
-from fairseq2.datasets.data_reader import SyncMode as SyncMode
 from fairseq2.datasets.error import DataReadError as DataReadError
 from fairseq2.datasets.error import DatasetError as DatasetError
 from fairseq2.datasets.handler import DatasetHandler as DatasetHandler

--- a/src/fairseq2/datasets/speech.py
+++ b/src/fairseq2/datasets/speech.py
@@ -14,13 +14,22 @@ from typing import Final, final
 import torch
 from typing_extensions import override
 
-from fairseq2.datasets.config import Batching, DataReadOptions
+from fairseq2.datasets.config import DataReadOptions
 from fairseq2.datasets.data_reader import DataPipelineReader, DataReader
 from fairseq2.datasets.hub import DatasetHubAccessor
 from fairseq2.error import NotSupportedError
 from fairseq2.gang import Gang
 from fairseq2.models.sequence import SequenceBatch
 from fairseq2.typing import DataType
+
+
+@dataclass(kw_only=True)
+class SpeechReadOptions(DataReadOptions):
+    dtype: DataType = torch.float32
+    """The data type of the decoded audio sequences."""
+
+    normalize_audio: bool = False
+    """If ``True``, normalizes audio to have zero mean and unit variance."""
 
 
 class SpeechDataset(ABC):
@@ -33,7 +42,6 @@ class SpeechDataset(ABC):
         gang: Gang,
         min_audio_len: int,
         max_audio_len: int,
-        batching: Batching,
         options: SpeechReadOptions | None = None,
     ) -> DataReader[SequenceBatch]:
         """Create a dataset reader.
@@ -48,8 +56,6 @@ class SpeechDataset(ABC):
         :param max_audio_len:
             The maximum audio length of each example. Examples longer than this
             value will be dropped.
-        :param batching:
-            The batching strategy for returned examples.
         :param options:
             The read options.
         """
@@ -57,15 +63,6 @@ class SpeechDataset(ABC):
     @abstractmethod
     def splits(self) -> set[str]:
         """Return the set of splits."""
-
-
-@dataclass
-class SpeechReadOptions(DataReadOptions):
-    dtype: DataType = torch.float32
-    """The data type of the decoded audio sequences."""
-
-    normalize_audio: bool = False
-    """If ``True``, normalizes audio to have zero mean and unit variance."""
 
 
 GENERIC_SPEECH_DATASET_FAMILY: Final = "generic_speech"
@@ -86,7 +83,6 @@ class GenericSpeechDataset(SpeechDataset):
         gang: Gang,
         min_audio_len: int,
         max_audio_len: int,
-        batching: Batching,
         options: SpeechReadOptions | None = None,
     ) -> DataPipelineReader[SequenceBatch]:
         raise NotSupportedError("not supported yet.")

--- a/src/fairseq2/recipes/hg/dataset.py
+++ b/src/fairseq2/recipes/hg/dataset.py
@@ -10,7 +10,7 @@ from collections.abc import Callable
 from typing import Any
 
 from fairseq2.data.data_pipeline import Collater, create_bucket_sizes, read_sequence
-from fairseq2.datasets import Batching, LengthBatching, StaticBatching
+from fairseq2.datasets import Batching, DataReadOptions, LengthBatching, StaticBatching
 from fairseq2.datasets.data_reader import BatchT, DataPipelineReader
 from fairseq2.gang import Gang
 
@@ -146,11 +146,9 @@ def create_hf_reader(
     builder.prefetch(num_prefetch)
 
     pipeline = builder.map(converter).and_return()
-    return DataPipelineReader[BatchT](
-        "hg",
-        pipeline,
-        gang,
-        num_accumulate=num_accumulate,
-        drop_remainder=False,
-        sync_batches=True,
+
+    options = DataReadOptions(
+        num_accumulate=num_accumulate, drop_remainder=False, sync_batches=True
     )
+
+    return DataPipelineReader[BatchT]("hg", pipeline, gang, options)

--- a/src/fairseq2/recipes/lm/preference_finetune/recipe.py
+++ b/src/fairseq2/recipes/lm/preference_finetune/recipe.py
@@ -413,7 +413,8 @@ def load_preference_finetuner(
     else:
         batching = LengthBatching(config.max_num_tokens)
 
-    options = PreferenceReadOptions(
+    read_options = PreferenceReadOptions(
+        batching=batching,
         example_shuffle_window=config.example_shuffle_window,
         batch_shuffle_window=config.batch_shuffle_window,
         num_accumulate=config.gradient_accumulation,
@@ -426,12 +427,7 @@ def load_preference_finetuner(
 
     try:
         data_reader = dataset.create_reader(
-            tokenizer,
-            dp_gang,
-            config.min_seq_len,
-            config.max_seq_len,
-            batching,
-            options,
+            tokenizer, dp_gang, config.min_seq_len, config.max_seq_len, read_options
         )
     except ValueError as ex:
         raise ValueError(

--- a/src/fairseq2/recipes/mt/translate.py
+++ b/src/fairseq2/recipes/mt/translate.py
@@ -17,7 +17,7 @@ from fairseq2.assets import AssetCardNotFoundError, default_asset_store
 from fairseq2.checkpoint import FileCheckpointMetadataProvider
 from fairseq2.config_registry import ConfigRegistry
 from fairseq2.data.text import TextTokenizer, get_text_tokenizer_hub
-from fairseq2.datasets import StaticBatching
+from fairseq2.datasets import StaticBatching, SyncMode
 from fairseq2.datasets.text import (
     GenericTextDataset,
     TextReadOptions,
@@ -235,8 +235,13 @@ def load_text_translator(
 
     seed = config.seed
 
-    options = TextReadOptions(
-        sync_mode="until_last", num_prefetch=config.num_prefetch, seed=seed
+    batching = StaticBatching(config.batch_size)
+
+    read_options = TextReadOptions(
+        batching=batching,
+        sync_mode=SyncMode.UNTIL_LAST,
+        num_prefetch=config.num_prefetch,
+        seed=seed,
     )
 
     try:
@@ -246,8 +251,7 @@ def load_text_translator(
             gang,
             config.min_seq_len,
             config.max_seq_len,
-            StaticBatching(config.batch_size),
-            options,
+            read_options,
         )
     except ValueError as ex:
         raise ValueError(

--- a/src/fairseq2/recipes/wav2vec2/eval.py
+++ b/src/fairseq2/recipes/wav2vec2/eval.py
@@ -16,7 +16,7 @@ from typing_extensions import override
 from fairseq2.assets import AssetCardNotFoundError, default_asset_store
 from fairseq2.checkpoint import FileCheckpointMetadataProvider
 from fairseq2.config_registry import ConfigRegistry
-from fairseq2.datasets import LengthBatching
+from fairseq2.datasets import LengthBatching, SyncMode
 from fairseq2.datasets.speech import (
     GenericSpeechDataset,
     SpeechReadOptions,
@@ -180,10 +180,13 @@ def load_wav2vec2_evaluator(
 
     seed = config.seed
 
-    options = SpeechReadOptions(
+    batching = LengthBatching(config.max_num_elements)
+
+    read_options = SpeechReadOptions(
+        batching=batching,
         dtype=config.dtype,
         normalize_audio=config.normalize_audio,
-        sync_mode="until_last",
+        sync_mode=SyncMode.UNTIL_LAST,
         num_prefetch=config.num_prefetch,
         seed=seed,
     )
@@ -194,8 +197,7 @@ def load_wav2vec2_evaluator(
             gang,
             config.min_audio_len,
             config.max_audio_len,
-            LengthBatching(config.max_num_elements),
-            options,
+            read_options,
         )
     except ValueError as ex:
         raise ValueError(


### PR DESCRIPTION
This is the last PR before the recipe refactoring. It moves `batching` configuration to `DataReadOptions` and also converts `SyncMode` to an enumeration.