### PR TITLE
Revise the implementation of CheckpointManager

### DIFF
--- a/src/fairseq2/checkpoint/_metadata_provider.py
+++ b/src/fairseq2/checkpoint/_metadata_provider.py
@@ -180,14 +180,15 @@ class FileCheckpointMetadataLoader:
             )
 
         if num_shards == 1:
-            filename = "model.pt"
+            pathname = "model.pt"
         else:
-            filename = "model.{shard_idx}.pt"
+            # TODO: Fix once DownloadManager refactoring complete!
+            pathname = "model.0{shard_idx}.pt"
 
         def add_checkpoint_metadata(name: str, step_nr: int) -> None:
-            model_file = self._checkpoint_dir.joinpath(f"step_{step_nr}/{filename}")
+            path = self._checkpoint_dir.joinpath(f"step_{step_nr}/{pathname}")
 
-            cache[name] = {"base": "checkpoint", "checkpoint": str(model_file)}
+            cache[name] = {"base": "checkpoint", "checkpoint": str(path)}
 
         max_step_nr = -1
 

--- a/src/fairseq2/models/_handler.py
+++ b/src/fairseq2/models/_handler.py
@@ -390,18 +390,11 @@ class StandardModelHandler(ModelHandler):
             to_empty(model, device=gangs.root.device)
 
         # Load the model state.
-        model_key = checkpoint.get("model_key", "model")
-
-        if not isinstance(model_key, str):
-            raise ModelLoadError(
-                model_name, f"The 'model_key' in the '{model_name}' checkpoint is expected to be of type `str`, but is of type `{type(model_key)}` instead."  # fmt: skip
-            )
-
         try:
-            state_dict = checkpoint[model_key]
+            state_dict = checkpoint["model"]
         except KeyError:
             raise ModelLoadError(
-                model_name, f"The '{model_name}' checkpoint does not contain a '{model_key}' key."  # fmt: skip
+                model_name, f"The '{model_name}' checkpoint does not contain a 'model' key."  # fmt: skip
             ) from None
 
         if not isinstance(state_dict, dict):

--- a/src/fairseq2/nn/data_parallel/__init__.py
+++ b/src/fairseq2/nn/data_parallel/__init__.py
@@ -24,7 +24,9 @@ from fairseq2.nn.data_parallel._fsdp import (
     FSDPParameterInitializer as FSDPParameterInitializer,
 )
 from fairseq2.nn.data_parallel._fsdp import FSDPWrapPolicy as FSDPWrapPolicy
-from fairseq2.nn.data_parallel._fsdp import fsdp_full_state_dict as fsdp_full_state_dict
+from fairseq2.nn.data_parallel._fsdp import (
+    fsdp_local_state_dict as fsdp_local_state_dict,
+)
 from fairseq2.nn.data_parallel._fsdp import (
     fsdp_summon_full_parameters as fsdp_summon_full_parameters,
 )

--- a/src/fairseq2/recipes/common/_model.py
+++ b/src/fairseq2/recipes/common/_model.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from contextlib import nullcontext
 from pathlib import Path
-from typing import cast, final
+from typing import Mapping, cast, final
 
 import torch
 from torch import Tensor
@@ -616,6 +616,10 @@ class LocalModel(Model):
     @override
     def state_dict(self) -> dict[str, object]:
         return self._module.state_dict()
+
+    @override
+    def load_state_dict(self, state_dict: Mapping[str, object]) -> None:
+        self._module.load_state_dict(state_dict)
 
     @override
     def no_sync(self) -> ContextManager:

--- a/src/fairseq2/recipes/common/_trainer.py
+++ b/src/fairseq2/recipes/common/_trainer.py
@@ -91,7 +91,7 @@ def create_trainer(
         max_num_steps=regime_section.num_steps,
         max_num_data_epochs=regime_section.num_data_epochs,
         score_metric_descriptor=score_metric_descriptor,
-        lower_better=regime_section.lower_score_better,
+        lower_score_better=regime_section.lower_score_better,
         valid_units=valid_units,
         valid_data_readers=valid_data_readers,
         validate_after_n_steps=regime_section.validate_after_n_steps,

--- a/src/fairseq2/recipes/model.py
+++ b/src/fairseq2/recipes/model.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import Mapping
 
 from torch import Tensor
 from torch.nn import Module
@@ -18,6 +19,9 @@ from fairseq2.typing import ContextManager
 class Model(ABC):
     @abstractmethod
     def state_dict(self) -> dict[str, object]: ...
+
+    @abstractmethod
+    def load_state_dict(self, state_dict: Mapping[str, object]) -> None: ...
 
     @abstractmethod
     def no_sync(self) -> ContextManager: ...


### PR DESCRIPTION
This PR revises the implementation of `CheckpointManager`. The major change is that we do not consolidate FSDP models anymore during checkpointing. Since we want to avoid using PyTorch's DCP APIs, instead we convert ShardedTensors/DTensors to regular tensors during saving, and consolidate them on-the-fly during loading similar to how original fairseq/fairscale behaves.