### PR TITLE
Improve to_ddp implementation

### DIFF
--- a/src/fairseq2/nn/ddp.py
+++ b/src/fairseq2/nn/ddp.py
@@ -10,18 +10,23 @@ import torch.distributed as dist
 from torch import Tensor
 from torch.distributed import GradBucket
 from torch.futures import Future
-from torch.nn import Module
+from torch.nn import Module, SyncBatchNorm
 from torch.nn.parallel import DistributedDataParallel as DDP
 
+from fairseq2.error import NotSupportedError
 from fairseq2.gang import Gang
-from fairseq2.nn.utils.module import to_device
+from fairseq2.nn.utils.module import (
+    infer_device,
+    reset_non_persistent_buffers,
+    to_device,
+    to_empty,
+)
 
 
 def to_ddp(
     module: Module,
     dp_gang: Gang,
     *,
-    broadcast_buffers: bool = False,
     find_unused_parameters: bool = False,
     static_graph: bool = False,
     normalize_gradients: bool = True,
@@ -30,19 +35,45 @@ def to_ddp(
 
     :param module: The module to be wrapped with DDP.
     :param dp_gang: The data parallel gang over which to replicate the module.
-    :param broadcast_buffers: See the corresponding DDP documentation.
     :param find_unused_parameters: See the corresponding DDP documentation.
     :param static_graph: See the corresponding DDP documentation.
     :param normalize_gradients: If ``True``, normalizes gradients by the world
         size of the underlying process group.
     """
-    to_device(module, dp_gang.device)
+    try:
+        module_device = infer_device(module)
+    except ValueError as ex:
+        raise DistributedSetupError(
+            "The device of `module` is not valid. See the nested exception for details."
+        ) from ex
+
+    # DDP has no explicit support for meta initialization.
+    if module_device.type == "meta":
+        if dp_gang.rank == 0:
+            # Since DDP always broadcasts the model from the coordinator process
+            # materialize the model there.
+            to_device(module, dp_gang.device)
+        else:
+            # For all other ranks, skip initialization as the parameters will be
+            # overwritten anyways.
+            to_empty(module, dp_gang.device)
+
+            # Non-persistent buffers are never part of module's state, so we
+            # have to initialize them.
+            reset_non_persistent_buffers(module, recurse=False)
+
+    try:
+        process_group = dp_gang.as_process_group()
+    except NotSupportedError:
+        raise DistributedSetupError(
+            "The specified distributed gang does not support conversion to a process group."
+        )
 
     try:
         ddp = DDP(
             module,
-            broadcast_buffers=broadcast_buffers,
-            process_group=dp_gang.as_process_group(),
+            broadcast_buffers=False,
+            process_group=process_group,
             find_unused_parameters=find_unused_parameters,
             static_graph=static_graph,
         )
@@ -51,9 +82,13 @@ def to_ddp(
             "DDP cannot be initialized. See the nested exception for details."
         ) from ex
 
+    # We do not broadcast buffers during training for performance reasons, so
+    # ensure that batch normalization works.
+    SyncBatchNorm.convert_sync_batchnorm(ddp, process_group)
+
     # DDP, by default, normalizes gradients by the world size of the underlying
     # process group. For sequence-based tasks this is typically not ideal since
-    # batch sizes can vary. Here, we disable that behavior.
+    # batch sizes can vary. Here, we disable that behavior if requested.
     if not normalize_gradients:
         ddp.register_comm_hook(state=dp_gang, hook=_allreduce_hook)
 

--- a/src/fairseq2/recipes/common/_distributed.py
+++ b/src/fairseq2/recipes/common/_distributed.py
@@ -76,12 +76,10 @@ def wrap_ddp(base_model: Module, gangs: Gangs, static_graph: bool) -> Module:
 
     log.info("Wrapping the model with DDP and broadcasting to all processes.")
 
-    dp_model = to_ddp(
-        base_model,
-        gangs.dp,
-        find_unused_parameters=not static_graph,
-        static_graph=static_graph,
-    )
+    # We do not set DDP's `static_graph` parameter. Unfortunately, support for
+    # that feature is finicky in DDP. `find_unused_parameters` is still useful
+    # though and can have measurable impact on perfomance.
+    dp_model = to_ddp(base_model, gangs.dp, find_unused_parameters=not static_graph)
 
     log.info("Model wrapped with DDP and broadcasted.")
 

--- a/src/fairseq2/recipes/common/_model.py
+++ b/src/fairseq2/recipes/common/_model.py
@@ -261,7 +261,7 @@ class CardBasedModelLoader(ModelLoader):
                     model = handler.load(card, gangs, dtype, model_config)
             else:
                 model = handler.create(
-                    model_config, gangs, dtype, handler.supports_meta
+                    model_config, gangs, dtype, meta=handler.supports_meta
                 )
         except NotSupportedError as ex:
             raise ModelLoadError(
@@ -385,7 +385,7 @@ class PathBasedModelLoader(ModelLoader):
                     ) from None
             else:
                 model = handler.create(
-                    model_config, gangs, dtype, handler.supports_meta
+                    model_config, gangs, dtype, meta=handler.supports_meta
                 )
         except NotSupportedError as ex:
             raise ModelLoadError(
@@ -528,7 +528,7 @@ class ModelCreator(ModelLoader):
                     ) from None
             else:
                 model = handler.create(
-                    model_config, gangs, dtype, handler.supports_meta
+                    model_config, gangs, dtype, meta=handler.supports_meta
                 )
         except NotSupportedError as ex:
             raise ModelLoadError(


### PR DESCRIPTION
This PR improves the implementation of `to_ddp` with more efficient model initialization by materializing the model only on rank 0. It also converts all `BatchNorm` modules to `SyncBatchNorm`. Particularly required for Conformer and similar architectures where batch normalization is used.