### PR TITLE
Instantiate metric recorders on rank 0 only

### DIFF
--- a/src/fairseq2/recipes/common/_evaluator.py
+++ b/src/fairseq2/recipes/common/_evaluator.py
@@ -31,7 +31,7 @@ def create_evaluator(
     gangs: Gangs,
     seed: int,
 ) -> Evaluator[BatchT]:
-    metric_recorder = create_metric_recorder(context, recipe_config, output_dir)
+    metric_recorder = create_metric_recorder(context, recipe_config, gangs, output_dir)
 
     profiler = create_profiler(context, recipe_config, gangs, output_dir)
 

--- a/src/fairseq2/recipes/common/_generator.py
+++ b/src/fairseq2/recipes/common/_generator.py
@@ -30,7 +30,7 @@ def create_generator(
     gangs: Gangs,
     seed: int,
 ) -> Generator[BatchT]:
-    metric_recorder = create_metric_recorder(context, recipe_config, output_dir)
+    metric_recorder = create_metric_recorder(context, recipe_config, gangs, output_dir)
 
     profiler = create_profiler(context, recipe_config, gangs, output_dir)
 

--- a/src/fairseq2/recipes/common/_trainer.py
+++ b/src/fairseq2/recipes/common/_trainer.py
@@ -55,7 +55,7 @@ def create_trainer(
         recipe_config, metric_descriptors
     )
 
-    metric_recorder = create_metric_recorder(context, recipe_config, output_dir)
+    metric_recorder = create_metric_recorder(context, recipe_config, gangs, output_dir)
 
     profiler = create_profiler(context, recipe_config, gangs, output_dir)
 


### PR DESCRIPTION
This PR ensures that `MetricRecorder` instances are constructed only on rank 0. Some recorders such as `WandbRecorder` has the side effect of setting up their environment during construction which causes redundant/duplicate artifacts to be generated. The actual metric records are not affected though since we always write them on rank 0.