### PR TITLE
Refactor vocabulary info in recipes

### DIFF
--- a/doc/source/basics/cli.rst
+++ b/doc/source/basics/cli.rst
@@ -79,7 +79,7 @@ or add, delete values:
     fairseq2 lm instruction_finetune <OUTPUT_DIR> --config del:common.metric_recorders.tensorboard
 
     # Add a configuration key
-    fairseq2 lm instruction_finetune <OUTPUT_DIR> --config add:common.metric_recorders.tensorboard="{enabled: true}"
+    fairseq2 lm instruction_finetune <OUTPUT_DIR> --config set:common.metric_recorders.tensorboard="{enabled: true}"
 
 .. note::
 
@@ -88,12 +88,12 @@ or add, delete values:
 3. Adding and Removing Values
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Use ``add:`` and ``del:`` directives for more advanced configuration:
+Use ``set:`` and ``del:`` directives for more advanced configuration:
 
 .. code-block:: bash
 
     # Add a new configuration value
-    fairseq2 lm instruction_finetune <OUTPUT_DIR> --config add:new_param=value
+    fairseq2 lm instruction_finetune <OUTPUT_DIR> --config set:new_param=value
 
     # Remove a configuration value
     fairseq2 lm instruction_finetune <OUTPUT_DIR> --config del:unwanted_param
@@ -110,7 +110,7 @@ You can combine all these methods, with later values taking precedence:
         --config-file override.yaml \
         --config max_num_tokens=512 \
         optimizer_config.lr=4e-5 \
-        add:custom_param=value
+        set:custom_param=value
 
 Asset Management
 ----------------

--- a/src/fairseq2/assets/cards/models/llama.yaml
+++ b/src/fairseq2/assets/cards/models/llama.yaml
@@ -75,10 +75,6 @@ use_v2_tokenizer: true
 
 name: llama3_instruct
 base: llama3
-model_config:
-  vocab_info:
-    _set_:
-      eos_idx: 128009  # EOT (end-of-turn)
 use_eot: true  # instruct tokenizer to use EOT instead of EOS
 
 ---

--- a/src/fairseq2/assets/cards/models/s2t_transformer.yaml
+++ b/src/fairseq2/assets/cards/models/s2t_transformer.yaml
@@ -8,8 +8,7 @@ name: s2t_transformer_mustc_asr_de_s
 model_family: s2t_transformer
 model_arch: small
 model_config:
-  target_vocab_info:
-    size: 5000
+  target_vocab_size: 5000
 task: transcription
 target_langs: [en]
 checkpoint: "https://dl.fbaipublicfiles.com/fairseq/s2t/mustc_de_asr_transformer_s.pt"
@@ -23,9 +22,7 @@ name: s2t_transformer_mustc_asr_es_s
 model_family: s2t_transformer
 model_arch: small
 model_config:
-  target_vocab_info:
-    _set_:
-      size: 5000
+  target_vocab_size: 5000
 task: transcription
 target_langs: [en]
 checkpoint: "https://dl.fbaipublicfiles.com/fairseq/s2t/mustc_es_asr_transformer_s.pt"
@@ -51,9 +48,7 @@ name: s2t_transformer_mustc_st_de_s
 model_family: s2t_transformer
 model_arch: small
 model_config:
-  target_vocab_info:
-    _set_:
-      size: 8000
+  target_vocab_size: 8000
 task: translation
 target_langs: [de]
 checkpoint: "https://dl.fbaipublicfiles.com/fairseq/s2t/mustc_de_st_transformer_s.pt"

--- a/src/fairseq2/checkpoint/_metadata_provider.py
+++ b/src/fairseq2/checkpoint/_metadata_provider.py
@@ -28,9 +28,7 @@ from fairseq2.utils.yaml import YamlDumper
 
 class CheckpointMetadataSaver(ABC):
     @abstractmethod
-    def save(
-        self, model_family: str, model_config: object, tokenizer_name: str | None = None
-    ) -> None: ...
+    def save(self, model_family: str, model_config: object) -> None: ...
 
 
 @final
@@ -52,9 +50,7 @@ class FileCheckpointMetadataSaver(CheckpointMetadataSaver):
         self._file_system = file_system
         self._yaml_dumper = yaml_dumper
 
-    def save(
-        self, model_family: str, model_config: object, tokenizer_name: str | None = None
-    ) -> None:
+    def save(self, model_family: str, model_config: object) -> None:
         if self._gangs.root.rank == 0:
             unstructured_config = unstructure(model_config)
 
@@ -65,9 +61,6 @@ class FileCheckpointMetadataSaver(CheckpointMetadataSaver):
                     "_set_": unstructured_config,
                 },
             }
-
-            if tokenizer_name is not None:
-                metadata["tokenizer_ref"] = tokenizer_name
 
             if self._gangs.tp.size != 1:
                 metadata["num_shards"] = self._gangs.tp.size

--- a/src/fairseq2/cli/commands/chatbot.py
+++ b/src/fairseq2/cli/commands/chatbot.py
@@ -34,7 +34,7 @@ from fairseq2.models.decoder import DecoderModel
 from fairseq2.recipes import RecipeError
 from fairseq2.recipes.common import (
     load_text_tokenizer,
-    setup_inference_gangs,
+    setup_gangs,
     setup_reference_model,
     setup_torch,
 )
@@ -129,7 +129,7 @@ class RunChatbotHandler(CliCommandHandler):
         )
 
         try:
