### PR TITLE
Expose LLaMA RoPE scaling function as a public API

### DIFF
--- a/src/fairseq2/models/llama/__init__.py
+++ b/src/fairseq2/models/llama/__init__.py
@@ -15,6 +15,9 @@ from fairseq2.models.llama._config import (
     register_llama_configs as register_llama_configs,
 )
 from fairseq2.models.llama._factory import LLaMAFactory as LLaMAFactory
+from fairseq2.models.llama._factory import (
+    init_llama_scaled_freqs as init_llama_scaled_freqs,
+)
 from fairseq2.models.llama._handler import LLaMAModelHandler as LLaMAModelHandler
 from fairseq2.models.llama._handler import (
     convert_llama_checkpoint as convert_llama_checkpoint,

--- a/src/fairseq2/models/llama/_factory.py
+++ b/src/fairseq2/models/llama/_factory.py
@@ -107,7 +107,7 @@ class LLaMAFactory:
 
         if config.use_scaled_rope:
             freqs_init_fn = partial(
-                _init_scaled_freqs, rope_scaling=config.rope_scaling
+                init_llama_scaled_freqs, rope_scaling=config.rope_scaling
             )
         else:
             freqs_init_fn = None
@@ -179,7 +179,7 @@ class LLaMAFactory:
         return RMSNorm(model_dim, bias=False, device=device, dtype=dtype)
 
 
-def _init_scaled_freqs(
+def init_llama_scaled_freqs(
     pos_encoder: RotaryEncoder, rope_scaling: LLaMARopeScalingConfig
 ) -> Tensor:
     device = pos_encoder.freqs.device


### PR DESCRIPTION
Renames `_init_scaled_freqs` to `init_llama_scaled_freqs` and exposes it as a public API.