### PR TITLE
adding parquet fragment distribution smoother via rejection

### DIFF
--- a/src/fairseq2/data/parquet/__init__.py
+++ b/src/fairseq2/data/parquet/__init__.py
@@ -24,6 +24,7 @@ from fairseq2.data.parquet.fragment_loading import (
 from fairseq2.data.parquet.fragment_streaming import (
     FragmentStreamingConfig,
     ParquetFragmentStreamer,
+    RejectionDistributionSmoother,
 )
 from fairseq2.data.parquet.fragment_streaming.primitives import (
     init_parquet_dataset,

--- a/src/fairseq2/data/parquet/arrow_transform.py
+++ b/src/fairseq2/data/parquet/arrow_transform.py
@@ -28,7 +28,7 @@ def _fix_list_offset(arr: pa.Array) -> pa.Array:
     """
     if not is_list_like(arr):
         return arr
-    if arr.offset == 0:
+    if arr.offset == 0 and arr.offsets[0].as_py() == 0:
         return arr
 
     new_values = _fix_list_offset(pc.list_flatten(arr))
@@ -298,7 +298,6 @@ def filter_list_with_min_max_length(
     min_length: int,
     max_length: int,
 ) -> pa.Table:
-
     def _length_filter(column):
         filter_min = pc.greater_equal(pc.list_value_length(table[column]), min_length)
         filter_max = pc.less_equal(pc.list_value_length(table[column]), max_length)

--- a/src/fairseq2/data/parquet/fragment_loading/builder.py
+++ b/src/fairseq2/data/parquet/fragment_loading/builder.py
@@ -138,7 +138,6 @@ class ParquetFragmentLoader:
             self.columns = None
 
     def apply(self, fragment_pipeline: DataPipelineBuilder) -> DataPipelineBuilder:
-
         def load_fn(fragment: pa.dataset.ParquetFileFragment) -> pa.Table | None:
             return SafeFragment(fragment).load(
                 columns=self.columns,

--- a/src/fairseq2/data/parquet/fragment_streaming/__init__.py
+++ b/src/fairseq2/data/parquet/fragment_streaming/__init__.py
@@ -13,3 +13,6 @@ from fairseq2.data.parquet.fragment_streaming.config import (
 from fairseq2.data.parquet.fragment_streaming.config import (
     ParquetDatasetLimitOptions as ParquetDatasetLimitOptions,
 )
+from fairseq2.data.parquet.fragment_streaming.primitives import (
+    RejectionDistributionSmoother as RejectionDistributionSmoother,
+)


### PR DESCRIPTION
**What does this PR do? Please describe:**
Adding Rejection sampling over parquet fragments.

List of all backwards-incompatible changes.
- just adding new feature, no BC

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
