### PR TITLE
Call setup_fairseq2 automatically

### DIFF
--- a/src/fairseq2/__init__.py
+++ b/src/fairseq2/__init__.py
@@ -12,4 +12,57 @@ import fairseq2n  # Report any fairseq2n initialization error eagerly.
 
 # isort: split
 
-from fairseq2.setup import setup_fairseq2 as setup_fairseq2
+from fairseq2.context import RuntimeContext
+from fairseq2.error import InternalError
+from fairseq2.utils.progress import ProgressReporter
+
+_default_context: RuntimeContext | None = None
+
+_setting_up: bool = False
+
+
+def setup_fairseq2(progress_reporter: ProgressReporter | None = None) -> RuntimeContext:
+    """
+    Sets up fairseq2.
+
+    As part of the initialization, this function also registers extensions
+    with via setuptools' `entry-point`__ mechanism. See
+    :doc:`/basics/runtime_extensions` for more information.
+
+    .. important::
+
+        This function must be called before using any of the fairseq2 APIs.
+
+    .. __: https://setuptools.pypa.io/en/latest/userguide/entry_point.html
+    """
+    from fairseq2.setup import setup_library
+
+    global _default_context
+    global _setting_up
+
+    if _default_context is not None:
+        return _default_context
+
+    if _setting_up:
+        raise RuntimeError("`setup_fairseq2()` cannot be called recursively.")
+
+    _setting_up = True
+
+    try:
+        context = setup_library(progress_reporter)
+    finally:
+        _setting_up = False
+
+    _default_context = context
+
+    return context
+
+
+def get_runtime_context() -> RuntimeContext:
+    if _default_context is None:
+        setup_fairseq2()
+
+    if _default_context is None:
+        raise InternalError("fairseq2 is not initialized.")
+
+    return _default_context

--- a/src/fairseq2/cli/_main.py
+++ b/src/fairseq2/cli/_main.py
@@ -13,14 +13,14 @@ from signal import SIG_DFL, SIGINT, raise_signal, signal
 import torch
 from torch.cuda import OutOfMemoryError
 
+from fairseq2 import setup_fairseq2
 from fairseq2.cli._logging import setup_logging
 from fairseq2.cli._setup import setup_cli
 from fairseq2.cli.utils.rich import create_rich_progress_reporter
-from fairseq2.context import get_runtime_context
 from fairseq2.error import ContractError, InternalError
 from fairseq2.extensions import ExtensionError
 from fairseq2.logging import LoggingSetupError, log
-from fairseq2.setup import SetupError, setup_fairseq2
+from fairseq2.setup import SetupError
 from fairseq2.utils.env import InvalidEnvironmentVariableError, get_rank
 
 
@@ -68,9 +68,7 @@ def _run() -> int:
 
         progress_reporter = create_rich_progress_reporter(rank)
 
-        setup_fairseq2(progress_reporter)
-
-        context = get_runtime_context()
+        context = setup_fairseq2(progress_reporter)
 
         cli = setup_cli(context)
     except SetupError:

--- a/src/fairseq2/context.py
+++ b/src/fairseq2/context.py
@@ -89,21 +89,3 @@ class RuntimeContext:
     @property
     def wall_watch(self) -> Stopwatch:
         return self._wall_watch
-
-
-_default_context: RuntimeContext | None = None
-
-
-def set_runtime_context(context: RuntimeContext) -> None:
-    global _default_context
-
-    _default_context = context
-
-
-def get_runtime_context() -> RuntimeContext:
-    if _default_context is None:
-        raise RuntimeError(
-            "fairseq2 is not initialized. Make sure to call `fairseq2.setup_fairseq2()`."
-        )
-
-    return _default_context

--- a/src/fairseq2/data/text/tokenizers/_hub.py
+++ b/src/fairseq2/data/text/tokenizers/_hub.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from typing import final
 
