### PR TITLE
Convert Trainer to a full state machine

### DIFF
--- a/src/fairseq2/datasets/asr.py
+++ b/src/fairseq2/datasets/asr.py
@@ -268,12 +268,8 @@ class GenericAsrDataset(AsrDataset):
             source_data = cast(SequenceData, example["audio"]["data"]["waveform"])
             target_data = cast(SequenceData, example["text"])
 
-            source_seqs, source_padding_mask = get_seqs_and_padding_mask(
-                source_data, gang.device
-            )
-            target_seqs, target_padding_mask = get_seqs_and_padding_mask(
-                target_data, gang.device
-            )
+            source_seqs, source_padding_mask = get_seqs_and_padding_mask(source_data)
+            target_seqs, target_padding_mask = get_seqs_and_padding_mask(target_data)
 
             return Seq2SeqBatch(
                 source_seqs,

--- a/src/fairseq2/datasets/instruction.py
+++ b/src/fairseq2/datasets/instruction.py
@@ -313,9 +313,9 @@ class GenericInstructionDataset(InstructionDataset):
         def to_batch(example: dict[str, Any]) -> SequenceBatch:
             indices = cast(SequenceData, example["indices"])
 
-            seqs, padding_mask = get_seqs_and_padding_mask(indices, gang.device)
+            seqs, padding_mask = get_seqs_and_padding_mask(indices)
 
-            target_mask = example["target_mask"]["seqs"].to(gang.device)
+            target_mask = example["target_mask"]["seqs"]
 
             return SequenceBatch(seqs, padding_mask, target_mask, example=example)
 

--- a/src/fairseq2/datasets/preference.py
+++ b/src/fairseq2/datasets/preference.py
@@ -34,10 +34,12 @@ from fairseq2.datasets import (
     StaticBatching,
 )
 from fairseq2.datasets._utils import _load_files_and_weights
+from fairseq2.device import SupportsDeviceTransfer
 from fairseq2.error import NotSupportedError
 from fairseq2.gang import Gang
 from fairseq2.models.sequence import SequenceBatch
 from fairseq2.nn.padding import get_seqs_and_padding_mask
+from fairseq2.typing import Device
 
 
 @dataclass(kw_only=True)
@@ -62,13 +64,30 @@ class PreferenceReadOptions(DataReadOptions):
 
 
 @dataclass
-class PreferenceBatch:
+class PreferenceBatch(SupportsDeviceTransfer):
     """Represents a preference optimization dataset batch."""
 
     chosen: SequenceBatch
     rejected: SequenceBatch
     reference_score_chosen: torch.Tensor | None
     reference_score_rejected: torch.Tensor | None
+
+    @property
+    def batch_size(self) -> int:
+        """The size of the batch dimension."""
+        return self.chosen.batch_size
+
+    @override
+    def to(self, device: Device) -> None:
+        self.chosen.to(device)
+
+        self.rejected.to(device)
+
+        if self.reference_score_chosen is not None:
+            self.reference_score_chosen = self.reference_score_chosen.to(device)
+
+        if self.reference_score_rejected is not None:
+            self.reference_score_rejected = self.reference_score_rejected.to(device)
 
 
 class PreferenceDataset(ABC):
@@ -308,15 +327,13 @@ class GenericPreferenceDataset(PreferenceDataset):
             indices_chosen = cast(SequenceData, example["indices_chosen"])
             indices_rejected = cast(SequenceData, example["indices_rejected"])
 
-            seqs_chosen, padding_mask_chosen = get_seqs_and_padding_mask(
-                indices_chosen, gang.device
-            )
+            seqs_chosen, padding_mask_chosen = get_seqs_and_padding_mask(indices_chosen)
             seqs_rejected, padding_mask_rejected = get_seqs_and_padding_mask(
-                indices_rejected, gang.device
+                indices_rejected
             )
 
-            target_mask_chosen = example["target_mask_chosen"]["seqs"].to(gang.device)
-            target_mask_rejected = example["target_mask_rejected"]["seqs"].to(gang.device)  # fmt: skip
+            target_mask_chosen = example["target_mask_chosen"]["seqs"]
+            target_mask_rejected = example["target_mask_rejected"]["seqs"]
 
             batch_chosen = SequenceBatch(
                 seqs_chosen,
@@ -336,12 +353,12 @@ class GenericPreferenceDataset(PreferenceDataset):
             if all(example["reference_score_chosen"]):
                 batch_reference_scores_chosen = torch.Tensor(
                     example["reference_score_chosen"]
-                ).to(gang.device)
+                )
             batch_reference_scores_rejected = None
             if all(example["reference_score_rejected"]):
                 batch_reference_scores_rejected = torch.Tensor(
                     example["reference_score_rejected"]
-                ).to(gang.device)
+                )
 
             return PreferenceBatch(
                 batch_chosen,

--- a/src/fairseq2/datasets/text.py
+++ b/src/fairseq2/datasets/text.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from dataclasses import dataclass
-from functools import partial
 from pathlib import Path
 from typing import Any, Final, cast, final
 
@@ -37,7 +36,6 @@ from fairseq2.error import NotSupportedError
 from fairseq2.gang import Gang
 from fairseq2.models.sequence import SequenceBatch
 from fairseq2.nn.padding import get_seqs_and_padding_mask
-from fairseq2.typing import Device
 
 
 @dataclass(kw_only=True)
@@ -210,19 +208,17 @@ class GenericTextDataset(TextDataset):
         # Prefetch `num_prefetch` batches in background.
         builder.prefetch(options.num_prefetch)
 
-        f = partial(self._to_batch, device=gang.device)
-
-        pipeline = builder.map(f).and_return()
+        pipeline = builder.map(self._to_batch).and_return()
 
         return DataPipelineReader[SequenceBatch](
             self._name, "default", pipeline, gang, options
         )
 
     @staticmethod
-    def _to_batch(example: dict[str, Any], device: Device) -> SequenceBatch:
+    def _to_batch(example: dict[str, Any]) -> SequenceBatch:
         data = cast(SequenceData, example["indices"])
 
-        seqs, padding_mask = get_seqs_and_padding_mask(data, device)
+        seqs, padding_mask = get_seqs_and_padding_mask(data)
 
         return SequenceBatch(seqs, padding_mask, example=example)
 

--- a/src/fairseq2/device.py
+++ b/src/fairseq2/device.py
@@ -202,3 +202,8 @@ class CudaDeviceStatTracker(DeviceStatTracker):
     @override
     def reset(self) -> None:
         torch.cuda.reset_peak_memory_stats()
+
+
+class SupportsDeviceTransfer(ABC):
+    @abstractmethod
+    def to(self, device: Device) -> None: ...

--- a/src/fairseq2/recipes/_evaluator.py
+++ b/src/fairseq2/recipes/_evaluator.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from contextlib import nullcontext
-from itertools import count
 from typing import Generic, TypeVar, final
 
 import torch
@@ -17,7 +16,7 @@ from torch.profiler import record_function
 from typing_extensions import override
 
 from fairseq2.datasets import DataReader, DataReadError
-from fairseq2.device import DeviceStatTracker
+from fairseq2.device import DeviceStatTracker, SupportsDeviceTransfer
 from fairseq2.error import InternalError, InvalidOperationError
 from fairseq2.gang import GangError, Gangs
 from fairseq2.logging import log
@@ -29,23 +28,25 @@ from fairseq2.recipes._metrics import extend_batch_metrics
 from fairseq2.recipes._model import Model
 from fairseq2.recipes._recipe import Recipe, RecipeStopException
 from fairseq2.typing import CPU, ContextManager, DataType
-from fairseq2.utils.progress import ProgressReporter
+from fairseq2.utils.progress import ProgressReporter, ProgressTask
 from fairseq2.utils.rng import RngBag
 from fairseq2.utils.stopwatch import Stopwatch
 
-BatchT_contra = TypeVar("BatchT_contra", contravariant=True)
+BatchT_contra = TypeVar(
+    "BatchT_contra", bound=SupportsDeviceTransfer, contravariant=True
+)
 
 
 class EvalUnit(ABC, Generic[BatchT_contra]):
     """Represents a unit to be used with :class:`Evaluator` or :class:`Trainer`."""
 
+    def set_train_step_nr(self, step_nr: int) -> None:
+        pass
+
     @abstractmethod
     def __call__(self, batch: BatchT_contra) -> None: ...
 
     def finalize(self) -> None:
-        pass
-
-    def set_train_step_nr(self, step_nr: int) -> None:
         pass
 
     @property
@@ -61,7 +62,7 @@ class EvalUnit(ABC, Generic[BatchT_contra]):
     def metric_bag(self) -> MetricBag: ...
 
 
-BatchT = TypeVar("BatchT")
+BatchT = TypeVar("BatchT", bound=SupportsDeviceTransfer)
 
 
 @final
@@ -186,86 +187,105 @@ class Evaluator(Recipe, Generic[BatchT]):
 
         self._device_stat_tracker.reset()
 
+        eod = False
+
         with progress_task, self._lapse_watch:
-            for step_nr in count(start=self._step_nr + 1):
+            while not eod:
                 if self._stop_requested:
                     raise RecipeStopException()
 
-                self._step_nr = step_nr
-
-                progress_task.step(1)
-
-                with record_function(f"step_{step_nr}"):
-                    if not self._run_step(unit, data_reader):
-                        break
-
-                self._profiler.step()
+                batches = self._read_next_batches(unit, data_reader)
+                if batches is None:
+                    eod = True
+                else:
+                    self._run_step(unit, batches, progress_task)
 
             with self._compute_watch:
                 with record_function("finalize"):
-                    with self._maybe_autocast():
-                        try:
-                            unit.finalize()
-                        except UnitError as ex:
-                            s = "evaluator"
-
-                            if unit.name:
-                                s = f"'{unit.name}' {s}"
-
-                            raise RecipeError(
-                                f"The {s} unit has failed to finalize. See the nested exception for details."
-                            ) from ex
+                    self._call_unit_finalize(unit)
 
         self._publish_metrics(unit)
 
-        self._reset_watches()
+    def _read_next_batches(
+        self, unit: EvalUnit[BatchT], data_reader: DataReader[BatchT]
+    ) -> list[BatchT] | None:
+        with self._data_watch:
+            try:
+                batches = next(data_reader)
+            except DataReadError as ex:
+                s = "evaluator"
 
-        self._num_batches_read = 0
+                if unit.name:
+                    s = f"'{unit.name}' {s}"
+
+                raise RecipeError(
+                    f"The {s} data read operation has failed. See the nested exception for details."
+                ) from ex
+            except StopIteration:
+                batches = None
+
+            if batches is None:
+                data_reader.reset()
+
+        return batches
 
     def _run_step(
-        self, unit: EvalUnit[BatchT], data_reader: DataReader[BatchT]
-    ) -> bool:
-        step_nr = self._step_nr
+        self, unit: EvalUnit[BatchT], batches: list[BatchT], progress_task: ProgressTask
+    ) -> None:
+        self._step_nr += 1
 
