### PR TITLE
Handle restrict checkpoint loading per model instead of family

### DIFF
--- a/src/fairseq2/assets/cards/models/nllb-200.yaml
+++ b/src/fairseq2/assets/cards/models/nllb-200.yaml
@@ -219,6 +219,7 @@ name: nllb-200_dense_1b
 base: nllb-200
 model_arch: nllb_dense_1b
 checkpoint: "https://tinyurl.com/nllb200dense1bcheckpoint"
+restrict: false
 
 ---
 
@@ -226,6 +227,7 @@ name: nllb-200_dense_3b
 base: nllb-200
 model_arch: nllb_dense_3b
 checkpoint: "https://tinyurl.com/nllb200dense3bcheckpoint"
+restrict: false
 
 ---
 
@@ -233,6 +235,7 @@ name: nllb-200_dense_distill_1b
 base: nllb-200
 model_arch: nllb_dense_1b
 checkpoint: "https://tinyurl.com/nllb200densedst1bcheckpoint"
+restrict: false
 
 ---
 
@@ -240,3 +243,4 @@ name: nllb-200_dense_distill_600m
 base: nllb-200
 model_arch: nllb_dense_600m
 checkpoint: "https://tinyurl.com/nllb200densedst600mcheckpoint"
+restrict: false

--- a/src/fairseq2/assets/cards/models/s2t_conformer.yaml
+++ b/src/fairseq2/assets/cards/models/s2t_conformer.yaml
@@ -10,6 +10,7 @@ model_arch: conformer_medium
 task: translation
 target_langs: [de]
 checkpoint: "https://dl.fbaipublicfiles.com/fairseq/conformer/covost2/en_de/abs_asr_pt_avg_last_10_checkpoint.pt"
+restrict: false
 tokenizer: "https://dl.fbaipublicfiles.com/fairseq/s2t/covost2_en_de_st_vocab_char.zip;path=spm_char.model"
 tokenizer_family: s2t_transformer
 
@@ -24,5 +25,6 @@ model_config:
 task: translation
 target_langs: [de]
 checkpoint: "https://dl.fbaipublicfiles.com/fairseq/conformer/covost2/en_de/rel_pos_asr_pt_avg_last_10_checkpoint.pt"
+restrict: false
 tokenizer: "https://dl.fbaipublicfiles.com/fairseq/s2t/covost2_en_de_st_vocab_char.zip;path=spm_char.model"
 tokenizer_family: s2t_transformer

--- a/src/fairseq2/assets/cards/models/s2t_transformer.yaml
+++ b/src/fairseq2/assets/cards/models/s2t_transformer.yaml
@@ -13,6 +13,7 @@ model_config:
 task: transcription
 target_langs: [en]
 checkpoint: "https://dl.fbaipublicfiles.com/fairseq/s2t/mustc_de_asr_transformer_s.pt"
+restrict: false
 tokenizer: "https://dl.fbaipublicfiles.com/fairseq/s2t/mustc_de_asr_vocab_unigram5000.zip;path=spm_unigram_5000.model"
 tokenizer_family: s2t_transformer
 
@@ -28,6 +29,7 @@ model_config:
 task: transcription
 target_langs: [en]
 checkpoint: "https://dl.fbaipublicfiles.com/fairseq/s2t/mustc_es_asr_transformer_s.pt"
+restrict: false
 tokenizer: "https://dl.fbaipublicfiles.com/fairseq/s2t/mustc_es_asr_vocab_unigram5000.zip;path=spm_unigram_5000.model"
 tokenizer_family: s2t_transformer
 
@@ -39,6 +41,7 @@ model_arch: medium
 task: transcription
 target_langs: [en]
 checkpoint: "https://dl.fbaipublicfiles.com/fairseq/s2t/mustc_joint_asr_transformer_m.pt"
+restrict: false
 tokenizer: "https://dl.fbaipublicfiles.com/fairseq/s2t/mustc_joint_asr_vocab_unigram10000.zip;path=spm_unigram_10000.model"
 tokenizer_family: s2t_transformer
 
@@ -54,6 +57,7 @@ model_config:
 task: translation
 target_langs: [de]
 checkpoint: "https://dl.fbaipublicfiles.com/fairseq/s2t/mustc_de_st_transformer_s.pt"
+restrict: false
 tokenizer: "https://dl.fbaipublicfiles.com/fairseq/s2t/mustc_de_st_vocab_unigram8000.zip;path=spm_unigram_8000.model"
 tokenizer_family: s2t_transformer
 
