### PR TITLE
Do not close gangs in case of an error

### DIFF
--- a/src/fairseq2/recipes/evaluator.py
+++ b/src/fairseq2/recipes/evaluator.py
@@ -186,8 +186,8 @@ class Evaluator(Generic[BatchT]):
             log.info("Evaluation terminated!")
 
             raise
-        finally:
-            self._gangs.close()
+
+        self._gangs.close()
 
         elapsed_time = self._wall_watch.get_elapsed_time()
 

--- a/src/fairseq2/recipes/generator.py
+++ b/src/fairseq2/recipes/generator.py
@@ -154,8 +154,8 @@ class Generator(Generic[BatchT]):
             log.info("Generation terminated!")
 
             raise
-        finally:
-            self._gangs.close()
+
+        self._gangs.close()
 
         elapsed_time = self._wall_watch.get_elapsed_time()
 

--- a/src/fairseq2/recipes/trainer.py
+++ b/src/fairseq2/recipes/trainer.py
@@ -583,7 +583,7 @@ class Trainer(StatefulObjectBag, Generic[BatchT]):
         finally:
             self._garbage_collector.enable(False)
 
-            self._gangs.close()
+        self._gangs.close()
 
         if self._should_stop:
             log.info("Training stopped at step {}!", self._step_nr)


### PR DESCRIPTION
This PR moves `gangs.close()` from the `finally` block of `Trainer`, `Evaluator`, and `Generator` to the outer scope. `destroy_process_group` internally calls `ncclCommAbort` which is a collective operation. In case of an error, there is no guarantee that all ranks will enter their `finally` block and this causes the process to hang unless the error occurs on all ranks.