### PR TITLE
Improve checkpoint conversion handling

### DIFF
--- a/src/fairseq2/recipes/asr/_eval.py
+++ b/src/fairseq2/recipes/asr/_eval.py
@@ -98,8 +98,8 @@ def register_asr_eval_configs(context: RuntimeContext) -> None:
 
     preset = registry.decorator
 
-    @preset("wav2vec2_base_10h")
-    def base_10h() -> AsrEvalConfig:
+    @preset("wav2vec2")
+    def wav2vec2() -> AsrEvalConfig:
         return AsrEvalConfig()
 
 

--- a/src/fairseq2/recipes/common/_asset.py
+++ b/src/fairseq2/recipes/common/_asset.py
@@ -93,7 +93,7 @@ class ExtraPathRegistrar:
         try:
             provider = file_metadata_loader.load()
         except FileNotFoundError:
-            log.warning("The '{}' path pointed to by `common.assets.extra_path` does not exist.", extra_path)  # fmt: skip
+            log.warning("'{}' path pointed to by `common.assets.extra_path` does not exist.", extra_path)  # fmt: skip
 
             return
 
@@ -137,7 +137,7 @@ class CheckpointDirectoryRegistrar:
         try:
             provider = checkpoint_metadata_loader.load()
         except FileNotFoundError:
-            log.warning("The checkpoint metadata file (model.yaml) is not found under the '{}' directory. Make sure that `common.assets.checkpoint_dir` points to the base checkpoint directory used during training.", checkpoint_dir)  # fmt: skip
+            log.warning("The checkpoint metadata file (model.yaml) is not found under '{}'. Make sure that `common.assets.checkpoint_dir` points to the base checkpoint directory used during training.", checkpoint_dir)  # fmt: skip
 
             return
 

--- a/src/fairseq2/recipes/lm/_instruction_finetune.py
+++ b/src/fairseq2/recipes/lm/_instruction_finetune.py
@@ -209,26 +209,6 @@ def register_instruction_finetune_configs(context: RuntimeContext) -> None:
 
         return config
 