-        log.debug("Running step {}.", step_nr)
+        progress_task.step(1)
 
-        # Collect the batches.
-        with self._data_watch:
-            with record_function(f"step_{step_nr}_data_load"):
-                try:
-                    batches = next(data_reader)
-                except DataReadError as ex:
-                    s = "evaluator"
+        with record_function(f"step_{self._step_nr}"):
+            self._do_run_step(unit, batches)
 
-                    if unit.name:
-                        s = f"'{unit.name}' {s}"
+        self._profiler.step()
 
-                    raise RecipeError(
-                        f"The {s} data read operation has failed. See the nested exception for details."
-                    ) from ex
-                except StopIteration:
-                    return False
+    def _do_run_step(self, unit: EvalUnit[BatchT], batches: list[BatchT]) -> None:
+        log.debug("Running step {}.", self._step_nr)
 
-        # Call the unit.
         with self._compute_watch:
-            for batch_nr, batch in enumerate(batches):
-                with record_function(f"step_{step_nr}_{batch_nr}_forward"):
-                    with self._maybe_autocast():
-                        try:
-                            unit(batch)
-                        except UnitError as ex:
-                            s = "evaluator"
+            batches.reverse()
 
-                            if unit.name:
-                                s = f"'{unit.name}' {s}"
+            num_batches = len(batches)
 
