### PR TITLE
Materialize empty model on rank 0

### DIFF
--- a/src/fairseq2/recipes/common/_model.py
+++ b/src/fairseq2/recipes/common/_model.py
@@ -517,15 +517,18 @@ class ModelCreator(ModelLoader):
             log.info("Checkpoint found. Loading '{}' model on data parallel rank 0.", model_name)  # fmt: skip
 
         try:
-            if gangs.dp.rank == 0 and saved_model_path is not None:
-                try:
-                    model = handler.load_from_path(
-                        saved_model_path, model_name, model_config, gangs, dtype
-                    )
-                except FileNotFoundError:
-                    raise ModelLoadError(
-                        model_name, f"The '{model_name}' model cannot be found at the '{saved_model_path}' path."  # fmt: skip
-                    ) from None
+            if gangs.dp.rank == 0:
+                if saved_model_path is not None:
+                    try:
+                        model = handler.load_from_path(
+                            saved_model_path, model_name, model_config, gangs, dtype
+                        )
+                    except FileNotFoundError:
+                        raise ModelLoadError(
+                            model_name, f"The '{model_name}' model cannot be found at the '{saved_model_path}' path."  # fmt: skip
+                        ) from None
+                else:
+                    model = handler.create(model_config, gangs, dtype, meta=False)
             else:
                 model = handler.create(
                     model_config, gangs, dtype, meta=handler.supports_meta

--- a/src/fairseq2/recipes/common/_ref_model.py
+++ b/src/fairseq2/recipes/common/_ref_model.py
@@ -144,7 +144,7 @@ class ReferenceModelLoader(Generic[ModelT]):
                 model = handler.load(card, gangs, dtype, model_config)
             else:
                 model = handler.create(
-                    model_config, gangs, dtype, handler.supports_meta
+                    model_config, gangs, dtype, meta=handler.supports_meta
                 )
         except NotSupportedError as ex:
             raise ModelLoadError(


### PR DESCRIPTION
This PR has another nit improvement where we eagerly materialize an empty model before entering the `setup_data_parallel` call. As a slightly related work, also improves the implementation of `broadcast_module` and avoids broadcasting non-persistent buffers by default.