### PR TITLE
Remove implicit model saving from CheckpointManager

### DIFF
--- a/src/fairseq2/recipes/trainer.py
+++ b/src/fairseq2/recipes/trainer.py
@@ -600,9 +600,7 @@ class Trainer(StatefulObjectBag, Generic[BatchT]):
         log.info("Attempting to load the last checkpoint.")
 
         try:
-            step_nr, state = self._checkpoint_manager.load_last_checkpoint(
-                load_model=False
-            )
+            step_nr, state = self._checkpoint_manager.load_last_checkpoint()
         except CheckpointNotFoundError:
             log.info("No checkpoint found. Starting training.")
 


### PR DESCRIPTION
This PR is the first in `CheckpointManager` as part of the v0.5 work. It removes support for implicit model saving in `save_state()` to reduce the complexity of the implementation before upcoming new features.