-                            raise RecipeError(
-                                f"The {s} unit has failed. See the nested exception for details."
-                            ) from ex
+            for batch_nr in range(num_batches):
+                batch = batches.pop()
+
+                batch.to(self._gangs.root.device)
+
+                with record_function(f"step_{self._step_nr}_{batch_nr}"):
+                    self._call_unit(unit, batch)
 
         self._num_batches_read += 1
 
-        return True
+    def _call_unit(self, unit: EvalUnit[BatchT], batch: BatchT) -> None:
+        with self._maybe_autocast():
+            try:
+                unit(batch)
+            except UnitError as ex:
+                s = "evaluator"
+
+                if unit.name:
+                    s = f"'{unit.name}' {s}"
+
+                raise RecipeError(
+                    f"The {s} unit has failed. See the nested exception for details."
+                ) from ex
+
+    def _call_unit_finalize(self, unit: EvalUnit[BatchT]) -> None:
+        with self._maybe_autocast():
+            try:
+                unit.finalize()
+            except UnitError as ex:
+                s = "evaluator"
+
+                if unit.name:
+                    s = f"'{unit.name}' {s}"
+
+                raise RecipeError(
+                    f"The {s} unit has failed to finalize. See the nested exception for details."
+                ) from ex
 
     def _maybe_autocast(self) -> ContextManager:
         if self._dtype == torch.float32 or not self._amp:
