### PR TITLE
Use logprob scores in sampling generator

### DIFF
--- a/src/fairseq2/generation/_sampling/_generator.py
+++ b/src/fairseq2/generation/_sampling/_generator.py
@@ -767,7 +767,8 @@ class _AbstractSamplingSequenceGeneratorOp(ABC):
             # (S)
             step_scores = self._step_scores[seq_idx, :seq_len]
 
-            score = step_scores.sum()
+            # Skip the first step since its score is always 0.
+            score = step_scores[1:].log().sum()
 
             if self._normalize_scores:
                 # Since the first step's score is always 0, do not include it in


### PR DESCRIPTION
A small PR that changes the step scores produced by the sampling sequence generator to logprobs as it is more conventional than regular probs.