### PR TITLE
Keep having model_key in checkpoints

### DIFF
--- a/src/fairseq2/models/_handler.py
+++ b/src/fairseq2/models/_handler.py
@@ -315,7 +315,7 @@ class AbstractModelHandler(ModelHandler):
                 model_name, f"The checkpoint of the '{model_name}' model cannot be loaded. See the nested exception for details."  # fmt: skip
             ) from ex
 
-        if "fs2" not in checkpoint and "model_key" not in checkpoint:
+        if "fs2" not in checkpoint:
             try:
                 checkpoint = self._convert_checkpoint(checkpoint, config)
             except (KeyError, ValueError) as ex:


### PR DESCRIPTION
Although model_key was supposed to be an optional entry, this PR adds it back to the saved checkpoints since apparently vLLM has a hard-coded requirement for it. As an additional feature, we also have a logic now to flush NFS lookup caches (along with a gang barrier) to make sure that all processes have a consistent view of the underlying file system.