### PR TITLE
Improve FSDP auto-wrap

### DIFF
--- a/src/fairseq2/models/fsdp.py
+++ b/src/fairseq2/models/fsdp.py
@@ -9,6 +9,9 @@ from __future__ import annotations
 from functools import partial
 from typing import Literal
 
+from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
+    CheckpointWrapper,
+)
 from torch.distributed.fsdp.wrap import transformer_auto_wrap_policy
 from torch.nn import Module
 
@@ -26,14 +29,11 @@ def get_fsdp_wrap_policy(
 ) -> tuple[FSDPWrapPolicy | None, list[Module] | None]:
     """Return the FSDP wrap policy for ``model`` along with ignored modules.
 
-    :param model:
-        The model to be wrapped.
-    :param wrap_granularity:
-        The granularity at which to wrap modules of ``model``.
-
+    :param model: The model to be wrapped.
+    :param wrap_granularity: The granularity at which to wrap modules of ``model``.
           - 'layer': Wraps individual layers (e.g. :class:`TransformerDecoderLayer`).
           - 'stack': Wraps layer stacks (e.g. :class:`TransformerDecoder`).
-          - 'model': Wraps ``model`` only.
+          - 'model': Wraps ``model``.
     """
     if wrap_granularity == "model":
         return None, None
@@ -44,6 +44,14 @@ def get_fsdp_wrap_policy(
         kls = {TransformerEncoder, TransformerDecoder}
     elif wrap_granularity == "layer":
         kls = {TransformerEncoderLayer, TransformerDecoderLayer}
+
+        # We make the assumption that if the model uses activation checkpointing,
+        # it is at the layer granularity.
+        for m in model.modules():
+            if isinstance(m, CheckpointWrapper):
+                kls = {CheckpointWrapper}
+
+                break
     else:
         raise ValueError(
             f"`wrap_granularity` must be 'layer', 'stack', or 'model', but is '{wrap_granularity}' instead."


### PR DESCRIPTION
A nit PR for FSDP1 that wraps `CheckpointWrapper` instead of encoder/decoder layer in case the model uses activation checkpointing.