### PR TITLE
qwen2.5 modeling support + conversion back to hf ckpt format

### DIFF
--- a/src/fairseq2/cli/_setup.py
+++ b/src/fairseq2/cli/_setup.py
@@ -14,6 +14,7 @@ from fairseq2.cli.commands.llama import (
     ConvertLLaMACheckpointHandler,
     WriteHFLLaMAConfigHandler,
 )
+from fairseq2.cli.commands.qwen import ConvertQwen25CheckpointHandler
 from fairseq2.cli.commands.recipe import RecipeCommandHandler
 from fairseq2.context import RuntimeContext
 from fairseq2.data.text.tokenizers import (
@@ -104,6 +105,7 @@ def setup_cli(context: RuntimeContext) -> Cli:
     _register_asset_cli(cli)
     _register_chatbot_cli(cli)
     _register_llama_cli(cli)
+    _register_qwen_cli(cli)
     _register_lm_cli(cli)
     _register_mt_cli(cli)
     _register_wav2vec2_asr_cli(cli)
@@ -179,6 +181,16 @@ def _register_llama_cli(cli: Cli) -> None:
         name="write_hf_config",
         handler=WriteHFLLaMAConfigHandler(),
         help="write fairseq2 LLaMA configurations in Hugging Face format",
+    )
+
+
+def _register_qwen_cli(cli: Cli) -> None:
+    group = cli.add_group("qwen25", help="LLaMA recipes")
+
+    group.add_command(
+        name="convert_fs2_to_hf_checkpoint",
+        handler=ConvertQwen25CheckpointHandler(),
+        help="convert fairseq2 Qwen2.5 checkpoints to HF checkpoints",
     )
 
 

--- a/src/fairseq2/cli/commands/qwen/__init__.py
+++ b/src/fairseq2/cli/commands/qwen/__init__.py
@@ -1,0 +1,11 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from fairseq2.cli.commands.qwen._convert_to_hf_checkpoint import (
+    ConvertQwen25CheckpointHandler as ConvertQwen25CheckpointHandler,
+)

--- a/src/fairseq2/cli/commands/qwen/_convert_to_hf_checkpoint.py
+++ b/src/fairseq2/cli/commands/qwen/_convert_to_hf_checkpoint.py
@@ -19,10 +19,10 @@ from fairseq2.assets import (
     AssetCardFieldNotFoundError,
     AssetCardNotFoundError,
 )
-from fairseq2.cli import CliArgumentError, CliCommandHandler
+from fairseq2.cli import CliArgumentError, CliCommandHandler, CliCommandError
 from fairseq2.cli.utils.rich import get_error_console
 from fairseq2.context import RuntimeContext
