### PR TITLE
Introduce save_model_only

### DIFF
--- a/src/fairseq2/checkpoint/_metadata_provider.py
+++ b/src/fairseq2/checkpoint/_metadata_provider.py
@@ -229,22 +229,24 @@ class FileCheckpointMetadataLoader:
             except OSError as ex:
                 raise load_error() from ex
 
-            if fp is not None:
-                try:
-                    line = fp.readline()
-                except OSError as ex:
-                    raise load_error() from ex
-                finally:
-                    fp.close()
+            if fp is None:
+                continue
 
-                try:
-                    score = float(line)
-                except ValueError:
-                    raise AssetMetadataLoadError(
-                        f"The score of the training step {step_nr} cannot be parsed as a floating-point number."
-                    ) from None
+            try:
+                line = fp.readline()
+            except OSError as ex:
+                raise load_error() from ex
+            finally:
+                fp.close()
 
-                scores.append((score, step_nr))
+            try:
+                score = float(line)
+            except ValueError:
+                raise AssetMetadataLoadError(
+                    f"The score of the training step {step_nr} cannot be parsed as a floating-point number."
+                ) from None
+
+            scores.append((score, step_nr))
 
         if max_step_nr == -1:
             return cache

--- a/src/fairseq2/recipes/common/_model.py
+++ b/src/fairseq2/recipes/common/_model.py
@@ -232,7 +232,9 @@ class CardBasedModelLoader(ModelLoader):
             dtype = torch.float32
 
         try:
-            step_nr = self._checkpoint_manager.maybe_get_last_step_number()
+            step_nr = self._checkpoint_manager.maybe_get_last_step_number(
+                exclude_model_only=True
+            )
         except CheckpointError:
             raise ModelLoadError(
                 model_name, "The last training checkpoint cannot be retrieved. See the nested exception for details."  # fmt: skip
@@ -360,7 +362,9 @@ class PathBasedModelLoader(ModelLoader):
             dtype = torch.float32
 
         try:
-            step_nr = self._checkpoint_manager.maybe_get_last_step_number()
+            step_nr = self._checkpoint_manager.maybe_get_last_step_number(
+                exclude_model_only=True
+            )
         except CheckpointError:
             raise ModelLoadError(
                 model_name, "The last training checkpoint cannot be retrieved. See the nested exception for details."  # fmt: skip
@@ -498,7 +502,9 @@ class ModelCreator(ModelLoader):
             dtype = torch.float32
 
         try:
-            step_nr = self._checkpoint_manager.maybe_get_last_step_number()
+            step_nr = self._checkpoint_manager.maybe_get_last_step_number(
+                exclude_model_only=True
+            )
         except CheckpointError:
             raise ModelLoadError(
                 model_name, "The last training checkpoint cannot be retrieved. See the nested exception for details."  # fmt: skip

--- a/src/fairseq2/recipes/common/_trainer.py
+++ b/src/fairseq2/recipes/common/_trainer.py
@@ -126,6 +126,7 @@ def create_trainer(
         checkpoint_every_n_steps=regime_section.checkpoint_every_n_steps,
         checkpoint_after_n_data_epochs=regime_section.checkpoint_after_n_data_epochs,
         checkpoint_every_n_data_epochs=regime_section.checkpoint_every_n_data_epochs,
+        save_model_only=regime_section.save_model_only,
         keep_last_n_checkpoints=regime_section.keep_last_n_checkpoints,
         keep_best_n_checkpoints=regime_section.keep_best_n_checkpoints,
         keep_checkpoint_every_n_steps=regime_section.keep_checkpoint_every_n_steps,

--- a/src/fairseq2/recipes/config.py
+++ b/src/fairseq2/recipes/config.py
@@ -250,6 +250,8 @@ class RegimeSection:
     checkpoint_every_n_data_epochs: int | None = None
     """The data epoch interval at which to checkpoint."""
 
+    save_model_only: bool = False
+
     keep_last_n_checkpoints: int | None = None
     """The number of checkpoints to keep. If ``None``, none will be deleted."""
 


### PR DESCRIPTION
This PR introduces a new `save_model_only` option to save only the model state during checkpointing. This is in particular helpful to save disk space for short-running, non-preempted tasks where the user does not need to restore the training.