### PR TITLE
Fix intermediate_size calculation in Llama config convert function

### DIFF
--- a/src/fairseq2/models/llama/integ.py
+++ b/src/fairseq2/models/llama/integ.py
@@ -55,7 +55,9 @@ def convert_to_huggingface_config(arch: str, config: LLaMAConfig) -> dict[str, o
     multiple_of = config.ffn_inner_dim_to_multiple
 
     # Taken from https://github.com/huggingface/transformers/blob/82fcac0a7e40dc6cc5e3121d714b9b16775293ad/src/transformers/models/llama/convert_llama_weights_to_hf.py#L171.
-    intermediate_size = multiple_of * (int(multiplier * int(8 * config.model_dim / 3)) + multiple_of - 1) // multiple_of  # fmt: skip
+    intermediate_size = multiple_of * ((int(multiplier * int(8 * config.model_dim / 3)) + multiple_of - 1) // multiple_of)  # fmt: skip
+    
+    print("intermediate_size:", intermediate_size)
 
     if config.rope_scaling is not None:
         rope_scaling = {

--- a/src/fairseq2/models/llama/integ.py
+++ b/src/fairseq2/models/llama/integ.py
@@ -56,8 +56,6 @@ def convert_to_huggingface_config(arch: str, config: LLaMAConfig) -> dict[str, o
 
     # Taken from https://github.com/huggingface/transformers/blob/82fcac0a7e40dc6cc5e3121d714b9b16775293ad/src/transformers/models/llama/convert_llama_weights_to_hf.py#L171.
     intermediate_size = multiple_of * ((int(multiplier * int(8 * config.model_dim / 3)) + multiple_of - 1) // multiple_of)  # fmt: skip
-    
-    print("intermediate_size:", intermediate_size)
 
     if config.rope_scaling is not None:
         rope_scaling = {

--- a/tests/unit/models/llama/test_integ.py
+++ b/tests/unit/models/llama/test_integ.py
@@ -1,0 +1,23 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from fairseq2.models.llama import get_llama_model_hub
+from fairseq2.models.llama.integ import convert_to_huggingface_config
+
+
+def test_intermediate_size_is_correct() -> None:
+    # "intermediate_size" is an expected parameter in the HF Llama config
+    # and is computed dynamically from other parameters in Fairseq2
+    # We only check it for one arch
+    arch = "llama3_2_1b"
+
+    model_config = get_llama_model_hub().load_config(arch)
+
+    config_json = convert_to_huggingface_config(arch, model_config)
+
+    assert config_json["intermediate_size"] == 8192


### PR DESCRIPTION
**What does this PR do? Please describe:**
Fix missing parentheses yielding incorrect intermediate_size values, used for generating the HF config.json of Llama models (useful mainly for vLLM compat).

Tested on arch `llama3_2_1b` where the expected intermediate_size is 8192, while the conversion script was yielding 8446.

**Does your PR introduce any breaking changes? If yes, please list them:**
No

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [ ] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