-            gangs = setup_inference_gangs(context, gang_section)
+            gangs = setup_gangs(context, gang_section)
         except RecipeError as ex:
             raise CliCommandError(
                 "The chatbot setup has failed. See the nested exception for details."

--- a/src/fairseq2/cli/commands/chatbot.py
+++ b/src/fairseq2/cli/commands/chatbot.py
@@ -38,7 +38,7 @@ from fairseq2.recipes.common import (
     setup_reference_model,
     setup_torch,
 )
-from fairseq2.recipes.config import CommonSection, GangSection, ReferenceModelSection
+from fairseq2.recipes.config import CommonSection, GangSection, ReferenceModelSection, TextTokenizerSection
 from fairseq2.typing import CPU
 from fairseq2.utils.rng import RngBag
 
@@ -113,20 +113,18 @@ class RunChatbotHandler(CliCommandHandler):
 
         view = CliChatbotView(args.model_name, console)
 
-        args.gang = GangSection(
+        set_torch_distributed_variables(context, args.cluster)
+
+        common_section = CommonSection()
+
+        setup_torch(context, common_section, output_dir=None)
+
+        gang_section = GangSection(
             tensor_parallel_size=args.tensor_parallel_size, timeout=999
         )
 
-        args.model = ReferenceModelSection(name=args.model_name)
-
-        args.common = CommonSection()
-
-        set_torch_distributed_variables(context, args.cluster)
-
-        setup_torch(context, args)
-
         try:
-            gangs = setup_gangs(context, args)
+            gangs = setup_gangs(context, gang_section)
         except RecipeError as ex:
             raise CliCommandError(
                 "The chatbot setup has failed. See the nested exception for details."
@@ -135,11 +133,13 @@ class RunChatbotHandler(CliCommandHandler):
         if gangs.dp.size > 1:
             log.warning("Using redundant data parallelism which may reduce throughput. It is recommended to use one device per model (shard).")  # fmt: skip
 
+        model_section = ReferenceModelSection(name=args.model_name)
+
         try:
             model = setup_reference_model(
                 DecoderModel,
                 context,
-                args.model_name,
+                model_section,
                 gangs,
                 args.dtype,
                 mp=False,
@@ -152,18 +152,24 @@ class RunChatbotHandler(CliCommandHandler):
 
         module = cast(DecoderModel, model.module)
 
-        sampler = TopPSampler(p=args.top_p)
-
-        generator = SamplingSequenceGenerator(
-            module, sampler, temperature=args.temperature, max_gen_len=args.max_gen_len
-        )
+        tokenizer_section = TextTokenizerSection(name=args.model_name)
 
         try:
-            tokenizer = load_text_tokenizer(context, args)
+            tokenizer = load_text_tokenizer(context, tokenizer_section)
         except RecipeError as ex:
             raise CliCommandError(
                 "The chatbot setup has failed. See the nested exception for details."
             ) from ex
+
+        sampler = TopPSampler(p=args.top_p)
+
+        generator = SamplingSequenceGenerator(
+            module,
+            tokenizer.vocab_info,
+            sampler,
+            temperature=args.temperature,
+            max_gen_len=args.max_gen_len,
+        )
 
         card = context.asset_store.retrieve_card(args.model_name)
 

--- a/src/fairseq2/cli/commands/chatbot.py
+++ b/src/fairseq2/cli/commands/chatbot.py
@@ -34,11 +34,16 @@ from fairseq2.models.decoder import DecoderModel
 from fairseq2.recipes import RecipeError
 from fairseq2.recipes.common import (
     load_text_tokenizer,
-    setup_gangs,
+    setup_inference_gangs,
     setup_reference_model,
     setup_torch,
 )
-from fairseq2.recipes.config import CommonSection, GangSection, ReferenceModelSection, TextTokenizerSection
+from fairseq2.recipes.config import (
+    CommonSection,
+    GangSection,
+    ReferenceModelSection,
+    TextTokenizerSection,
+)
 from fairseq2.typing import CPU
 from fairseq2.utils.rng import RngBag
 
@@ -124,14 +129,14 @@ class RunChatbotHandler(CliCommandHandler):
         )
 
         try:
-            gangs = setup_gangs(context, gang_section)
+            gangs = setup_inference_gangs(context, gang_section)
         except RecipeError as ex:
             raise CliCommandError(
                 "The chatbot setup has failed. See the nested exception for details."
             ) from ex
 
         if gangs.dp.size > 1:
-            log.warning("Using redundant data parallelism which may reduce throughput. It is recommended to use one device per model (shard).")  # fmt: skip
+            log.warning("Using redundant data parallelism which may reduce throughput.")  # fmt: skip
 
         model_section = ReferenceModelSection(name=args.model_name)
 

--- a/src/fairseq2/data/text/tokenizers/nllb.py
+++ b/src/fairseq2/data/text/tokenizers/nllb.py
@@ -23,7 +23,7 @@ from fairseq2.data.text.tokenizers.sentencepiece import (
     SentencePieceDecoder,
     SentencePieceEncoder,
     SentencePieceModel,
-    vocab_info_from_sentencepiece,
+    get_sentencepiece_vocabulary_info,
 )
 from fairseq2.typing import Device
 
@@ -63,7 +63,7 @@ class NllbTokenizer(TextTokenizer):
 
         self._default_lang = default_lang
 
-        self._vocab_info = vocab_info_from_sentencepiece(self._model)
+        self._vocab_info = get_sentencepiece_vocabulary_info(self._model)
 
     @override
     def create_encoder(

--- a/src/fairseq2/data/text/tokenizers/s2t_transformer.py
+++ b/src/fairseq2/data/text/tokenizers/s2t_transformer.py
@@ -22,7 +22,7 @@ from fairseq2.data.text.tokenizers.sentencepiece import (
     SentencePieceDecoder,
     SentencePieceEncoder,
     SentencePieceModel,
-    vocab_info_from_sentencepiece,
+    get_sentencepiece_vocabulary_info,
 )
 from fairseq2.typing import Device
 
@@ -62,7 +62,7 @@ class S2TTransformerTokenizer(TextTokenizer):
         self._target_langs = target_langs
         self._default_target_lang = default_target_lang
 
-        self._vocab_info = vocab_info_from_sentencepiece(self._model)
+        self._vocab_info = get_sentencepiece_vocabulary_info(self._model)
 
     @override
     def create_encoder(

--- a/src/fairseq2/data/text/tokenizers/sentencepiece.py
+++ b/src/fairseq2/data/text/tokenizers/sentencepiece.py
@@ -125,7 +125,7 @@ class BasicSentencePieceTokenizer(TextTokenizer):
     def __init__(self, path: Path) -> None:
         self._model = SentencePieceModel(path)
 
-        self._vocab_info = vocab_info_from_sentencepiece(self._model)
+        self._vocab_info = get_sentencepiece_vocabulary_info(self._model)
 
     @override
     def create_encoder(
@@ -216,7 +216,7 @@ class RawSentencePieceTokenizer(TextTokenizer):
     def __init__(self, path: Path) -> None:
         self._model = SentencePieceModel(path)
 
-        self._vocab_info = vocab_info_from_sentencepiece(self._model)
+        self._vocab_info = get_sentencepiece_vocabulary_info(self._model)
 
     @override
     def create_encoder(
@@ -277,7 +277,7 @@ def load_raw_sentencepiece_tokenizer(path: Path, card: AssetCard) -> TextTokeniz
         ) from ex
 
 
-def vocab_info_from_sentencepiece(model: SentencePieceModel) -> VocabularyInfo:
+def get_sentencepiece_vocabulary_info(model: SentencePieceModel) -> VocabularyInfo:
     """Return the vocabulary information of ``model``."""
     return VocabularyInfo(
         model.vocabulary_size,

--- a/src/fairseq2/datasets/_utils.py
+++ b/src/fairseq2/datasets/_utils.py
@@ -55,7 +55,7 @@ def _load_files_and_weights(
     manifest_file = path.joinpath("MANIFEST")
 
     try:
-        with manifest_file.open() as fp:
+        with manifest_file.open(encoding="utf-8") as fp:
             content = list(fp)
     except FileNotFoundError:
         content = None

--- a/src/fairseq2/datasets/asr.py
+++ b/src/fairseq2/datasets/asr.py
@@ -289,7 +289,7 @@ class GenericAsrDataset(AsrDataset):
         manifest_file = self._manifest_dir.joinpath(f"{split}.tsv")
 
         try:
-            with manifest_file.open() as fp:
+            with manifest_file.open(encoding="utf-8") as fp:
                 line = fp.readline().rstrip()
         except OSError as ex:
             raise DataReadError(

--- a/src/fairseq2/datasets/instruction.py
+++ b/src/fairseq2/datasets/instruction.py
@@ -414,7 +414,7 @@ class GenericInstructionDataset(InstructionDataset):
         lines = []
 
         # TODO(balioglu): Do in C++.
-        with path.open() as fp:
+        with path.open(encoding="utf-8") as fp:
             for line in fp:
                 lines.append(line)
 

--- a/src/fairseq2/datasets/parallel_text.py
+++ b/src/fairseq2/datasets/parallel_text.py
@@ -171,7 +171,7 @@ class GenericParallelTextDataset(ParallelTextDataset):
             manifest_file = path.joinpath(split).joinpath("MANIFEST")
 
             try:
-                with manifest_file.open() as fp:
+                with manifest_file.open(encoding="utf-8") as fp:
                     content = list(fp)
             except OSError as ex:
                 raise DatasetLoadError(

--- a/src/fairseq2/datasets/preference.py
+++ b/src/fairseq2/datasets/preference.py
@@ -377,7 +377,7 @@ class GenericPreferenceDataset(PreferenceDataset):
         lines = []
 
         # TODO(balioglu): Do in C++.
-        with path.open() as fp:
+        with path.open(encoding="utf-8") as fp:
             for line in fp:
                 lines.append(line)
 

--- a/src/fairseq2/generation/_beam_search/_handler.py
+++ b/src/fairseq2/generation/_beam_search/_handler.py
@@ -11,6 +11,7 @@ from typing import Final, final
 
 from typing_extensions import override
 
+from fairseq2.data import VocabularyInfo
 from fairseq2.generation._beam_search._algo import (
     STANDARD_BEAM_SEARCH_ALGO,
     BeamSearchAlgorithmHandler,
@@ -92,7 +93,9 @@ class BeamSearchSequenceGeneratorHandler(SequenceGeneratorHandler):
         self._algorithm_handlers = algorithm_handlers
 
     @override
-    def create(self, model: DecoderModel, config: object) -> SequenceGenerator:
+    def create(
+        self, model: DecoderModel, vocab_info: VocabularyInfo, config: object
+    ) -> SequenceGenerator:
         config = structure(config, BeamSearchConfig)
 
         validate(config)
@@ -116,6 +119,7 @@ class BeamSearchSequenceGeneratorHandler(SequenceGeneratorHandler):
 
         return BeamSearchSequenceGenerator(
             model,
+            vocab_info,
             algorithm=algorithm,
             beam_size=config.beam_size,
             min_gen_len=config.min_gen_len,
@@ -151,7 +155,12 @@ class BeamSearchSeq2SeqGeneratorHandler(Seq2SeqGeneratorHandler):
         self._algorithm_handlers = algorithm_handlers
 
     @override
-    def create(self, model: EncoderDecoderModel, config: object) -> Seq2SeqGenerator:
+    def create(
+        self,
+        model: EncoderDecoderModel,
+        target_vocab_info: VocabularyInfo,
+        config: object,
+    ) -> Seq2SeqGenerator:
         config = structure(config, BeamSearchConfig)
 
         validate(config)
@@ -172,6 +181,7 @@ class BeamSearchSeq2SeqGeneratorHandler(Seq2SeqGeneratorHandler):
 
         return BeamSearchSeq2SeqGenerator(
             model,
+            target_vocab_info,
             algorithm=algorithm,
             beam_size=config.beam_size,
             min_gen_len=config.min_gen_len,

--- a/src/fairseq2/generation/_handler.py
+++ b/src/fairseq2/generation/_handler.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 
+from fairseq2.data import VocabularyInfo
 from fairseq2.generation._generator import Seq2SeqGenerator, SequenceGenerator
 from fairseq2.models.decoder import DecoderModel
 from fairseq2.models.encoder_decoder import EncoderDecoderModel
@@ -15,7 +16,9 @@ from fairseq2.models.encoder_decoder import EncoderDecoderModel
 
 class SequenceGeneratorHandler(ABC):
     @abstractmethod
-    def create(self, model: DecoderModel, config: object) -> SequenceGenerator: ...
+    def create(
+        self, model: DecoderModel, vocab_info: VocabularyInfo, config: object
+    ) -> SequenceGenerator: ...
 
     @property
     @abstractmethod
@@ -29,7 +32,10 @@ class SequenceGeneratorHandler(ABC):
 class Seq2SeqGeneratorHandler(ABC):
     @abstractmethod
     def create(
-        self, model: EncoderDecoderModel, config: object
+        self,
+        model: EncoderDecoderModel,
+        target_vocab_info: VocabularyInfo,
+        config: object,
     ) -> Seq2SeqGenerator: ...
 
     @property

--- a/src/fairseq2/generation/_sampling/_handler.py
+++ b/src/fairseq2/generation/_sampling/_handler.py
@@ -11,6 +11,7 @@ from typing import Final, final
 
 from typing_extensions import override
 
+from fairseq2.data import VocabularyInfo
 from fairseq2.generation._generator import Seq2SeqGenerator, SequenceGenerator
 from fairseq2.generation._handler import (
     Seq2SeqGeneratorHandler,
@@ -89,7 +90,9 @@ class SamplingSequenceGeneratorHandler(SequenceGeneratorHandler):
         self._sampler_handlers = sampler_handlers
 
     @override
-    def create(self, model: DecoderModel, config: object) -> SequenceGenerator:
+    def create(
+        self, model: DecoderModel, vocab_info: VocabularyInfo, config: object
+    ) -> SequenceGenerator:
         config = structure(config, SamplingConfig)
 
         validate(config)
@@ -118,6 +121,7 @@ class SamplingSequenceGeneratorHandler(SequenceGeneratorHandler):
 
         return SamplingSequenceGenerator(
             model,
+            vocab_info,
             sampler,
             min_gen_len=config.min_gen_len,
             max_gen_len=max_gen_len,
@@ -151,7 +155,12 @@ class SamplingSeq2SeqGeneratorHandler(Seq2SeqGeneratorHandler):
         self._sampler_handlers = sampler_handlers
 
     @override
-    def create(self, model: EncoderDecoderModel, config: object) -> Seq2SeqGenerator:
+    def create(
+        self,
+        model: EncoderDecoderModel,
+        target_vocab_info: VocabularyInfo,
+        config: object,
+    ) -> Seq2SeqGenerator:
         config = structure(config, SamplingConfig)
 
         validate(config)
@@ -177,6 +186,7 @@ class SamplingSeq2SeqGeneratorHandler(Seq2SeqGeneratorHandler):
 
         return SamplingSeq2SeqGenerator(
             model,
+            target_vocab_info,
             sampler,
             min_gen_len=config.min_gen_len,
             max_gen_len=max_gen_len,

--- a/src/fairseq2/models/decoder.py
+++ b/src/fairseq2/models/decoder.py
@@ -11,7 +11,6 @@ from abc import abstractmethod
 from torch import Tensor
 from typing_extensions import override
 
-from fairseq2.data import VocabularyInfo
 from fairseq2.models.sequence import SequenceBatch, SequenceModel, SequenceModelOutput
 from fairseq2.nn import IncrementalStateBag
 from fairseq2.nn.padding import PaddingMask
@@ -22,18 +21,12 @@ class DecoderModel(SequenceModel):
 
     model_dim: int
 
-    def __init__(
-        self, model_dim: int, max_seq_len: int, vocab_info: VocabularyInfo
-    ) -> None:
+    def __init__(self, model_dim: int, max_seq_len: int) -> None:
         """
-        :param model_dim:
-            The dimensionality of the model.
-        :param max_seq_len:
-            The maximum length of sequences produced by the model.
-        :param vocab_info:
-            The vocabulary information of sequences produced by the model.
+        :param model_dim: The dimensionality of the model.
+        :param max_seq_len: The maximum length of produced sequences.
         """
-        super().__init__(max_seq_len, vocab_info)
+        super().__init__(max_seq_len)
 
         self.model_dim = model_dim
 

--- a/src/fairseq2/models/encoder_decoder.py
+++ b/src/fairseq2/models/encoder_decoder.py
@@ -22,12 +22,14 @@ class EncoderDecoderModel(Seq2SeqModel):
 
     model_dim: int
 
-    def __init__(self, model_dim: int, max_target_seq_len: int) -> None:
+    def __init__(
+        self, model_dim: int, max_source_seq_len: int, max_target_seq_len: int
+    ) -> None:
         """
         :param model_dim: The dimensionality of the model.
         :param max_target_seq_len: The maximum length of produced sequences.
         """
-        super().__init__(max_target_seq_len)
+        super().__init__(max_source_seq_len, max_target_seq_len)
 
         self.model_dim = model_dim
 

--- a/src/fairseq2/models/encoder_decoder.py
+++ b/src/fairseq2/models/encoder_decoder.py
@@ -11,7 +11,6 @@ from abc import abstractmethod
 from torch import Tensor
 from typing_extensions import override
 
-from fairseq2.data import VocabularyInfo
 from fairseq2.models.seq2seq import Seq2SeqBatch, Seq2SeqModel
 from fairseq2.models.sequence import SequenceModelOutput
 from fairseq2.nn import IncrementalStateBag
@@ -23,18 +22,12 @@ class EncoderDecoderModel(Seq2SeqModel):
 
     model_dim: int
 
-    def __init__(
-        self, model_dim: int, max_target_seq_len: int, target_vocab_info: VocabularyInfo
-    ) -> None:
+    def __init__(self, model_dim: int, max_target_seq_len: int) -> None:
         """
-        :param model_dim:
-            The dimensionality of the model.
-        :param max_target_seq_len:
-            The maximum length of sequences produced by the model.
-        :param target_vocab_info:
-            The vocabulary information of sequences produced by the model.
+        :param model_dim: The dimensionality of the model.
+        :param max_target_seq_len: The maximum length of produced sequences.
         """
-        super().__init__(max_target_seq_len, target_vocab_info)
+        super().__init__(max_target_seq_len)
 
         self.model_dim = model_dim
 

--- a/src/fairseq2/models/llama/__init__.py
+++ b/src/fairseq2/models/llama/__init__.py
@@ -20,7 +20,7 @@ from fairseq2.models.llama._config import (
 from fairseq2.models.llama._factory import LLaMAFactory as LLaMAFactory
 from fairseq2.models.llama._factory import create_llama_model as create_llama_model
 from fairseq2.models.llama._factory import (
-    init_llama_scaled_freqs as init_llama_scaled_freqs,
+    init_llama_rope_freqs as init_llama_rope_freqs,
 )
 from fairseq2.models.llama._shard import shard_llama_model as shard_llama_model
 

--- a/src/fairseq2/models/llama/_config.py
+++ b/src/fairseq2/models/llama/_config.py
@@ -10,7 +10,6 @@ from dataclasses import dataclass, field
 from typing import Final, Literal
 
 from fairseq2.context import RuntimeContext
-from fairseq2.data import VocabularyInfo
 
 LLAMA_MODEL_FAMILY: Final = "llama"
 
@@ -29,12 +28,11 @@ class LLaMAConfig:
     max_seq_len: int = 2048
     """The maximum sequence length."""
 
-    vocab_info: VocabularyInfo = field(
-        default_factory=lambda: VocabularyInfo(
-            size=32000, unk_idx=0, bos_idx=1, eos_idx=2, pad_idx=None
-        )
-    )
-    """The vocabulary information."""
+    vocab_size: int = 32_000
+    """The size of the vocabulary."""
+
+    pad_idx: int | None = None
+    """The index of the PAD symbol in the vocabulary."""
 
     tie_embeddings: bool = False
     """If ``True``, ties the embedding table and the output projection layer."""
@@ -196,11 +194,7 @@ def register_llama_configs(context: RuntimeContext) -> None:
         config = llama2_7b()
 
         config.max_seq_len = 8192
-
-        config.vocab_info = VocabularyInfo(
-            size=128_256, unk_idx=None, bos_idx=128_000, eos_idx=128_001, pad_idx=None
-        )
-
+        config.vocab_size = 128_256
         config.num_key_value_heads = 8
         config.ffn_inner_dim = 4096 * 4
         config.ffn_inner_dim_multiplier = 1.3
@@ -214,11 +208,7 @@ def register_llama_configs(context: RuntimeContext) -> None:
         config = llama2_70b()
 
         config.max_seq_len = 8192
-
-        config.vocab_info = VocabularyInfo(
-            size=128_256, unk_idx=None, bos_idx=128_000, eos_idx=128_001, pad_idx=None
-        )
-
+        config.vocab_size = 128_256
         config.rope_theta = 500_000.0
 
         return config

--- a/src/fairseq2/models/llama/_config.py
+++ b/src/fairseq2/models/llama/_config.py
@@ -195,6 +195,7 @@ def register_llama_configs(context: RuntimeContext) -> None:
 
         config.max_seq_len = 8192
         config.vocab_size = 128_256
+        config.pad_idx = 128_004
         config.num_key_value_heads = 8
         config.ffn_inner_dim = 4096 * 4
         config.ffn_inner_dim_multiplier = 1.3
@@ -209,6 +210,7 @@ def register_llama_configs(context: RuntimeContext) -> None:
 
         config.max_seq_len = 8192
         config.vocab_size = 128_256
+        config.pad_idx = 128_004
         config.rope_theta = 500_000.0
 
         return config

--- a/src/fairseq2/models/llama/_factory.py
+++ b/src/fairseq2/models/llama/_factory.py
@@ -70,8 +70,8 @@ class LLaMAFactory:
             decoder_frontend,
             decoder,
             final_proj,
+            pad_idx=config.pad_idx,
             max_seq_len=config.max_seq_len,
-            vocab_info=config.vocab_info,
         )
 
     def create_embedding(self) -> Embedding:
@@ -87,7 +87,7 @@ class LLaMAFactory:
             _init_truncated_normal(embed.weight, bias=None, std=std)
 
         return StandardEmbedding(
-            num_embeddings=config.vocab_info.size,
+            num_embeddings=config.vocab_size,
             embedding_dim=config.model_dim,
             init_fn=init_embed,
         )
@@ -123,7 +123,7 @@ class LLaMAFactory:
 
         if config.use_scaled_rope:
             freqs_init_fn = partial(
-                init_llama_scaled_freqs, rope_scaling=config.rope_scaling
+                init_llama_rope_freqs, rope_scaling=config.rope_scaling
             )
         else:
             freqs_init_fn = None
@@ -244,7 +244,7 @@ class LLaMAFactory:
 
         return Linear(
             config.model_dim,
-            config.vocab_info.size,
+            config.vocab_size,
             bias=False,
             init_fn=init_projection,
         )
@@ -265,7 +265,7 @@ def _init_truncated_normal(
         nn.init.zeros_(bias)
 
 
-def init_llama_scaled_freqs(
+def init_llama_rope_freqs(
     pos_encoder: RotaryEncoder, rope_scaling: LLaMARopeScalingConfig
 ) -> Tensor:
     device = pos_encoder.freqs.device

--- a/src/fairseq2/models/llama/_factory.py
+++ b/src/fairseq2/models/llama/_factory.py
@@ -64,7 +64,7 @@ class LLaMAFactory:
 
         decoder = self.create_decoder()
 
-        final_proj = self.create_final_proj(embed)
+        final_proj = self.create_final_projection(embed)
 
         return TransformerDecoderModel(
             decoder_frontend,
@@ -222,7 +222,7 @@ class LLaMAFactory:
 
         return (2 * (n + 1)) ** 0.5  # type: ignore[no-any-return]
 
-    def create_final_proj(self, embed: Embedding) -> Projection:
+    def create_final_projection(self, embed: Embedding) -> Projection:
         config = self._config
 
         if config.tie_embeddings:

--- a/src/fairseq2/models/llama/integ.py
+++ b/src/fairseq2/models/llama/integ.py
@@ -70,12 +70,19 @@ def convert_to_hg_llama_config(config: LLaMAConfig) -> dict[str, object]:
     else:
         rope_scaling = None
 
+    if config.vocab_size == 32_000:  # LLaMA 1 and 2
+        bos_idx = 1
+        eos_idx = 2
+    else:
+        bos_idx = 128_000
+        eos_idx = 128_001
+
     # We only specify the parameters made explicit in the Hugging Face converter.
     # See https://github.com/huggingface/transformers/blob/93aafdc620d39b9ec714ffecf015a085ea221282/src/transformers/models/llama/convert_llama_weights_to_hf.py#L384.
     return {
         "architectures": ["Fairseq2LlamaForCausalLM"],
-        "bos_token_id": config.vocab_info.bos_idx,
-        "eos_token_id": config.vocab_info.eos_idx,
+        "bos_token_id": bos_idx,
+        "eos_token_id": eos_idx,
         "hidden_size": config.model_dim,
         "intermediate_size": intermediate_size,
         "max_position_embeddings": config.max_seq_len,
@@ -87,5 +94,5 @@ def convert_to_hg_llama_config(config: LLaMAConfig) -> dict[str, object]:
         "rope_scaling": rope_scaling,
         "rope_theta": config.rope_theta,
         "tie_word_embeddings": config.tie_embeddings,
-        "vocab_size": config.vocab_info.size,
+        "vocab_size": config.vocab_size,
     }

--- a/src/fairseq2/models/mistral/_config.py
+++ b/src/fairseq2/models/mistral/_config.py
@@ -6,11 +6,10 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Final
 
 from fairseq2.context import RuntimeContext
-from fairseq2.data import VocabularyInfo
 
 MISTRAL_MODEL_FAMILY: Final = "mistral"
 
@@ -29,12 +28,11 @@ class MistralConfig:
     max_seq_len: int = 8192
     """The maximum sequence length."""
 
-    vocab_info: VocabularyInfo = field(
-        default_factory=lambda: VocabularyInfo(
-            size=32000, unk_idx=0, bos_idx=1, eos_idx=2, pad_idx=None
-        )
-    )
-    """The vocabulary information."""
+    vocab_size: int = 32_000
+    """The size of the vocabulary."""
+
+    pad_idx: int | None = None
+    """The index of the PAD symbol in the vocabulary."""
 
     attn_window_len: int = 4096
     """The local attention window length."""

--- a/src/fairseq2/models/mistral/_factory.py
+++ b/src/fairseq2/models/mistral/_factory.py
@@ -63,8 +63,8 @@ class MistralFactory:
             decoder_frontend,
             decoder,
             final_proj,
+            pad_idx=None,
             max_seq_len=config.max_seq_len,
-            vocab_info=config.vocab_info,
         )
 
     def create_decoder_frontend(self) -> TransformerFrontend:
@@ -80,7 +80,7 @@ class MistralFactory:
         config = self._config
 
         return StandardEmbedding(
-            num_embeddings=config.vocab_info.size, embedding_dim=config.model_dim
+            num_embeddings=config.vocab_size, embedding_dim=config.model_dim
         )
 
     def create_decoder(self) -> TransformerDecoder:
@@ -161,7 +161,7 @@ class MistralFactory:
 
         return Linear(
             config.model_dim,
-            config.vocab_info.size,
+            config.vocab_size,
             bias=False,
             init_fn=init_final_projection,
         )

--- a/src/fairseq2/models/mistral/_factory.py
+++ b/src/fairseq2/models/mistral/_factory.py
@@ -10,7 +10,7 @@ from fairseq2.models.mistral._config import MistralConfig
 from fairseq2.models.transformer import (
     TransformerEmbeddingFrontend,
     TransformerFrontend,
-    init_final_projection,
+    init_transformer_final_projection,
 )
 from fairseq2.models.transformer_decoder import TransformerDecoderModel
 from fairseq2.nn import (
@@ -57,13 +57,13 @@ class MistralFactory:
 
         decoder = self.create_decoder()
 
-        final_proj = self.create_final_proj()
+        final_proj = self.create_final_projection()
 
         return TransformerDecoderModel(
             decoder_frontend,
             decoder,
             final_proj,
-            pad_idx=None,
+            pad_idx=config.pad_idx,
             max_seq_len=config.max_seq_len,
         )
 
@@ -156,14 +156,14 @@ class MistralFactory:
             config.model_dim, config.ffn_inner_dim, bias=False, inner_dim_scale=1.0
         )
 
-    def create_final_proj(self) -> Projection:
+    def create_final_projection(self) -> Projection:
         config = self._config
 
         return Linear(
             config.model_dim,
             config.vocab_size,
             bias=False,
-            init_fn=init_final_projection,
+            init_fn=init_transformer_final_projection,
         )
 
     @staticmethod

--- a/src/fairseq2/models/nllb/_config.py
+++ b/src/fairseq2/models/nllb/_config.py
@@ -7,7 +7,6 @@
 from __future__ import annotations
 
 from fairseq2.context import RuntimeContext
-from fairseq2.data import VocabularyInfo
 from fairseq2.models.transformer import TransformerConfig
 from fairseq2.nn.transformer import TransformerNormOrder
 
@@ -43,9 +42,8 @@ def register_nllb_configs(context: RuntimeContext) -> None:
         config = registry.get("base")
 
         config.model_dim = 1024
-        config.vocab_info = VocabularyInfo(
-            size=256206, unk_idx=1, bos_idx=2, eos_idx=3, pad_idx=0
-        )
+        config.vocab_size = 256_206
+        config.pad_idx = 0
         config.num_encoder_layers = 24
         config.num_decoder_layers = 24
         config.num_encoder_attn_heads = 16

--- a/src/fairseq2/models/s2t_transformer/_config.py
+++ b/src/fairseq2/models/s2t_transformer/_config.py
@@ -37,8 +37,8 @@ class S2TTransformerConfig:
     target_vocab_size: int = 10_000
     """The size of the target vocabulary."""
 
-    pad_idx: int | None = 1
-    """The index of the PAD symbol in the vocabulary."""
+    pad_idx: int = 1
+    """The index of the PAD symbol in the target vocabulary."""
 
     use_relative_pos: bool = False
     """If ``True``, uses relative positional encodings for source sequences."""

--- a/src/fairseq2/models/s2t_transformer/_config.py
+++ b/src/fairseq2/models/s2t_transformer/_config.py
@@ -6,11 +6,10 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Final
 
 from fairseq2.context import RuntimeContext
-from fairseq2.data import VocabularyInfo
 
 S2T_TRANSFORMER_MODEL_FAMILY: Final = "s2t_transformer"
 
@@ -35,12 +34,11 @@ class S2TTransformerConfig:
     max_target_seq_len: int = 1024
     """The maximum target sequence length."""
 
-    target_vocab_info: VocabularyInfo = field(
-        default_factory=lambda: VocabularyInfo(
-            size=10000, unk_idx=3, bos_idx=0, eos_idx=2, pad_idx=1
-        )
-    )
-    """The target vocabulary information."""
+    target_vocab_size: int = 10_000
+    """The size of the target vocabulary."""
+
+    pad_idx: int | None = 1
+    """The index of the PAD symbol in the vocabulary."""
 
     use_relative_pos: bool = False
     """If ``True``, uses relative positional encodings for source sequences."""
@@ -124,9 +122,7 @@ def register_s2t_transformer_configs(context: RuntimeContext) -> None:
             max_source_seq_len=6000,
             num_fbank_channels=80,
             max_target_seq_len=1024,
-            target_vocab_info=VocabularyInfo(
-                size=181, unk_idx=3, bos_idx=0, eos_idx=2, pad_idx=1
-            ),
+            target_vocab_size=181,
             use_relative_pos=False,
             use_conformer=True,
             num_encoder_layers=12,

--- a/src/fairseq2/models/s2t_transformer/_factory.py
+++ b/src/fairseq2/models/s2t_transformer/_factory.py
@@ -80,8 +80,8 @@ class S2TTransformerFactory:
             decoder_frontend,
             decoder,
             final_proj,
+            pad_idx=config.pad_idx,
             max_target_seq_len=config.max_target_seq_len,
-            target_vocab_info=config.target_vocab_info,
         )
 
     def create_encoder_frontend(self) -> TransformerFrontend:
@@ -223,9 +223,9 @@ class S2TTransformerFactory:
         config = self._config
 
         return StandardEmbedding(
-            num_embeddings=config.target_vocab_info.size,
+            num_embeddings=config.target_vocab_size,
             embedding_dim=config.model_dim,
-            pad_idx=config.target_vocab_info.pad_idx,
+            pad_idx=config.pad_idx,
             init_fn=init_scaled_embedding,
         )
 
@@ -279,7 +279,7 @@ class S2TTransformerFactory:
 
         return Linear(
             config.model_dim,
-            config.target_vocab_info.size,
+            config.target_vocab_size,
             bias=False,
             init_fn=init_final_projection,
         )

--- a/src/fairseq2/models/s2t_transformer/_factory.py
+++ b/src/fairseq2/models/s2t_transformer/_factory.py
@@ -16,7 +16,7 @@ from fairseq2.models.transformer import (
     TransformerEmbeddingFrontend,
     TransformerFrontend,
     TransformerModel,
-    init_final_projection,
+    init_transformer_final_projection,
 )
 from fairseq2.nn import (
     Embedding,
@@ -72,7 +72,7 @@ class S2TTransformerFactory:
 
         decoder = self.create_decoder()
 
-        final_proj = self.create_final_proj()
+        final_proj = self.create_final_projection()
 
         return TransformerModel(
             encoder_frontend,
@@ -81,6 +81,7 @@ class S2TTransformerFactory:
             decoder,
             final_proj,
             pad_idx=config.pad_idx,
+            max_source_seq_len=config.max_source_seq_len,
             max_target_seq_len=config.max_target_seq_len,
         )
 
@@ -274,12 +275,12 @@ class S2TTransformerFactory:
             config.model_dim, config.num_decoder_attn_heads, sdpa=sdpa
         )
 
-    def create_final_proj(self) -> Projection:
+    def create_final_projection(self) -> Projection:
         config = self._config
 
         return Linear(
             config.model_dim,
             config.target_vocab_size,
             bias=False,
-            init_fn=init_final_projection,
+            init_fn=init_transformer_final_projection,
         )

--- a/src/fairseq2/models/seq2seq.py
+++ b/src/fairseq2/models/seq2seq.py
@@ -13,7 +13,6 @@ from torch import Tensor
 from torch.nn import Module
 from typing_extensions import override
 
-from fairseq2.data import VocabularyInfo
 from fairseq2.device import SupportsDeviceTransfer
 from fairseq2.models.sequence import SequenceBatch, SequenceModelOutput
 from fairseq2.nn.padding import PaddingMask
@@ -24,29 +23,19 @@ class Seq2SeqModel(Module, ABC):
     """Represents a sequence-to-sequence model."""
 
     max_target_seq_len: int
-    target_vocab_info: VocabularyInfo
 
-    def __init__(
-        self,
-        max_target_seq_len: int,
-        target_vocab_info: VocabularyInfo,
-    ) -> None:
+    def __init__(self, max_target_seq_len: int) -> None:
         """
-        :param max_target_seq_len:
-            The maximum length of sequences produced by the model.
-        :param target_vocab_info:
-            The vocabulary information of sequences produced by the model.
+        :param max_target_seq_len: The maximum length of produced sequences.
         """
         super().__init__()
 
         self.max_target_seq_len = max_target_seq_len
-        self.target_vocab_info = target_vocab_info
 
     @abstractmethod
     def forward(self, batch: Seq2SeqBatch) -> SequenceModelOutput:
         """
-        :param batch:
-            The batch of sequences to process.
+        :param batch: The batch of sequences to process.
         """
 
 

--- a/src/fairseq2/models/seq2seq.py
+++ b/src/fairseq2/models/seq2seq.py
@@ -22,14 +22,16 @@ from fairseq2.typing import Device
 class Seq2SeqModel(Module, ABC):
     """Represents a sequence-to-sequence model."""
 
+    max_source_seq_len: int
     max_target_seq_len: int
 
-    def __init__(self, max_target_seq_len: int) -> None:
+    def __init__(self, max_source_seq_len: int, max_target_seq_len: int) -> None:
         """
         :param max_target_seq_len: The maximum length of produced sequences.
         """
         super().__init__()
 
+        self.max_source_seq_len = max_source_seq_len
         self.max_target_seq_len = max_target_seq_len
 
     @abstractmethod

--- a/src/fairseq2/models/sequence.py
+++ b/src/fairseq2/models/sequence.py
@@ -14,7 +14,6 @@ from torch import Tensor
 from torch.nn import Module
 from typing_extensions import override
 
-from fairseq2.data import VocabularyInfo
 from fairseq2.device import SupportsDeviceTransfer
 from fairseq2.nn.functional import cross_entropy
 from fairseq2.nn.padding import PaddingMask
@@ -25,25 +24,19 @@ class SequenceModel(Module, ABC):
     """Represents a sequence model."""
 
     max_seq_len: int
-    vocab_info: VocabularyInfo
 
-    def __init__(self, max_seq_len: int, vocab_info: VocabularyInfo) -> None:
+    def __init__(self, max_seq_len: int) -> None:
         """
-        :param max_seq_len:
-            The maximum length of sequences produced by the model.
-        :param vocab_info:
-            The vocabulary information of sequences produced by the model.
+        :param max_seq_len: The maximum length of produced sequences.
         """
         super().__init__()
 
         self.max_seq_len = max_seq_len
-        self.vocab_info = vocab_info
 
     @abstractmethod
     def forward(self, batch: SequenceBatch) -> SequenceModelOutput:
         """
-        :param batch:
-            The batch of sequences to process.
+        :param batch: The batch of sequences to process.
         """
 
 

--- a/src/fairseq2/models/transformer/__init__.py
+++ b/src/fairseq2/models/transformer/__init__.py
@@ -23,7 +23,7 @@ from fairseq2.models.transformer._factory import (
     create_transformer_model as create_transformer_model,
 )
 from fairseq2.models.transformer._factory import (
-    init_final_projection as init_final_projection,
+    init_transformer_final_projection as init_transformer_final_projection,
 )
 from fairseq2.models.transformer._frontend import (
     TransformerEmbeddingFrontend as TransformerEmbeddingFrontend,

--- a/src/fairseq2/models/transformer/_config.py
+++ b/src/fairseq2/models/transformer/_config.py
@@ -6,11 +6,10 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Final
 
 from fairseq2.context import RuntimeContext
-from fairseq2.data import VocabularyInfo
 from fairseq2.nn.transformer import TransformerNormOrder
 
 TRANSFORMER_MODEL_FAMILY: Final = "transformer"
@@ -30,12 +29,11 @@ class TransformerConfig:
     max_seq_len: int = 1024
     """The maximum sequence length."""
 
-    vocab_info: VocabularyInfo = field(
-        default_factory=lambda: VocabularyInfo(
-            size=32768, unk_idx=None, bos_idx=None, eos_idx=1, pad_idx=0
-        )
-    )
-    """The vocabulary information."""
+    vocab_size: int = 32_768
+    """The size of the vocabulary."""
+
+    pad_idx: int | None = 0
+    """The index of the PAD symbol in the vocabulary."""
 
     num_encoder_layers: int = 6
     """The number of encoder layers."""

--- a/src/fairseq2/models/transformer/_config.py
+++ b/src/fairseq2/models/transformer/_config.py
@@ -32,7 +32,7 @@ class TransformerConfig:
     vocab_size: int = 32_768
     """The size of the vocabulary."""
 
-    pad_idx: int | None = 0
+    pad_idx: int = 0
     """The index of the PAD symbol in the vocabulary."""
 
     num_encoder_layers: int = 6

--- a/src/fairseq2/models/transformer/_factory.py
+++ b/src/fairseq2/models/transformer/_factory.py
@@ -70,17 +70,17 @@ class TransformerFactory:
             frontend,
             decoder,
             final_proj,
+            pad_idx=config.pad_idx,
             max_target_seq_len=config.max_seq_len,
-            target_vocab_info=config.vocab_info,
         )
 
     def create_embedding(self) -> Embedding:
         config = self._config
 
         return StandardEmbedding(
-            num_embeddings=config.vocab_info.size,
+            num_embeddings=config.vocab_size,
             embedding_dim=config.model_dim,
-            pad_idx=config.vocab_info.pad_idx,
+            pad_idx=config.pad_idx,
             init_fn=init_scaled_embedding,
         )
 
@@ -175,7 +175,7 @@ class TransformerFactory:
         if isinstance(embed, StandardEmbedding):
             return TiedProjection(embed.weight, bias=None)
 
-        return Linear(config.model_dim, config.vocab_info.size, bias=False)
+        return Linear(config.model_dim, config.vocab_size, bias=False)
 
 
 def init_final_projection(proj: Linear) -> None:

--- a/src/fairseq2/models/transformer/_factory.py
+++ b/src/fairseq2/models/transformer/_factory.py
@@ -62,7 +62,7 @@ class TransformerFactory:
 
         decoder = self.create_decoder()
 
-        final_proj = self.create_final_proj(embed)
+        final_proj = self.create_final_projection(embed)
 
         return TransformerModel(
             frontend,
@@ -71,6 +71,7 @@ class TransformerFactory:
             decoder,
             final_proj,
             pad_idx=config.pad_idx,
+            max_source_seq_len=config.max_seq_len,
             max_target_seq_len=config.max_seq_len,
         )
 
@@ -169,16 +170,21 @@ class TransformerFactory:
             norm_order=config.norm_order,
         )
 
-    def create_final_proj(self, embed: Embedding) -> Projection:
+    def create_final_projection(self, embed: Embedding) -> Projection:
         config = self._config
 
         if isinstance(embed, StandardEmbedding):
             return TiedProjection(embed.weight, bias=None)
 
-        return Linear(config.model_dim, config.vocab_size, bias=False)
+        return Linear(
+            config.model_dim,
+            config.vocab_size,
+            bias=False,
+            init_fn=init_transformer_final_projection,
+        )
 
 
-def init_final_projection(proj: Linear) -> None:
+def init_transformer_final_projection(proj: Linear) -> None:
     nn.init.normal_(proj.weight, std=proj.input_dim**-0.5)
 
     if proj.bias is not None:

--- a/src/fairseq2/models/transformer/_model.py
+++ b/src/fairseq2/models/transformer/_model.py
@@ -40,6 +40,7 @@ class TransformerModel(EncoderDecoderModel):
         final_proj: Projection,
         *,
         pad_idx: int | None,
+        max_source_seq_len: int,
         max_target_seq_len: int,
     ) -> None:
         """
@@ -50,7 +51,7 @@ class TransformerModel(EncoderDecoderModel):
         :param final_proj: The projection to apply to decoder outputs.
         :param max_target_seq_len: The maximum length of produced sequences.
         """
-        super().__init__(encoder.model_dim, max_target_seq_len)
+        super().__init__(encoder.model_dim, max_source_seq_len, max_target_seq_len)
 
         self.encoder_frontend = encoder_frontend
         self.encoder = encoder

--- a/src/fairseq2/models/wav2vec2/asr/_config.py
+++ b/src/fairseq2/models/wav2vec2/asr/_config.py
@@ -10,7 +10,6 @@ from dataclasses import dataclass, field
 from typing import Final
 
 from fairseq2.context import RuntimeContext
-from fairseq2.data import VocabularyInfo
 from fairseq2.models.wav2vec2 import Wav2Vec2Config, Wav2Vec2EncoderConfig
 
 WAV2VEC2_ASR_MODEL_FAMILY: Final = "wav2vec2_asr"
@@ -34,12 +33,8 @@ class Wav2Vec2AsrConfig:
     )
     """The configuration of the encoder."""
 
-    vocab_info: VocabularyInfo = field(
-        default_factory=lambda: VocabularyInfo(
-            size=32, unk_idx=3, bos_idx=0, eos_idx=2, pad_idx=1
-        )
-    )
-    """The vocabulary information."""
+    vocab_size: int = 32
+    """The number of output characters."""
 
     final_dropout_p: float = 0.0
     """The dropout probability on the output of the encoder."""

--- a/src/fairseq2/models/wav2vec2/asr/_config.py
+++ b/src/fairseq2/models/wav2vec2/asr/_config.py
@@ -33,8 +33,8 @@ class Wav2Vec2AsrConfig:
     )
     """The configuration of the encoder."""
 
-    vocab_size: int = 32
-    """The number of output characters."""
+    target_vocab_size: int = 32
+    """The size of the target vocabulary."""
 
     final_dropout_p: float = 0.0
     """The dropout probability on the output of the encoder."""

--- a/src/fairseq2/models/wav2vec2/asr/_factory.py
+++ b/src/fairseq2/models/wav2vec2/asr/_factory.py
@@ -6,6 +6,8 @@
 
 from __future__ import annotations
 
+import torch.nn as nn
+
 from fairseq2.models.wav2vec2 import (
     StandardWav2Vec2Masker,
     Wav2Vec2EncoderFactory,
@@ -14,6 +16,7 @@ from fairseq2.models.wav2vec2 import (
 )
 from fairseq2.models.wav2vec2.asr._config import Wav2Vec2AsrConfig
 from fairseq2.models.wav2vec2.asr._model import Wav2Vec2AsrModel
+from fairseq2.nn import Linear, Projection
 from fairseq2.nn.transformer import TransformerEncoder
 
 
@@ -37,10 +40,12 @@ class Wav2Vec2AsrFactory:
         else:
             masker = None
 
+        final_proj = self.create_final_projection()
+
         return Wav2Vec2AsrModel(
             encoder_frontend,
             encoder,
-            config.vocab_size,
+            final_proj,
             masker=masker,
             final_dropout_p=config.final_dropout_p,
         )
@@ -68,3 +73,20 @@ class Wav2Vec2AsrFactory:
             config.max_spatial_mask_prob,
             config.min_num_spatial_mask_spans,
         )
+
+    def create_final_projection(self) -> Projection:
+        config = self._config
+
+        return Linear(
+            config.encoder_config.model_dim,
+            config.target_vocab_size,
+            bias=True,
+            init_fn=init_final_projection,
+        )
+
+
+def init_final_projection(proj: Linear) -> None:
+    nn.init.xavier_uniform_(proj.weight)
+
+    if proj.bias is not None:
+        nn.init.zeros_(proj.bias)

--- a/src/fairseq2/models/wav2vec2/asr/_factory.py
+++ b/src/fairseq2/models/wav2vec2/asr/_factory.py
@@ -40,7 +40,7 @@ class Wav2Vec2AsrFactory:
         return Wav2Vec2AsrModel(
             encoder_frontend,
             encoder,
-            config.vocab_info,
+            config.vocab_size,
             masker=masker,
             final_dropout_p=config.final_dropout_p,
         )

--- a/src/fairseq2/models/wav2vec2/asr/_model.py
+++ b/src/fairseq2/models/wav2vec2/asr/_model.py
@@ -8,14 +8,13 @@ from __future__ import annotations
 
 from typing import final
 
-import torch.nn as nn
 from torch.nn import Dropout
 from typing_extensions import override
 
 from fairseq2.models.asr import AsrModel, AsrModelOutput
 from fairseq2.models.sequence import SequenceBatch
 from fairseq2.models.wav2vec2 import Wav2Vec2Frontend, Wav2Vec2Masker
-from fairseq2.nn import Linear
+from fairseq2.nn import Projection
 from fairseq2.nn.transformer import TransformerEncoder
 from fairseq2.typing import DataType, Device
 
@@ -29,13 +28,13 @@ class Wav2Vec2AsrModel(AsrModel):
     encoder_frontend: Wav2Vec2Frontend
     masker: Wav2Vec2Masker | None
     final_dropout: Dropout | None
-    final_proj: Linear
+    final_proj: Projection
 
     def __init__(
         self,
         encoder_frontend: Wav2Vec2Frontend,
         encoder: TransformerEncoder,
-        vocab_size: int,
+        final_proj: Projection,
         *,
         masker: Wav2Vec2Masker | None = None,
         final_dropout_p: float = 0.0,
@@ -63,14 +62,7 @@ class Wav2Vec2AsrModel(AsrModel):
         else:
             self.register_module("final_dropout", None)
 
-        self.final_proj = Linear(
-            self.model_dim,
-            vocab_size,
-            bias=True,
-            init_fn=_init_final_projection,
-            device=device,
-            dtype=dtype,
-        )
+        self.final_proj = final_proj
 
     @override
     def forward(self, batch: SequenceBatch) -> AsrModelOutput:
@@ -94,11 +86,3 @@ class Wav2Vec2AsrModel(AsrModel):
         logits = self.final_proj(seqs)
 
         return AsrModelOutput(logits, padding_mask)
-
-
-def _init_final_projection(proj: Linear) -> None:
-    """Initialize ``proj`` as the final projection of a wav2vec 2.0 ASR model."""
-    nn.init.xavier_uniform_(proj.weight)
-
-    if proj.bias is not None:
-        nn.init.zeros_(proj.bias)

--- a/src/fairseq2/nn/transformer/__init__.py
+++ b/src/fairseq2/nn/transformer/__init__.py
@@ -108,6 +108,12 @@ from fairseq2.nn.transformer._multihead_attention import (
 from fairseq2.nn.transformer._multihead_attention import (
     StaticAttentionState as StaticAttentionState,
 )
+from fairseq2.nn.transformer._multihead_attention import (
+    init_mha_output_projection as init_mha_output_projection,
+)
+from fairseq2.nn.transformer._multihead_attention import (
+    init_qkv_projection as init_qkv_projection,
+)
 from fairseq2.nn.transformer._norm_order import (
     TransformerNormOrder as TransformerNormOrder,
 )

--- a/src/fairseq2/nn/transformer/_multihead_attention.py
+++ b/src/fairseq2/nn/transformer/_multihead_attention.py
@@ -377,7 +377,7 @@ class StandardMultiheadAttention(MultiheadAttention):
                 v_dim,
                 model_dim,
                 output_proj_bias,
-                init_fn=output_proj_init_fn or init_output_projection,
+                init_fn=output_proj_init_fn or init_mha_output_projection,
                 device=device,
                 dtype=dtype,
             )
@@ -579,7 +579,7 @@ def init_qkv_projection(proj: Linear) -> None:
         nn.init.zeros_(proj.bias)
 
 
-def init_output_projection(proj: Linear) -> None:
+def init_mha_output_projection(proj: Linear) -> None:
     """Initialize ``proj`` as a multi-head attention output projection."""
     nn.init.xavier_uniform_(proj.weight)
 

--- a/src/fairseq2/recipes/asr/_eval.py
+++ b/src/fairseq2/recipes/asr/_eval.py
@@ -26,7 +26,7 @@ from fairseq2.recipes.common import (
     load_dataset,
     load_text_tokenizer,
     register_extra_asset_paths,
-    setup_gangs,
+    setup_inference_gangs,
     setup_reference_model,
     setup_torch,
 )
@@ -119,7 +119,7 @@ def load_asr_evaluator(
 
     setup_torch(context, config.common, output_dir)
 
-    gangs = setup_gangs(context, config.gang)
+    gangs = setup_inference_gangs(context, config.gang)
 
     seed = config.common.seed
 

--- a/src/fairseq2/recipes/asr/_eval.py
+++ b/src/fairseq2/recipes/asr/_eval.py
@@ -26,7 +26,7 @@ from fairseq2.recipes.common import (
     load_dataset,
     load_text_tokenizer,
     register_extra_asset_paths,
-    setup_inference_gangs,
+    setup_gangs,
     setup_reference_model,
     setup_torch,
 )
@@ -119,7 +119,7 @@ def load_asr_evaluator(
 
     setup_torch(context, config.common, output_dir)
 
-    gangs = setup_inference_gangs(context, config.gang)
+    gangs = setup_gangs(context, config.gang)
 
     seed = config.common.seed
 

--- a/src/fairseq2/recipes/common/__init__.py
+++ b/src/fairseq2/recipes/common/__init__.py
@@ -40,6 +40,7 @@ from fairseq2.recipes.common._error import (
 )
 from fairseq2.recipes.common._evaluator import create_evaluator as create_evaluator
 from fairseq2.recipes.common._gang import setup_gangs as setup_gangs
+from fairseq2.recipes.common._gang import setup_training_gangs as setup_training_gangs
 from fairseq2.recipes.common._generation import (
     create_seq2seq_generator as create_seq2seq_generator,
 )

--- a/src/fairseq2/recipes/common/__init__.py
+++ b/src/fairseq2/recipes/common/__init__.py
@@ -39,7 +39,7 @@ from fairseq2.recipes.common._error import (
     ModelPathNotFoundError as ModelPathNotFoundError,
 )
 from fairseq2.recipes.common._evaluator import create_evaluator as create_evaluator
-from fairseq2.recipes.common._gang import setup_inference_gangs as setup_inference_gangs
+from fairseq2.recipes.common._gang import setup_gangs as setup_gangs
 from fairseq2.recipes.common._gang import setup_training_gangs as setup_training_gangs
 from fairseq2.recipes.common._generation import (
     create_seq2seq_generator as create_seq2seq_generator,

--- a/src/fairseq2/recipes/common/__init__.py
+++ b/src/fairseq2/recipes/common/__init__.py
@@ -39,7 +39,7 @@ from fairseq2.recipes.common._error import (
     ModelPathNotFoundError as ModelPathNotFoundError,
 )
 from fairseq2.recipes.common._evaluator import create_evaluator as create_evaluator
-from fairseq2.recipes.common._gang import setup_gangs as setup_gangs
+from fairseq2.recipes.common._gang import setup_inference_gangs as setup_inference_gangs
 from fairseq2.recipes.common._gang import setup_training_gangs as setup_training_gangs
 from fairseq2.recipes.common._generation import (
     create_seq2seq_generator as create_seq2seq_generator,

--- a/src/fairseq2/recipes/common/_asset.py
+++ b/src/fairseq2/recipes/common/_asset.py
@@ -19,12 +19,14 @@ from fairseq2.checkpoint import FileCheckpointMetadataLoader
 from fairseq2.context import RuntimeContext
 from fairseq2.logging import log
 from fairseq2.recipes import RecipeError
-from fairseq2.recipes.config import CommonSection, get_config_section
+from fairseq2.recipes.config import CommonSection
 from fairseq2.utils.file import FileSystem
 from fairseq2.utils.yaml import StandardYamlLoader
 
 
-def register_extra_asset_paths(context: RuntimeContext, recipe_config: object) -> None:
+def register_extra_asset_paths(
+    context: RuntimeContext, common_section: CommonSection
+) -> None:
     asset_store = context.asset_store
 
     file_system = context.file_system
@@ -38,7 +40,7 @@ def register_extra_asset_paths(context: RuntimeContext, recipe_config: object) -
     )
 
     try:
-        extra_path_registrar.register(recipe_config)
+        extra_path_registrar.register(common_section)
     except AssetMetadataLoadError as ex:
         raise RecipeError(
             "`common.assets.extra_path` cannot be registered as an asset card path. See the nested exception for details."
@@ -49,7 +51,7 @@ def register_extra_asset_paths(context: RuntimeContext, recipe_config: object) -
     )
 
     try:
-        checkpoint_dir_registrar.register(recipe_config)
+        checkpoint_dir_registrar.register(common_section)
     except AssetMetadataLoadError as ex:
         raise RecipeError(
             "`common.assets.checkpoint_dir` cannot be registered as an asset card path. See the nested exception for details."
@@ -72,9 +74,7 @@ class ExtraPathRegistrar:
         self._file_system = file_system
         self._asset_metadata_file_loader = asset_metadata_file_loader
 
-    def register(self, recipe_config: object) -> None:
-        common_section = get_config_section(recipe_config, "common", CommonSection)
-
+    def register(self, common_section: CommonSection) -> None:
         extra_path = common_section.assets.extra_path
         if extra_path is None:
             return
@@ -116,9 +116,7 @@ class CheckpointDirectoryRegistrar:
         self._file_system = file_system
         self._asset_metadata_file_loader = asset_metadata_file_loader
 
-    def register(self, recipe_config: object) -> None:
-        common_section = get_config_section(recipe_config, "common", CommonSection)
-
+    def register(self, common_section: CommonSection) -> None:
         checkpoint_dir = common_section.assets.checkpoint_dir
         if checkpoint_dir is None:
             return

--- a/src/fairseq2/recipes/common/_dataset.py
+++ b/src/fairseq2/recipes/common/_dataset.py
@@ -30,20 +30,22 @@ from fairseq2.gang import GangError, Gangs
 from fairseq2.logging import log
 from fairseq2.recipes import RecipeError
 from fairseq2.recipes.common._error import DatasetPathNotFoundError
-from fairseq2.recipes.config import DatasetSection, get_config_section
+from fairseq2.recipes.config import DatasetSection
 from fairseq2.registry import Provider
 
 DatasetT = TypeVar("DatasetT")
 
 
 def load_dataset(
-    kls: type[DatasetT], context: RuntimeContext, recipe_config: object, gangs: Gangs
+    kls: type[DatasetT],
+    context: RuntimeContext,
+    dataset_section: DatasetSection,
+    gangs: Gangs,
 ) -> DatasetT:
     dataset_handlers = context.get_registry(DatasetHandler)
 
     dataset_loader: DatasetLoader
 
-    dataset_section = get_config_section(recipe_config, "dataset", DatasetSection)
     if dataset_section.path is not None:
         dataset_loader = PathBasedDatasetLoader(kls, dataset_handlers)
     elif dataset_section.name is not None:
@@ -56,7 +58,7 @@ def load_dataset(
         )
 
     try:
-        dataset = dataset_loader.load(recipe_config, gangs)
+        dataset = dataset_loader.load(dataset_section, gangs)
     except DatasetLoadError as ex:
         raise RecipeError(
             f"The '{ex.dataset_name}' dataset cannot be loaded. See the nested exception for details."
@@ -67,7 +69,7 @@ def load_dataset(
 
 class DatasetLoader(ABC):
     @abstractmethod
-    def load(self, recipe_config: object, gangs: Gangs) -> object: ...
+    def load(self, dataset_section: DatasetSection, gangs: Gangs) -> object: ...
 
 
 @final
@@ -87,12 +89,10 @@ class CardBasedDatasetLoader(DatasetLoader):
         self._dataset_handlers = dataset_handlers
 
     @override
-    def load(self, recipe_config: object, gangs: Gangs) -> object:
-        dataset_section = get_config_section(recipe_config, "dataset", DatasetSection)
-
+    def load(self, dataset_section: DatasetSection, gangs: Gangs) -> object:
         dataset_name = dataset_section.name
         if dataset_name is None:
-            raise ValueError("`recipe_config.dataset.name` must be specified.")
+            raise ValueError("`dataset_section.name` must be specified.")
 
         try:
             card = self._asset_store.retrieve_card(dataset_name)
@@ -144,14 +144,12 @@ class PathBasedDatasetLoader(DatasetLoader):
         self._dataset_handlers = dataset_handlers
 
     @override
-    def load(self, recipe_config: object, gangs: Gangs) -> object:
-        dataset_section = get_config_section(recipe_config, "dataset", DatasetSection)
-
+    def load(self, dataset_section: DatasetSection, gangs: Gangs) -> object:
         dataset_family = dataset_section.family
 
         data_path = dataset_section.path
         if data_path is None:
-            raise ValueError("`recipe.dataset.path` must be specified.")
+            raise ValueError("`dataset_section.path` must be specified.")
 
         dataset_name = "custom"
 

--- a/src/fairseq2/recipes/common/_dataset.py
+++ b/src/fairseq2/recipes/common/_dataset.py
@@ -151,7 +151,7 @@ class PathBasedDatasetLoader(DatasetLoader):
         if data_path is None:
             raise ValueError("`dataset_section.path` must be specified.")
 
-        dataset_name = "custom"
+        dataset_name = "recipe"
 
         try:
             handler = self._dataset_handlers.get(dataset_family)
@@ -161,7 +161,7 @@ class PathBasedDatasetLoader(DatasetLoader):
         if not issubclass(handler.kls, self._kls):
             raise InvalidDatasetTypeError(dataset_name, handler.kls, self._kls)
 
-        log.info("Loading the dataset.")
+        log.info("Loading the '{}' dataset.", dataset_name)
 
         try:
             dataset = handler.load_from_path(data_path, dataset_name)

--- a/src/fairseq2/recipes/common/_evaluator.py
+++ b/src/fairseq2/recipes/common/_evaluator.py
@@ -18,27 +18,26 @@ from fairseq2.recipes import Evaluator, EvalUnit
 from fairseq2.recipes.common._device import create_device_stat_tracker
 from fairseq2.recipes.common._metrics import create_metric_recorder
 from fairseq2.recipes.common._profilers import create_profiler
-from fairseq2.recipes.config import EvaluatorSection, get_config_section
+from fairseq2.recipes.config import CommonSection, EvaluatorSection
 
 BatchT = TypeVar("BatchT", bound=SupportsDeviceTransfer)
 
 
 def create_evaluator(
     context: RuntimeContext,
-    recipe_config: object,
+    evaluator_section: EvaluatorSection,
+    common_section: CommonSection,
     output_dir: Path,
     units: Sequence[EvalUnit[BatchT]],
     data_readers: Sequence[DataReader[BatchT]],
     gangs: Gangs,
     seed: int,
 ) -> Evaluator[BatchT]:
-    metric_recorder = create_metric_recorder(context, recipe_config, gangs, output_dir)
+    metric_recorder = create_metric_recorder(context, common_section, gangs, output_dir)
 
-    profiler = create_profiler(context, recipe_config, gangs, output_dir)
+    profiler = create_profiler(context, common_section, gangs, output_dir)
 
     device_stat_tracker = create_device_stat_tracker(gangs)
-
-    evaluator_section = get_config_section(recipe_config, "evaluator", EvaluatorSection)
 
     return Evaluator[BatchT](
         units=units,

--- a/src/fairseq2/recipes/common/_gang.py
+++ b/src/fairseq2/recipes/common/_gang.py
@@ -24,14 +24,14 @@ from fairseq2.recipes.config import (
     GangSection,
     TrainerSection,
 )
-from fairseq2.recipes.utils.log import log_environment_info, log_gangs
+from fairseq2.recipes.utils.log import log_environment_info, log_ranks
 from fairseq2.utils.env import InvalidEnvironmentVariableError, get_local_world_size
 
 
-def setup_gangs(context: RuntimeContext, gang_section: GangSection) -> Gangs:
+def setup_inference_gangs(context: RuntimeContext, gang_section: GangSection) -> Gangs:
     gangs = _do_setup_gangs(context, gang_section)
 
-    log_gangs(log, gangs)
+    log_ranks(log, gangs)
 
     return gangs
 
@@ -48,7 +48,7 @@ def setup_training_gangs(
             "The hybrid sharded data parallel gangs cannot set up. See the nested exception for details."
         ) from ex
 
-    log_gangs(log, gangs)
+    log_ranks(log, gangs)
 
     return gangs
 

--- a/src/fairseq2/recipes/common/_gang.py
+++ b/src/fairseq2/recipes/common/_gang.py
@@ -28,7 +28,7 @@ from fairseq2.recipes.utils.log import log_environment_info, log_ranks
 from fairseq2.utils.env import InvalidEnvironmentVariableError, get_local_world_size
 
 
-def setup_inference_gangs(context: RuntimeContext, gang_section: GangSection) -> Gangs:
+def setup_gangs(context: RuntimeContext, gang_section: GangSection) -> Gangs:
     gangs = _do_setup_gangs(context, gang_section)
 
     log_ranks(log, gangs)

--- a/src/fairseq2/recipes/common/_gang.py
+++ b/src/fairseq2/recipes/common/_gang.py
@@ -21,16 +21,39 @@ from fairseq2.logging import log
 from fairseq2.recipes import RecipeError
 from fairseq2.recipes.common import HybridShardingNotSupportedError
 from fairseq2.recipes.config import (
-    ConfigSectionNotFoundError,
     GangSection,
     TrainerSection,
-    get_config_section,
 )
-from fairseq2.recipes.utils.log import log_environment_info
+from fairseq2.recipes.utils.log import log_environment_info, log_gangs
 from fairseq2.utils.env import InvalidEnvironmentVariableError, get_local_world_size
 
 
-def setup_gangs(context: RuntimeContext, recipe_config: object) -> Gangs:
+def setup_gangs(context: RuntimeContext, gang_section: GangSection) -> Gangs:
+    gangs = _do_setup_gangs(context, gang_section)
+
+    log_gangs(log, gangs)
+
+    return gangs
+
+
+def setup_training_gangs(
+    context: RuntimeContext, gang_section: GangSection, trainer_section: TrainerSection
+) -> Gangs:
+    gangs = _do_setup_gangs(context, gang_section)
+
+    try:
+        gangs = _maybe_setup_fsdp_gangs(context, trainer_section, gangs)
+    except GangError as ex:
+        raise RecipeError(
+            "The hybrid sharded data parallel gangs cannot set up. See the nested exception for details."
+        ) from ex
+
+    log_gangs(log, gangs)
+
+    return gangs
+
+
+def _do_setup_gangs(context: RuntimeContext, gang_section: GangSection) -> Gangs:
     try:
         device = determine_default_device(context)
     except DeviceDetectionError as ex:
@@ -43,8 +66,6 @@ def setup_gangs(context: RuntimeContext, recipe_config: object) -> Gangs:
     log_environment_info(log, device)
 
     log.info("Initializing the root gang.")
-
-    gang_section = get_config_section(recipe_config, "gang", GangSection)
 
     timeout = timedelta(minutes=gang_section.timeout)
 
@@ -85,33 +106,12 @@ def setup_gangs(context: RuntimeContext, recipe_config: object) -> Gangs:
 
     log.info("Parallel gangs initialized.")
 
-    try:
-        gangs = _maybe_setup_fsdp_gangs(context, recipe_config, gangs)
-    except GangError as ex:
-        raise RecipeError(
-            "The hybrid sharded data parallel gangs cannot set up. See the nested exception for details."
-        ) from ex
-
-    s = (
-        f"Data: {gangs.dp.rank} | "
-        f"Data/Replicated: {gangs.rdp.rank} | "
-        f"Data/Sharded: {gangs.sdp.rank} | "
-        f"Tensor: {gangs.tp.rank}"
-    )
-
-    log.info("Process Ranks - {}", s)
-
     return gangs
 
 
 def _maybe_setup_fsdp_gangs(
-    context: RuntimeContext, recipe_config: object, gangs: Gangs
+    context: RuntimeContext, trainer_section: TrainerSection, gangs: Gangs
 ) -> Gangs:
-    try:
-        trainer_section = get_config_section(recipe_config, "trainer", TrainerSection)
-    except ConfigSectionNotFoundError:
-        return gangs
-
     if trainer_section.data_parallelism != "fsdp":
         return gangs
 

--- a/src/fairseq2/recipes/common/_generator.py
+++ b/src/fairseq2/recipes/common/_generator.py
@@ -17,27 +17,26 @@ from fairseq2.recipes import Generator, GeneratorUnit
 from fairseq2.recipes.common._device import create_device_stat_tracker
 from fairseq2.recipes.common._metrics import create_metric_recorder
 from fairseq2.recipes.common._profilers import create_profiler
-from fairseq2.recipes.config import GeneratorSection, get_config_section
+from fairseq2.recipes.config import CommonSection, GeneratorSection
 
 BatchT = TypeVar("BatchT", bound=SupportsDeviceTransfer)
 
 
 def create_generator(
     context: RuntimeContext,
-    recipe_config: object,
+    generator_section: GeneratorSection,
+    common_section: CommonSection,
     output_dir: Path,
     unit: GeneratorUnit[BatchT],
     data_reader: DataReader[BatchT],
     gangs: Gangs,
     seed: int,
 ) -> Generator[BatchT]:
-    metric_recorder = create_metric_recorder(context, recipe_config, gangs, output_dir)
+    metric_recorder = create_metric_recorder(context, common_section, gangs, output_dir)
 
-    profiler = create_profiler(context, recipe_config, gangs, output_dir)
+    profiler = create_profiler(context, common_section, gangs, output_dir)
 
     device_stat_tracker = create_device_stat_tracker(gangs)
-
-    generator_section = get_config_section(recipe_config, "generator", GeneratorSection)
 
     return Generator[BatchT](
         unit=unit,

--- a/src/fairseq2/recipes/common/_metrics.py
+++ b/src/fairseq2/recipes/common/_metrics.py
@@ -17,19 +17,22 @@ from fairseq2.metrics.recorders import (
     MetricRecorderHandler,
     UnknownMetricRecorderError,
 )
-from fairseq2.recipes.config import CommonSection, get_config_section
+from fairseq2.recipes.config import CommonSection
 from fairseq2.registry import Provider
 from fairseq2.utils.structured import StructureError
 
 
 def create_metric_recorder(
-    context: RuntimeContext, recipe_config: object, gangs: Gangs, output_dir: Path
+    context: RuntimeContext,
+    common_section: CommonSection,
+    gangs: Gangs,
+    output_dir: Path,
 ) -> MetricRecorder:
     recorder_handlers = context.get_registry(MetricRecorderHandler)
 
     creator = MetricRecorderCreator(recorder_handlers)
 
-    return creator.create(recipe_config, gangs, output_dir)
+    return creator.create(common_section, gangs, output_dir)
 
 
 @final
@@ -42,10 +45,8 @@ class MetricRecorderCreator:
         self._metric_recorder_handlers = metric_recorder_handlers
 
     def create(
-        self, recipe_config: object, gangs: Gangs, output_dir: Path
+        self, common_section: CommonSection, gangs: Gangs, output_dir: Path
     ) -> MetricRecorder:
-        common_section = get_config_section(recipe_config, "common", CommonSection)
-
         recorders = []
 
         for recorder_name, recorder_config in common_section.metric_recorders.items():

--- a/src/fairseq2/recipes/common/_model.py
+++ b/src/fairseq2/recipes/common/_model.py
@@ -31,12 +31,6 @@ from fairseq2.checkpoint import (
 )
 from fairseq2.config_registry import ConfigNotFoundError
 from fairseq2.context import RuntimeContext
-from fairseq2.data.text.tokenizers import (
-    TextTokenizerLoadError,
-    UnknownTextTokenizerError,
-    resolve_text_tokenizer_reference,
-    text_tokenizer_asset_card_error,
-)
 from fairseq2.error import ContractError, NotSupportedError
 from fairseq2.gang import GangError, Gangs
 from fairseq2.logging import log
@@ -61,13 +55,7 @@ from fairseq2.recipes.common._error import (
     ModelParallelismNotSupportedError,
     ModelPathNotFoundError,
 )
-from fairseq2.recipes.config import (
-    ConfigSectionNotFoundError,
-    ModelSection,
-    TextTokenizerSection,
-    TrainerSection,
-    get_config_section,
-)
+from fairseq2.recipes.config import ModelSection, TrainerSection
 from fairseq2.recipes.utils.log import log_config, log_model
 from fairseq2.registry import Provider
 from fairseq2.typing import ContextManager, DataClass, is_dataclass_instance
@@ -79,20 +67,27 @@ from fairseq2.utils.yaml import StandardYamlDumper
 def setup_model(
     kls: type[Module],
     context: RuntimeContext,
-    recipe_config: object,
+    model_section: ModelSection,
+    trainer_section: TrainerSection,
     output_dir: Path,
     gangs: Gangs,
     checkpoint_manager: CheckpointManager,
     static_graph: bool = True,
 ) -> Model:
     model = load_base_model(
-        kls, context, recipe_config, output_dir, gangs, checkpoint_manager
+        kls,
+        context,
+        model_section,
+        trainer_section,
+        output_dir,
+        gangs,
+        checkpoint_manager,
     )
 
-    model = prepare_model(context, recipe_config, model, gangs)
+    model = prepare_model(context, trainer_section, model, gangs)
 
     model = setup_data_parallel_model(
-        context, recipe_config, model, gangs, static_graph
+        context, trainer_section, model, gangs, static_graph
     )
 
     log_model(log, model.module, gangs)
@@ -103,7 +98,8 @@ def setup_model(
 def load_base_model(
     kls: type[Module],
     context: RuntimeContext,
-    recipe_config: object,
+    model_section: ModelSection,
+    trainer_section: TrainerSection,
     output_dir: Path,
     gangs: Gangs,
     checkpoint_manager: CheckpointManager,
@@ -124,7 +120,6 @@ def load_base_model(
 
     model_loader: ModelLoader
 
-    model_section = get_config_section(recipe_config, "model", ModelSection)
     if model_section.checkpoint is not None:
         model_loader = PathBasedModelLoader(
             kls, model_handlers, model_card_saver, checkpoint_manager
@@ -143,7 +138,7 @@ def load_base_model(
         )
 
     try:
-        return model_loader.load(recipe_config, gangs)
+        return model_loader.load(model_section, trainer_section, gangs)
     except ShardedModelLoadError:
         raise
     except ModelLoadError as ex:
@@ -158,7 +153,9 @@ def load_base_model(
 
 class ModelLoader(ABC):
     @abstractmethod
-    def load(self, recipe_config: object, gangs: Gangs) -> Model: ...
+    def load(
+        self, model_section: ModelSection, trainer_section: TrainerSection, gangs: Gangs
+    ) -> Model: ...
 
 
 @final
@@ -184,9 +181,9 @@ class CardBasedModelLoader(ModelLoader):
         self._checkpoint_manager = checkpoint_manager
 
     @override
-    def load(self, recipe_config: object, gangs: Gangs) -> Model:
-        model_section = get_config_section(recipe_config, "model", ModelSection)
-
+    def load(
+        self, model_section: ModelSection, trainer_section: TrainerSection, gangs: Gangs
+    ) -> Model:
         model_name = model_section.name
         if model_name is None:
             raise ValueError("`recipe_config.model.name` must be specified.")
@@ -229,7 +226,6 @@ class CardBasedModelLoader(ModelLoader):
         log_config(log, "Model Config", model_config)
 
         # Load the model.
-        trainer_section = get_config_section(recipe_config, "trainer", TrainerSection)
         if trainer_section.mixed_precision == "off":
             dtype = trainer_section.dtype
         else:
@@ -289,7 +285,7 @@ class CardBasedModelLoader(ModelLoader):
 
         model = LocalModel(model_name, module, model_config, handler)
 
-        self._card_saver.save(recipe_config, model)
+        self._card_saver.save(model)
 
         return model
 
@@ -314,9 +310,9 @@ class PathBasedModelLoader(ModelLoader):
         self._checkpoint_manager = checkpoint_manager
 
     @override
-    def load(self, recipe_config: object, gangs: Gangs) -> Model:
-        model_section = get_config_section(recipe_config, "model", ModelSection)
-
+    def load(
+        self, model_section: ModelSection, trainer_section: TrainerSection, gangs: Gangs
+    ) -> Model:
         model_family = model_section.family
         if model_family is None:
             raise ValueError("`recipe_config.model.family` must be specified.")
@@ -327,7 +323,7 @@ class PathBasedModelLoader(ModelLoader):
 
         model_path = self._format_as_sharded_path(model_path, gangs)
 
-        model_name = "recipe"
+        model_name = "custom"
 
         try:
             handler = self._model_handlers.get(model_family)
@@ -358,7 +354,6 @@ class PathBasedModelLoader(ModelLoader):
         log_config(log, "Model Config", model_config)
 
         # Load the model.
-        trainer_section = get_config_section(recipe_config, "trainer", TrainerSection)
         if trainer_section.mixed_precision == "off":
             dtype = trainer_section.dtype
         else:
@@ -423,7 +418,7 @@ class PathBasedModelLoader(ModelLoader):
 
         model = LocalModel(model_name, module, model_config, handler)
 
-        self._card_saver.save(recipe_config, model)
+        self._card_saver.save(model)
 
         return model
 
@@ -459,14 +454,14 @@ class ModelCreator(ModelLoader):
         self._checkpoint_manager = checkpoint_manager
 
     @override
-    def load(self, recipe_config: object, gangs: Gangs) -> Model:
-        model_section = get_config_section(recipe_config, "model", ModelSection)
-
+    def load(
+        self, model_section: ModelSection, trainer_section: TrainerSection, gangs: Gangs
+    ) -> Model:
         model_family = model_section.family
         if model_family is None:
             raise ValueError("`recipe_config.model.family` must be specified.")
 
-        model_name = "recipe"
+        model_name = "custom"
 
         try:
             handler = self._model_handlers.get(model_family)
@@ -497,7 +492,6 @@ class ModelCreator(ModelLoader):
         log_config(log, "Model Config", model_config)
 
         # Create the model.
-        trainer_section = get_config_section(recipe_config, "trainer", TrainerSection)
         if trainer_section.mixed_precision == "off":
             dtype = trainer_section.dtype
         else:
@@ -562,7 +556,7 @@ class ModelCreator(ModelLoader):
             is_empty_initialized=step_nr is None,
         )
 
-        self._card_saver.save(recipe_config, model)
+        self._card_saver.save(model)
 
         return model
 
@@ -666,7 +660,7 @@ class LocalModel(Model):
 
 class ModelCardSaver(ABC):
     @abstractmethod
-    def save(self, recipe_config: object, mode: Model) -> None: ...
+    def save(self, mode: Model) -> None: ...
 
 
 @final
@@ -683,58 +677,13 @@ class StandardModelCardSaver(ModelCardSaver):
         self._checkpoint_metadata_saver = checkpoint_metadata_saver
 
     @override
-    def save(self, recipe_config: object, model: Model) -> None:
-        try:
-            tokenizer_name = self._get_text_tokenizer_name(recipe_config)
-        except TextTokenizerLoadError as ex:
-            raise AssetMetadataSaveError(
-                "The asset card of the model text tokenizer cannot be loaded. See the nested exception for details."
-            ) from ex
-
-        self._checkpoint_metadata_saver.save(
-            model.handler.family, model.config, tokenizer_name
-        )
-
-    def _get_text_tokenizer_name(self, recipe_config: object) -> str | None:
-        try:
-            tokenizer_section = get_config_section(
-                recipe_config, "text_tokenizer", TextTokenizerSection
-            )
-        except ConfigSectionNotFoundError:
-            tokenizer_section = None
-
-        if tokenizer_section is None:
-            model_section = get_config_section(recipe_config, "model", ModelSection)
-
-            tokenizer_name = model_section.name
-            if tokenizer_name is None:
-                return None
-        else:
-            tokenizer_name = tokenizer_section.name
-
-        try:
-            card = self._asset_store.retrieve_card(tokenizer_name)
-        except AssetCardNotFoundError:
-            if tokenizer_section is not None:
-                raise UnknownTextTokenizerError(tokenizer_name) from None
-
-            return None
-        except AssetCardError as ex:
-            raise text_tokenizer_asset_card_error(tokenizer_name) from ex
-
-        try:
-            card = resolve_text_tokenizer_reference(self._asset_store, card)
-        except AssetCardError as ex:
-            raise text_tokenizer_asset_card_error(tokenizer_name) from ex
-
-        return card.name
+    def save(self, model: Model) -> None:
+        self._checkpoint_metadata_saver.save(model.handler.family, model.config)
 
 
 def prepare_model(
-    context: RuntimeContext, recipe_config: object, model: Model, gangs: Gangs
+    context: RuntimeContext, trainer_section: TrainerSection, model: Model, gangs: Gangs
 ) -> Model:
-    trainer_section = get_config_section(recipe_config, "trainer", TrainerSection)
-
     if trainer_section.activation_checkpointing:
         use_layerwise_activation_checkpointing(model.module)
 
@@ -745,7 +694,5 @@ def prepare_model(
         log.info("Compiling '{}' model.", model.name)
 
         model.handler.compile(model.module, model.config)
-
-        log.info("Model compiled.")
 
     return model

--- a/src/fairseq2/recipes/common/_model.py
+++ b/src/fairseq2/recipes/common/_model.py
@@ -323,7 +323,7 @@ class PathBasedModelLoader(ModelLoader):
 
         model_path = self._format_as_sharded_path(model_path, gangs)
 
-        model_name = "custom"
+        model_name = "recipe"
 
         try:
             handler = self._model_handlers.get(model_family)
@@ -461,7 +461,7 @@ class ModelCreator(ModelLoader):
         if model_family is None:
             raise ValueError("`recipe_config.model.family` must be specified.")
 
-        model_name = "custom"
+        model_name = "recipe"
 
         try:
             handler = self._model_handlers.get(model_family)

--- a/src/fairseq2/recipes/common/_profilers.py
+++ b/src/fairseq2/recipes/common/_profilers.py
@@ -17,19 +17,22 @@ from fairseq2.profilers import (
     ProfilerHandler,
     UnknownProfilerError,
 )
-from fairseq2.recipes.config import CommonSection, get_config_section
+from fairseq2.recipes.config import CommonSection
 from fairseq2.registry import Provider
 from fairseq2.utils.structured import StructureError
 
 
 def create_profiler(
-    context: RuntimeContext, recipe_config: object, gangs: Gangs, output_dir: Path
+    context: RuntimeContext,
+    common_section: CommonSection,
+    gangs: Gangs,
+    output_dir: Path,
 ) -> Profiler:
     profiler_handlers = context.get_registry(ProfilerHandler)
 
     creator = ProfilerCreator(profiler_handlers)
 
-    return creator.create(recipe_config, gangs, output_dir)
+    return creator.create(common_section, gangs, output_dir)
 
 
 @final
@@ -39,9 +42,9 @@ class ProfilerCreator:
     def __init__(self, profiler_handlers: Provider[ProfilerHandler]) -> None:
         self._profiler_handlers = profiler_handlers
 
-    def create(self, recipe_config: object, gangs: Gangs, output_dir: Path) -> Profiler:
-        common_section = get_config_section(recipe_config, "common", CommonSection)
-
+    def create(
+        self, common_section: CommonSection, gangs: Gangs, output_dir: Path
+    ) -> Profiler:
         profilers = []
 
         for profiler_name, profiler_config in common_section.profilers.items():

--- a/src/fairseq2/recipes/common/_text_tokenizer.py
+++ b/src/fairseq2/recipes/common/_text_tokenizer.py
@@ -26,25 +26,19 @@ from fairseq2.data.text.tokenizers import (
 )
 from fairseq2.logging import log
 from fairseq2.recipes import RecipeError
-from fairseq2.recipes.config import (
-    ConfigSectionNotFoundError,
-    ModelSection,
-    ReferenceModelSection,
-    TextTokenizerSection,
-    get_config_section,
-)
+from fairseq2.recipes.config import TextTokenizerSection
 from fairseq2.registry import Provider
 
 
 def load_text_tokenizer(
-    context: RuntimeContext, recipe_config: object
+    context: RuntimeContext, tokenizer_section: TextTokenizerSection
 ) -> TextTokenizer:
     tokenizer_handlers = context.get_registry(TextTokenizerHandler)
 
     loader = TextTokenizerLoader(context.asset_store, tokenizer_handlers)
 
     try:
-        return loader.load(recipe_config)
+        return loader.load(tokenizer_section)
     except TextTokenizerLoadError as ex:
         raise RecipeError(
             f"The '{ex.tokenizer_name}' tokenizer cannot be loaded. See the nested exception for details."
@@ -64,36 +58,8 @@ class TextTokenizerLoader:
         self._asset_store = asset_store
         self._tokenizer_handlers = tokenizer_handlers
 
-    def load(self, recipe_config: object) -> TextTokenizer:
-        tokenizer_name: str | None
-
-        try:
-            tokenizer_section = get_config_section(
-                recipe_config, "text_tokenizer", TextTokenizerSection
-            )
-        except ConfigSectionNotFoundError:
-            tokenizer_section = None
-
-        if tokenizer_section is not None:
-            tokenizer_name = tokenizer_section.name
-        else:
-            try:
-                eval_model_section = get_config_section(
-                    recipe_config, "model", ReferenceModelSection
-                )
-            except TypeError:
-                eval_model_section = None
-
-            if eval_model_section is not None:
-                tokenizer_name = eval_model_section.name
-            else:
-                model_section = get_config_section(recipe_config, "model", ModelSection)
-
-                tokenizer_name = model_section.name
-                if tokenizer_name is None:
-                    raise ValueError(
-                        "`config.text_tokenizer.name` or `config.model.name` must be specified."
-                    )
+    def load(self, tokenizer_section: TextTokenizerSection) -> TextTokenizer:
+        tokenizer_name = tokenizer_section.name
 
         try:
             card = self._asset_store.retrieve_card(tokenizer_name)

--- a/src/fairseq2/recipes/common/_text_tokenizer.py
+++ b/src/fairseq2/recipes/common/_text_tokenizer.py
@@ -27,6 +27,7 @@ from fairseq2.data.text.tokenizers import (
 from fairseq2.logging import log
 from fairseq2.recipes import RecipeError
 from fairseq2.recipes.config import TextTokenizerSection
+from fairseq2.recipes.utils.log import log_tokenizer
 from fairseq2.registry import Provider
 
 
@@ -92,5 +93,7 @@ class TextTokenizerLoader:
         tokenizer = handler.load(card)
 
         log.info("Tokenizer loaded.")
+
+        log_tokenizer(log, tokenizer)
 
         return tokenizer

--- a/src/fairseq2/recipes/common/_torch.py
+++ b/src/fairseq2/recipes/common/_torch.py
@@ -13,16 +13,16 @@ import torch
 from fairseq2.context import RuntimeContext
 from fairseq2.logging import log
 from fairseq2.recipes import RecipeError
-from fairseq2.recipes.config import CommonSection, get_config_section
+from fairseq2.recipes.config import CommonSection
 from fairseq2.utils.env import get_rank
 from fairseq2.utils.threading import ThreadingError, get_num_threads
 
 
 def setup_torch(
-    context: RuntimeContext, recipe_config: object, output_dir: Path | None = None
+    context: RuntimeContext,
+    common_section: CommonSection,
+    output_dir: Path | None,
 ) -> None:
-    common_section = get_config_section(recipe_config, "common", CommonSection)
-
     _set_environment_variables(context, output_dir)
 
     _set_num_threads(context, common_section.num_threads)

--- a/src/fairseq2/recipes/common/_trainer.py
+++ b/src/fairseq2/recipes/common/_trainer.py
@@ -31,7 +31,7 @@ from fairseq2.recipes import (
 from fairseq2.recipes.common._device import create_device_stat_tracker
 from fairseq2.recipes.common._metrics import create_metric_recorder
 from fairseq2.recipes.common._profilers import create_profiler
-from fairseq2.recipes.config import RegimeSection, TrainerSection, get_config_section
+from fairseq2.recipes.config import CommonSection, RegimeSection, TrainerSection
 from fairseq2.utils.gc import (
     CPythonGarbageCollector,
     GarbageCollector,
@@ -43,7 +43,9 @@ BatchT = TypeVar("BatchT", bound=SupportsDeviceTransfer)
 
 def create_trainer(
     context: RuntimeContext,
-    recipe_config: object,
+    trainer_section: TrainerSection,
+    regime_section: RegimeSection,
+    common_section: CommonSection,
     output_dir: Path,
     unit: TrainUnit[BatchT],
     data_reader: DataReader[BatchT],
@@ -59,23 +61,19 @@ def create_trainer(
 ) -> Trainer[BatchT]:
     score_metric_descriptor = get_score_metric_descriptor(context, score_metric)
 
-    metric_recorder = create_metric_recorder(context, recipe_config, gangs, output_dir)
+    metric_recorder = create_metric_recorder(context, common_section, gangs, output_dir)
 
-    profiler = create_profiler(context, recipe_config, gangs, output_dir)
+    profiler = create_profiler(context, common_section, gangs, output_dir)
 
-    garbage_collector = create_garbage_collector(context, recipe_config)
+    garbage_collector = create_garbage_collector(context, trainer_section)
 
     device_stat_tracker = create_device_stat_tracker(gangs)
-
-    trainer_section = get_config_section(recipe_config, "trainer", TrainerSection)
 
     # TODO: Fix once we support static mixed precision on single device.
     if trainer_section.mixed_precision == "static":
         amp = gangs.root.size == 1 or trainer_section.data_parallelism != "fsdp"
     else:
         amp = trainer_section.mixed_precision == "dynamic"
-
-    regime_section = get_config_section(recipe_config, "regime", RegimeSection)
 
     if gangs.root.device.type == "cpu":
         log.warning("Based on your environment setup the training will be run on CPU. If this was not intended, check your job options (e.g. pass `--gpus-per-node` on Slurm).")  # fmt: skip
@@ -161,10 +159,8 @@ def get_score_metric_descriptor(
 
 
 def create_garbage_collector(
-    context: RuntimeContext, recipe_config: object
+    context: RuntimeContext, trainer_section: TrainerSection
 ) -> GarbageCollector:
-    trainer_section = get_config_section(recipe_config, "trainer", TrainerSection)
-
     if trainer_section.gc_every_n_steps is None:
         return NoopGarbageCollector()
 

--- a/src/fairseq2/recipes/config.py
+++ b/src/fairseq2/recipes/config.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Literal, TypeAlias, TypeVar
+from typing import Literal, TypeAlias
 
 import torch
 
@@ -438,33 +438,3 @@ class Seq2SeqGeneratorSection:
     config: object = field(default_factory=BeamSearchConfig)
 
     batch_size: int = 1
-
-
-ConfigSectionT = TypeVar("ConfigSectionT")
-
-
-def get_config_section(
-    config: object, name: str, kls: type[ConfigSectionT]
-) -> ConfigSectionT:
-    try:
-        section = getattr(config, name)
-    except AttributeError:
-        raise ConfigSectionNotFoundError(name) from None
-
-    if not isinstance(section, kls):
-        raise TypeError(
-            f"The '{name}' configuration section must be of type `{kls}`, but is of type `{type(section)}` instead."
-        )
-
-    return section
-
-
-class ConfigSectionNotFoundError(Exception):
-    section: str
-
-    def __init__(self, section: str) -> None:
-        super().__init__(
-            f"The recipe configuration does not have a section named '{section}'."
-        )
-
-        self.section = section

--- a/src/fairseq2/recipes/lm/__init__.py
+++ b/src/fairseq2/recipes/lm/__init__.py
@@ -38,10 +38,16 @@ from fairseq2.recipes.lm._loss_eval import (
     register_lm_loss_eval_configs as register_lm_loss_eval_configs,
 )
 from fairseq2.recipes.lm._preference_finetune._common import (
+    POFinetuneMetricBag as POFinetuneMetricBag,
+)
+from fairseq2.recipes.lm._preference_finetune._config import (
     POCriterionSection as POCriterionSection,
 )
-from fairseq2.recipes.lm._preference_finetune._common import (
-    POFinetuneMetricBag as POFinetuneMetricBag,
+from fairseq2.recipes.lm._preference_finetune._config import (
+    POFinetuneConfig as POFinetuneConfig,
+)
+from fairseq2.recipes.lm._preference_finetune._config import (
+    POFinetuneDatasetSection as POFinetuneDatasetSection,
 )
 from fairseq2.recipes.lm._preference_finetune._cpo import (
     CPO_FINETUNE_UNIT as CPO_FINETUNE_UNIT,
@@ -93,12 +99,6 @@ from fairseq2.recipes.lm._preference_finetune._orpo import (
 )
 from fairseq2.recipes.lm._preference_finetune._orpo import (
     OrpoFinetuneUnitHandler as OrpoFinetuneUnitHandler,
-)
-from fairseq2.recipes.lm._preference_finetune._recipe import (
-    POFinetuneConfig as POFinetuneConfig,
-)
-from fairseq2.recipes.lm._preference_finetune._recipe import (
-    POFinetuneDatasetSection as POFinetuneDatasetSection,
 )
 from fairseq2.recipes.lm._preference_finetune._recipe import (
     load_po_finetuner as load_po_finetuner,

--- a/src/fairseq2/recipes/lm/_instruction_finetune.py
+++ b/src/fairseq2/recipes/lm/_instruction_finetune.py
@@ -41,9 +41,9 @@ from fairseq2.recipes.common import (
     load_dataset,
     load_text_tokenizer,
     register_extra_asset_paths,
-    setup_gangs,
     setup_model,
     setup_torch,
+    setup_training_gangs,
 )
 from fairseq2.recipes.config import (
     CommonSection,
@@ -54,6 +54,7 @@ from fairseq2.recipes.config import (
     ModelSection,
     OptimizerSection,
     RegimeSection,
+    TextTokenizerSection,
     TrainerSection,
 )
 from fairseq2.typing import CPU
@@ -70,6 +71,10 @@ class InstructionFinetuneConfig:
 
     dataset: InstructionFinetuneDatasetSection = field(
         default_factory=lambda: InstructionFinetuneDatasetSection()
+    )
+
+    tokenizer: TextTokenizerSection = field(
+        default_factory=lambda: TextTokenizerSection(name="llama3_instruct")
     )
 
     gang: GangSection = field(default_factory=lambda: GangSection())
@@ -207,11 +212,11 @@ def load_instruction_finetuner(
 
     validate(config)
 
-    register_extra_asset_paths(context, config)
+    register_extra_asset_paths(context, config.common)
 
-    setup_torch(context, config, output_dir)
+    setup_torch(context, config.common, output_dir)
 
-    gangs = setup_gangs(context, config)
+    gangs = setup_training_gangs(context, config.gang, config.trainer)
 
     checkpoint_manager = create_checkpoint_manager(context, gangs, output_dir)
 
@@ -222,21 +227,29 @@ def load_instruction_finetuner(
     seed += 1
 
     model = setup_model(
-        DecoderModel, context, config, output_dir, gangs, checkpoint_manager
+        DecoderModel,
+        context,
+        config.model,
+        config.trainer,
+        output_dir,
+        gangs,
+        checkpoint_manager,
     )
+
+    dataset = load_dataset(InstructionDataset, context, config.dataset, gangs)
+
+    tokenizer = load_text_tokenizer(context, config.tokenizer)
 
     # TODO(balioglu): investigate!
     # The memory efficient SDPA implementation in PyTorch is not stable when
     # used with padded inputs.
     enable_memory_efficient_torch_sdpa(model.module, False)
 
-    optimizer = create_optimizer(context, config, model)
+    optimizer = create_optimizer(context, config.optimizer, model)
 
-    lr_scheduler = create_lr_scheduler(context, config, optimizer)
-
-    dataset = load_dataset(InstructionDataset, context, config, gangs)
-
-    tokenizer = load_text_tokenizer(context, config)
+    lr_scheduler = create_lr_scheduler(
+        context, config.lr_scheduler, config.regime, optimizer
+    )
 
     # Initialize the unit.
     criterion = InstructionFinetuneCriterion(model)
@@ -314,7 +327,9 @@ def load_instruction_finetuner(
 
     return create_trainer(
         context,
-        config,
+        config.trainer,
+        config.regime,
+        config.common,
         output_dir,
         unit,
         data_reader,

--- a/src/fairseq2/recipes/lm/_loss_eval.py
+++ b/src/fairseq2/recipes/lm/_loss_eval.py
@@ -26,7 +26,7 @@ from fairseq2.recipes.common import (
     load_dataset,
     load_text_tokenizer,
     register_extra_asset_paths,
-    setup_inference_gangs,
+    setup_gangs,
     setup_reference_model,
     setup_torch,
 )
@@ -119,7 +119,7 @@ def load_lm_loss_evaluator(
 
     setup_torch(context, config.common, output_dir)
 
-    gangs = setup_inference_gangs(context, config.gang)
+    gangs = setup_gangs(context, config.gang)
 
     seed = config.common.seed
 

--- a/src/fairseq2/recipes/lm/_loss_eval.py
+++ b/src/fairseq2/recipes/lm/_loss_eval.py
@@ -36,6 +36,7 @@ from fairseq2.recipes.config import (
     EvaluatorSection,
     GangSection,
     ReferenceModelSection,
+    TextTokenizerSection,
 )
 from fairseq2.recipes.lm._instruction_finetune import (
     InstructionFinetuneCriterion,
@@ -55,6 +56,10 @@ class LMLossEvalConfig:
 
     dataset: LMLossEvalDatasetSection = field(
         default_factory=lambda: LMLossEvalDatasetSection()
+    )
+
+    tokenizer: TextTokenizerSection = field(
+        default_factory=lambda: TextTokenizerSection(name="llama3_instruct")
     )
 
     gang: GangSection = field(default_factory=lambda: GangSection())
@@ -110,11 +115,11 @@ def load_lm_loss_evaluator(
 
     validate(config)
 
-    register_extra_asset_paths(context, config)
+    register_extra_asset_paths(context, config.common)
 
-    setup_torch(context, config, output_dir)
+    setup_torch(context, config.common, output_dir)
 
-    gangs = setup_gangs(context, config)
+    gangs = setup_gangs(context, config.gang)
 
     seed = config.common.seed
 
@@ -125,16 +130,16 @@ def load_lm_loss_evaluator(
     model = setup_reference_model(
         DecoderModel,
         context,
-        config.model.name,
+        config.model,
         gangs,
         config.evaluator.dtype,
         config.evaluator.amp,
         config.evaluator.torch_compile,
     )
 
-    dataset = load_dataset(InstructionDataset, context, config, gangs)
+    dataset = load_dataset(InstructionDataset, context, config.dataset, gangs)
 
-    tokenizer = load_text_tokenizer(context, config)
+    tokenizer = load_text_tokenizer(context, config.tokenizer)
 
     # Initialize the unit.
     criterion = InstructionFinetuneCriterion(model)
@@ -163,5 +168,12 @@ def load_lm_loss_evaluator(
     seed += 1
 
     return create_evaluator(
-        context, config, output_dir, [unit], [data_reader], gangs, seed
+        context,
+        config.evaluator,
+        config.common,
+        output_dir,
+        [unit],
+        [data_reader],
+        gangs,
+        seed,
     )

--- a/src/fairseq2/recipes/lm/_loss_eval.py
+++ b/src/fairseq2/recipes/lm/_loss_eval.py
@@ -26,7 +26,7 @@ from fairseq2.recipes.common import (
     load_dataset,
     load_text_tokenizer,
     register_extra_asset_paths,
-    setup_gangs,
+    setup_inference_gangs,
     setup_reference_model,
     setup_torch,
 )
@@ -119,7 +119,7 @@ def load_lm_loss_evaluator(
 
     setup_torch(context, config.common, output_dir)
 
-    gangs = setup_gangs(context, config.gang)
+    gangs = setup_inference_gangs(context, config.gang)
 
     seed = config.common.seed
 

--- a/src/fairseq2/recipes/lm/_preference_finetune/_common.py
+++ b/src/fairseq2/recipes/lm/_preference_finetune/_common.py
@@ -6,8 +6,6 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-
 import torch
 from torch import Tensor
 from torcheval.metrics import Mean
@@ -38,13 +36,6 @@ def _gather_lprobs_avg(
     average_logps = total_logps / target.target_mask.sum(-1)
 
     return total_logps, average_logps
-
-
-@dataclass(kw_only=True)
-class POCriterionSection:
-    name: str
-
-    config: object
 
 
 class POFinetuneMetricBag(SequenceMetricBag):

--- a/src/fairseq2/recipes/lm/_preference_finetune/_config.py
+++ b/src/fairseq2/recipes/lm/_preference_finetune/_config.py
@@ -1,0 +1,136 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import torch
+import torch.distributed
+
+from fairseq2.datasets.preference import (
+    GENERIC_PREFERENCE_DATASET_FAMILY,
+)
+from fairseq2.optim import ADAMW_OPTIMIZER, AdamWConfig
+from fairseq2.optim.lr_scheduler import COSINE_ANNEALING_LR, CosineAnnealingLRConfig
+from fairseq2.recipes.config import (
+    CommonSection,
+    DatasetSection,
+    FsdpSection,
+    GangSection,
+    LRSchedulerSection,
+    ModelSection,
+    OptimizerSection,
+    RegimeSection,
+    TextTokenizerSection,
+    TrainerSection,
+)
+
+
+@dataclass(kw_only=True)
+class POFinetuneConfig:
+    model: ModelSection = field(
+        default_factory=lambda: ModelSection(name="llama3_1_8b_instruct")
+    )
+
+    dataset: POFinetuneDatasetSection = field(
+        default_factory=lambda: POFinetuneDatasetSection()
+    )
+
+    tokenizer: TextTokenizerSection = field(
+        default_factory=lambda: TextTokenizerSection(name="llama3_instruct")
+    )
+
+    gang: GangSection = field(default_factory=lambda: GangSection())
+
+    trainer: TrainerSection = field(
+        default_factory=lambda: TrainerSection(
+            dtype=torch.bfloat16,
+            data_parallelism="fsdp",
+            fsdp=FsdpSection(fp32_reduce=True),
+            activation_checkpointing=True,
+        )
+    )
+
+    criterion: POCriterionSection
+
+    optimizer: OptimizerSection = field(
+        default_factory=lambda: OptimizerSection(
+            name=ADAMW_OPTIMIZER,
+            config=AdamWConfig(
+                lr=5.5e-06, betas=(0.9, 0.95), weight_decay=0.1, impl="fused"
+            ),
+        )
+    )
+
+    lr_scheduler: LRSchedulerSection = field(
+        default_factory=lambda: LRSchedulerSection(
+            name=COSINE_ANNEALING_LR, config=CosineAnnealingLRConfig(final_lr_scale=0.2)
+        )
+    )
+
+    regime: RegimeSection = field(
+        default_factory=lambda: RegimeSection(
+            num_steps=5_000,
+            checkpoint_every_n_steps=1_000,
+            keep_last_n_checkpoints=1,
+            publish_metrics_every_n_steps=10,
+        )
+    )
+
+    common: CommonSection = field(default_factory=lambda: CommonSection())
+
+
+@dataclass(kw_only=True)
+class POFinetuneDatasetSection(DatasetSection):
+    name: str = "gsm8k_dpo"
+
+    family: str = GENERIC_PREFERENCE_DATASET_FAMILY
+
+    path: Path | None = None
+
+    source_encode_mode: str = "prompt"
+    """The encode mode for the prompt, determines what special tokens to add."""
+
+    target_encode_mode: str = "prompt_response"
+    """The encode mode for the target, determines what special tokens to add."""
+
+    mask_source_tokens: bool = True
+    """If ``False``, calculates loss on the `src` tokens as well as the `tgt` tokens."""
+
+    min_seq_len: int = 1
+    """The minimum sum of ``src + tgt_chosen`` and ``src + tgt_rejected``.
+    Shorter sequences will be dropped."""
+
+    max_seq_len: int = 8192
+    """The maximum sum of ``src + tgt_chosen`` and ``src + tgt_rejected``.
+    Longer sequences will be dropped."""
+
+    max_num_tokens: int = 8192 * 2
+    """The maximum number of total `src`, `tgt_chosen`, and `tgt_rejected` tokens per batch."""
+
+    batch_size: int | None = None
+    """If not ``None``, ignores `max_num_tokens` and each batch will have `batch_size` examples."""
+
+    example_shuffle_window: int = 10_000
+    """The size of the sliding window for shuffling examples."""
+
+    batch_shuffle_window: int = 1_000
+    """The size of the sliding window for shuffling batches."""
+
+    num_prefetch: int = 4
+    """The number of batches to prefetch in background."""
+
+    extras: dict[str, object] = field(default_factory=dict)
+    """The dataset-specific extra options."""
+
+
+@dataclass(kw_only=True)
+class POCriterionSection:
+    name: str
+
+    config: object

--- a/src/fairseq2/recipes/lm/_preference_finetune/_cpo.py
+++ b/src/fairseq2/recipes/lm/_preference_finetune/_cpo.py
@@ -19,12 +19,11 @@ from fairseq2.gang import Gang, Gangs
 from fairseq2.metrics import Mean
 from fairseq2.models.sequence import SequenceModelOutput, as_auto_regressive_input
 from fairseq2.recipes import Model, TrainUnit
-from fairseq2.recipes.config import get_config_section
 from fairseq2.recipes.lm._preference_finetune._common import (
-    POCriterionSection,
     POFinetuneMetricBag,
     _gather_lprobs,
 )
+from fairseq2.recipes.lm._preference_finetune._config import POFinetuneConfig
 from fairseq2.recipes.lm._preference_finetune._handler import POFinetuneUnitHandler
 from fairseq2.utils.structured import structure
 from fairseq2.utils.validation import validate
@@ -158,13 +157,9 @@ class CpoFinetuneConfig:
 class CpoFinetuneUnitHandler(POFinetuneUnitHandler):
     @override
     def create(
-        self, model: Model, gangs: Gangs, recipe_config: object
+        self, model: Model, gangs: Gangs, recipe_config: POFinetuneConfig
     ) -> TrainUnit[PreferenceBatch]:
-        criterion_section = get_config_section(
-            recipe_config, "criterion", POCriterionSection
-        )
-
-        config = structure(criterion_section.config, CpoFinetuneConfig)
+        config = structure(recipe_config.criterion.config, CpoFinetuneConfig)
 
         validate(config)
 

--- a/src/fairseq2/recipes/lm/_preference_finetune/_handler.py
+++ b/src/fairseq2/recipes/lm/_preference_finetune/_handler.py
@@ -11,12 +11,13 @@ from abc import ABC, abstractmethod
 from fairseq2.datasets.preference import PreferenceBatch
 from fairseq2.gang import Gangs
 from fairseq2.recipes import Model, TrainUnit
+from fairseq2.recipes.lm._preference_finetune._config import POFinetuneConfig
 
 
 class POFinetuneUnitHandler(ABC):
     @abstractmethod
     def create(
-        self, model: Model, gangs: Gangs, recipe_config: object
+        self, model: Model, gangs: Gangs, recipe_config: POFinetuneConfig
     ) -> TrainUnit[PreferenceBatch]: ...
 
     @property

--- a/src/fairseq2/recipes/lm/_preference_finetune/_orpo.py
+++ b/src/fairseq2/recipes/lm/_preference_finetune/_orpo.py
@@ -19,12 +19,11 @@ from fairseq2.gang import Gang, Gangs
 from fairseq2.metrics import Mean
 from fairseq2.models.sequence import SequenceModelOutput, as_auto_regressive_input
 from fairseq2.recipes import Model, TrainUnit
-from fairseq2.recipes.config import get_config_section
 from fairseq2.recipes.lm._preference_finetune._common import (
-    POCriterionSection,
     POFinetuneMetricBag,
     _gather_lprobs,
 )
+from fairseq2.recipes.lm._preference_finetune._config import POFinetuneConfig
 from fairseq2.recipes.lm._preference_finetune._handler import POFinetuneUnitHandler
 from fairseq2.utils.structured import structure
 from fairseq2.utils.validation import validate
@@ -161,13 +160,9 @@ class OrpoFinetuneConfig:
 class OrpoFinetuneUnitHandler(POFinetuneUnitHandler):
     @override
     def create(
-        self, model: Model, gangs: Gangs, recipe_config: object
+        self, model: Model, gangs: Gangs, recipe_config: POFinetuneConfig
     ) -> TrainUnit[PreferenceBatch]:
-        criterion_section = get_config_section(
-            recipe_config, "criterion", POCriterionSection
-        )
-
-        config = structure(criterion_section.config, OrpoFinetuneConfig)
+        config = structure(recipe_config.criterion.config, OrpoFinetuneConfig)
 
         validate(config)
 

--- a/src/fairseq2/recipes/lm/_preference_finetune/_recipe.py
+++ b/src/fairseq2/recipes/lm/_preference_finetune/_recipe.py
@@ -6,24 +6,19 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 from pathlib import Path
-
-import torch
-import torch.distributed
 
 from fairseq2.context import RuntimeContext
 from fairseq2.datasets import Batching, LengthBatching, StaticBatching
 from fairseq2.datasets.preference import (
-    GENERIC_PREFERENCE_DATASET_FAMILY,
     PreferenceBatch,
     PreferenceDataset,
     PreferenceReadOptions,
 )
 from fairseq2.models.decoder import DecoderModel
 from fairseq2.nn.transformer import enable_memory_efficient_torch_sdpa
-from fairseq2.optim import ADAMW_OPTIMIZER, AdamWConfig
-from fairseq2.optim.lr_scheduler import COSINE_ANNEALING_LR, CosineAnnealingLRConfig
+from fairseq2.optim import AdamWConfig
+from fairseq2.optim.lr_scheduler import CosineAnnealingLRConfig
 from fairseq2.recipes import Trainer
 from fairseq2.recipes.common import (
     create_checkpoint_manager,
@@ -33,22 +28,14 @@ from fairseq2.recipes.common import (
     load_dataset,
     load_text_tokenizer,
     register_extra_asset_paths,
-    setup_gangs,
     setup_model,
     setup_torch,
+    setup_training_gangs,
 )
-from fairseq2.recipes.config import (
-    CommonSection,
-    DatasetSection,
-    FsdpSection,
-    GangSection,
-    LRSchedulerSection,
-    ModelSection,
-    OptimizerSection,
-    RegimeSection,
-    TrainerSection,
+from fairseq2.recipes.lm._preference_finetune._config import (
+    POCriterionSection,
+    POFinetuneConfig,
 )
-from fairseq2.recipes.lm._preference_finetune._common import POCriterionSection
 from fairseq2.recipes.lm._preference_finetune._dpo import (
     DPO_FINETUNE_UNIT,
     DpoFinetuneConfig,
@@ -63,104 +50,6 @@ from fairseq2.utils.structured import structure
 from fairseq2.utils.validation import validate
 
 
-@dataclass(kw_only=True)
-class POFinetuneConfig:
-    model: ModelSection = field(
-        default_factory=lambda: ModelSection(name="llama3_1_8b_instruct")
-    )
-
-    dataset: POFinetuneDatasetSection = field(
-        default_factory=lambda: POFinetuneDatasetSection()
-    )
-
-    gang: GangSection = field(default_factory=lambda: GangSection())
-
-    trainer: TrainerSection = field(
-        default_factory=lambda: TrainerSection(
-            dtype=torch.bfloat16,
-            data_parallelism="fsdp",
-            fsdp=FsdpSection(fp32_reduce=True),
-            activation_checkpointing=True,
-        )
-    )
-
-    criterion: POCriterionSection = field(
-        default_factory=lambda: POCriterionSection(
-            name=DPO_FINETUNE_UNIT, config=DpoFinetuneConfig()
-        )
-    )
-
-    optimizer: OptimizerSection = field(
-        default_factory=lambda: OptimizerSection(
-            name=ADAMW_OPTIMIZER,
-            config=AdamWConfig(
-                lr=5.5e-06, betas=(0.9, 0.95), weight_decay=0.1, impl="fused"
-            ),
-        )
-    )
-
-    lr_scheduler: LRSchedulerSection = field(
-        default_factory=lambda: LRSchedulerSection(
-            name=COSINE_ANNEALING_LR, config=CosineAnnealingLRConfig(final_lr_scale=0.2)
-        )
-    )
-
-    regime: RegimeSection = field(
-        default_factory=lambda: RegimeSection(
-            num_steps=5_000,
-            checkpoint_every_n_steps=1_000,
-            keep_last_n_checkpoints=1,
-            publish_metrics_every_n_steps=10,
-        )
-    )
-
-    common: CommonSection = field(default_factory=lambda: CommonSection())
-
-
-@dataclass(kw_only=True)
-class POFinetuneDatasetSection(DatasetSection):
-    name: str = "gsm8k_dpo"
-
-    family: str = GENERIC_PREFERENCE_DATASET_FAMILY
-
-    path: Path | None = None
-
-    source_encode_mode: str = "prompt"
-    """The encode mode for the prompt, determines what special tokens to add."""
-
-    target_encode_mode: str = "prompt_response"
-    """The encode mode for the target, determines what special tokens to add."""
-
-    mask_source_tokens: bool = True
-    """If ``False``, calculates loss on the `src` tokens as well as the `tgt` tokens."""
-
-    min_seq_len: int = 1
-    """The minimum sum of ``src + tgt_chosen`` and ``src + tgt_rejected``.
-    Shorter sequences will be dropped."""
-
-    max_seq_len: int = 8192
-    """The maximum sum of ``src + tgt_chosen`` and ``src + tgt_rejected``.
-    Longer sequences will be dropped."""
-
-    max_num_tokens: int = 8192 * 2
-    """The maximum number of total `src`, `tgt_chosen`, and `tgt_rejected` tokens per batch."""
-
-    batch_size: int | None = None
-    """If not ``None``, ignores `max_num_tokens` and each batch will have `batch_size` examples."""
-
-    example_shuffle_window: int = 10_000
-    """The size of the sliding window for shuffling examples."""
-
-    batch_shuffle_window: int = 1_000
-    """The size of the sliding window for shuffling batches."""
-
-    num_prefetch: int = 4
-    """The number of batches to prefetch in background."""
-
-    extras: dict[str, object] = field(default_factory=dict)
-    """The dataset-specific extra options."""
-
-
 def register_po_finetune_configs(context: RuntimeContext) -> None:
     registry = context.get_config_registry(POFinetuneConfig)
 
@@ -168,7 +57,11 @@ def register_po_finetune_configs(context: RuntimeContext) -> None:
 
     @preset("llama3_1_instruct")
     def llama3_1_instruct() -> POFinetuneConfig:
-        return POFinetuneConfig()
+        return POFinetuneConfig(
+            criterion=POCriterionSection(
+                name=DPO_FINETUNE_UNIT, config=DpoFinetuneConfig()
+            )
+        )
 
     @preset("llama3_1_instruct_constant_lr")
     def llama3_1_instruct_constant_lr() -> POFinetuneConfig:
@@ -213,11 +106,11 @@ def load_po_finetuner(
 
     validate(config)
 
-    register_extra_asset_paths(context, config)
+    register_extra_asset_paths(context, config.common)
 
-    setup_torch(context, config, output_dir)
+    setup_torch(context, config.common, output_dir)
 
-    gangs = setup_gangs(context, config)
+    gangs = setup_training_gangs(context, config.gang, config.trainer)
 
     checkpoint_manager = create_checkpoint_manager(context, gangs, output_dir)
 
@@ -228,7 +121,13 @@ def load_po_finetuner(
     seed += 1
 
     model = setup_model(
-        DecoderModel, context, config, output_dir, gangs, checkpoint_manager
+        DecoderModel,
+        context,
+        config.model,
+        config.trainer,
+        output_dir,
+        gangs,
+        checkpoint_manager,
     )
 
     # TODO(balioglu): investigate!
@@ -236,13 +135,15 @@ def load_po_finetuner(
     # used with padded inputs.
     enable_memory_efficient_torch_sdpa(model.module, False)
 
-    optimizer = create_optimizer(context, config, model)
+    optimizer = create_optimizer(context, config.optimizer, model)
 
-    lr_scheduler = create_lr_scheduler(context, config, optimizer)
+    lr_scheduler = create_lr_scheduler(
+        context, config.lr_scheduler, config.regime, optimizer
+    )
 
-    dataset = load_dataset(PreferenceDataset, context, config, gangs)
+    dataset = load_dataset(PreferenceDataset, context, config.dataset, gangs)
 
-    tokenizer = load_text_tokenizer(context, config)
+    tokenizer = load_text_tokenizer(context, config.tokenizer)
 
     # Initialize the train unit.
     unit_handlers = context.get_registry(POFinetuneUnitHandler)
@@ -286,7 +187,9 @@ def load_po_finetuner(
 
     return create_trainer(
         context,
-        config,
+        config.trainer,
+        config.regime,
+        config.common,
         output_dir,
         unit,
         data_reader,

--- a/src/fairseq2/recipes/lm/_preference_finetune/_simpo.py
+++ b/src/fairseq2/recipes/lm/_preference_finetune/_simpo.py
@@ -19,12 +19,11 @@ from fairseq2.gang import Gang, Gangs
 from fairseq2.metrics import Mean
 from fairseq2.models.sequence import SequenceModelOutput, as_auto_regressive_input
 from fairseq2.recipes import Model, TrainUnit
-from fairseq2.recipes.config import get_config_section
 from fairseq2.recipes.lm._preference_finetune._common import (
-    POCriterionSection,
     POFinetuneMetricBag,
     _gather_lprobs_avg,
 )
+from fairseq2.recipes.lm._preference_finetune._config import POFinetuneConfig
 from fairseq2.recipes.lm._preference_finetune._handler import POFinetuneUnitHandler
 from fairseq2.utils.structured import structure
 from fairseq2.utils.validation import validate
@@ -168,13 +167,9 @@ class SimPOFinetuneConfig:
 class SimPOFinetuneUnitHandler(POFinetuneUnitHandler):
     @override
     def create(
-        self, model: Model, gangs: Gangs, recipe_config: object
+        self, model: Model, gangs: Gangs, recipe_config: POFinetuneConfig
     ) -> TrainUnit[PreferenceBatch]:
-        criterion_section = get_config_section(
-            recipe_config, "criterion", POCriterionSection
-        )
-
-        config = structure(criterion_section.config, SimPOFinetuneConfig)
+        config = structure(recipe_config.criterion.config, SimPOFinetuneConfig)
 
         validate(config)
 

--- a/src/fairseq2/recipes/lm/_text_generate.py
+++ b/src/fairseq2/recipes/lm/_text_generate.py
@@ -52,6 +52,7 @@ from fairseq2.recipes.config import (
     GeneratorSection,
     ReferenceModelSection,
     SequenceGeneratorSection,
+    TextTokenizerSection,
 )
 from fairseq2.typing import CPU
 from fairseq2.utils.file import FileMode
@@ -68,6 +69,10 @@ class TextGenerateConfig:
 
     dataset: TextGenerateDatasetSection = field(
         default_factory=lambda: TextGenerateDatasetSection()
+    )
+
+    tokenizer: TextTokenizerSection = field(
+        default_factory=lambda: TextTokenizerSection(name="llama3_instruct")
     )
 
     gang: GangSection = field(default_factory=lambda: GangSection())
@@ -151,11 +156,11 @@ def load_text_generator(
 
     validate(config)
 
-    register_extra_asset_paths(context, config)
+    register_extra_asset_paths(context, config.common)
 
-    setup_torch(context, config, output_dir)
+    setup_torch(context, config.common, output_dir)
 
-    gangs = setup_gangs(context, config)
+    gangs = setup_gangs(context, config.gang)
 
     seed = config.common.seed
 
@@ -166,19 +171,21 @@ def load_text_generator(
     model = setup_reference_model(
         DecoderModel,
         context,
-        config.model.name,
+        config.model,
         gangs,
         config.generator.dtype,
         config.generator.amp,
         config.generator.torch_compile,
     )
 
-    dataset = load_dataset(InstructionDataset, context, config, gangs)
+    dataset = load_dataset(InstructionDataset, context, config.dataset, gangs)
 
-    tokenizer = load_text_tokenizer(context, config)
+    tokenizer = load_text_tokenizer(context, config.tokenizer)
 
     # Initialize the unit.
-    seq_generator = create_seq_generator(context, config, model)
+    seq_generator = create_seq_generator(
+        context, config.seq_generator, model, tokenizer.vocab_info
+    )
 
     if gangs.tp.rank == 0:
         file_system = context.file_system
@@ -247,7 +254,16 @@ def load_text_generator(
 
     seed += 1
 
-    return create_generator(context, config, output_dir, unit, data_reader, gangs, seed)
+    return create_generator(
+        context,
+        config.generator,
+        config.common,
+        output_dir,
+        unit,
+        data_reader,
+        gangs,
+        seed,
+    )
 
 
 @final

--- a/src/fairseq2/recipes/lm/_text_generate.py
+++ b/src/fairseq2/recipes/lm/_text_generate.py
@@ -41,7 +41,7 @@ from fairseq2.recipes.common import (
     load_dataset,
     load_text_tokenizer,
     register_extra_asset_paths,
-    setup_gangs,
+    setup_inference_gangs,
     setup_reference_model,
     setup_torch,
 )
@@ -160,7 +160,7 @@ def load_text_generator(
 
     setup_torch(context, config.common, output_dir)
 
-    gangs = setup_gangs(context, config.gang)
+    gangs = setup_inference_gangs(context, config.gang)
 
     seed = config.common.seed
 

--- a/src/fairseq2/recipes/lm/_text_generate.py
+++ b/src/fairseq2/recipes/lm/_text_generate.py
@@ -41,7 +41,7 @@ from fairseq2.recipes.common import (
     load_dataset,
     load_text_tokenizer,
     register_extra_asset_paths,
-    setup_inference_gangs,
+    setup_gangs,
     setup_reference_model,
     setup_torch,
 )
@@ -160,7 +160,7 @@ def load_text_generator(
 
     setup_torch(context, config.common, output_dir)
 
-    gangs = setup_inference_gangs(context, config.gang)
+    gangs = setup_gangs(context, config.gang)
 
     seed = config.common.seed
 

--- a/src/fairseq2/recipes/mt/_eval.py
+++ b/src/fairseq2/recipes/mt/_eval.py
@@ -43,7 +43,7 @@ from fairseq2.recipes.common import (
     load_dataset,
     load_text_tokenizer,
     register_extra_asset_paths,
-    setup_gangs,
+    setup_inference_gangs,
     setup_reference_model,
     setup_torch,
 )
@@ -148,7 +148,7 @@ def load_mt_evaluator(
 
     setup_torch(context, config.common, output_dir)
 
-    gangs = setup_gangs(context, config.gang)
+    gangs = setup_inference_gangs(context, config.gang)
 
     seed = config.common.seed
 

--- a/src/fairseq2/recipes/mt/_translate.py
+++ b/src/fairseq2/recipes/mt/_translate.py
@@ -40,7 +40,7 @@ from fairseq2.recipes.common import (
     load_dataset,
     load_text_tokenizer,
     register_extra_asset_paths,
-    setup_gangs,
+    setup_inference_gangs,
     setup_reference_model,
     setup_torch,
 )
@@ -141,7 +141,7 @@ def load_text_translator(
 
     setup_torch(context, config.common, output_dir)
 
-    gangs = setup_gangs(context, config.gang)
+    gangs = setup_inference_gangs(context, config.gang)
 
     seed = config.common.seed
 

--- a/src/fairseq2/recipes/utils/log.py
+++ b/src/fairseq2/recipes/utils/log.py
@@ -17,6 +17,7 @@ from rich.pretty import pretty_repr
 from torch.nn import Module
 
 import fairseq2
+from fairseq2.data.text.tokenizers import TextTokenizer
 from fairseq2.gang import Gangs
 from fairseq2.logging import LogWriter
 from fairseq2.metrics import format_as_byte_size
@@ -229,4 +230,23 @@ def log_model(log: LogWriter, model: Module, gangs: Gangs) -> None:
         f"Total Size (bytes): {format_as_byte_size(si.total_size_bytes)}"
     )
 
-    log.info("Model (rank {}) - {} | Layout:\n{}", gangs.root.rank, s, model)
+    log.info("Model (rank {}) - {}\n{}", gangs.root.rank, s, model)
+
+
+def log_tokenizer(log: LogWriter, tokenizer: TextTokenizer) -> None:
+    if not log.is_enabled_for_info():
+        return
+
+    vi = tokenizer.vocab_info
+
+    s = (
+        f"Size: {vi.size:,} | "
+        f"UNK: {vi.unk_idx} | "
+        f"BOS: {vi.bos_idx} | "
+        f"EOS: {vi.eos_idx} | "
+        f"PAD: {vi.pad_idx} | "
+        f"BOH: {vi.boh_idx} | "
+        f"EOH: {vi.eoh_idx}"
+    )
+
+    log.info("Tokenizer - {}", s)

--- a/src/fairseq2/recipes/utils/log.py
+++ b/src/fairseq2/recipes/utils/log.py
@@ -200,7 +200,7 @@ def log_environment_variables(log: LogWriter) -> None:
     log.info("Environment Variables - {}", ", ".join(kv))
 
 
-def log_gangs(log: LogWriter, gangs: Gangs) -> None:
+def log_ranks(log: LogWriter, gangs: Gangs) -> None:
     s = (
         f"Data: {gangs.dp.rank} | "
         f"Data/Replicated: {gangs.rdp.rank} | "

--- a/src/fairseq2/recipes/utils/log.py
+++ b/src/fairseq2/recipes/utils/log.py
@@ -200,6 +200,17 @@ def log_environment_variables(log: LogWriter) -> None:
     log.info("Environment Variables - {}", ", ".join(kv))
 
 
+def log_gangs(log: LogWriter, gangs: Gangs) -> None:
+    s = (
+        f"Data: {gangs.dp.rank} | "
+        f"Data/Replicated: {gangs.rdp.rank} | "
+        f"Data/Sharded: {gangs.sdp.rank} | "
+        f"Tensor: {gangs.tp.rank}"
+    )
+
+    log.info("Process Ranks - {}", s)
+
+
 def log_model(log: LogWriter, model: Module, gangs: Gangs) -> None:
     """Log information about ``model``."""
     if not log.is_enabled_for_info():

--- a/src/fairseq2/recipes/wav2vec2/_eval.py
+++ b/src/fairseq2/recipes/wav2vec2/_eval.py
@@ -28,7 +28,7 @@ from fairseq2.recipes.common import (
     create_evaluator,
     load_dataset,
     register_extra_asset_paths,
-    setup_inference_gangs,
+    setup_gangs,
     setup_reference_model,
     setup_torch,
 )
@@ -122,7 +122,7 @@ def load_wav2vec2_evaluator(
 
     setup_torch(context, config.common, output_dir)
 
-    gangs = setup_inference_gangs(context, config.gang)
+    gangs = setup_gangs(context, config.gang)
 
     seed = config.common.seed
 

--- a/src/fairseq2/recipes/wav2vec2/_eval.py
+++ b/src/fairseq2/recipes/wav2vec2/_eval.py
@@ -28,7 +28,7 @@ from fairseq2.recipes.common import (
     create_evaluator,
     load_dataset,
     register_extra_asset_paths,
-    setup_gangs,
+    setup_inference_gangs,
     setup_reference_model,
     setup_torch,
 )
@@ -122,7 +122,7 @@ def load_wav2vec2_evaluator(
 
     setup_torch(context, config.common, output_dir)
 
-    gangs = setup_gangs(context, config.gang)
+    gangs = setup_inference_gangs(context, config.gang)
 
     seed = config.common.seed
 

--- a/src/fairseq2/recipes/wav2vec2/_eval.py
+++ b/src/fairseq2/recipes/wav2vec2/_eval.py
@@ -118,11 +118,11 @@ def load_wav2vec2_evaluator(
 
     validate(config)
 
-    register_extra_asset_paths(context, config)
+    register_extra_asset_paths(context, config.common)
 
-    setup_torch(context, config, output_dir)
+    setup_torch(context, config.common, output_dir)
 
-    gangs = setup_gangs(context, config)
+    gangs = setup_gangs(context, config.gang)
 
     seed = config.common.seed
 
@@ -133,14 +133,14 @@ def load_wav2vec2_evaluator(
     model = setup_reference_model(
         Wav2Vec2Model,
         context,
-        config.model.name,
+        config.model,
         gangs,
         config.evaluator.dtype,
         config.evaluator.amp,
         config.evaluator.torch_compile,
     )
 
-    dataset = load_dataset(SpeechDataset, context, config, gangs)
+    dataset = load_dataset(SpeechDataset, context, config.dataset, gangs)
 
     # Initialize the unut.
     criterion = Wav2Vec2Criterion(
@@ -172,7 +172,14 @@ def load_wav2vec2_evaluator(
     seed += 1
 
     return create_evaluator(
-        context, config, output_dir, [unit], [data_reader], gangs, seed
+        context,
+        config.evaluator,
+        config.common,
+        output_dir,
+        [unit],
+        [data_reader],
+        gangs,
+        seed,
     )
 
 

--- a/src/fairseq2/utils/file.py
+++ b/src/fairseq2/utils/file.py
@@ -120,7 +120,7 @@ class LocalFileSystem(FileSystem):
                     f"`mode` must be a valid `FileMode` value, but is `{mode}` instead."
                 )
 
-        fp = path.open(m)
+        fp = path.open(m, encoding="utf-8")
 
         return cast(TextIO, fp)
 

--- a/src/fairseq2/utils/merge.py
+++ b/src/fairseq2/utils/merge.py
@@ -153,30 +153,6 @@ def _do_merge_map(
         if k not in ignored_keys:
             output[k] = deepcopy(v)
 
-    add_keys = source.get("_add_")
-    if add_keys is not None:
-        if not isinstance(add_keys, Mapping):
-            pathname = build_pathname("_add_")
-
-            raise MergeError(
-                f"'{pathname}' at `source` must be of type `{Mapping}`, but is of type `{type(add_keys)}` instead."
-            )
-
-        for idx, (add_key, value) in enumerate(add_keys.items()):
-            if not isinstance(add_key, str):
-                pathname = build_pathname("_add_")
-
-                raise MergeError(
-                    f"Each key under '{pathname}' at `source` must be of type `str`, but the key at index {idx} is of type `{type(add_key)}` instead."
-                )
-
-            if add_key in output:
-                pathname = build_pathname(add_key)
-
-                raise MergeError(f"`target` already has an item at path '{pathname}'.")
-
-            output[add_key] = deepcopy(value)
-
     set_keys = source.get("_set_")
     if set_keys is not None:
         if not isinstance(set_keys, Mapping):
@@ -194,17 +170,10 @@ def _do_merge_map(
                     f"Each key under '{pathname}' at `source` must be of type `str`, but the key at index {idx} is of type `{type(set_key)}` instead."
                 )
 
-            if set_key not in output:
-                pathname = build_pathname(set_key)
-
-                raise MergeError(
-                    f"`target` does not have an item at path '{pathname}'."
-                )
-
             output[set_key] = deepcopy(value)
 
     for key, source_value in source.items():
-        if key == "_del_" or key == "_add_" or key == "_set_":
+        if key == "_del_" or key == "_set_":
             continue
 
         try:

--- a/tests/integration/generation/test_incremental_decode.py
+++ b/tests/integration/generation/test_incremental_decode.py
@@ -33,10 +33,6 @@ def test_incremental_decoding_works() -> None:
 
     tokenizer = tokenizer_hub.load(model_name)
 
-    pad_idx = tokenizer.vocab_info.pad_idx
-
-    assert pad_idx is not None
-
     # Set up encoder and decoder inputs.
     source_token_encoder = tokenizer.create_encoder(
         task="translation", lang="deu_Latn", mode="source", device=device
@@ -54,6 +50,10 @@ def test_incremental_decoding_works() -> None:
         target_token_encoder(EN_SENTENCE),
         target_token_encoder(EN_SENTENCE),
     ]
+
+    pad_idx = tokenizer.vocab_info.pad_idx
+
+    assert pad_idx is not None
 
     source_seqs, source_padding_mask = pad_seqs(source_indices, pad_idx)
     target_seqs, target_padding_mask = pad_seqs(target_indices, pad_idx)

--- a/tests/integration/generation/test_sampling.py
+++ b/tests/integration/generation/test_sampling.py
@@ -37,7 +37,7 @@ def test_greedy_sampling() -> None:
 
     sampler = TopKSampler(k=1)
 
-    generator = SamplingSeq2SeqGenerator(model, sampler)
+    generator = SamplingSeq2SeqGenerator(model, tokenizer.vocab_info, sampler)
 
     translator = TextTranslator(
         generator, tokenizer, source_lang="eng_Latn", target_lang="deu_Latn"

--- a/tests/integration/generation/test_step_processor.py
+++ b/tests/integration/generation/test_step_processor.py
@@ -85,7 +85,9 @@ class TestBannedSequenceProcessor:
         banned_seqs = [text_encoder(b) for b in banned_words]
 
         generator = BeamSearchSeq2SeqGenerator(
-            self.model, step_processors=[BannedSequenceProcessor(banned_seqs)]
+            self.model,
+            self.tokenizer.vocab_info,
+            step_processors=[BannedSequenceProcessor(banned_seqs)],
         )
 
         translator = TextTranslator(

--- a/tests/integration/models/test_llama_lora.py
+++ b/tests/integration/models/test_llama_lora.py
@@ -22,7 +22,6 @@ def test_lora_wrappers_llama_works() -> None:
     model_config = LLaMAConfig(
         model_dim=1024,
         max_seq_len=2048,
-        vocab_size=32_000,
         num_layers=16,
         num_attn_heads=8,
         num_key_value_heads=8,

--- a/tests/integration/models/test_llama_lora.py
+++ b/tests/integration/models/test_llama_lora.py
@@ -6,7 +6,6 @@
 
 import torch
 
-from fairseq2.data import VocabularyInfo
 from fairseq2.models.llama import LLaMAConfig, LLaMAFactory
 from fairseq2.models.llama.lora import get_llama_lora_config
 from fairseq2.nn.lora import (
@@ -23,9 +22,7 @@ def test_lora_wrappers_llama_works() -> None:
     model_config = LLaMAConfig(
         model_dim=1024,
         max_seq_len=2048,
-        vocab_info=VocabularyInfo(
-            size=32000, unk_idx=0, bos_idx=1, eos_idx=2, pad_idx=None
-        ),
+        vocab_size=32_000,
         num_layers=16,
         num_attn_heads=8,
         num_key_value_heads=8,

--- a/tests/integration/models/test_nllb.py
+++ b/tests/integration/models/test_nllb.py
@@ -34,7 +34,9 @@ def test_load_dense_distill_600m() -> None:
 
     tokenizer = tokenizer_hub.load(model_name)
 
-    generator = BeamSearchSeq2SeqGenerator(model, echo_prompt=True, max_seq_len=128)
+    generator = BeamSearchSeq2SeqGenerator(
+        model, tokenizer.vocab_info, echo_prompt=True, max_seq_len=128
+    )
 
     translator = TextTranslator(
         generator, tokenizer, source_lang="eng_Latn", target_lang="deu_Latn"

--- a/tests/integration/models/test_s2t_transformer.py
+++ b/tests/integration/models/test_s2t_transformer.py
@@ -72,7 +72,7 @@ def assert_translation(
 ) -> None:
     fbank = torch.load(TEST_FBANK_PATH, weights_only=True).to(device)
 
-    generator = BeamSearchSeq2SeqGenerator(model)
+    generator = BeamSearchSeq2SeqGenerator(model, tokenizer.vocab_info)
 
     converter = SequenceToTextConverter(
         generator, tokenizer, task="translation", target_lang="de"

--- a/tests/unit/utils/test_merge.py
+++ b/tests/unit/utils/test_merge.py
@@ -76,15 +76,13 @@ def test_merge_object_works() -> None:
 
     source = {
         "_del_": ["foo3"],
-        "_add_": {
-            "foo6": 1.0,
-        },
         "_set_": {
             "foo5": 2.0,
+            "foo6": 1.0,
         },
         "foo2": {
             "_del_": ["foo2_foo1"],
-            "_add_": {
+            "_set_": {
                 "foo2_foo4": "a",
             },
         },
@@ -162,18 +160,18 @@ def test_merge_map_raises_error_when_type_is_invalid() -> None:
         merge_map(target, source)
 
     target = {"foo1": {"foo2": {}}}
-    source = {"foo1": {"foo2": {"_add_": "foo"}}}
+    source = {"foo1": {"foo2": {"_set_": "foo"}}}
 
     with pytest.raises(
-        MergeError, match=rf"^'foo1\.foo2\._add_' at `source` must be of type `{Mapping}`, but is of type `{str}` instead\.$"  # fmt: skip
+        MergeError, match=rf"^'foo1\.foo2\._set_' at `source` must be of type `{Mapping}`, but is of type `{str}` instead\.$"  # fmt: skip
     ):
         merge_map(target, source)
 
     target = {"foo1": {"foo2": {}}}
-    source = {"foo1": {"foo2": {"_add_": {0: "foo"}}}}
+    source = {"foo1": {"foo2": {"_set_": {0: "foo"}}}}
 
     with pytest.raises(
-        MergeError, match=rf"^Each key under 'foo1\.foo2\._add_' at `source` must be of type `str`, but the key at index 0 is of type `{int}` instead\.$"  # fmt: skip
+        MergeError, match=rf"^Each key under 'foo1\.foo2\._set_' at `source` must be of type `str`, but the key at index 0 is of type `{int}` instead\.$"  # fmt: skip
     ):
         merge_map(target, source)
 


### PR DESCRIPTION
This PR bundles three features:

- Removes `vocab_info` from `SequenceModel` and `Seq2SeqModel` and relies on the passed tokenizer to infer the vocabulary information.
- Per user feedback, `fairseq2.recipes.common` functions now expect as argument specific configuration sections instead of the general recipe configuration for better readability and mypy compatibility.
- Removes the `_add_` directive for configuration handling and extends `_set_` to handle both adding and setting configuration keys. This also makes the logic consistent with `_set_` being the equivalent of `dict[key] = value` and `_del_` being the equivalent of `del dict[key]`.