-    @preset("llama2_7b_chat")
-    def llama2_7b_chat() -> InstructionFinetuneConfig:
-        config = llama3_1_instruct()
-
-        config.model.name = "llama2_7b_chat"
-        config.dataset.max_seq_len = 4096
-        config.dataset.max_num_tokens = 4096 * 2
-        config.dataset.max_num_valid_tokens = 4096 * 2
-
-        return config
-
-    @preset("llama2_70b_chat")
-    def llama2_70b_chat() -> InstructionFinetuneConfig:
-        config = llama2_7b_chat()
-
-        config.model.name = "llama2_70b_chat"
-        config.gang.tensor_parallel_size = 8
-
-        return config
-
 
 def load_instruction_finetuner(
     context: RuntimeContext, config: object, output_dir: Path

--- a/src/fairseq2/recipes/lm/_text_generate.py
+++ b/src/fairseq2/recipes/lm/_text_generate.py
@@ -107,39 +107,22 @@ def register_text_generate_configs(context: RuntimeContext) -> None:
 
     preset = registry.decorator
 
-    @preset("llama2_7b_chat")
-    def llama2_7b_chat() -> TextGenerateConfig:
-        config = llama3_8b_instruct()
-
-        config.model.name = "llama2_7b_chat"
-
-        return config
-
-    @preset("llama2_70b_chat")
-    def llama2_70b_chat() -> TextGenerateConfig:
-        config = llama2_7b_chat()
-
-        config.model.name = "llama2_70b_chat"
-        config.gang.tensor_parallel_size = 8
-
-        return config
-
-    @preset("llama3_8b_instruct")
-    def llama3_8b_instruct() -> TextGenerateConfig:
+    @preset("llama3_instruct")
+    def llama3_instruct() -> TextGenerateConfig:
         return TextGenerateConfig()
 
     @preset("llama3_70b_instruct")
     def llama3_70b_instruct() -> TextGenerateConfig:
-        config = llama3_8b_instruct()
+        config = llama3_instruct()
 
         config.model.name = "llama3_70b_instruct"
         config.gang.tensor_parallel_size = 8
 
         return config
 
-    @preset("llama3_1_8b_instruct")
-    def llama3_1_8b_instruct() -> TextGenerateConfig:
-        config = llama3_8b_instruct()
+    @preset("llama3_1_instruct")
+    def llama3_1_instruct() -> TextGenerateConfig:
+        config = llama3_instruct()
 
         config.model.name = "llama3_1_8b_instruct"
 

--- a/src/fairseq2/recipes/mt/_eval.py
+++ b/src/fairseq2/recipes/mt/_eval.py
@@ -120,8 +120,8 @@ def register_mt_eval_configs(context: RuntimeContext) -> None:
 
     preset = registry.decorator
 
-    @preset("nllb_dense_600m")
-    def nllb_dense_600m() -> MTEvalConfig:
+    @preset("nllb_dense")
+    def nllb_dense() -> MTEvalConfig:
         return MTEvalConfig()
 
 

--- a/src/fairseq2/recipes/mt/_train.py
+++ b/src/fairseq2/recipes/mt/_train.py
@@ -183,7 +183,7 @@ def register_mt_train_configs(context: RuntimeContext) -> None:
 
     @preset("nllb_dense_300m")
     def nllb_dense_300m() -> MTTrainConfig:
-        config = nllb_dense_600m()
+        config = nllb_dense()
 
         assert isinstance(config.lr_scheduler.config, MyleLRConfig)
 
@@ -196,8 +196,8 @@ def register_mt_train_configs(context: RuntimeContext) -> None:
 
         return config
 
-    @preset("nllb_dense_600m")
-    def nllb_dense_600m() -> MTTrainConfig:
+    @preset("nllb_dense")
+    def nllb_dense() -> MTTrainConfig:
         return MTTrainConfig()
 
 

--- a/src/fairseq2/recipes/mt/_translate.py
+++ b/src/fairseq2/recipes/mt/_translate.py
@@ -114,8 +114,8 @@ def register_text_translate_configs(context: RuntimeContext) -> None:
 
     preset = registry.decorator
 
-    @preset("nllb_dense_600m")
-    def nllb_dense_600m() -> TextTranslateConfig:
+    @preset("nllb_dense")
+    def nllb_dense() -> TextTranslateConfig:
         return TextTranslateConfig()
 
 

--- a/src/fairseq2/recipes/trainer.py
+++ b/src/fairseq2/recipes/trainer.py
@@ -582,7 +582,9 @@ class Trainer(StatefulObjectBag, Generic[BatchT]):
         log.info("Attempting to load the last checkpoint.")
 
         try:
-            step_nr, state = self._checkpoint_manager.load_last_checkpoint()
+            step_nr, state = self._checkpoint_manager.load_last_checkpoint(
+                load_model=False
+            )
         except CheckpointNotFoundError:
             log.info("No checkpoint found. Starting training.")
 

--- a/src/fairseq2/setup/_cli/_commands.py
+++ b/src/fairseq2/setup/_cli/_commands.py
@@ -83,7 +83,7 @@ def _register_asr_cli(cli: Cli) -> None:
     eval_handler = RecipeCommandHandler(
         loader=load_asr_evaluator,
         config_kls=AsrEvalConfig,
-        default_preset="wav2vec2_base_10h",
+        default_preset="wav2vec2",
         extra_sweep_keys=extra_sweep_keys,
     )
 
@@ -184,7 +184,7 @@ def _register_lm_cli(cli: Cli) -> None:
     text_generate_handler = RecipeCommandHandler(
         loader=load_text_generator,
         config_kls=TextGenerateConfig,
-        default_preset="llama3_1_8b_instruct",
+        default_preset="llama3_1_instruct",
     )
 
     group.add_command(
@@ -203,7 +203,7 @@ def _register_mt_cli(cli: Cli) -> None:
     eval_handler = RecipeCommandHandler(
         loader=load_mt_evaluator,
         config_kls=MTEvalConfig,
-        default_preset="nllb_dense_600m",
+        default_preset="nllb_dense",
         extra_sweep_keys=extra_sweep_keys,
     )
 
@@ -217,7 +217,7 @@ def _register_mt_cli(cli: Cli) -> None:
     train_handler = RecipeCommandHandler(
         loader=load_mt_trainer,
         config_kls=MTTrainConfig,
-        default_preset="nllb_dense_600m",
+        default_preset="nllb_dense",
         extra_sweep_keys=extra_sweep_keys,
     )
 
@@ -231,7 +231,7 @@ def _register_mt_cli(cli: Cli) -> None:
     text_translate_handler = RecipeCommandHandler(
         loader=load_text_translator,
         config_kls=TextTranslateConfig,
-        default_preset="nllb_dense_600m",
+        default_preset="nllb_dense",
         extra_sweep_keys=extra_sweep_keys,
     )
 


### PR DESCRIPTION
This PR reintroduces backwards-compatibility in `CheckpointManager` and also fixes the preset config names of first-party recipes.