+from fairseq2 import get_runtime_context
 from fairseq2.assets import (
     AssetCard,
     AssetCardError,
@@ -15,7 +16,6 @@ from fairseq2.assets import (
     AssetCardNotFoundError,
     AssetStore,
 )
-from fairseq2.context import get_runtime_context
 from fairseq2.data.text.tokenizers._error import (
     UnknownTextTokenizerError,
     UnknownTextTokenizerFamilyError,

--- a/src/fairseq2/datasets/_hub.py
+++ b/src/fairseq2/datasets/_hub.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from typing import Generic, TypeVar, cast, final
 
+from fairseq2 import get_runtime_context
 from fairseq2.assets import (
     AssetCard,
     AssetCardError,
@@ -15,7 +16,6 @@ from fairseq2.assets import (
     AssetCardNotFoundError,
     AssetStore,
 )
-from fairseq2.context import get_runtime_context
 from fairseq2.datasets._error import (
     InvalidDatasetTypeError,
     UnknownDatasetError,

--- a/src/fairseq2/models/_hub.py
+++ b/src/fairseq2/models/_hub.py
@@ -11,6 +11,7 @@ from typing import Generic, TypeVar, cast, final
 import torch
 from torch.nn import Module
 
+from fairseq2 import get_runtime_context
 from fairseq2.assets import (
     AssetCard,
     AssetCardError,
@@ -18,7 +19,6 @@ from fairseq2.assets import (
     AssetCardNotFoundError,
     AssetStore,
 )
-from fairseq2.context import get_runtime_context
 from fairseq2.gang import Gangs, fake_gangs
 from fairseq2.models._error import (
     InvalidModelConfigTypeError,

--- a/src/fairseq2/setup/__init__.py
+++ b/src/fairseq2/setup/__init__.py
@@ -12,7 +12,6 @@ from fairseq2.setup._asset import (
 from fairseq2.setup._datasets import DatasetRegistrar as DatasetRegistrar
 from fairseq2.setup._error import SetupError as SetupError
 from fairseq2.setup._models import ModelRegistrar as ModelRegistrar
-from fairseq2.setup._root import setup_fairseq2 as setup_fairseq2
 from fairseq2.setup._root import setup_library as setup_library
 from fairseq2.setup._text_tokenizers import (
     TextTokenizerRegistrar as TextTokenizerRegistrar,

--- a/src/fairseq2/setup/_root.py
+++ b/src/fairseq2/setup/_root.py
@@ -7,7 +7,6 @@
 from __future__ import annotations
 
 import os
-from enum import Enum
 from typing import Mapping
 
 from fairseq2.assets import (
@@ -16,7 +15,7 @@ from fairseq2.assets import (
     InProcAssetDownloadManager,
     StandardAssetStore,
 )
-from fairseq2.context import RuntimeContext, set_runtime_context
+from fairseq2.context import RuntimeContext
 from fairseq2.extensions import run_extensions
 from fairseq2.setup._asset import register_assets
 from fairseq2.setup._chatbots import register_chatbots
@@ -39,51 +38,6 @@ from fairseq2.setup._recipes import register_recipes
 from fairseq2.setup._text_tokenizers import register_text_tokenizer_families
 from fairseq2.utils.file import FileSystem, LocalFileSystem
 from fairseq2.utils.progress import NoopProgressReporter, ProgressReporter
-
-
-class _SetupState(Enum):
-    NOT_CALLED = 0
-    IN_CALL = 1
-    CALLED = 2
-
-
-_setup_state: _SetupState = _SetupState.NOT_CALLED
-
-
-def setup_fairseq2(progress_reporter: ProgressReporter | None = None) -> None:
-    """
-    Sets up fairseq2.
-
-    As part of the initialization, this function also registers extensions
-    with via setuptools' `entry-point`__ mechanism. See
-    :doc:`/basics/runtime_extensions` for more information.
-
-    .. important::
-
-        This function must be called before using any of the fairseq2 APIs.
-
-    .. __: https://setuptools.pypa.io/en/latest/userguide/entry_point.html
-    """
-    global _setup_state
-
-    if _setup_state == _SetupState.CALLED:
-        return
-
-    if _setup_state == _SetupState.IN_CALL:
-        raise RuntimeError("`setup_fairseq2()` cannot be called recursively.")
-
-    _setup_state = _SetupState.IN_CALL
-
-    try:
-        context = setup_library(progress_reporter)
-    except Exception:
-        _setup_state = _SetupState.NOT_CALLED
-
-        raise
-
-    set_runtime_context(context)
-
-    _setup_state = _SetupState.CALLED
 
 
 def setup_library(progress_reporter: ProgressReporter | None = None) -> RuntimeContext:

--- a/tests/integration/models/test_llama.py
+++ b/tests/integration/models/test_llama.py
@@ -9,7 +9,7 @@ from typing import cast
 
 import pytest
 
-from fairseq2.context import get_runtime_context
+from fairseq2 import get_runtime_context
 from fairseq2.models.llama import LLaMAConfig, LLaMAFactory, convert_llama_checkpoint
 from fairseq2.models.llama.integ import convert_to_reference_llama_checkpoint
 

--- a/tests/unit/nn/utils/test_module.py
+++ b/tests/unit/nn/utils/test_module.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from torch.nn import Parameter
 
-from fairseq2.context import get_runtime_context
+from fairseq2 import get_runtime_context
 from fairseq2.models.transformer import TransformerConfig, TransformerFactory
 from fairseq2.nn.utils.module import select_parameters
 from fairseq2.typing import META


### PR DESCRIPTION
This PR revises the implementation of `setup_fairseq2` and `get_runtime_context` functions so that `get_runtime_context` automatically calls `setup_fairseq2` if the library is not yet initialized.