### PR TITLE
Remove optimizer state dict from model

### DIFF
--- a/src/fairseq2/nn/data_parallel/__init__.py
+++ b/src/fairseq2/nn/data_parallel/__init__.py
@@ -24,15 +24,9 @@ from fairseq2.nn.data_parallel._fsdp import (
     FSDPParameterInitializer as FSDPParameterInitializer,
 )
 from fairseq2.nn.data_parallel._fsdp import FSDPWrapPolicy as FSDPWrapPolicy
+from fairseq2.nn.data_parallel._fsdp import fsdp_full_state_dict as fsdp_full_state_dict
 from fairseq2.nn.data_parallel._fsdp import (
-    get_fsdp_full_state_dict as get_fsdp_full_state_dict,
+    fsdp_summon_full_parameters as fsdp_summon_full_parameters,
 )
-from fairseq2.nn.data_parallel._fsdp import (
-    get_fsdp_optim_state_dict as get_fsdp_optim_state_dict,
-)
-from fairseq2.nn.data_parallel._fsdp import (
-    load_fsdp_optim_state_dict as load_fsdp_optim_state_dict,
-)
-from fairseq2.nn.data_parallel._fsdp import summon_fsdp as summon_fsdp
 from fairseq2.nn.data_parallel._fsdp import to_fsdp as to_fsdp
 from fairseq2.nn.data_parallel._sharded import load_with_sdp_gang as load_with_sdp_gang

--- a/src/fairseq2/recipes/common/_gang.py
+++ b/src/fairseq2/recipes/common/_gang.py
@@ -103,7 +103,7 @@ def _maybe_setup_fsdp_gangs(
     if trainer_section.data_parallelism != "fsdp":
         return gangs
 
-    if trainer_section.fsdp.hsdp:
+    if trainer_section.fsdp.hybrid:
         log.info("Initializing hybrid sharded data parallel gangs.")
 
         try:

--- a/src/fairseq2/recipes/config.py
+++ b/src/fairseq2/recipes/config.py
@@ -178,7 +178,7 @@ class FsdpSection:
     granularity: FsdpGranularity = "layer"
     """The granularity at which to wrap the model."""
 
-    hsdp: bool = False
+    hybrid: bool = False
     """If ``True``, uses hybrid sharded data parallelism."""
 
     reshard_after_forward: bool = True

--- a/src/fairseq2/recipes/model.py
+++ b/src/fairseq2/recipes/model.py
@@ -7,11 +7,9 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import Mapping
 
 from torch import Tensor
 from torch.nn import Module
-from torch.optim import Optimizer
 
 from fairseq2.models import ModelHandler
 from fairseq2.typing import ContextManager
@@ -19,24 +17,16 @@ from fairseq2.typing import ContextManager
 
 class Model(ABC):
     @abstractmethod
+    def state_dict(self) -> dict[str, object]: ...
+
+    @abstractmethod
     def no_sync(self) -> ContextManager: ...
 
     @abstractmethod
     def clip_gradient_norm(self, max_norm: float | None) -> Tensor: ...
 
     @abstractmethod
-    def state_dict(self) -> dict[str, object]: ...
-
-    @abstractmethod
-    def optim_state_dict(self, optim: Optimizer) -> dict[str, object]: ...
-
-    @abstractmethod
-    def load_optim_state_dict(
-        self, optim: Optimizer, state_dict: Mapping[str, object]
-    ) -> None: ...
-
-    @abstractmethod
-    def summon_parameters(self) -> ContextManager: ...
+    def summon_full_parameters(self) -> ContextManager: ...
 
     @property
     @abstractmethod
@@ -60,4 +50,4 @@ class Model(ABC):
 
     @property
     @abstractmethod
-    def is_empty_init(self) -> bool: ...
+    def is_empty_initialized(self) -> bool: ...

--- a/src/fairseq2/recipes/wav2vec2/asr/_train.py
+++ b/src/fairseq2/recipes/wav2vec2/asr/_train.py
@@ -240,7 +240,7 @@ def load_wav2vec2_asr_trainer(
 
     # If we start the training with an empty ASR model, use the weights of a
     # pretrained wav2vec 2.0 model.
-    if model.is_empty_init:
+    if model.is_empty_initialized:
         pt_model = load_reference_model(
             Wav2Vec2Model,
             context,


### PR DESCRIPTION
This PR removes optimizer state_dict handling from `fairseq2.recipes.Model` as newer PyTorch versions (>= 2.2) do not require that workaround.