### PR TITLE
Move data parallel APIs

### DIFF
--- a/src/fairseq2/checkpoint/_manager.py
+++ b/src/fairseq2/checkpoint/_manager.py
@@ -17,7 +17,7 @@ from typing_extensions import override
 
 from fairseq2.error import InvalidOperationError
 from fairseq2.gang import Gangs
-from fairseq2.nn.fsdp import load_with_sdp_gang
+from fairseq2.nn.data_parallel import load_with_sdp_gang
 from fairseq2.typing import CPU
 from fairseq2.utils.file import (
     FileMode,

--- a/src/fairseq2/models/_handler.py
+++ b/src/fairseq2/models/_handler.py
@@ -31,7 +31,7 @@ from fairseq2.models._error import (
     UnknownModelArchitectureError,
     model_asset_card_error,
 )
-from fairseq2.nn.fsdp import load_with_sdp_gang
+from fairseq2.nn.data_parallel import load_with_sdp_gang
 from fairseq2.nn.utils.module import (
     load_state_dict,
     reset_non_persistent_buffers,

--- a/src/fairseq2/models/fsdp.py
+++ b/src/fairseq2/models/fsdp.py
@@ -15,7 +15,7 @@ from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
 from torch.distributed.fsdp.wrap import transformer_auto_wrap_policy
 from torch.nn import Module
 
-from fairseq2.nn.fsdp import FSDPWrapPolicy
+from fairseq2.nn.data_parallel import FSDPWrapPolicy
 from fairseq2.nn.transformer import (
     TransformerDecoder,
     TransformerDecoderLayer,

--- a/src/fairseq2/nn/data_parallel/__init__.py
+++ b/src/fairseq2/nn/data_parallel/__init__.py
@@ -1,0 +1,38 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from fairseq2.nn.data_parallel._ddp import to_ddp as to_ddp
+from fairseq2.nn.data_parallel._error import (
+    DistributedSetupError as DistributedSetupError,
+)
+from fairseq2.nn.data_parallel._fsdp import (
+    FSDP_LOW_MEMORY_POLICY as FSDP_LOW_MEMORY_POLICY,
+)
+from fairseq2.nn.data_parallel._fsdp import (
+    FSDP_STANDARD_MEMORY_POLICY as FSDP_STANDARD_MEMORY_POLICY,
+)
+from fairseq2.nn.data_parallel._fsdp import (
+    FSDP_VERY_LOW_MEMORY_POLICY as FSDP_VERY_LOW_MEMORY_POLICY,
+)
+from fairseq2.nn.data_parallel._fsdp import FSDPMemoryPolicy as FSDPMemoryPolicy
+from fairseq2.nn.data_parallel._fsdp import (
+    FSDPParameterInitializer as FSDPParameterInitializer,
+)
+from fairseq2.nn.data_parallel._fsdp import FSDPWrapPolicy as FSDPWrapPolicy
+from fairseq2.nn.data_parallel._fsdp import (
+    get_fsdp_full_state_dict as get_fsdp_full_state_dict,
+)
+from fairseq2.nn.data_parallel._fsdp import (
+    get_fsdp_optim_state_dict as get_fsdp_optim_state_dict,
+)
+from fairseq2.nn.data_parallel._fsdp import (
+    load_fsdp_optim_state_dict as load_fsdp_optim_state_dict,
+)
+from fairseq2.nn.data_parallel._fsdp import summon_fsdp as summon_fsdp
+from fairseq2.nn.data_parallel._fsdp import to_fsdp as to_fsdp
+from fairseq2.nn.data_parallel._sharded import load_with_sdp_gang as load_with_sdp_gang

--- a/src/fairseq2/nn/data_parallel/_ddp.py
+++ b/src/fairseq2/nn/data_parallel/_ddp.py
@@ -15,6 +15,7 @@ from torch.nn.parallel import DistributedDataParallel as DDP
 
 from fairseq2.error import NotSupportedError
 from fairseq2.gang import Gang, Gangs
+from fairseq2.nn.data_parallel._error import DistributedSetupError
 from fairseq2.nn.utils.module import (
     infer_device,
     reset_non_persistent_buffers,
@@ -114,7 +115,3 @@ def _allreduce_hook(gang: Gang, bucket: GradBucket) -> Future[Tensor]:
         return output[0]
 
     return ft.then(return_reduced_bucket)  # type: ignore[no-any-return]
-
-
-class DistributedSetupError(Exception):
-    pass

--- a/src/fairseq2/nn/data_parallel/_error.py
+++ b/src/fairseq2/nn/data_parallel/_error.py
@@ -1,0 +1,11 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+
+class DistributedSetupError(Exception):
+    pass

--- a/src/fairseq2/nn/data_parallel/_sharded.py
+++ b/src/fairseq2/nn/data_parallel/_sharded.py
@@ -1,0 +1,24 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from contextlib import nullcontext
+
+from torch.distributed._shard import load_with_process_group
+
+from fairseq2.error import NotSupportedError
+from fairseq2.gang import Gangs
+from fairseq2.typing import ContextManager
+
+
+def load_with_sdp_gang(gangs: Gangs) -> ContextManager:
+    try:
+        pg = gangs.sdp.as_process_group()
+    except NotSupportedError:
+        return nullcontext()
+
+    return load_with_process_group(pg)

--- a/src/fairseq2/recipes/common/_distributed.py
+++ b/src/fairseq2/recipes/common/_distributed.py
@@ -23,12 +23,13 @@ from fairseq2.gang import GangError, Gangs
 from fairseq2.logging import log
 from fairseq2.models import ModelHandler
 from fairseq2.models.fsdp import get_fsdp_wrap_policy
-from fairseq2.nn.ddp import DistributedSetupError, to_ddp
-from fairseq2.nn.fsdp import (
+from fairseq2.nn.data_parallel import (
+    DistributedSetupError,
     get_fsdp_full_state_dict,
     get_fsdp_optim_state_dict,
     load_fsdp_optim_state_dict,
     summon_fsdp,
+    to_ddp,
     to_fsdp,
 )
 from fairseq2.nn.utils.gradient import clip_gradient_norm


### PR DESCRIPTION
This PR moves DDP and FSDP APIs to `fairseq2.data_parallel`.