@@ -343,12 +363,20 @@ class Evaluator(Recipe, Generic[BatchT]):
                 "The collective barrier after the metric sync operation has failed. See the nested exception for details."
             ) from ex
 
-    def _reset_watches(self) -> None:
+        self._reset_lapse_metrics(unit)
+
+    def _reset_lapse_metrics(self, unit: EvalUnit[BatchT]) -> None:
+        unit.metric_bag.reset_metrics()
+
         self._data_watch.reset()
 
         self._compute_watch.reset()
 
         self._lapse_watch.reset()
+
+        self._device_stat_tracker.reset()
+
+        self._num_batches_read = 0
 
     @override
     def request_stop(self) -> None:

--- a/src/fairseq2/recipes/common/_evaluator.py
+++ b/src/fairseq2/recipes/common/_evaluator.py
@@ -12,6 +12,7 @@ from typing import TypeVar
 
 from fairseq2.context import RuntimeContext
 from fairseq2.datasets import DataReader
+from fairseq2.device import SupportsDeviceTransfer
 from fairseq2.gang import Gangs
 from fairseq2.recipes import Evaluator, EvalUnit
 from fairseq2.recipes.common._device import create_device_stat_tracker
@@ -19,7 +20,7 @@ from fairseq2.recipes.common._metrics import create_metric_recorder
 from fairseq2.recipes.common._profilers import create_profiler
 from fairseq2.recipes.config import EvaluatorSection, get_config_section
 
-BatchT = TypeVar("BatchT")
+BatchT = TypeVar("BatchT", bound=SupportsDeviceTransfer)
 
 
 def create_evaluator(

--- a/src/fairseq2/recipes/common/_generator.py
+++ b/src/fairseq2/recipes/common/_generator.py
@@ -11,6 +11,7 @@ from typing import TypeVar
 
 from fairseq2.context import RuntimeContext
 from fairseq2.datasets import DataReader
+from fairseq2.device import SupportsDeviceTransfer
 from fairseq2.gang import Gangs
 from fairseq2.recipes import Generator, GeneratorUnit
 from fairseq2.recipes.common._device import create_device_stat_tracker
@@ -18,7 +19,7 @@ from fairseq2.recipes.common._metrics import create_metric_recorder
 from fairseq2.recipes.common._profilers import create_profiler
 from fairseq2.recipes.config import GeneratorSection, get_config_section
 
-BatchT = TypeVar("BatchT")
+BatchT = TypeVar("BatchT", bound=SupportsDeviceTransfer)
 
 
 def create_generator(

--- a/src/fairseq2/recipes/common/_trainer.py
+++ b/src/fairseq2/recipes/common/_trainer.py
@@ -15,6 +15,7 @@ from torch.optim import Optimizer
 from fairseq2.checkpoint import CheckpointManager
 from fairseq2.context import RuntimeContext
 from fairseq2.datasets import DataReader
+from fairseq2.device import SupportsDeviceTransfer
 from fairseq2.gang import Gangs
 from fairseq2.logging import log
 from fairseq2.metrics import MetricDescriptor, UnknownMetricDescriptorError
@@ -37,7 +38,7 @@ from fairseq2.utils.gc import (
     NoopGarbageCollector,
 )
 
-BatchT = TypeVar("BatchT")
+BatchT = TypeVar("BatchT", bound=SupportsDeviceTransfer)
 
 
 def create_trainer(


### PR DESCRIPTION
This PR finalizes the refactoring of `Trainer`. Internally the implementation now uses a full state machine which reduces the complexity. As a related feature, the batches are now moved to GPU within the training loop instead of within the data reader to ensure that gradient accumulation does not cause increased GPU memory use.