### PR TITLE
using dtype and device in hub.load

### DIFF
--- a/src/fairseq2/models/_hub.py
+++ b/src/fairseq2/models/_hub.py
@@ -81,6 +81,8 @@ class ModelHub(Generic[ModelT, ModelConfigT]):
             raise ValueError(
                 "`gangs` and `device` must not be specified at the same time."
             )
+        if device is None:
+            device = torch.get_default_device()
 
         if device is not None:
             if device.type == "meta":
@@ -88,7 +90,7 @@ class ModelHub(Generic[ModelT, ModelConfigT]):
 
             gangs = fake_gangs(device)
         elif gangs is None:
-            gangs = fake_gangs(CPU)
+            gangs = fake_gangs(device)
         else:
             if gangs.root.device.type == "meta":
                 raise ValueError("`gangs` must be on a real device.")
@@ -114,7 +116,7 @@ class ModelHub(Generic[ModelT, ModelConfigT]):
             )
 
         if dtype is None:
-            dtype = torch.float32
+            dtype = torch.get_default_dtype()
 
         model = handler.load(card, gangs, dtype, config=config)
 

--- a/src/fairseq2/models/_hub.py
+++ b/src/fairseq2/models/_hub.py
@@ -17,7 +17,7 @@ from fairseq2.gang import Gangs, fake_gangs
 from fairseq2.models._error import UnknownModelError, UnknownModelFamilyError
 from fairseq2.models._handler import ModelHandler, get_model_family
 from fairseq2.registry import Provider
-from fairseq2.typing import CPU, DataType, Device
+from fairseq2.typing import DataType, Device
 
 ModelT = TypeVar("ModelT", bound=Module)
 


### PR DESCRIPTION
**What does this PR do? Please describe:**
Using default dtype and device when creating models from hub.

**Does your PR introduce any breaking changes? If yes, please list them:**
- I dont think there're any BC

**Check list:**
- [x] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
