### PR TITLE
Support tied embeddings in LLaMA

### DIFF
--- a/src/fairseq2/assets/cards/models/llama.yaml
+++ b/src/fairseq2/assets/cards/models/llama.yaml
@@ -128,13 +128,6 @@ num_shards: 8
 
 ---
 
-name: llama3_3_70b_instruct
-base: llama3_instruct
-model_arch: llama3_1_70b
-num_shards: 8
-
----
-
 name: llama3_1_70b_instruct
 base: llama3_instruct
 model_arch: llama3_1_70b
@@ -163,3 +156,10 @@ model_arch: llama3_2_3b
 name: llama3_2_3b_instruct
 base: llama3_instruct
 model_arch: llama3_2_3b
+
+---
+
+name: llama3_3_70b_instruct
+base: llama3_instruct
+model_arch: llama3_1_70b
+num_shards: 8

--- a/src/fairseq2/models/llama/_config.py
+++ b/src/fairseq2/models/llama/_config.py
@@ -36,6 +36,9 @@ class LLaMAConfig:
     )
     """The vocabulary information."""
 
+    tie_embeddings: bool = False
+    """If ``True``, ties the embedding table and the output projection layer."""
+
     num_layers: int = 32
     """The number of decoder layers."""
 
@@ -245,6 +248,7 @@ def register_llama_configs(context: RuntimeContext) -> None:
         config = llama3_1_8b()
 
         config.model_dim = 2048
+        config.tie_embeddings = True
         config.ffn_inner_dim = 2048 * 4
         config.ffn_inner_dim_multiplier = 1.5
         config.ffn_inner_dim_to_multiple = 256

--- a/src/fairseq2/models/llama/_factory.py
+++ b/src/fairseq2/models/llama/_factory.py
@@ -28,6 +28,7 @@ from fairseq2.nn import (
     RMSNorm,
     RotaryEncoder,
     StandardEmbedding,
+    TiedProjection,
 )
 from fairseq2.nn.transformer import (
     FeedForwardNetwork,
@@ -57,11 +58,13 @@ class LLaMAFactory:
     def create_model(self) -> TransformerDecoderModel:
         config = self._config
 
-        decoder_frontend = self.create_decoder_frontend()
+        embed = self.create_embedding()
+
+        decoder_frontend = self.create_decoder_frontend(embed)
 
         decoder = self.create_decoder()
 
-        final_proj = self.create_final_proj()
+        final_proj = self.create_final_proj(embed)
 
         return TransformerDecoderModel(
             decoder_frontend,
@@ -71,20 +74,18 @@ class LLaMAFactory:
             vocab_info=config.vocab_info,
         )
 
-    def create_decoder_frontend(self) -> TransformerFrontend:
-        config = self._config
-
-        embed = self.create_embedding()
-
-        return TransformerEmbeddingFrontend(
-            embed, pos_encoder=None, no_scale=True, dropout_p=config.dropout_p
-        )
-
     def create_embedding(self) -> Embedding:
         config = self._config
 
         return StandardEmbedding(
             num_embeddings=config.vocab_info.size, embedding_dim=config.model_dim
+        )
+
+    def create_decoder_frontend(self, embed: Embedding) -> TransformerFrontend:
+        config = self._config
+
+        return TransformerEmbeddingFrontend(
+            embed, pos_encoder=None, no_scale=True, dropout_p=config.dropout_p
         )
 
     def create_decoder(self) -> TransformerDecoder:
@@ -166,8 +167,16 @@ class LLaMAFactory:
             inner_dropout_p=config.dropout_p,
         )
 
-    def create_final_proj(self) -> Projection:
+    def create_final_proj(self, embed: Embedding) -> Projection:
         config = self._config
+
+        if config.tie_embeddings:
+            if not isinstance(embed, StandardEmbedding):
+                raise TypeError(
+                    f"`embed` must be of type `{StandardEmbedding}` when `config.tie_embeddings` is set, but is of type `{type(embed)}` instead."
+                )
+
+            return TiedProjection(embed.weight, bias=None)
 
         return Linear(
             config.model_dim,

--- a/src/fairseq2/models/llama/integ.py
+++ b/src/fairseq2/models/llama/integ.py
@@ -86,6 +86,6 @@ def convert_to_hg_llama_config(config: LLaMAConfig) -> dict[str, object]:
         "rms_norm_eps": 1e-5,
         "rope_scaling": rope_scaling,
         "rope_theta": config.rope_theta,
-        "tie_word_embeddings": False,
+        "tie_word_embeddings": config.tie_embeddings,
         "vocab_size": config.vocab_info.size,
     }


### PR DESCRIPTION
LLaMA 3.2 1B (and likely future LLaMA models) ties embedding table and final projection weight similar to the original Transformer model. Although this is not well documented in the reference implementation, the checkpoint makes it clear that tied embeddings were used. This PR introduces support for tied embeddings and updates the llama_3_2_1b architecture to use it.