@@ -65,5 +69,6 @@ model_arch: medium
 task: translation
 target_langs: [de, es, fr, it, nl, pt, ro, ru]
 checkpoint: "https://dl.fbaipublicfiles.com/fairseq/s2t/mustc_multilingual_st_transformer_m.pt"
+restrict: false
 tokenizer: "https://dl.fbaipublicfiles.com/fairseq/s2t/mustc_multilingual_st_vocab_unigram10000.zip;path=spm_unigram_10000.model"
 tokenizer_family: s2t_transformer

--- a/src/fairseq2/checkpoint/_manager.py
+++ b/src/fairseq2/checkpoint/_manager.py
@@ -407,7 +407,9 @@ class FileCheckpointManager(CheckpointManager):
                 file = step_dir.joinpath(filename)
 
                 try:
-                    part = self._tensor_loader.load(file, map_location=CPU)
+                    part = self._tensor_loader.load(
+                        file, map_location=CPU, restrict=False
+                    )
                 except FileNotFoundError:
                     part = {}
                 except TensorLoadError as ex:
@@ -483,7 +485,9 @@ class FileCheckpointManager(CheckpointManager):
         )
 
         try:
-            metadata = self._tensor_loader.load(metadata_file, map_location=CPU)
+            metadata = self._tensor_loader.load(
+                metadata_file, map_location=CPU, restrict=False
+            )
         except FileNotFoundError:
             metadata = None
         except TensorLoadError as ex:

--- a/src/fairseq2/recipes/common/_checkpoint.py
+++ b/src/fairseq2/recipes/common/_checkpoint.py
@@ -21,7 +21,7 @@ def create_checkpoint_manager(
 
     file_system = context.file_system
 
-    tensor_loader = TorchTensorLoader(file_system, restrict=False)
+    tensor_loader = TorchTensorLoader(file_system)
     tensor_dumper = TorchTensorDumper(file_system)
 
     return FileCheckpointManager(

--- a/src/fairseq2/setup/_models.py
+++ b/src/fairseq2/setup/_models.py
@@ -47,15 +47,13 @@ from fairseq2.models.wav2vec2.asr import (
     Wav2Vec2AsrModelHandler,
     register_wav2vec2_asr_configs,
 )
-from fairseq2.utils.file import StandardTensorLoader, TorchTensorLoader
+from fairseq2.utils.file import StandardTensorLoader
 
 
 def _register_models(context: RuntimeContext) -> None:
     asset_download_manager = context.asset_download_manager
 
     tensor_loader = StandardTensorLoader(context.file_system)
-
-    unsafe_tensor_loader = TorchTensorLoader(context.file_system, restrict=False)
 
     registry = context.get_registry(ModelHandler)
 
@@ -124,7 +122,7 @@ def _register_models(context: RuntimeContext) -> None:
     default_arch = "medium"
 
     handler = S2TTransformerModelHandler(
-        configs, default_arch, asset_download_manager, unsafe_tensor_loader
+        configs, default_arch, asset_download_manager, tensor_loader
     )
 
     registry.register(handler.family, handler)
@@ -137,7 +135,7 @@ def _register_models(context: RuntimeContext) -> None:
     default_arch = "base"
 
     handler = TransformerModelHandler(
-        configs, default_arch, asset_download_manager, unsafe_tensor_loader
+        configs, default_arch, asset_download_manager, tensor_loader
     )
 
     registry.register(handler.family, handler)
@@ -163,7 +161,7 @@ def _register_models(context: RuntimeContext) -> None:
     default_arch = "base"
 
     handler = Wav2Vec2ModelHandler(
-        configs, default_arch, asset_download_manager, unsafe_tensor_loader
+        configs, default_arch, asset_download_manager, tensor_loader
     )
 
     registry.register(handler.family, handler)
@@ -176,7 +174,7 @@ def _register_models(context: RuntimeContext) -> None:
     default_arch = "base_10h"
 
     handler = Wav2Vec2AsrModelHandler(
-        configs, default_arch, asset_download_manager, unsafe_tensor_loader
+        configs, default_arch, asset_download_manager, tensor_loader
     )
 
     registry.register(handler.family, handler)


### PR DESCRIPTION
This PR improves the `TensorLoader` API and moves the `restrict` parameter from `__init__` to `load()`. With this change, `ModelHandler` can now specify restricted checkpoints per model instead of per family.