-from fairseq2.error import InternalError, ProgramError
+from fairseq2.error import InternalError
 from fairseq2.logging import log
 from fairseq2.models import ModelConfigLoadError, ModelHandler
 from fairseq2.models.qwen25 import (
@@ -74,8 +74,8 @@ class ConvertQwen25CheckpointHandler(CliCommandHandler):
 
         input_dir: Path = args.input_dir
 
-        def read_error() -> ProgramError:
-            return ProgramError(
+        def read_error() -> CliCommandError:
+            return CliCommandError(
                 f"The '{input_dir}' directory cannot be read. See the nested exception for details."
             )
 

--- a/src/fairseq2/cli/commands/qwen/_convert_to_hf_checkpoint.py
+++ b/src/fairseq2/cli/commands/qwen/_convert_to_hf_checkpoint.py
@@ -1,0 +1,236 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from argparse import ArgumentParser, Namespace
+from itertools import count
+from pathlib import Path
+from typing import final
+from safetensors.torch import save_file
+
+from typing_extensions import override
+
+from fairseq2.assets import (
+    AssetCardError,
+    AssetCardFieldNotFoundError,
+    AssetCardNotFoundError,
+)
+from fairseq2.cli import CliArgumentError, CliCommandHandler
+from fairseq2.cli.utils.rich import get_error_console
+from fairseq2.context import RuntimeContext
+from fairseq2.error import InternalError, ProgramError
+from fairseq2.logging import log
+from fairseq2.models import ModelConfigLoadError, ModelHandler
+from fairseq2.models.qwen25 import (
+    QWEN25_MODEL_FAMILY,
+    Qwen25Config,
+    convert_qwen_fs2_to_hf_checkpoint,
+)
+
+try:
+    from transformers.models.qwen2 import Qwen2ForCausalLM
+except ImportError:
+    raise RuntimeError(
+        "transformers library is required to convert Qwen model to HF checkpoint. Install it via `pip install transformers`."
+    )
+
+from fairseq2.utils.file import (
+    TensorLoadError,
+    TorchTensorLoader,
+)
+
+
+@final
+class ConvertQwen25CheckpointHandler(CliCommandHandler):
+    @override
+    def init_parser(self, parser: ArgumentParser) -> None:
+        parser.add_argument(
+            "model",
+            type=str,
+            help="model for which to generate params.json",
+        )
+
+        parser.add_argument(
+            "input_dir",
+            type=Path,
+            help="checkpoint directory",
+        )
+
+        parser.add_argument(
+            "output_dir",
+            type=Path,
+            help="output directory to store reference checkpoint",
+        )
+
+    @override
+    def run(
+        self, context: RuntimeContext, parser: ArgumentParser, args: Namespace
+    ) -> int:
+        file_system = context.file_system
+
+        input_dir: Path = args.input_dir
+
+        def read_error() -> ProgramError:
+            return ProgramError(
+                f"The '{input_dir}' directory cannot be read. See the nested exception for details."
+            )
+
+        try:
+            input_exists = file_system.is_dir(input_dir)
+        except OSError as ex:
+            raise read_error() from ex
+
+        if not input_exists:
+            raise CliArgumentError("input_dir", "must be a directory")
+
+        # Determine input checkpoint files.
+        input_file = input_dir.joinpath("model.pt")
+
+        try:
+            input_file_exists = file_system.exists(input_file)
+        except OSError as ex:
+            raise read_error() from ex
+
+        input_files = []
+
+        if input_file_exists:
+            input_files.append(input_file)
+        else:
+            raise NotImplementedError("TP>1 Qwen models not supported yet")
+            for shard_idx in count():
+                input_file = args.input_dir.joinpath(f"model.{shard_idx}.pt")
+
+                try:
+                    input_file_exists = file_system.exists(input_file)
+                except OSError as ex:
+                    raise read_error() from ex
+
+                if not input_file_exists:
+                    break
+
+                input_files.append(input_file)
+
+        if not input_files:
+            raise CliArgumentError(
+                "input_dir", "must contain a model checkpoint file (i.e. model.pt)"
+            )
+
+        output_dir: Path = args.output_dir
+
+        def write_error() -> ProgramError:
+            return ProgramError(
+                f"The '{output_dir}' directory cannot be created. See the nested exception for details."
+            )
+
+        try:
+            output_exists = file_system.exists(output_dir)
+        except OSError as ex:
+            raise write_error() from ex
+
+        if output_exists:
+            log.error("argument output_dir: already exists")
+
+            return 2
+
+        try:
+            file_system.make_directory(output_dir)
+        except OSError as ex:
+            raise write_error() from ex
+
+        # Load the model configuration.
+        try:
+            card = context.asset_store.retrieve_card(args.model)
+        except AssetCardNotFoundError:
+            raise CliArgumentError(
+                "model", f"'{args.model}' is not a known LLaMA model. Use `fairseq2 assets list` to see the available models."  # fmt: skip
+            ) from None
+        except AssetCardError as ex:
+            raise ProgramError(
+                f"The '{args.model}' asset card cannot be read. See the nested exception for details."
+            ) from ex
+
+        try:
+            family = card.field("model_family").as_(str)
+        except AssetCardFieldNotFoundError:
+            raise CliArgumentError(
+                "model", f"'{args.model}' is not a known LLaMA model. Use `fairseq2 assets list` to see the available models."  # fmt: skip
+            ) from None
+        except AssetCardError as ex:
+            raise ProgramError(
+                f"The '{args.model}' asset card cannot be read. See the nested exception for details."
+            ) from ex
+
+        if family != QWEN25_MODEL_FAMILY:
+            raise CliArgumentError(
+                "model", f"'{args.model}' is not a model of QWEN2.5 family."
+            )
+
+        model_handlers = context.get_registry(ModelHandler)
+
+        try:
+            model_handler = model_handlers.get(QWEN25_MODEL_FAMILY)
+        except LookupError:
+            raise InternalError(
+                "The LLaMA model handler cannot be found. Please file a bug report."
+            ) from None
+
+        try:
+            model_config = model_handler.load_config(card)
+        except ModelConfigLoadError as ex:
+            raise ProgramError(
+                f"The configuration of '{args.model}' cannot be loaded. See the nested exception for details."
+            ) from ex
+
+        if not isinstance(model_config, Qwen25Config):
+            raise InternalError(
+                "The model configuration type is not valid. Please file a bug report."
+            )
+
+        # Begin conversion.
+        console = get_error_console()
+
+        tensor_loader = TorchTensorLoader(file_system)
+
+        with console.status("[bold green]Converting...") as status:
+            for input_file in input_files:
+
+                def file_write_error() -> ProgramError:
+                    return ProgramError(
+                        f"The '{input_file}' checkpoint file cannot be converted. See the nested exception for details."
+                    )
+
+                status.update(f"[bold green]Loading {input_file.name}...")
+
+                try:
+                    checkpoint = tensor_loader.load(input_file)
+                except TensorLoadError as ex:
+                    raise file_write_error() from ex
+
+                status.update(f"[bold green]Converting {input_file.name} ...")  # fmt: skip
+
+                hf_config = model_config.to_hf_config()
+
+                try:
+                    ref_state_dict = convert_qwen_fs2_to_hf_checkpoint(
+                        checkpoint[checkpoint["model_key"]], model_config
+                    )
+                except (TypeError, KeyError) as ex:
+                    raise file_write_error() from ex
+
+                model = Qwen2ForCausalLM(hf_config)
+
+                model.load_state_dict(ref_state_dict)
+
+                model.save_pretrained(args.output_dir)
+                hf_config.save_pretrained(args.output_dir)
+
+                log.info("{} converted!", input_file.name)
+
+        if model_config is None:
+            return 0
+
+        return 0

--- a/src/fairseq2/data/text/tokenizers/huggingface_tokenizer.py
+++ b/src/fairseq2/data/text/tokenizers/huggingface_tokenizer.py
@@ -1,0 +1,144 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+from typing import final
+
+import torch
+from torch import Tensor
+from typing_extensions import override
+
+from fairseq2.data import VocabularyInfo
+from fairseq2.data.text.tokenizers import (
+    TextTokenDecoder,
+    TextTokenEncoder,
+)
+from fairseq2.typing import Device
+from transformers import AutoTokenizer
+
+
+@final
+class HuggingfaceTokenizerEncoder(TextTokenEncoder):
+    """Represents a tiktoken decoder."""
+
+    _tokenizer: AutoTokenizer
+    _prefix_indices: list[int]
+    _suffix_indices: list[int]
+    _prefix_index_tensor: Tensor | None
+    _suffix_index_tensor: Tensor | None
+    _device: Device | None
+    _pin_memory: bool
+
+    def __init__(
+        self,
+        tokenizer: AutoTokenizer,
+        *,
+        prefix_tokens: Sequence[str] | None = None,
+        suffix_tokens: Sequence[str] | None = None,
+        device: Device | None = None,
+        pin_memory: bool = False,
+    ) -> None:
+        """
+        :param tokenizer:
+            The huggingface :class:`AutoTokenizer` object.
+        :param prefix_tokens:
+            The prefix tokens to encode with input text.
+        :param suffix_tokens:
+            The suffix tokens to encode with input text.
+        :param device:
+            The device on which to construct tensors.
+        :param pin_memory:
+            If ``True``, uses pinned memory while constructing tensors.
+        """
+        self._tokenizer = tokenizer
+
+        # Prefix
+        if prefix_tokens:
+            self._prefix_indices = self._tokenizer.convert_tokens_to_ids(prefix_tokens)
+
+            self._prefix_index_tensor = torch.tensor(
+                self._prefix_indices, dtype=torch.int64, device=device
+            )
+        else:
+            self._prefix_indices = []
+
+            self._prefix_index_tensor = None
+
+        # Suffix
+        if suffix_tokens:
+            self._suffix_indices = self._tokenizer.convert_tokens_to_ids(suffix_tokens)
+
+            self._suffix_index_tensor = torch.tensor(
+                self._suffix_indices, dtype=torch.int64, device=device
+            )
+        else:
+            self._suffix_indices = []
+
+            self._suffix_index_tensor = None
+
+        self._device = device
+        self._pin_memory = pin_memory
+
+    @override
+    def __call__(self, text: str) -> Tensor:
+        # fairseq2 tokenizer adds special tokens on its own
+        indices = self._tokenizer.encode(text, add_special_tokens=False)
+
+        if self._prefix_indices:
+            indices = self._prefix_indices + indices
+
+        if self._suffix_indices:
+            indices.extend(self._suffix_indices)
+
+        return torch.tensor(
+            indices, dtype=torch.int64, device=self._device, pin_memory=self._pin_memory
+        )
+
+    @override
+    def encode_as_tokens(self, text: str) -> list[str]:
+        indices = self(text).tolist()
+
+        tokens = self._tokenizer.convert_tds_to_tokens(indices)
+
+        return tokens
+
+    @property
+    @override
+    def prefix_indices(self) -> Tensor | None:
+        return self._prefix_index_tensor
+
+    @property
+    @override
+    def suffix_indices(self) -> Tensor | None:
+        return self._suffix_index_tensor
+
+
+@final
+class HuggingfaceTokenizerDecoder(TextTokenDecoder):
+    """Represents a tiktoken decoder."""
+
+    _tokenizer: AutoTokenizer
+
+    def __init__(self, tokenizer: AutoTokenizer) -> None:
+        self._tokenizer = tokenizer
+
+    @override
+    def __call__(self, token_indices: Tensor) -> str:
+        if token_indices.dim() != 1:
+            raise ValueError(
+                f"`token_indices` must be one dimensional, but has {token_indices.dim()} dimensions instead."
+            )
+
+        return self._tokenizer.decode(token_indices)
+
+    @override
+    def decode_from_tokens(self, tokens: Sequence[str]) -> str:
+        indices = self._tokenizer.convert_tokens_to_ids(tokens)
+
+        return self._tokenizer.decode(indices)

--- a/src/fairseq2/data/text/tokenizers/huggingface_tokenizer.py
+++ b/src/fairseq2/data/text/tokenizers/huggingface_tokenizer.py
@@ -20,7 +20,13 @@ from fairseq2.data.text.tokenizers import (
     TextTokenEncoder,
 )
 from fairseq2.typing import Device
-from transformers import AutoTokenizer
+
+try:
+    from transformers import AutoTokenizer
+except ImportError:
+    raise RuntimeError(
+        "transformers library is required to use HF tokenizers. Install it via `pip install transformers`."
+    )
 
 
 @final

--- a/src/fairseq2/data/text/tokenizers/llama.py
+++ b/src/fairseq2/data/text/tokenizers/llama.py
@@ -100,7 +100,7 @@ class LLaMA3TokenizerHuggingFace(TextTokenizer):
 
     @override
     def create_decoder(self) -> TiktokenDecoder:
-        return HuggingfaceTokenizerDecoder(self._model)
+        return HuggingfaceTokenizerDecoder(self._tokenizer)
 
     @property
     @override

--- a/src/fairseq2/data/text/tokenizers/llama.py
+++ b/src/fairseq2/data/text/tokenizers/llama.py
@@ -29,7 +29,13 @@ from fairseq2.data.text.tokenizers.huggingface_tokenizer import (
     HuggingfaceTokenizerDecoder,
 )
 from fairseq2.typing import Device
-from transformers import AutoTokenizer
+
+try:
+    from transformers import AutoTokenizer
+except ImportError:
+    raise RuntimeError(
+        "transformers library is required to use HF tokenizers. Install it via `pip install transformers`."
+    )
 
 
 @final

--- a/src/fairseq2/data/text/tokenizers/qwen25.py
+++ b/src/fairseq2/data/text/tokenizers/qwen25.py
@@ -27,7 +27,13 @@ from fairseq2.data.text.tokenizers.huggingface_tokenizer import (
     HuggingfaceTokenizerDecoder,
 )
 from fairseq2.typing import Device
-from transformers import AutoTokenizer
+
+try:
+    from transformers import AutoTokenizer
+except ImportError:
+    raise RuntimeError(
+        "transformers library is required to use HF tokenizers. Install it via `pip install transformers`."
+    )
 
 
 @final

--- a/src/fairseq2/data/text/tokenizers/qwen25.py
+++ b/src/fairseq2/data/text/tokenizers/qwen25.py
@@ -1,0 +1,130 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Final, final
+
+from typing_extensions import override
+
+from fairseq2.assets import AssetCard, AssetCardError
+from fairseq2.data import VocabularyInfo
+from fairseq2.data.text.tokenizers import (
+    TextTokenizer,
+    TextTokenizerLoadError,
+    text_tokenizer_asset_card_error,
+)
+from fairseq2.data.text.tokenizers.tiktoken import (
+    TiktokenDecoder,
+    TiktokenEncoder,
+)
+from fairseq2.data.text.tokenizers.huggingface_tokenizer import (
+    HuggingfaceTokenizerEncoder,
+    HuggingfaceTokenizerDecoder,
+)
+from fairseq2.typing import Device
+from transformers import AutoTokenizer
+
+
+@final
+class Qwen25TokenizerHuggingFace(TextTokenizer):
+    """Represents a HuggingFace version of LLama 3 tokenizer"""
+
+    _tokenizer: AutoTokenizer
+    _bos_token: str
+    _eos_token: str
+
+    def __init__(self, path: Path) -> None:
+
+        self._tokenizer = AutoTokenizer.from_pretrained(path)
+
+        self._eos_token = self._tokenizer.special_tokens_map["eos_token"]
+        self._bos_token = None
+
+    @override
+    def create_encoder(
+        self,
+        *,
+        task: str | None = None,
+        lang: str | None = None,
+        mode: str | None = None,
+        device: Device | None = None,
+        pin_memory: bool = False,
+    ) -> TiktokenEncoder:
+        if task is not None:
+            raise ValueError(f"`task` must be `None`, but is '{task}' instead.")
+
+        if lang is not None:
+            raise ValueError(f"`lang` must be `None`, but is '{lang}' instead.")
+
+        match mode:
+            case None | "default":
+                prefix_tokens = []
+                suffix_tokens = [self._eos_token]
+            case "prompt":
+                prefix_tokens = []
+                # In prompt mode, we expect the generator to finish the sequence.
+                suffix_tokens = []
+            case "prompt_response":
+                prefix_tokens = []
+                suffix_tokens = [self._eos_token]
+            case "as_is":
+                prefix_tokens = []
+                suffix_tokens = []
+            case _:
+                raise ValueError(
+                    f"`mode` must be one of the following values, but is '{mode}' instead: default, prompt, prompt_response, as_is"
+                )
+
+        return HuggingfaceTokenizerEncoder(
+            self._tokenizer,
+            prefix_tokens=prefix_tokens,
+            suffix_tokens=suffix_tokens,
+            device=device,
+            pin_memory=pin_memory,
+        )
+
+    @override
+    def create_raw_encoder(
+        self, *, device: Device | None = None, pin_memory: bool = False
+    ) -> TiktokenEncoder:
+        return HuggingfaceTokenizerEncoder(
+            self._tokenizer, device=device, pin_memory=pin_memory
+        )
+
+    @override
+    def create_decoder(self) -> TiktokenDecoder:
+        return HuggingfaceTokenizerDecoder(self._tokenizer)
+
+    @property
+    @override
+    def vocab_info(self) -> VocabularyInfo:
+        eos_idx = self._tokenizer.convert_tokens_to_ids(self._eos_token)
+        vocab_info = VocabularyInfo(
+            size=len(self._tokenizer),
+            bos_idx=None,
+            eos_idx=eos_idx,
+            unk_idx=None,
+            pad_idx=None,
+        )
+        return vocab_info
+
+
+QWEN25_TOKENIZER_FAMILY: Final = "qwen25"
+
+
+def load_qwen25_tokenizer(path: Path, card: AssetCard) -> TextTokenizer:
+    try:
+        return Qwen25TokenizerHuggingFace(path)
+    except ValueError as ex:
+        raise TextTokenizerLoadError(
+            card.name, f"The '{card.name}' asset card does not contain a valid text tokenizer configuration of the '{QWEN25_TOKENIZER_FAMILY}' family. See the nested exception for details."  # fmt: skip
+        ) from ex
+    except RuntimeError as ex:
+        raise TextTokenizerLoadError(
+            card.name, f"The '{card.name}' text tokenizer cannot be loaded. See the nested exception for details."  # fmt: skip
+        ) from ex

--- a/src/fairseq2/models/llama/_config.py
+++ b/src/fairseq2/models/llama/_config.py
@@ -79,6 +79,7 @@ class LLaMAConfig:
     encoder, aiming to increase the context length.
     """
 
+<<<<<<< HEAD
     init_std: float | None = None
     """
     If not ``None``, the standard deviation to initialize input embeddings and
@@ -93,6 +94,8 @@ class LLaMAConfig:
     the decoder.
     """
 
+=======
+>>>>>>> a379e752 (qwen25 model working)
     dropout_p: float = 0.0
     """The dropout probability on outputs of Transformer layers."""
 

--- a/src/fairseq2/models/llama/_config.py
+++ b/src/fairseq2/models/llama/_config.py
@@ -79,7 +79,6 @@ class LLaMAConfig:
     encoder, aiming to increase the context length.
     """
 
-<<<<<<< HEAD
     init_std: float | None = None
     """
     If not ``None``, the standard deviation to initialize input embeddings and
@@ -94,8 +93,6 @@ class LLaMAConfig:
     the decoder.
     """
 
-=======
->>>>>>> a379e752 (qwen25 model working)
     dropout_p: float = 0.0
     """The dropout probability on outputs of Transformer layers."""
 

--- a/src/fairseq2/models/qwen25/__init__.py
+++ b/src/fairseq2/models/qwen25/__init__.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from fairseq2.models.qwen25._checkpoint import (
     convert_qwen_checkpoint as convert_qwen_checkpoint,
+    convert_qwen_fs2_to_hf_checkpoint as convert_qwen_fs2_to_hf_checkpoint,
 )
 from fairseq2.models.qwen25._config import QWEN25_MODEL_FAMILY as QWEN25_MODEL_FAMILY
 from fairseq2.models.qwen25._config import Qwen25Config as Qwen25Config

--- a/src/fairseq2/models/qwen25/__init__.py
+++ b/src/fairseq2/models/qwen25/__init__.py
@@ -1,0 +1,26 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from fairseq2.models.qwen25._checkpoint import (
+    convert_qwen_checkpoint as convert_qwen_checkpoint,
+)
+from fairseq2.models.qwen25._config import QWEN25_MODEL_FAMILY as QWEN25_MODEL_FAMILY
+from fairseq2.models.qwen25._config import Qwen25Config as Qwen25Config
+from fairseq2.models.qwen25._config import (
+    register_qwen_configs as register_qwen_configs,
+)
+from fairseq2.models.qwen25._factory import Qwen25Factory as Qwen25Factory
+from fairseq2.models.qwen25._factory import create_qwen25_model as create_qwen25_model
+from fairseq2.models.qwen25._shard import shard_qwen_model as shard_qwen_model
+
+# isort: split
+
+from fairseq2.models import ModelHubAccessor
+from fairseq2.models.transformer_decoder import TransformerDecoderModel
+
+get_llama_model_hub = ModelHubAccessor(TransformerDecoderModel, Qwen25Config)

--- a/src/fairseq2/models/qwen25/_checkpoint.py
+++ b/src/fairseq2/models/qwen25/_checkpoint.py
@@ -37,4 +37,8 @@ def convert_qwen_checkpoint(
 
     checkpoint = convert_model_state_dict(checkpoint, key_map)
 
+    # if weights are tied, we need to create a copy in statedict here for model loading
+    if config.tie_embeddings:
+        checkpoint["final_proj.weight"] = checkpoint["decoder_frontend.embed.weight"]
+
     return {"model": checkpoint}

--- a/src/fairseq2/models/qwen25/_checkpoint.py
+++ b/src/fairseq2/models/qwen25/_checkpoint.py
@@ -14,12 +14,8 @@ from fairseq2.models.qwen25._config import Qwen25Config
 from fairseq2.models.utils.checkpoint import convert_model_state_dict
 import torch
 
-
-def convert_qwen_checkpoint(
-    checkpoint: dict[str, object], config: Qwen25Config
-) -> dict[str, object]:
-    key_map = {
-        # fmt: off
+key_map = {
+    # fmt: off
         r"^model\.layers\.([0-9]+)\.self_attn\.q_proj\.":        r"decoder.layers.\1.self_attn.q_proj.",
         r"^model\.layers\.([0-9]+)\.self_attn\.k_proj\.":        r"decoder.layers.\1.self_attn.k_proj.",
         r"^model\.layers\.([0-9]+)\.self_attn\.v_proj\.":        r"decoder.layers.\1.self_attn.v_proj.",
@@ -32,8 +28,30 @@ def convert_qwen_checkpoint(
         r"^model\.norm\.":                                       r"decoder.layer_norm.",
         r"^model\.embed_tokens\.":                               r"decoder_frontend.embed.",
         r"^lm_head\.":                                           r"final_proj.",
-        # fmt: on
-    }
+    # fmt: on
+}
+
+reverse_key_map = {
+    # fmt: off
+    r"^decoder\.layers\.([0-9]+)\.self_attn\.q_proj\.":          r"model.layers.\1.self_attn.q_proj.",
+    r"^decoder\.layers\.([0-9]+)\.self_attn\.k_proj\.":          r"model.layers.\1.self_attn.k_proj.",
+    r"^decoder\.layers\.([0-9]+)\.self_attn\.v_proj\.":          r"model.layers.\1.self_attn.v_proj.",
+    r"^decoder\.layers\.([0-9]+)\.self_attn\.output_proj\.":     r"model.layers.\1.self_attn.o_proj.",
+    r"^decoder\.layers\.([0-9]+)\.ffn_layer_norm\.":             r"model.layers.\1.post_attention_layernorm.",
+    r"^decoder\.layers\.([0-9]+)\.ffn\.gate_proj\.":             r"model.layers.\1.mlp.gate_proj.",
+    r"^decoder\.layers\.([0-9]+)\.ffn\.output_proj\.":           r"model.layers.\1.mlp.down_proj.",
+    r"^decoder\.layers\.([0-9]+)\.ffn\.inner_proj\.":            r"model.layers.\1.mlp.up_proj.",
+    r"^decoder\.layers\.([0-9]+)\.self_attn_layer_norm\.":       r"model.layers.\1.input_layernorm.",
+    r"^decoder\.layer_norm\.":                                   r"model.norm.",
+    r"^decoder_frontend\.embed\.":                               r"model.embed_tokens.",
+    r"^final_proj\.":                                            r"lm_head.",
+    # fmt: on
+}
+
+
+def convert_qwen_checkpoint(
+    checkpoint: dict[str, object], config: Qwen25Config
+) -> dict[str, object]:
 
     checkpoint = convert_model_state_dict(checkpoint, key_map)
 
@@ -42,3 +60,16 @@ def convert_qwen_checkpoint(
         checkpoint["final_proj.weight"] = checkpoint["decoder_frontend.embed.weight"]
 
     return {"model": checkpoint}
+
+
+def convert_qwen_fs2_to_hf_checkpoint(
+    checkpoint: dict[str, object], config: Qwen25Config
+):
+
+    checkpoint = convert_model_state_dict(checkpoint, reverse_key_map)
+
+    # if emb weights are tied, we need to remove the lm head from ckpt
+    if config.tie_embeddings:
+        del checkpoint["lm_head.weight"]
+
+    return checkpoint

--- a/src/fairseq2/models/qwen25/_checkpoint.py
+++ b/src/fairseq2/models/qwen25/_checkpoint.py
@@ -1,0 +1,74 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from typing import cast
+
+from torch import Tensor
+
+from fairseq2.models.qwen25._config import Qwen25Config
+from fairseq2.models.utils.checkpoint import convert_model_state_dict
+import torch
+
+
+def convert_qwen_checkpoint(
+    checkpoint: dict[str, object], config: Qwen25Config
+) -> dict[str, object]:
+    # Check if we have a reference or Hugging Face checkpoint.
+    head_dim = config.model_dim // config.num_attn_heads
+
+    def permute_rotary(w: Tensor, num_heads: int) -> Tensor:
+        # (H, M) -> (H_d, 2, D / 2, M)
+        w = w.view(num_heads, 2, head_dim // 2, config.model_dim)
+
+        # (H_d, 2, D / 2, M) -> (H_d, D / 2, 2, M)
+        w = w.transpose(1, 2)
+
+        # (H_d, D / 2, 2, M) -> (H, M)
+        return w.reshape(-1, config.model_dim)
+
+    for idx in range(config.num_layers):
+        q_key = f"model.layers.{idx}.self_attn.q_proj.weight"
+        k_key = f"model.layers.{idx}.self_attn.k_proj.weight"
+
+        q_proj = cast(Tensor, checkpoint[q_key])
+        k_proj = cast(Tensor, checkpoint[k_key])
+
+        q_proj = permute_rotary(q_proj, config.num_attn_heads)
+        k_proj = permute_rotary(k_proj, config.num_key_value_heads)
+
+        checkpoint[q_key] = q_proj
+        checkpoint[k_key] = k_proj
+
+    key_map = {
+        # fmt: off
+        r"^model\.layers\.([0-9]+)\.self_attn\.q_proj\.":        r"decoder.layers.\1.self_attn.q_proj.",
+        r"^model\.layers\.([0-9]+)\.self_attn\.k_proj\.":        r"decoder.layers.\1.self_attn.k_proj.",
+        r"^model\.layers\.([0-9]+)\.self_attn\.v_proj\.":        r"decoder.layers.\1.self_attn.v_proj.",
+        r"^model\.layers\.([0-9]+)\.self_attn\.o_proj\.":        r"decoder.layers.\1.self_attn.output_proj.",
+        r"^model\.layers\.([0-9]+)\.post_attention_layernorm\.": r"decoder.layers.\1.ffn_layer_norm.",
+        r"^model\.layers\.([0-9]+)\.mlp\.gate_proj\.":           r"decoder.layers.\1.ffn.gate_proj.",
+        r"^model\.layers\.([0-9]+)\.mlp\.down_proj\.":           r"decoder.layers.\1.ffn.output_proj.",
+        r"^model\.layers\.([0-9]+)\.mlp\.up_proj\.":             r"decoder.layers.\1.ffn.inner_proj.",
+        r"^model\.layers\.([0-9]+)\.input_layernorm\.":          r"decoder.layers.\1.self_attn_layer_norm.",
+        r"^model\.norm\.":                                       r"decoder.layer_norm.",
+        r"^model\.embed_tokens\.":                               r"decoder_frontend.embed.",
+        r"^lm_head\.":                                           r"final_proj.",
+        # fmt: on
+    }
+
+    checkpoint = convert_model_state_dict(checkpoint, key_map)
+
+    # # adding head scaler
+    # head_dim = config.model_dim // config.num_attn_heads
+    # scale = head_dim**-0.5
+    # scale_tensor = torch.empty(config.num_attn_heads).fill_(scale) 
+    # for idx in range(config.num_layers):
+    #     key = f"decoder.layers.{idx}.self_attn.head_scale_weight"
+    #     checkpoint[key] = scale_tensor
+
+    return {"model": checkpoint}

--- a/src/fairseq2/models/qwen25/_config.py
+++ b/src/fairseq2/models/qwen25/_config.py
@@ -24,11 +24,7 @@ class Qwen25Config:
     max_seq_len: int
     """The maximum sequence length."""
 
-    vocab_info: VocabularyInfo = field(
-        default_factory=lambda: VocabularyInfo(
-            size=152064, unk_idx=None, bos_idx=151643, eos_idx=151645, pad_idx=None
-        )
-    )
+    vocab_info: VocabularyInfo
     """The vocabulary information."""
 
     num_layers: int
@@ -49,11 +45,7 @@ class Qwen25Config:
     dropout_p: float = 0.0
     """The dropout probability on outputs of Transformer layers."""
 
-@dataclass(kw_only=True)
-class Qwen25HFRopeConfigPatch:
-    rope_theta: float
-    hidden_size: int
-    num_attention_heads: int
+    tie_embeddings: bool
 
 
 def register_qwen_configs(context: RuntimeContext) -> None:
@@ -61,8 +53,12 @@ def register_qwen_configs(context: RuntimeContext) -> None:
 
     arch = registry.decorator
 
-    @arch("qwen25_7b")
-    def qwen25_7b():
+    @arch("qwen25_7b_instruct")
+    def qwen25_7b_instruct():
+        vocab_info = VocabularyInfo(
+            size=152064, unk_idx=None, bos_idx=151643, eos_idx=151645, pad_idx=None
+        )
+
         config = Qwen25Config(
             model_dim=3584,
             max_seq_len=32768,
@@ -70,9 +66,68 @@ def register_qwen_configs(context: RuntimeContext) -> None:
             num_attn_heads=28,
             num_key_value_heads=4,
             ffn_inner_dim=18944,
-            rope_theta=1000000.0
+            rope_theta=1000000.0,
+            tie_embeddings=False,
+            vocab_info=vocab_info
         )
 
         return config
     
+    @arch("qwen25_7b")
+    def qwen25_7b():
+        config = qwen25_7b_instruct()
+        config.vocab_info.eos_idx = 151643
+        config.max_seq_len = 131072
+        return config
+
+    @arch("qwen25_1_5b_instruct")
+    def qwen25_1_5b_instruct():
+        vocab_info = VocabularyInfo(
+            size=151936, unk_idx=None, bos_idx=151643, eos_idx=151645, pad_idx=None
+        )
+
+        config = Qwen25Config(
+            model_dim=1536,
+            max_seq_len=32768,
+            num_layers=28,
+            num_attn_heads=12,
+            num_key_value_heads=2,
+            ffn_inner_dim=8960,
+            rope_theta=1000000.0,
+            tie_embeddings=True,
+            vocab_info=vocab_info
+        )
     
+        return config
+    
+    @arch("qwen25_1_5b")
+    def qwen25_1_5b():
+        config = qwen25_1_5b_instruct()
+        config.vocab_info.eos_idx = 151643
+        config.max_seq_len = 131072
+        return config
+    
+    @arch("qwen25_3b_instruct")
+    def qwen25_3b_instruct():
+        vocab_info = VocabularyInfo(
+            size=151936, unk_idx=None, bos_idx=151643, eos_idx=151645, pad_idx=None
+        )
+        config = Qwen25Config(
+            model_dim=2048,
+            max_seq_len=32768,
+            num_layers=36,
+            num_attn_heads=16,
+            num_key_value_heads=2,
+            ffn_inner_dim=11008,
+            rope_theta=1000000.0,
+            tie_embeddings=True,
+            vocab_info=vocab_info
+        )
+    
+        return config
+    
+    @arch("qwen25_3b")
+    def qwen25_3b():
+        config = qwen25_3b_instruct()
+        config.vocab_info.eos_idx = 151643
+        return config

--- a/src/fairseq2/models/qwen25/_config.py
+++ b/src/fairseq2/models/qwen25/_config.py
@@ -1,0 +1,78 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Final
+
+from fairseq2.context import RuntimeContext
+from fairseq2.data import VocabularyInfo
+from fairseq2.models.llama._config import LLaMARopeScalingConfig
+
+QWEN25_MODEL_FAMILY: Final = "qwen25"
+
+@dataclass(kw_only=True)
+class Qwen25Config:
+    """Abstract config without defaults"""
+    model_dim: int
+    """The dimensionality of the model."""
+
+    max_seq_len: int
+    """The maximum sequence length."""
+
+    vocab_info: VocabularyInfo = field(
+        default_factory=lambda: VocabularyInfo(
+            size=152064, unk_idx=None, bos_idx=151643, eos_idx=151645, pad_idx=None
+        )
+    )
+    """The vocabulary information."""
+
+    num_layers: int
+    """The number of decoder layers."""
+
+    num_attn_heads: int
+    """The number of attention heads in decoder layers."""
+
+    num_key_value_heads: int
+    """The number of key/value heads for Grouped Query Attention."""
+
+    ffn_inner_dim: int
+    """The dimensionality of inner projection layers in feed-forward networks."""
+
+    rope_theta: float
+    """The coefficient of the long-term decay of the Rotary position encoder."""
+
+    dropout_p: float = 0.0
+    """The dropout probability on outputs of Transformer layers."""
+
+@dataclass(kw_only=True)
+class Qwen25HFRopeConfigPatch:
+    rope_theta: float
+    hidden_size: int
+    num_attention_heads: int
+
+
+def register_qwen_configs(context: RuntimeContext) -> None:
+    registry = context.get_config_registry(Qwen25Config)
+
+    arch = registry.decorator
+
+    @arch("qwen25_7b")
+    def qwen25_7b():
+        config = Qwen25Config(
+            model_dim=3584,
+            max_seq_len=32768,
+            num_layers=28,
+            num_attn_heads=28,
+            num_key_value_heads=4,
+            ffn_inner_dim=18944,
+            rope_theta=1000000.0
+        )
+
+        return config
+    
+    

--- a/src/fairseq2/models/qwen25/_factory.py
+++ b/src/fairseq2/models/qwen25/_factory.py
@@ -1,0 +1,186 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import math
+from functools import partial
+
+import torch
+from torch import Tensor
+
+from fairseq2.models.qwen25._config import Qwen25Config, Qwen25HFRopeConfigPatch
+from fairseq2.models.transformer import (
+    TransformerEmbeddingFrontend,
+    TransformerFrontend,
+    init_final_projection,
+)
+from fairseq2.models.transformer_decoder import TransformerDecoderModel
+from fairseq2.nn import (
+    Embedding,
+    LayerNorm,
+    Linear,
+    PositionEncoder,
+    Projection,
+    RMSNorm,
+    RotaryEncoder,
+    StandardEmbedding,
+)
+from fairseq2.nn.transformer import (
+    FeedForwardNetwork,
+    GLUFeedForwardNetworkV2,
+    MultiheadAttention,
+    StandardMultiheadAttention,
+    StandardTransformerDecoder,
+    StandardTransformerDecoderLayer,
+    TransformerDecoder,
+    TransformerDecoderLayer,
+    TransformerNormOrder,
+    create_default_sdpa
+)
+from fairseq2.nn.transformer._multihead_attention import init_output_projection
+from fairseq2.typing import DataType, Device
+
+from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS
+
+def create_qwen25_model(config: Qwen25Config) -> TransformerDecoderModel:
+    return Qwen25Factory(config).create_model()
+
+def make_qwen_init_rope(config: Qwen25Config) -> Tensor:
+    base = config.rope_theta
+    partial_rotary_factor = 1.0
+    head_dim = config.model_dim // config.num_attn_heads
+    dim = int(head_dim * partial_rotary_factor)
+
+    # Compute the inverse frequencies
+    gen_freq = lambda rot_encoder: 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.int64).float().to(rot_encoder.freqs.device) / dim))
+    return gen_freq
+
+class Qwen25Factory:
+    _config: Qwen25Config
+
+    def __init__(self, config: Qwen25Config) -> None:
+        self._config = config
+
+    def create_model(self) -> TransformerDecoderModel:
+        config = self._config
+
+        decoder_frontend = self.create_decoder_frontend()
+
+        decoder = self.create_decoder()
+
+        final_proj = self.create_final_proj()
+
+        return TransformerDecoderModel(
+            decoder_frontend,
+            decoder,
+            final_proj,
+            max_seq_len=config.max_seq_len,
+            vocab_info=config.vocab_info,
+        )
+
+    def create_decoder_frontend(self) -> TransformerFrontend:
+        config = self._config
+
+        embed = self.create_embedding()
+
+        return TransformerEmbeddingFrontend(
+            embed, pos_encoder=None, no_scale=True, dropout_p=config.dropout_p
+        )
+
+    def create_embedding(self) -> Embedding:
+        config = self._config
+
+        return StandardEmbedding(
+            num_embeddings=config.vocab_info.size, embedding_dim=config.model_dim
+        )
+
+    def create_decoder(self) -> TransformerDecoder:
+        config = self._config
+
+        pos_encoder = self.create_position_encoder()
+
+        layers = []
+
+        for _ in range(config.num_layers):
+            layer = self.create_decoder_layer(pos_encoder)
+
+            layers.append(layer)
+
+        return StandardTransformerDecoder(
+            layers,
+            dropout_p=config.dropout_p,
+            norm_order=TransformerNormOrder.PRE,
+            layer_norm_factory=self.create_layer_norm,
+        )
+
+    def create_position_encoder(self) -> PositionEncoder:
+        config = self._config
+        init_fn = make_qwen_init_rope(config)
+
+        return RotaryEncoder(
+            config.model_dim // config.num_attn_heads,
+            config.max_seq_len, 
+            theta=config.rope_theta,
+            freqs_init_fn=init_fn
+        )
+
+    def create_decoder_layer(
+        self, pos_encoder: PositionEncoder
+    ) -> TransformerDecoderLayer:
+        self_attn = self.create_attention(pos_encoder)
+
+        ffn = self.create_ffn()
+
+        return StandardTransformerDecoderLayer(
+            self_attn,
+            encoder_decoder_attn=None,
+            ffn=ffn,
+            norm_order=TransformerNormOrder.PRE,
+            layer_norm_factory=self.create_layer_norm,
+        )
+
+    def create_attention(self, pos_encoder: PositionEncoder) -> MultiheadAttention:
+        config = self._config
+
+        sdpa = create_default_sdpa(attn_dropout_p=config.dropout_p)
+
+        return StandardMultiheadAttention(
+            config.model_dim,
+            config.num_attn_heads,
+            num_key_value_heads=config.num_key_value_heads,
+            sdpa=sdpa,
+            pos_encoder=pos_encoder,
+            # pos_encoder=None,
+            bias=True,
+            output_proj_bias=False,
+        )
+
+    def create_ffn(self) -> FeedForwardNetwork:
+        config = self._config
+
+        return GLUFeedForwardNetworkV2(
+            config.model_dim,
+            config.ffn_inner_dim,
+            bias=False,
+            inner_dropout_p=config.dropout_p,
+        )
+
+    def create_final_proj(self) -> Projection:
+        config = self._config
+
+        return Linear(
+            config.model_dim,
+            config.vocab_info.size,
+            bias=False,
+            init_fn=init_final_projection,
+        )
+
+    @staticmethod
+    def create_layer_norm(
+        model_dim: int, *, device: Device | None = None, dtype: DataType | None = None
+    ) -> LayerNorm:
+        return RMSNorm(model_dim, bias=False, device=device, dtype=dtype, eps=1e-06)

--- a/src/fairseq2/models/qwen25/_factory.py
+++ b/src/fairseq2/models/qwen25/_factory.py
@@ -6,16 +6,9 @@
 
 from __future__ import annotations
 
-import math
-from functools import partial
-
-import torch
-from torch import Tensor
-
 from fairseq2.models.qwen25._config import Qwen25Config
 from fairseq2.models.transformer import (
     TransformerEmbeddingFrontend,
-    TransformerFrontend,
     init_final_projection,
 )
 from fairseq2.models.transformer_decoder import TransformerDecoderModel
@@ -28,7 +21,7 @@ from fairseq2.nn import (
     RMSNorm,
     ReferenceRotaryEncoder,
     StandardEmbedding,
-    TiedProjection
+    TiedProjection,
 )
 from fairseq2.nn.transformer import (
     FeedForwardNetwork,
@@ -40,15 +33,14 @@ from fairseq2.nn.transformer import (
     TransformerDecoder,
     TransformerDecoderLayer,
     TransformerNormOrder,
-    create_default_sdpa
+    create_default_sdpa,
 )
-from fairseq2.nn.transformer._multihead_attention import init_output_projection
 from fairseq2.typing import DataType, Device
 
-from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS
 
 def create_qwen25_model(config: Qwen25Config) -> TransformerDecoderModel:
     return Qwen25Factory(config).create_model()
+
 
 class Qwen25Factory:
     _config: Qwen25Config

--- a/src/fairseq2/models/qwen25/_shard.py
+++ b/src/fairseq2/models/qwen25/_shard.py
@@ -1,0 +1,21 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from fairseq2.gang import Gangs
+from fairseq2.models.qwen25._config import Qwen25Config
+from fairseq2.models.transformer_decoder import (
+    TransformerDecoderModel,
+    shard_transformer_decoder_model,
+)
+
+
+def shard_qwen_model(
+    model: TransformerDecoderModel, config: Qwen25Config, gangs: Gangs
+) -> None:
+
+    shard_transformer_decoder_model(model, gangs, shard_embed_dim=False)

--- a/src/fairseq2/nn/__init__.py
+++ b/src/fairseq2/nn/__init__.py
@@ -24,6 +24,7 @@ from fairseq2.nn._position_encoder import (
 )
 from fairseq2.nn._position_encoder import PositionEncoder as PositionEncoder
 from fairseq2.nn._position_encoder import RotaryEncoder as RotaryEncoder
+from fairseq2.nn._position_encoder import ReferenceRotaryEncoder as ReferenceRotaryEncoder
 from fairseq2.nn._position_encoder import (
     Sinusoidal2dPositionEncoder as Sinusoidal2dPositionEncoder,
 )

--- a/src/fairseq2/nn/transformer/__init__.py
+++ b/src/fairseq2/nn/transformer/__init__.py
@@ -71,6 +71,7 @@ from fairseq2.nn.transformer._ffn import (
 )
 from fairseq2.nn.transformer._ffn import FeedForwardNetwork as FeedForwardNetwork
 from fairseq2.nn.transformer._ffn import GLUFeedForwardNetwork as GLUFeedForwardNetwork
+from fairseq2.nn.transformer._ffn import GLUFeedForwardNetworkV2 as GLUFeedForwardNetworkV2
 from fairseq2.nn.transformer._ffn import (
     StandardFeedForwardNetwork as StandardFeedForwardNetwork,
 )

--- a/src/fairseq2/nn/transformer/_ffn.py
+++ b/src/fairseq2/nn/transformer/_ffn.py
@@ -350,3 +350,82 @@ class GLUFeedForwardNetwork(FeedForwardNetwork):
             f"inner_dim_scale={self.inner_dim_scale:G}, "
             f"inner_dim_to_multiple={self.inner_dim_to_multiple}"
         )
+
+
+@final
+class GLUFeedForwardNetworkV2(FeedForwardNetwork):
+    """Represents a GLU-based Transformer feed-forward network as described in
+    :cite:t:`https://doi.org/10.48550/arxiv.2002.05202`"""
+
+    gate_proj: Projection
+    gate_activation: Module
+    inner_proj: Projection
+    inner_dropout: Dropout | None
+    output_proj: Projection
+
+    def __init__(
+        self,
+        model_dim: int,
+        inner_dim: int,
+        bias: bool,
+        *,
+        gate_activation: Module | None = None,
+        inner_dropout_p: float = 0.0,
+        device: Device | None = None,
+        dtype: DataType | None = None,
+    ) -> None:
+        """
+        :param model_dim:
+            The dimensionality of the model.
+        :param inner_dim:
+            The non-scaled dimensionality of the inner projection layer.
+        :param bias:
+            If ``True``, all projections learn an additive bias.
+        :param gate_activation:
+            The activation to apply to outputs of the gate projection. If
+            ``None``, :func:`~torch.nn.SiLU` will be used.
+        :param inner_dim_scale:
+            The scale factor for the dimensionality of the inner projection
+            layer.
+        :param inner_dim_to_multiple:
+            The dimensionality of the inner projection layer is rounded up to
+            the nearest multiple of this value.
+        :param inner_dropout_p:
+            The dropout probability on outputs of the inner projection layer.
+        """
+        super().__init__(model_dim)
+
+        self.gate_proj = Linear(model_dim, inner_dim, bias, device=device, dtype=dtype)
+
+        if gate_activation is None:
+            self.gate_activation = SiLU()
+        else:
+            self.gate_activation = gate_activation
+
+        self.inner_proj = Linear(model_dim, inner_dim, bias, device=device, dtype=dtype)
+
+        if inner_dropout_p > 0.0:
+            self.inner_dropout = Dropout(inner_dropout_p)
+        else:
+            self.register_module("inner_dropout", None)
+
+        self.output_proj = Linear(
+            inner_dim, model_dim, bias, device=device, dtype=dtype
+        )
+
+    @override
+    def forward(self, seqs: Tensor) -> Tensor:
+        gate = self.gate_proj(seqs)
+
+        gate = self.gate_activation(gate)
+
+        seqs = self.inner_proj(seqs)
+
+        seqs = seqs * gate
+
+        if self.inner_dropout is not None:
+            seqs = self.inner_dropout(seqs)
+
+        seqs = self.output_proj(seqs)
+
+        return seqs

--- a/src/fairseq2/setup/_models.py
+++ b/src/fairseq2/setup/_models.py
@@ -43,6 +43,14 @@ from fairseq2.models.llama import (
     register_llama_configs,
     shard_llama_model,
 )
+from fairseq2.models.qwen25 import (
+    QWEN25_MODEL_FAMILY,
+    Qwen25Config,
+    convert_qwen_checkpoint,
+    create_qwen25_model,
+    register_qwen_configs,
+    shard_qwen_model,
+)
 from fairseq2.models.mistral import (
     MISTRAL_MODEL_FAMILY,
     MistralConfig,
@@ -141,6 +149,21 @@ def register_model_families(context: RuntimeContext) -> None:
     )
 
     register_llama_configs(context)
+
+    # Qwen25
+    default_arch = "qwen25_7b"
+
+    registrar.register_family(
+        QWEN25_MODEL_FAMILY,
+        TransformerDecoderModel,
+        Qwen25Config,
+        default_arch,
+        create_qwen25_model,
+        checkpoint_converter=convert_qwen_checkpoint,
+        sharder=shard_qwen_model,
+    )
+
+    register_qwen_configs(context)
 
     # Mistral
     default_arch = "7b"

--- a/src/fairseq2/setup/_text_tokenizers.py
+++ b/src/fairseq2/setup/_text_tokenizers.py
@@ -22,6 +22,10 @@ from fairseq2.data.text.tokenizers.llama import (
     LLAMA_TOKENIZER_FAMILY,
     load_llama_tokenizer,
 )
+from fairseq2.data.text.tokenizers.qwen25 import (
+    QWEN25_TOKENIZER_FAMILY,
+    load_qwen25_tokenizer,
+)
 from fairseq2.data.text.tokenizers.mistral import (
     MISTRAL_TOKENIZER_FAMILY,
     load_mistral_tokenizer,
@@ -49,6 +53,11 @@ def register_text_tokenizer_families(context: RuntimeContext) -> None:
     # LLaMA
     registrar.register_family(
         LLAMA_TOKENIZER_FAMILY, load_llama_tokenizer
+    )
+
+    # Qwen25
+    registrar.register_family(
+        QWEN25_TOKENIZER_FAMILY, load_qwen25_tokenizer
     )
 
     # NLLB


### PR DESCRIPTION
**What does this PR do? Please describe:**

- adding support for qwen models that do not require tensor parallelism. All loading is done from HF safetensors and remapping of state dicts to fs2 format.
- hugging face tokenizer support added. qwen model uses hf based tokenizer
- qwen ckpt conversion command added to save it back into HF model.

all transformers imports are checked with try except given that transformers is not mandatory (yet)

Confirmed that this works by training SFT with 7B size, converting it back to HF and using with vllm.