### PR TITLE
Split internal package imports

### DIFF
--- a/src/fairseq2/assets/_dirs.py
+++ b/src/fairseq2/assets/_dirs.py
@@ -10,10 +10,13 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import final
 
-from fairseq2.assets._metadata_provider import AssetMetadataLoadError
 from fairseq2.logging import log
 from fairseq2.utils.env import InvalidEnvironmentVariableError, get_path_from_env
 from fairseq2.utils.file import FileSystem
+
+# isort: split
+
+from fairseq2.assets._metadata_provider import AssetMetadataLoadError
 
 
 @final

--- a/src/fairseq2/assets/_store.py
+++ b/src/fairseq2/assets/_store.py
@@ -14,12 +14,15 @@ from typing import Protocol, final
 
 from typing_extensions import override
 
+from fairseq2.error import ContractError
+
+# isort: split
+
 from fairseq2.assets._card import AssetCard, AssetCardError, AssetCardNotFoundError
 from fairseq2.assets._metadata_provider import (
     AssetMetadataNotFoundError,
     AssetMetadataProvider,
 )
-from fairseq2.error import ContractError
 
 
 class AssetLookupScope(Enum):

--- a/src/fairseq2/chatbots/_handler.py
+++ b/src/fairseq2/chatbots/_handler.py
@@ -8,9 +8,12 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 
-from fairseq2.chatbots._chatbot import Chatbot
 from fairseq2.data.text.tokenizers import TextTokenizer
 from fairseq2.generation import SequenceGenerator
+
+# isort: split
+
+from fairseq2.chatbots._chatbot import Chatbot
 
 
 class ChatbotHandler(ABC):

--- a/src/fairseq2/cli/_main.py
+++ b/src/fairseq2/cli/_main.py
@@ -14,14 +14,17 @@ import torch
 from torch.cuda import OutOfMemoryError
 
 from fairseq2 import setup_fairseq2
-from fairseq2.cli._logging import setup_logging
-from fairseq2.cli._setup import setup_cli
 from fairseq2.cli.utils.rich import create_rich_progress_reporter
 from fairseq2.error import ContractError, InternalError
 from fairseq2.extensions import ExtensionError
 from fairseq2.logging import LoggingSetupError, log
 from fairseq2.setup import SetupError
 from fairseq2.utils.env import InvalidEnvironmentVariableError, get_rank
+
+# isort: split
+
+from fairseq2.cli._logging import setup_logging
+from fairseq2.cli._setup import setup_cli
 
 
 def main() -> None:

--- a/src/fairseq2/data/text/tokenizers/_handler.py
+++ b/src/fairseq2/data/text/tokenizers/_handler.py
@@ -13,6 +13,9 @@ from typing import Protocol, final
 from typing_extensions import override
 
 from fairseq2.assets import AssetCard, AssetCardError, AssetDownloadManager
+
+# isort: split
+
 from fairseq2.data.text.tokenizers._error import text_tokenizer_asset_card_error
 from fairseq2.data.text.tokenizers._tokenizer import TextTokenizer
 

--- a/src/fairseq2/data/text/tokenizers/_hub.py
+++ b/src/fairseq2/data/text/tokenizers/_hub.py
@@ -16,6 +16,10 @@ from fairseq2.assets import (
     AssetCardNotFoundError,
     AssetStore,
 )
+from fairseq2.registry import Provider
+
+# isort: split
+
 from fairseq2.data.text.tokenizers._error import (
     UnknownTextTokenizerError,
     UnknownTextTokenizerFamilyError,
@@ -24,7 +28,6 @@ from fairseq2.data.text.tokenizers._error import (
 from fairseq2.data.text.tokenizers._handler import TextTokenizerHandler
 from fairseq2.data.text.tokenizers._ref import resolve_text_tokenizer_reference
 from fairseq2.data.text.tokenizers._tokenizer import TextTokenizer
-from fairseq2.registry import Provider
 
 
 @final

--- a/src/fairseq2/datasets/_data_reader.py
+++ b/src/fairseq2/datasets/_data_reader.py
@@ -13,9 +13,12 @@ from typing import TypeVar, final
 from typing_extensions import Self, override
 
 from fairseq2.data import DataPipeline, DataPipelineError
+from fairseq2.gang import Gang, GangError
+
+# isort: split
+
 from fairseq2.datasets._config import DataReadOptions, SyncMode
 from fairseq2.datasets._utils import _min_num_batches, _sum_num_batches
-from fairseq2.gang import Gang, GangError
 
 BatchT_co = TypeVar("BatchT_co", covariant=True)
 

--- a/src/fairseq2/datasets/_handler.py
+++ b/src/fairseq2/datasets/_handler.py
@@ -15,8 +15,11 @@ from typing import Protocol, final
 from typing_extensions import override
 
 from fairseq2.assets import AssetCard, AssetCardError, AssetDownloadManager
-from fairseq2.datasets._error import DatasetLoadError, dataset_asset_card_error
 from fairseq2.utils.file import FileSystem
+
+# isort: split
+
+from fairseq2.datasets._error import DatasetLoadError, dataset_asset_card_error
 
 
 class DatasetHandler(ABC):

--- a/src/fairseq2/datasets/_hub.py
+++ b/src/fairseq2/datasets/_hub.py
@@ -16,6 +16,10 @@ from fairseq2.assets import (
     AssetCardNotFoundError,
     AssetStore,
 )
+from fairseq2.registry import Provider
+
+# isort: split
+
 from fairseq2.datasets._error import (
     InvalidDatasetTypeError,
     UnknownDatasetError,
@@ -23,7 +27,6 @@ from fairseq2.datasets._error import (
     dataset_asset_card_error,
 )
 from fairseq2.datasets._handler import DatasetHandler
-from fairseq2.registry import Provider
 
 DatasetT = TypeVar("DatasetT")
 

--- a/src/fairseq2/datasets/_utils.py
+++ b/src/fairseq2/datasets/_utils.py
@@ -10,9 +10,12 @@ from pathlib import Path
 
 import torch
 
-from fairseq2.datasets._error import DatasetLoadError
 from fairseq2.gang import Gang, all_sum
 from fairseq2.logging import log
+
+# isort: split
+
+from fairseq2.datasets._error import DatasetLoadError
 
 
 def _min_num_batches(num_batches: int, gang: Gang) -> int:

--- a/src/fairseq2/datasets/instruction.py
+++ b/src/fairseq2/datasets/instruction.py
@@ -36,11 +36,14 @@ from fairseq2.datasets import (
     StaticBatching,
     UnknownSplitError,
 )
-from fairseq2.datasets._utils import _load_files_and_weights
 from fairseq2.error import NotSupportedError
 from fairseq2.gang import Gang
 from fairseq2.models.sequence import SequenceBatch
 from fairseq2.nn.padding import get_seqs_and_padding_mask
+
+# isort: split
+
+from fairseq2.datasets._utils import _load_files_and_weights
 
 
 @dataclass(kw_only=True)

--- a/src/fairseq2/datasets/preference.py
+++ b/src/fairseq2/datasets/preference.py
@@ -33,13 +33,16 @@ from fairseq2.datasets import (
     LengthBatching,
     StaticBatching,
 )
-from fairseq2.datasets._utils import _load_files_and_weights
 from fairseq2.device import SupportsDeviceTransfer
 from fairseq2.error import NotSupportedError
 from fairseq2.gang import Gang
 from fairseq2.models.sequence import SequenceBatch
 from fairseq2.nn.padding import get_seqs_and_padding_mask
 from fairseq2.typing import Device
+
+# isort: split
+
+from fairseq2.datasets._utils import _load_files_and_weights
 
 
 @dataclass(kw_only=True)

--- a/src/fairseq2/generation/_beam_search/_generator.py
+++ b/src/fairseq2/generation/_beam_search/_generator.py
@@ -19,6 +19,15 @@ from typing_extensions import override
 
 from fairseq2.data import VocabularyInfo
 from fairseq2.error import InternalError
+from fairseq2.models.decoder import DecoderModel
+from fairseq2.models.encoder_decoder import EncoderDecoderModel
+from fairseq2.models.sequence import SequenceModelOutput
+from fairseq2.nn import IncrementalStateBag
+from fairseq2.nn.padding import PaddingMask
+from fairseq2.utils.stopwatch import Stopwatch
+
+# isort: split
+
 from fairseq2.generation._beam_search._algo import (
     BeamSearchAlgorithm,
     BeamStep,
@@ -35,12 +44,6 @@ from fairseq2.generation._generator import (
     StepHook,
 )
 from fairseq2.generation._step_processor import StepProcessor
-from fairseq2.models.decoder import DecoderModel
-from fairseq2.models.encoder_decoder import EncoderDecoderModel
-from fairseq2.models.sequence import SequenceModelOutput
-from fairseq2.nn import IncrementalStateBag
-from fairseq2.nn.padding import PaddingMask
-from fairseq2.utils.stopwatch import Stopwatch
 
 
 @final

--- a/src/fairseq2/generation/_beam_search/_handler.py
+++ b/src/fairseq2/generation/_beam_search/_handler.py
@@ -12,6 +12,14 @@ from typing import Final, final
 from typing_extensions import override
 
 from fairseq2.data import VocabularyInfo
+from fairseq2.models.decoder import DecoderModel
+from fairseq2.models.encoder_decoder import EncoderDecoderModel
+from fairseq2.registry import Provider
+from fairseq2.utils.structured import structure
+from fairseq2.utils.validation import validate
+
+# isort: split
+
 from fairseq2.generation._beam_search._algo import (
     STANDARD_BEAM_SEARCH_ALGO,
     BeamSearchAlgorithmHandler,
@@ -26,11 +34,6 @@ from fairseq2.generation._handler import (
     Seq2SeqGeneratorHandler,
     SequenceGeneratorHandler,
 )
-from fairseq2.models.decoder import DecoderModel
-from fairseq2.models.encoder_decoder import EncoderDecoderModel
-from fairseq2.registry import Provider
-from fairseq2.utils.structured import structure
-from fairseq2.utils.validation import validate
 
 BEAM_SEARCH_GENERATOR: Final = "beam_search"
 

--- a/src/fairseq2/generation/_handler.py
+++ b/src/fairseq2/generation/_handler.py
@@ -9,9 +9,12 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 
 from fairseq2.data import VocabularyInfo
-from fairseq2.generation._generator import Seq2SeqGenerator, SequenceGenerator
 from fairseq2.models.decoder import DecoderModel
 from fairseq2.models.encoder_decoder import EncoderDecoderModel
+
+# isort: split
+
+from fairseq2.generation._generator import Seq2SeqGenerator, SequenceGenerator
 
 
 class SequenceGeneratorHandler(ABC):

--- a/src/fairseq2/generation/_sampling/_generator.py
+++ b/src/fairseq2/generation/_sampling/_generator.py
@@ -19,6 +19,16 @@ from typing_extensions import override
 
 from fairseq2.data import VocabularyInfo
 from fairseq2.error import InternalError
+from fairseq2.models.decoder import DecoderModel
+from fairseq2.models.encoder_decoder import EncoderDecoderModel
+from fairseq2.models.sequence import SequenceModelOutput
+from fairseq2.nn import IncrementalStateBag
+from fairseq2.nn.ops import repeat_interleave
+from fairseq2.nn.padding import PaddingMask
+from fairseq2.utils.stopwatch import Stopwatch
+
+# isort: split
+
 from fairseq2.generation._generator import (
     GenerationCounters,
     Hypothesis,
@@ -31,13 +41,6 @@ from fairseq2.generation._generator import (
 )
 from fairseq2.generation._sampling._sampler import Sampler
 from fairseq2.generation._step_processor import StepProcessor
-from fairseq2.models.decoder import DecoderModel
-from fairseq2.models.encoder_decoder import EncoderDecoderModel
-from fairseq2.models.sequence import SequenceModelOutput
-from fairseq2.nn import IncrementalStateBag
-from fairseq2.nn.ops import repeat_interleave
-from fairseq2.nn.padding import PaddingMask
-from fairseq2.utils.stopwatch import Stopwatch
 
 
 @final

--- a/src/fairseq2/generation/_sampling/_handler.py
+++ b/src/fairseq2/generation/_sampling/_handler.py
@@ -12,6 +12,14 @@ from typing import Final, final
 from typing_extensions import override
 
 from fairseq2.data import VocabularyInfo
+from fairseq2.models.decoder import DecoderModel
+from fairseq2.models.encoder_decoder import EncoderDecoderModel
+from fairseq2.registry import Provider
+from fairseq2.utils.structured import StructureError, structure
+from fairseq2.utils.validation import validate
+
+# isort: split
+
 from fairseq2.generation._generator import Seq2SeqGenerator, SequenceGenerator
 from fairseq2.generation._handler import (
     Seq2SeqGeneratorHandler,
@@ -27,11 +35,6 @@ from fairseq2.generation._sampling._sampler import (
     TopPSamplerConfig,
     UnknownSamplerError,
 )
-from fairseq2.models.decoder import DecoderModel
-from fairseq2.models.encoder_decoder import EncoderDecoderModel
-from fairseq2.registry import Provider
-from fairseq2.utils.structured import StructureError, structure
-from fairseq2.utils.validation import validate
 
 SAMPLING_GENERATOR: Final = "sampling"
 

--- a/src/fairseq2/metrics/recorders/_jsonl.py
+++ b/src/fairseq2/metrics/recorders/_jsonl.py
@@ -18,16 +18,19 @@ from torch import Tensor
 from typing_extensions import override
 
 from fairseq2.metrics import MetricDescriptor, format_as_int
+from fairseq2.registry import Provider
+from fairseq2.utils.file import FileMode, FileSystem
+from fairseq2.utils.structured import structure
+from fairseq2.utils.validation import validate
+
+# isort: split
+
 from fairseq2.metrics.recorders._handler import MetricRecorderHandler
 from fairseq2.metrics.recorders._recorder import (
     MetricRecorder,
     MetricRecordError,
     NoopMetricRecorder,
 )
-from fairseq2.registry import Provider
-from fairseq2.utils.file import FileMode, FileSystem
-from fairseq2.utils.structured import structure
-from fairseq2.utils.validation import validate
 
 
 @final

--- a/src/fairseq2/metrics/recorders/_log.py
+++ b/src/fairseq2/metrics/recorders/_log.py
@@ -15,11 +15,14 @@ from typing_extensions import override
 
 from fairseq2.logging import LogWriter
 from fairseq2.metrics import MetricDescriptor
-from fairseq2.metrics.recorders._handler import MetricRecorderHandler
-from fairseq2.metrics.recorders._recorder import MetricRecorder, NoopMetricRecorder
 from fairseq2.registry import Provider
 from fairseq2.utils.structured import structure
 from fairseq2.utils.validation import validate
+
+# isort: split
+
+from fairseq2.metrics.recorders._handler import MetricRecorderHandler
+from fairseq2.metrics.recorders._recorder import MetricRecorder, NoopMetricRecorder
 
 
 @final

--- a/src/fairseq2/metrics/recorders/_tensorboard.py
+++ b/src/fairseq2/metrics/recorders/_tensorboard.py
@@ -15,15 +15,18 @@ from typing_extensions import override
 
 from fairseq2.logging import log
 from fairseq2.metrics import MetricDescriptor
+from fairseq2.registry import Provider
+from fairseq2.utils.structured import structure
+from fairseq2.utils.validation import validate
+
+# isort: split
+
 from fairseq2.metrics.recorders._handler import MetricRecorderHandler
 from fairseq2.metrics.recorders._recorder import (
     MetricRecorder,
     MetricRecordError,
     NoopMetricRecorder,
 )
-from fairseq2.registry import Provider
-from fairseq2.utils.structured import structure
-from fairseq2.utils.validation import validate
 
 try:
     from torch.utils.tensorboard import SummaryWriter  # type: ignore[attr-defined]

--- a/src/fairseq2/metrics/recorders/_wandb.py
+++ b/src/fairseq2/metrics/recorders/_wandb.py
@@ -15,15 +15,18 @@ from typing_extensions import override
 
 from fairseq2.logging import log
 from fairseq2.metrics import MetricDescriptor
+from fairseq2.registry import Provider
+from fairseq2.utils.structured import structure
+from fairseq2.utils.validation import ValidationError, ValidationResult, validate
+
+# isort: split
+
 from fairseq2.metrics.recorders._handler import MetricRecorderHandler
 from fairseq2.metrics.recorders._recorder import (
     MetricRecorder,
     MetricRecordError,
     NoopMetricRecorder,
 )
-from fairseq2.registry import Provider
-from fairseq2.utils.structured import structure
-from fairseq2.utils.validation import ValidationError, ValidationResult, validate
 
 try:
     import wandb  # type: ignore[import-not-found]

--- a/src/fairseq2/models/_handler.py
+++ b/src/fairseq2/models/_handler.py
@@ -23,13 +23,6 @@ from fairseq2.assets import (
 from fairseq2.config_registry import ConfigNotFoundError, ConfigProvider
 from fairseq2.error import ContractError, NotSupportedError
 from fairseq2.gang import Gangs
-from fairseq2.models._error import (
-    ModelConfigLoadError,
-    ModelLoadError,
-    ShardedModelLoadError,
-    UnknownModelArchitectureError,
-    model_asset_card_error,
-)
 from fairseq2.models.fsdp import apply_default_fsdp
 from fairseq2.nn.data_parallel import FsdpGranularity, FsdpWrapper, load_with_sdp_gang
 from fairseq2.nn.utils.module import (
@@ -46,6 +39,16 @@ from fairseq2.utils.file import (
 from fairseq2.utils.merge import MergeError, merge_object
 from fairseq2.utils.structured import StructureError, structure, unstructure
 from fairseq2.utils.validation import validate
+
+# isort: split
+
+from fairseq2.models._error import (
+    ModelConfigLoadError,
+    ModelLoadError,
+    ShardedModelLoadError,
+    UnknownModelArchitectureError,
+    model_asset_card_error,
+)
 
 
 class ModelHandler(ABC):

--- a/src/fairseq2/models/_hub.py
+++ b/src/fairseq2/models/_hub.py
@@ -20,6 +20,11 @@ from fairseq2.assets import (
     AssetStore,
 )
 from fairseq2.gang import Gangs, fake_gangs
+from fairseq2.registry import Provider
+from fairseq2.typing import DataType, Device
+
+# isort: split
+
 from fairseq2.models._error import (
     InvalidModelConfigTypeError,
     InvalidModelTypeError,
@@ -29,8 +34,6 @@ from fairseq2.models._error import (
     model_asset_card_error,
 )
 from fairseq2.models._handler import ModelHandler
-from fairseq2.registry import Provider
-from fairseq2.typing import DataType, Device
 
 ModelT = TypeVar("ModelT", bound=Module)
 

--- a/src/fairseq2/models/conformer/_block.py
+++ b/src/fairseq2/models/conformer/_block.py
@@ -12,7 +12,6 @@ from torch import Tensor
 from torch.nn import Dropout
 from typing_extensions import override
 
-from fairseq2.models.conformer._convolution import ConformerConvolution
 from fairseq2.nn import LayerNorm
 from fairseq2.nn.padding import PaddingMask
 from fairseq2.nn.transformer import (
@@ -24,6 +23,10 @@ from fairseq2.nn.transformer import (
     create_standard_layer_norm,
 )
 from fairseq2.typing import DataType, Device
+
+# isort: split
+
+from fairseq2.models.conformer._convolution import ConformerConvolution
 
 
 @final

--- a/src/fairseq2/models/jepa/_checkpoint.py
+++ b/src/fairseq2/models/jepa/_checkpoint.py
@@ -9,8 +9,11 @@ from __future__ import annotations
 import torch
 from torch import Tensor
 
-from fairseq2.models.jepa._config import JepaConfig
 from fairseq2.models.utils.checkpoint import convert_model_state_dict
+
+# isort: split
+
+from fairseq2.models.jepa._config import JepaConfig
 
 
 def convert_jepa_checkpoint(

--- a/src/fairseq2/models/jepa/_factory.py
+++ b/src/fairseq2/models/jepa/_factory.py
@@ -13,8 +13,6 @@ import torch.nn as nn
 from torch import Tensor
 from torch.nn import GELU, Conv2d, Conv3d
 
-from fairseq2.models.jepa._config import JepaConfig, JepaEncoderConfig
-from fairseq2.models.jepa._model import JepaModel
 from fairseq2.models.transformer import TransformerFrontend
 from fairseq2.models.vit import (
     Conv2dPatchFeatureExtractor,
@@ -44,6 +42,11 @@ from fairseq2.nn.transformer import (
     create_default_sdpa,
 )
 from fairseq2.typing import DataType, Device
+
+# isort: split
+
+from fairseq2.models.jepa._config import JepaConfig, JepaEncoderConfig
+from fairseq2.models.jepa._model import JepaModel
 
 
 def create_jepa_model(config: JepaConfig) -> JepaModel:

--- a/src/fairseq2/models/jepa/classifier/_factory.py
+++ b/src/fairseq2/models/jepa/classifier/_factory.py
@@ -7,12 +7,6 @@
 from copy import copy
 
 from fairseq2.models.jepa import JepaEncoderFactory
-from fairseq2.models.jepa.classifier._config import JepaClassifierConfig
-from fairseq2.models.jepa.classifier._model import (
-    AttentivePooler,
-    CrossAttentionDecoderLayer,
-    JepaClassifierModel,
-)
 from fairseq2.models.transformer import TransformerFrontend
 from fairseq2.nn import IdentityProjection, Linear, Projection
 from fairseq2.nn.transformer import (
@@ -20,6 +14,15 @@ from fairseq2.nn.transformer import (
     StandardMultiheadAttention,
     TransformerEncoder,
     create_default_sdpa,
+)
+
+# isort: split
+
+from fairseq2.models.jepa.classifier._config import JepaClassifierConfig
+from fairseq2.models.jepa.classifier._model import (
+    AttentivePooler,
+    CrossAttentionDecoderLayer,
+    JepaClassifierModel,
 )
 
 

--- a/src/fairseq2/models/llama/_checkpoint.py
+++ b/src/fairseq2/models/llama/_checkpoint.py
@@ -10,8 +10,11 @@ from typing import cast
 
 from torch import Tensor
 
-from fairseq2.models.llama._config import LLaMAConfig
 from fairseq2.models.utils.checkpoint import convert_model_state_dict
+
+# isort: split
+
+from fairseq2.models.llama._config import LLaMAConfig
 
 
 def convert_llama_checkpoint(

--- a/src/fairseq2/models/llama/_factory.py
+++ b/src/fairseq2/models/llama/_factory.py
@@ -13,7 +13,6 @@ import torch
 import torch.nn as nn
 from torch import Tensor
 
-from fairseq2.models.llama._config import LLaMAConfig, LLaMARopeScalingConfig
 from fairseq2.models.transformer import (
     TransformerEmbeddingFrontend,
     TransformerFrontend,
@@ -43,6 +42,10 @@ from fairseq2.nn.transformer import (
     create_default_sdpa,
 )
 from fairseq2.typing import DataType, Device
+
+# isort: split
+
+from fairseq2.models.llama._config import LLaMAConfig, LLaMARopeScalingConfig
 
 
 def create_llama_model(config: LLaMAConfig) -> TransformerDecoderModel:

--- a/src/fairseq2/models/llama/_shard.py
+++ b/src/fairseq2/models/llama/_shard.py
@@ -7,11 +7,14 @@
 from __future__ import annotations
 
 from fairseq2.gang import Gangs
-from fairseq2.models.llama._config import LLaMAConfig
 from fairseq2.models.transformer_decoder import (
     TransformerDecoderModel,
     shard_transformer_decoder_model,
 )
+
+# isort: split
+
+from fairseq2.models.llama._config import LLaMAConfig
 
 
 def shard_llama_model(

--- a/src/fairseq2/models/mistral/_checkpoint.py
+++ b/src/fairseq2/models/mistral/_checkpoint.py
@@ -6,8 +6,11 @@
 
 from __future__ import annotations
 
-from fairseq2.models.mistral._config import MistralConfig
 from fairseq2.models.utils.checkpoint import convert_model_state_dict
+
+# isort: split
+
+from fairseq2.models.mistral._config import MistralConfig
 
 
 def convert_mistral_checkpoint(

--- a/src/fairseq2/models/mistral/_factory.py
+++ b/src/fairseq2/models/mistral/_factory.py
@@ -6,7 +6,6 @@
 
 from __future__ import annotations
 
-from fairseq2.models.mistral._config import MistralConfig
 from fairseq2.models.transformer import (
     TransformerEmbeddingFrontend,
     TransformerFrontend,
@@ -38,6 +37,10 @@ from fairseq2.nn.transformer import (
     create_default_sdpa,
 )
 from fairseq2.typing import DataType, Device
+
+# isort: split
+
+from fairseq2.models.mistral._config import MistralConfig
 
 
 def create_mistral_model(config: MistralConfig) -> TransformerDecoderModel:

--- a/src/fairseq2/models/s2t_transformer/_checkpoint.py
+++ b/src/fairseq2/models/s2t_transformer/_checkpoint.py
@@ -11,8 +11,11 @@ from typing import cast
 from torch import Tensor
 from torch.nn.modules.utils import consume_prefix_in_state_dict_if_present
 
-from fairseq2.models.s2t_transformer._config import S2TTransformerConfig
 from fairseq2.models.utils.checkpoint import convert_fairseq_checkpoint
+
+# isort: split
+
+from fairseq2.models.s2t_transformer._config import S2TTransformerConfig
 
 
 def convert_s2t_transformer_checkpoint(

--- a/src/fairseq2/models/s2t_transformer/_factory.py
+++ b/src/fairseq2/models/s2t_transformer/_factory.py
@@ -9,9 +9,6 @@ from __future__ import annotations
 from torch.nn import SiLU
 
 from fairseq2.models.conformer import ConformerBlock, ConformerConvolution
-from fairseq2.models.s2t_transformer._config import S2TTransformerConfig
-from fairseq2.models.s2t_transformer._feature_extractor import Conv1dFbankSubsampler
-from fairseq2.models.s2t_transformer._frontend import S2TTransformerFrontend
 from fairseq2.models.transformer import (
     TransformerEmbeddingFrontend,
     TransformerFrontend,
@@ -46,6 +43,12 @@ from fairseq2.nn.transformer import (
     create_default_sdpa,
 )
 from fairseq2.utils.lazy import Lazy
+
+# isort: split
+
+from fairseq2.models.s2t_transformer._config import S2TTransformerConfig
+from fairseq2.models.s2t_transformer._feature_extractor import Conv1dFbankSubsampler
+from fairseq2.models.s2t_transformer._frontend import S2TTransformerFrontend
 
 
 def create_s2t_transformer_model(config: S2TTransformerConfig) -> TransformerModel:

--- a/src/fairseq2/models/transformer/_checkpoint.py
+++ b/src/fairseq2/models/transformer/_checkpoint.py
@@ -12,8 +12,11 @@ import torch
 from torch import Tensor
 from torch.nn.modules.utils import consume_prefix_in_state_dict_if_present
 
-from fairseq2.models.transformer._config import TransformerConfig
 from fairseq2.models.utils.checkpoint import convert_fairseq_checkpoint
+
+# isort: split
+
+from fairseq2.models.transformer._config import TransformerConfig
 
 
 def convert_transformer_checkpoint(

--- a/src/fairseq2/models/transformer/_factory.py
+++ b/src/fairseq2/models/transformer/_factory.py
@@ -8,12 +8,6 @@ from __future__ import annotations
 
 import torch.nn as nn
 
-from fairseq2.models.transformer._config import TransformerConfig
-from fairseq2.models.transformer._frontend import (
-    TransformerEmbeddingFrontend,
-    TransformerFrontend,
-)
-from fairseq2.models.transformer._model import TransformerModel
 from fairseq2.nn import (
     Embedding,
     Linear,
@@ -39,6 +33,15 @@ from fairseq2.nn.transformer import (
     TransformerEncoderLayer,
     create_default_sdpa,
 )
+
+# isort: split
+
+from fairseq2.models.transformer._config import TransformerConfig
+from fairseq2.models.transformer._frontend import (
+    TransformerEmbeddingFrontend,
+    TransformerFrontend,
+)
+from fairseq2.models.transformer._model import TransformerModel
 
 
 def create_transformer_model(config: TransformerConfig) -> TransformerModel:

--- a/src/fairseq2/models/transformer/_model.py
+++ b/src/fairseq2/models/transformer/_model.py
@@ -13,10 +13,13 @@ from typing_extensions import override
 
 from fairseq2.models.encoder_decoder import EncoderDecoderModel
 from fairseq2.models.sequence import SequenceModelOutput
-from fairseq2.models.transformer._frontend import TransformerFrontend
 from fairseq2.nn import IncrementalStateBag, Projection
 from fairseq2.nn.padding import PaddingMask
 from fairseq2.nn.transformer import TransformerDecoder, TransformerEncoder
+
+# isort: split
+
+from fairseq2.models.transformer._frontend import TransformerFrontend
 
 
 @final

--- a/src/fairseq2/models/transformer_decoder/_sharder.py
+++ b/src/fairseq2/models/transformer_decoder/_sharder.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 from fairseq2.gang import Gangs
 from fairseq2.models.transformer import TransformerEmbeddingFrontend
-from fairseq2.models.transformer_decoder._model import TransformerDecoderModel
 from fairseq2.nn import (
     ColumnShardedLinear,
     Linear,
@@ -22,6 +21,10 @@ from fairseq2.nn.transformer import (
     StandardFeedForwardNetwork,
     StandardMultiheadAttention,
 )
+
+# isort: split
+
+from fairseq2.models.transformer_decoder._model import TransformerDecoderModel
 
 # mypy: disable-error-code="arg-type"
 

--- a/src/fairseq2/models/vit/_frontend.py
+++ b/src/fairseq2/models/vit/_frontend.py
@@ -13,9 +13,12 @@ from torch.nn import Dropout
 from typing_extensions import override
 
 from fairseq2.models.transformer import TransformerFrontend
-from fairseq2.models.vit._feature_extractor import PatchFeatureExtractor
 from fairseq2.nn import IncrementalStateBag, InterpolatedPositionEncoder
 from fairseq2.nn.padding import PaddingMask
+
+# isort: split
+
+from fairseq2.models.vit._feature_extractor import PatchFeatureExtractor
 
 
 @final

--- a/src/fairseq2/models/w2vbert/_checkpoint.py
+++ b/src/fairseq2/models/w2vbert/_checkpoint.py
@@ -13,8 +13,11 @@ from torch import Tensor
 from torch.nn.modules.utils import consume_prefix_in_state_dict_if_present
 
 from fairseq2.models.utils.checkpoint import convert_fairseq_checkpoint
-from fairseq2.models.w2vbert._config import W2VBertConfig
 from fairseq2.typing import CPU
+
+# isort: split
+
+from fairseq2.models.w2vbert._config import W2VBertConfig
 
 
 def convert_w2vbert_checkpoint(

--- a/src/fairseq2/models/w2vbert/_factory.py
+++ b/src/fairseq2/models/w2vbert/_factory.py
@@ -6,9 +6,12 @@
 
 from __future__ import annotations
 
+from fairseq2.models.wav2vec2 import Wav2Vec2Factory, Wav2Vec2Model
+
+# isort: split
+
 from fairseq2.models.w2vbert._config import W2VBertConfig
 from fairseq2.models.w2vbert._model import W2VBertModel
-from fairseq2.models.wav2vec2 import Wav2Vec2Factory, Wav2Vec2Model
 
 
 def create_w2vbert_model(config: W2VBertConfig) -> W2VBertModel:

--- a/src/fairseq2/models/wav2vec2/_checkpoint.py
+++ b/src/fairseq2/models/wav2vec2/_checkpoint.py
@@ -13,9 +13,12 @@ from torch import Tensor
 from torch.nn.modules.utils import consume_prefix_in_state_dict_if_present
 
 from fairseq2.models.utils.checkpoint import convert_fairseq_checkpoint
-from fairseq2.models.wav2vec2._config import Wav2Vec2Config
 from fairseq2.nn.transformer import TransformerNormOrder
 from fairseq2.typing import CPU
+
+# isort: split
+
+from fairseq2.models.wav2vec2._config import Wav2Vec2Config
 
 
 def convert_wav2vec2_checkpoint(

--- a/src/fairseq2/models/wav2vec2/_factory.py
+++ b/src/fairseq2/models/wav2vec2/_factory.py
@@ -10,22 +10,6 @@ from torch.nn import GELU, SiLU
 
 from fairseq2.models.conformer import ConformerBlock, ConformerConvolution
 from fairseq2.models.feature_extractor import SequenceFeatureExtractor
-from fairseq2.models.wav2vec2._config import Wav2Vec2Config, Wav2Vec2EncoderConfig
-from fairseq2.models.wav2vec2._feature_extractor import (
-    Wav2Vec2FbankFeatureExtractor,
-    Wav2Vec2FeatureExtractor,
-)
-from fairseq2.models.wav2vec2._frontend import Wav2Vec2Frontend
-from fairseq2.models.wav2vec2._masker import StandardWav2Vec2Masker, Wav2Vec2Masker
-from fairseq2.models.wav2vec2._model import Wav2Vec2Model
-from fairseq2.models.wav2vec2._position_encoder import (
-    Wav2Vec2PositionEncoder,
-    Wav2Vec2StackedPositionEncoder,
-)
-from fairseq2.models.wav2vec2._vector_quantizer import (
-    GumbelVectorQuantizer,
-    VectorQuantizer,
-)
 from fairseq2.nn import PositionEncoder, RotaryEncoder, init_bert_projection
 from fairseq2.nn.transformer import (
     FeedForwardNetwork,
@@ -42,6 +26,25 @@ from fairseq2.nn.transformer import (
     create_default_sdpa,
 )
 from fairseq2.utils.lazy import Lazy
+
+# isort: split
+
+from fairseq2.models.wav2vec2._config import Wav2Vec2Config, Wav2Vec2EncoderConfig
+from fairseq2.models.wav2vec2._feature_extractor import (
+    Wav2Vec2FbankFeatureExtractor,
+    Wav2Vec2FeatureExtractor,
+)
+from fairseq2.models.wav2vec2._frontend import Wav2Vec2Frontend
+from fairseq2.models.wav2vec2._masker import StandardWav2Vec2Masker, Wav2Vec2Masker
+from fairseq2.models.wav2vec2._model import Wav2Vec2Model
+from fairseq2.models.wav2vec2._position_encoder import (
+    Wav2Vec2PositionEncoder,
+    Wav2Vec2StackedPositionEncoder,
+)
+from fairseq2.models.wav2vec2._vector_quantizer import (
+    GumbelVectorQuantizer,
+    VectorQuantizer,
+)
 
 
 def create_wav2vec2_model(config: Wav2Vec2Config) -> Wav2Vec2Model:

--- a/src/fairseq2/models/wav2vec2/_frontend.py
+++ b/src/fairseq2/models/wav2vec2/_frontend.py
@@ -15,7 +15,6 @@ from typing_extensions import override
 from fairseq2.error import NotSupportedError
 from fairseq2.models.feature_extractor import SequenceFeatureExtractor
 from fairseq2.models.transformer import TransformerFrontend
-from fairseq2.models.wav2vec2._masker import Wav2Vec2Masker
 from fairseq2.nn import (
     IncrementalStateBag,
     LayerNorm,
@@ -25,6 +24,10 @@ from fairseq2.nn import (
 )
 from fairseq2.nn.padding import PaddingMask
 from fairseq2.typing import DataType, Device
+
+# isort: split
+
+from fairseq2.models.wav2vec2._masker import Wav2Vec2Masker
 
 
 @final

--- a/src/fairseq2/models/wav2vec2/_model.py
+++ b/src/fairseq2/models/wav2vec2/_model.py
@@ -16,17 +16,20 @@ from torch.nn.functional import cross_entropy
 
 from fairseq2.error import InternalError
 from fairseq2.models.sequence import SequenceBatch
+from fairseq2.nn import Linear
+from fairseq2.nn.ops import repeat_interleave
+from fairseq2.nn.padding import PaddingMask
+from fairseq2.nn.transformer import TransformerEncoder
+from fairseq2.typing import DataType, Device
+
+# isort: split
+
 from fairseq2.models.wav2vec2._frontend import Wav2Vec2Frontend
 from fairseq2.models.wav2vec2._masker import Wav2Vec2Masker, extract_masked_elements
 from fairseq2.models.wav2vec2._vector_quantizer import (
     VectorQuantizer,
     VectorQuantizerOutput,
 )
-from fairseq2.nn import Linear
-from fairseq2.nn.ops import repeat_interleave
-from fairseq2.nn.padding import PaddingMask
-from fairseq2.nn.transformer import TransformerEncoder
-from fairseq2.typing import DataType, Device
 
 
 @final

--- a/src/fairseq2/models/wav2vec2/asr/_checkpoint.py
+++ b/src/fairseq2/models/wav2vec2/asr/_checkpoint.py
@@ -12,8 +12,11 @@ from torch import Tensor
 from torch.nn.modules.utils import consume_prefix_in_state_dict_if_present
 
 from fairseq2.models.utils.checkpoint import convert_fairseq_checkpoint
-from fairseq2.models.wav2vec2.asr._config import Wav2Vec2AsrConfig
 from fairseq2.nn.transformer import TransformerNormOrder
+
+# isort: split
+
+from fairseq2.models.wav2vec2.asr._config import Wav2Vec2AsrConfig
 
 
 def convert_wav2vec2_asr_checkpoint(

--- a/src/fairseq2/models/wav2vec2/asr/_factory.py
+++ b/src/fairseq2/models/wav2vec2/asr/_factory.py
@@ -14,10 +14,13 @@ from fairseq2.models.wav2vec2 import (
     Wav2Vec2Frontend,
     Wav2Vec2Masker,
 )
-from fairseq2.models.wav2vec2.asr._config import Wav2Vec2AsrConfig
-from fairseq2.models.wav2vec2.asr._model import Wav2Vec2AsrModel
 from fairseq2.nn import Linear, Projection
 from fairseq2.nn.transformer import TransformerEncoder
+
+# isort: split
+
+from fairseq2.models.wav2vec2.asr._config import Wav2Vec2AsrConfig
+from fairseq2.models.wav2vec2.asr._model import Wav2Vec2AsrModel
 
 
 def create_wav2vec2_asr_model(config: Wav2Vec2AsrConfig) -> Wav2Vec2AsrModel:

--- a/src/fairseq2/nn/_position_encoder.py
+++ b/src/fairseq2/nn/_position_encoder.py
@@ -20,9 +20,12 @@ from torch.nn.parameter import Parameter
 from typing_extensions import override
 
 from fairseq2.error import InternalError
-from fairseq2.nn._incremental_state import IncrementalStateBag
 from fairseq2.nn.padding import PaddingMask
 from fairseq2.typing import DataType, Device
+
+# isort: split
+
+from fairseq2.nn._incremental_state import IncrementalStateBag
 
 
 class PositionEncoder(Module, ABC):

--- a/src/fairseq2/nn/data_parallel/_ddp.py
+++ b/src/fairseq2/nn/data_parallel/_ddp.py
@@ -17,13 +17,16 @@ from torch.nn.parallel import DistributedDataParallel as DDP
 
 from fairseq2.error import NotSupportedError
 from fairseq2.gang import Gang, Gangs
-from fairseq2.nn.data_parallel._error import DistributedSetupError
 from fairseq2.nn.utils.module import (
     infer_device,
     reset_non_persistent_buffers,
     to_device,
     to_empty,
 )
+
+# isort: split
+
+from fairseq2.nn.data_parallel._error import DistributedSetupError
 
 DdpModule: TypeAlias = DDP
 

--- a/src/fairseq2/nn/data_parallel/_fsdp.py
+++ b/src/fairseq2/nn/data_parallel/_fsdp.py
@@ -11,12 +11,12 @@ from typing import TYPE_CHECKING, Literal
 from torch.nn import Module
 
 from fairseq2.gang import Gangs
-from fairseq2.nn.data_parallel._common import FsdpApplier, FsdpGranularity
 from fairseq2.typing import ContextManager, DataType
 from fairseq2.utils.version import torch_greater_or_equal
 
 # isort: split
 
+from fairseq2.nn.data_parallel._common import FsdpApplier, FsdpGranularity
 from fairseq2.nn.data_parallel._fsdp1 import Fsdp1Module as Fsdp1Module
 from fairseq2.nn.data_parallel._fsdp1 import (
     fsdp1_local_state_dict as fsdp1_local_state_dict,

--- a/src/fairseq2/nn/data_parallel/_fsdp1.py
+++ b/src/fairseq2/nn/data_parallel/_fsdp1.py
@@ -31,17 +31,20 @@ from torch.nn import Module, Parameter, SyncBatchNorm
 
 from fairseq2.error import NotSupportedError
 from fairseq2.gang import Gangs
+from fairseq2.nn.utils.module import (
+    apply_to_parameters,
+    infer_device,
+)
+from fairseq2.typing import DataType
+
+# isort: split
+
 from fairseq2.nn.data_parallel._common import (
     FsdpApplier,
     FsdpGranularity,
     FsdpParameterInitializer,
 )
 from fairseq2.nn.data_parallel._error import DistributedSetupError
-from fairseq2.nn.utils.module import (
-    apply_to_parameters,
-    infer_device,
-)
-from fairseq2.typing import DataType
 
 # Suppress excessively noisy FSDP log messages that are wrongfully output at
 # the warning level when TORCH_DISTRIBUTED_DEBUG is set to INFO.

--- a/src/fairseq2/nn/data_parallel/_fsdp2.py
+++ b/src/fairseq2/nn/data_parallel/_fsdp2.py
@@ -27,14 +27,17 @@ from torch.nn import Module, Parameter, SyncBatchNorm
 
 from fairseq2.error import InvalidOperationError, NotSupportedError
 from fairseq2.gang import Gangs
+from fairseq2.nn.utils.module import apply_to_parameters, broadcast_module, infer_device
+from fairseq2.typing import DataType
+
+# isort: split
+
 from fairseq2.nn.data_parallel._common import (
     FsdpApplier,
     FsdpGranularity,
     FsdpParameterInitializer,
 )
 from fairseq2.nn.data_parallel._error import DistributedSetupError
-from fairseq2.nn.utils.module import apply_to_parameters, broadcast_module, infer_device
-from fairseq2.typing import DataType
 
 # Suppress yet another non-actionable FSDP warning as it originates from within
 # PyTorch itself.

--- a/src/fairseq2/nn/data_parallel/_fsdp2_compat.py
+++ b/src/fairseq2/nn/data_parallel/_fsdp2_compat.py
@@ -12,8 +12,11 @@ from torch.nn import Module
 
 from fairseq2.error import NotSupportedError
 from fairseq2.gang import Gangs
-from fairseq2.nn.data_parallel._common import FsdpApplier, FsdpGranularity
 from fairseq2.typing import ContextManager, DataType
+
+# isort: split
+
+from fairseq2.nn.data_parallel._common import FsdpApplier, FsdpGranularity
 
 
 @final

--- a/src/fairseq2/nn/transformer/_attention.py
+++ b/src/fairseq2/nn/transformer/_attention.py
@@ -19,6 +19,9 @@ from typing_extensions import override
 
 from fairseq2.logging import log
 from fairseq2.nn.padding import PaddingMask
+
+# isort: split
+
 from fairseq2.nn.transformer._attention_mask import AttentionMask, CausalAttentionMask
 
 

--- a/src/fairseq2/nn/transformer/_decoder.py
+++ b/src/fairseq2/nn/transformer/_decoder.py
@@ -20,6 +20,10 @@ from typing_extensions import override
 from fairseq2.error import InvalidOperationError
 from fairseq2.nn import IncrementalStateBag, LayerNorm
 from fairseq2.nn.padding import PaddingMask
+from fairseq2.typing import CPU, DataType, Device
+
+# isort: split
+
 from fairseq2.nn.transformer._attention_mask import (
     AttentionMaskFactory,
     CausalAttentionMaskFactory,
@@ -31,7 +35,6 @@ from fairseq2.nn.transformer._layer_norm import (
     create_standard_layer_norm,
 )
 from fairseq2.nn.transformer._norm_order import TransformerNormOrder
-from fairseq2.typing import CPU, DataType, Device
 
 
 class TransformerDecoder(Module, ABC):

--- a/src/fairseq2/nn/transformer/_decoder_layer.py
+++ b/src/fairseq2/nn/transformer/_decoder_layer.py
@@ -15,6 +15,10 @@ from typing_extensions import override
 
 from fairseq2.nn import IncrementalStateBag, LayerNorm
 from fairseq2.nn.padding import PaddingMask
+from fairseq2.typing import DataType, Device
+
+# isort: split
+
 from fairseq2.nn.transformer._attention_mask import AttentionMask
 from fairseq2.nn.transformer._ffn import FeedForwardNetwork
 from fairseq2.nn.transformer._layer_norm import (
@@ -24,7 +28,6 @@ from fairseq2.nn.transformer._layer_norm import (
 from fairseq2.nn.transformer._multihead_attention import MultiheadAttention
 from fairseq2.nn.transformer._norm_order import TransformerNormOrder
 from fairseq2.nn.transformer._residual import ResidualConnect, StandardResidualConnect
-from fairseq2.typing import DataType, Device
 
 
 class TransformerDecoderLayer(Module, ABC):

--- a/src/fairseq2/nn/transformer/_encoder.py
+++ b/src/fairseq2/nn/transformer/_encoder.py
@@ -21,6 +21,10 @@ from typing_extensions import override
 from fairseq2.error import InvalidOperationError
 from fairseq2.nn import LayerNorm
 from fairseq2.nn.padding import PaddingMask
+from fairseq2.typing import CPU, DataType, Device
+
+# isort: split
+
 from fairseq2.nn.transformer._attention_mask import AttentionMaskFactory
 from fairseq2.nn.transformer._encoder_layer import TransformerEncoderLayer
 from fairseq2.nn.transformer._layer_norm import (
@@ -28,7 +32,6 @@ from fairseq2.nn.transformer._layer_norm import (
     create_standard_layer_norm,
 )
 from fairseq2.nn.transformer._norm_order import TransformerNormOrder
-from fairseq2.typing import CPU, DataType, Device
 
 
 class TransformerEncoder(Module, ABC):

--- a/src/fairseq2/nn/transformer/_encoder_layer.py
+++ b/src/fairseq2/nn/transformer/_encoder_layer.py
@@ -15,6 +15,10 @@ from typing_extensions import override
 
 from fairseq2.nn import LayerNorm
 from fairseq2.nn.padding import PaddingMask
+from fairseq2.typing import DataType, Device
+
+# isort: split
+
 from fairseq2.nn.transformer._attention_mask import AttentionMask
 from fairseq2.nn.transformer._ffn import FeedForwardNetwork
 from fairseq2.nn.transformer._layer_norm import (
@@ -24,7 +28,6 @@ from fairseq2.nn.transformer._layer_norm import (
 from fairseq2.nn.transformer._multihead_attention import MultiheadAttention
 from fairseq2.nn.transformer._norm_order import TransformerNormOrder
 from fairseq2.nn.transformer._residual import ResidualConnect, StandardResidualConnect
-from fairseq2.typing import DataType, Device
 
 
 class TransformerEncoderLayer(Module, ABC):

--- a/src/fairseq2/nn/transformer/_ffn.py
+++ b/src/fairseq2/nn/transformer/_ffn.py
@@ -15,12 +15,15 @@ from torch.nn import Dropout, Module, ReLU, Sigmoid, SiLU
 from typing_extensions import override
 
 from fairseq2.nn import LayerNorm, Linear, Projection
+from fairseq2.typing import DataType, Device
+
+# isort: split
+
 from fairseq2.nn.transformer._layer_norm import (
     LayerNormFactory,
     create_standard_layer_norm,
 )
 from fairseq2.nn.transformer._norm_order import TransformerNormOrder
-from fairseq2.typing import DataType, Device
 
 
 class FeedForwardNetwork(Module, ABC):

--- a/src/fairseq2/nn/transformer/_multihead_attention.py
+++ b/src/fairseq2/nn/transformer/_multihead_attention.py
@@ -29,9 +29,12 @@ from fairseq2.nn import (
 )
 from fairseq2.nn.ops import repeat_interleave
 from fairseq2.nn.padding import PaddingMask
+from fairseq2.typing import DataType, Device
+
+# isort: split
+
 from fairseq2.nn.transformer._attention import SDPA, create_default_sdpa
 from fairseq2.nn.transformer._attention_mask import AttentionMask, AttentionMaskFactory
-from fairseq2.typing import DataType, Device
 
 
 class MultiheadAttention(Module, ABC):

--- a/src/fairseq2/nn/transformer/_relative_attention.py
+++ b/src/fairseq2/nn/transformer/_relative_attention.py
@@ -18,9 +18,12 @@ from typing_extensions import override
 
 from fairseq2.nn import Linear
 from fairseq2.nn.padding import PaddingMask
+from fairseq2.typing import DataType, Device
+
+# isort: split
+
 from fairseq2.nn.transformer._attention import SDPA, create_default_sdpa
 from fairseq2.nn.transformer._attention_mask import AttentionMask, CustomAttentionMask
-from fairseq2.typing import DataType, Device
 
 
 @final

--- a/src/fairseq2/nn/transformer/_shaw_attention.py
+++ b/src/fairseq2/nn/transformer/_shaw_attention.py
@@ -16,9 +16,12 @@ from typing_extensions import override
 from fairseq2.error import InternalError
 from fairseq2.nn import StandardEmbedding
 from fairseq2.nn.padding import PaddingMask
+from fairseq2.typing import DataType, Device
+
+# isort: split
+
 from fairseq2.nn.transformer._attention import SDPA, create_default_sdpa
 from fairseq2.nn.transformer._attention_mask import AttentionMask, CustomAttentionMask
-from fairseq2.typing import DataType, Device
 
 
 @final

--- a/src/fairseq2/optim/_adamw.py
+++ b/src/fairseq2/optim/_adamw.py
@@ -12,10 +12,13 @@ from typing import Final, Literal, final
 from torch.optim import AdamW, Optimizer
 from typing_extensions import override
 
-from fairseq2.optim._handler import OptimizerHandler
-from fairseq2.optim._optimizer import ParameterCollection
 from fairseq2.utils.structured import structure
 from fairseq2.utils.validation import validate
+
+# isort: split
+
+from fairseq2.optim._handler import OptimizerHandler
+from fairseq2.optim._optimizer import ParameterCollection
 
 ADAMW_OPTIMIZER: Final = "adamw"
 

--- a/src/fairseq2/optim/lr_scheduler/_cosine_annealing.py
+++ b/src/fairseq2/optim/lr_scheduler/_cosine_annealing.py
@@ -15,14 +15,17 @@ from torch.optim import Optimizer
 from typing_extensions import override
 
 from fairseq2.logging import log
+from fairseq2.utils.structured import structure
+from fairseq2.utils.validation import ValidationError, ValidationResult, validate
+
+# isort: split
+
 from fairseq2.optim.lr_scheduler._handler import LRSchedulerHandler
 from fairseq2.optim.lr_scheduler._lr_scheduler import (
     LRScheduler,
     LRSchedulerBase,
     get_per_param_group,
 )
-from fairseq2.utils.structured import structure
-from fairseq2.utils.validation import ValidationError, ValidationResult, validate
 
 
 @final

--- a/src/fairseq2/optim/lr_scheduler/_myle.py
+++ b/src/fairseq2/optim/lr_scheduler/_myle.py
@@ -13,14 +13,17 @@ from typing import Final, final
 from torch.optim import Optimizer
 from typing_extensions import override
 
+from fairseq2.utils.structured import structure
+from fairseq2.utils.validation import ValidationError, ValidationResult, validate
+
+# isort: split
+
 from fairseq2.optim.lr_scheduler._handler import LRSchedulerHandler
 from fairseq2.optim.lr_scheduler._lr_scheduler import (
     LRScheduler,
     LRSchedulerBase,
     get_per_param_group,
 )
-from fairseq2.utils.structured import structure
-from fairseq2.utils.validation import ValidationError, ValidationResult, validate
 
 
 @final

--- a/src/fairseq2/optim/lr_scheduler/_noam.py
+++ b/src/fairseq2/optim/lr_scheduler/_noam.py
@@ -12,10 +12,13 @@ from typing import Final, final
 from torch.optim import Optimizer
 from typing_extensions import override
 
-from fairseq2.optim.lr_scheduler._handler import LRSchedulerHandler
-from fairseq2.optim.lr_scheduler._lr_scheduler import LRScheduler, LRSchedulerBase
 from fairseq2.utils.structured import structure
 from fairseq2.utils.validation import validate
+
+# isort: split
+
+from fairseq2.optim.lr_scheduler._handler import LRSchedulerHandler
+from fairseq2.optim.lr_scheduler._lr_scheduler import LRScheduler, LRSchedulerBase
 
 
 @final

--- a/src/fairseq2/optim/lr_scheduler/_polynomial_decay.py
+++ b/src/fairseq2/optim/lr_scheduler/_polynomial_decay.py
@@ -13,6 +13,11 @@ from typing import Final, final
 from torch.optim import Optimizer
 from typing_extensions import override
 
+from fairseq2.utils.structured import structure
+from fairseq2.utils.validation import validate
+
+# isort: split
+
 from fairseq2.optim.lr_scheduler._error import UnspecifiedNumberOfStepsError
 from fairseq2.optim.lr_scheduler._handler import LRSchedulerHandler
 from fairseq2.optim.lr_scheduler._lr_scheduler import (
@@ -20,8 +25,6 @@ from fairseq2.optim.lr_scheduler._lr_scheduler import (
     LRSchedulerBase,
     get_per_param_group,
 )
-from fairseq2.utils.structured import structure
-from fairseq2.utils.validation import validate
 
 
 @final

--- a/src/fairseq2/optim/lr_scheduler/_tri_stage.py
+++ b/src/fairseq2/optim/lr_scheduler/_tri_stage.py
@@ -14,6 +14,11 @@ from typing import Final, final
 from torch.optim import Optimizer
 from typing_extensions import override
 
+from fairseq2.utils.structured import structure
+from fairseq2.utils.validation import ValidationError, ValidationResult, validate
+
+# isort: split
+
 from fairseq2.optim.lr_scheduler._error import UnspecifiedNumberOfStepsError
 from fairseq2.optim.lr_scheduler._handler import LRSchedulerHandler
 from fairseq2.optim.lr_scheduler._lr_scheduler import (
@@ -21,8 +26,6 @@ from fairseq2.optim.lr_scheduler._lr_scheduler import (
     LRSchedulerBase,
     get_per_param_group,
 )
-from fairseq2.utils.structured import structure
-from fairseq2.utils.validation import ValidationError, ValidationResult, validate
 
 
 @final

--- a/src/fairseq2/profilers/_handler.py
+++ b/src/fairseq2/profilers/_handler.py
@@ -10,6 +10,9 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 
 from fairseq2.gang import Gangs
+
+# isort: split
+
 from fairseq2.profilers._profiler import Profiler
 
 

--- a/src/fairseq2/recipes/_evaluator.py
+++ b/src/fairseq2/recipes/_evaluator.py
@@ -23,14 +23,17 @@ from fairseq2.logging import log
 from fairseq2.metrics import MetricBag, MetricBagError
 from fairseq2.metrics.recorders import MetricRecorder, MetricRecordError
 from fairseq2.profilers import Profiler
-from fairseq2.recipes._error import RecipeError, UnitError
-from fairseq2.recipes._metrics import extend_batch_metrics
-from fairseq2.recipes._model import Model
-from fairseq2.recipes._recipe import Recipe, RecipeStopException
 from fairseq2.typing import CPU, ContextManager, DataType
 from fairseq2.utils.progress import ProgressReporter, ProgressTask
 from fairseq2.utils.rng import RngBag
 from fairseq2.utils.stopwatch import Stopwatch
+
+# isort: split
+
+from fairseq2.recipes._error import RecipeError, UnitError
+from fairseq2.recipes._metrics import extend_batch_metrics
+from fairseq2.recipes._model import Model
+from fairseq2.recipes._recipe import Recipe, RecipeStopException
 
 BatchT_contra = TypeVar(
     "BatchT_contra", bound=SupportsDeviceTransfer, contravariant=True

--- a/src/fairseq2/recipes/_generator.py
+++ b/src/fairseq2/recipes/_generator.py
@@ -22,14 +22,17 @@ from fairseq2.logging import log
 from fairseq2.metrics import MetricBag, MetricBagError
 from fairseq2.metrics.recorders import MetricRecorder, MetricRecordError
 from fairseq2.profilers import Profiler
-from fairseq2.recipes._error import RecipeError, UnitError
-from fairseq2.recipes._metrics import extend_batch_metrics
-from fairseq2.recipes._model import Model
-from fairseq2.recipes._recipe import Recipe, RecipeStopException
 from fairseq2.typing import CPU, ContextManager, DataType
 from fairseq2.utils.progress import ProgressReporter, ProgressTask
 from fairseq2.utils.rng import RngBag
 from fairseq2.utils.stopwatch import Stopwatch
+
+# isort: split
+
+from fairseq2.recipes._error import RecipeError, UnitError
+from fairseq2.recipes._metrics import extend_batch_metrics
+from fairseq2.recipes._model import Model
+from fairseq2.recipes._recipe import Recipe, RecipeStopException
 
 BatchT_contra = TypeVar(
     "BatchT_contra", bound=SupportsDeviceTransfer, contravariant=True

--- a/src/fairseq2/recipes/_trainer.py
+++ b/src/fairseq2/recipes/_trainer.py
@@ -38,6 +38,15 @@ from fairseq2.nn.utils.gradient import check_gradient_norms, normalize_gradients
 from fairseq2.optim import DynamicLossScaler
 from fairseq2.optim.lr_scheduler import LRScheduler, get_effective_lr
 from fairseq2.profilers import Profiler
+from fairseq2.typing import CPU, ContextManager, DataType
+from fairseq2.utils.gc import GarbageCollector
+from fairseq2.utils.progress import ProgressReporter, ProgressTask
+from fairseq2.utils.rng import RngBag
+from fairseq2.utils.state import Stateful
+from fairseq2.utils.stopwatch import Stopwatch
+
+# isort: split
+
 from fairseq2.recipes._early_stopper import EarlyStopper
 from fairseq2.recipes._error import (
     InconsistentGradientNormError,
@@ -49,12 +58,6 @@ from fairseq2.recipes._metrics import extend_batch_metrics
 from fairseq2.recipes._model import Model
 from fairseq2.recipes._recipe import Recipe, RecipeStopException
 from fairseq2.recipes._validator import Validator
-from fairseq2.typing import CPU, ContextManager, DataType
-from fairseq2.utils.gc import GarbageCollector
-from fairseq2.utils.progress import ProgressReporter, ProgressTask
-from fairseq2.utils.rng import RngBag
-from fairseq2.utils.state import Stateful
-from fairseq2.utils.stopwatch import Stopwatch
 
 BatchT_contra = TypeVar(
     "BatchT_contra", bound=SupportsDeviceTransfer, contravariant=True

--- a/src/fairseq2/recipes/_validator.py
+++ b/src/fairseq2/recipes/_validator.py
@@ -25,13 +25,16 @@ from fairseq2.logging import log
 from fairseq2.metrics import MetricBagError, MetricDescriptor
 from fairseq2.metrics.recorders import MetricRecorder, MetricRecordError
 from fairseq2.profilers import Profiler
-from fairseq2.recipes._error import RecipeError, UnitError
-from fairseq2.recipes._evaluator import EvalUnit
-from fairseq2.recipes._metrics import extend_batch_metrics
 from fairseq2.typing import CPU, ContextManager, DataType
 from fairseq2.utils.progress import ProgressReporter, ProgressTask
 from fairseq2.utils.rng import RngBag
 from fairseq2.utils.stopwatch import Stopwatch
+
+# isort: split
+
+from fairseq2.recipes._error import RecipeError, UnitError
+from fairseq2.recipes._evaluator import EvalUnit
+from fairseq2.recipes._metrics import extend_batch_metrics
 
 
 class Validator(ABC):

--- a/src/fairseq2/recipes/asr/_eval.py
+++ b/src/fairseq2/recipes/asr/_eval.py
@@ -20,7 +20,6 @@ from fairseq2.gang import Gangs
 from fairseq2.models.asr import AsrModel
 from fairseq2.models.seq2seq import Seq2SeqBatch
 from fairseq2.recipes import Evaluator, EvalUnit, Model, RecipeError, UnitError
-from fairseq2.recipes.asr._common import AsrCriterion, AsrMetricBag, AsrScorer
 from fairseq2.recipes.common import (
     create_evaluator,
     load_dataset,
@@ -43,6 +42,10 @@ from fairseq2.utils.file import FileMode
 from fairseq2.utils.rng import manual_seed
 from fairseq2.utils.structured import structure
 from fairseq2.utils.validation import validate
+
+# isort: split
+
+from fairseq2.recipes.asr._common import AsrCriterion, AsrMetricBag, AsrScorer
 
 
 @dataclass(kw_only=True)

--- a/src/fairseq2/recipes/common/_dataset.py
+++ b/src/fairseq2/recipes/common/_dataset.py
@@ -29,9 +29,12 @@ from fairseq2.datasets import (
 from fairseq2.gang import GangError, Gangs
 from fairseq2.logging import log
 from fairseq2.recipes import RecipeError
-from fairseq2.recipes.common._error import DatasetPathNotFoundError
 from fairseq2.recipes.config import DatasetSection
 from fairseq2.registry import Provider
+
+# isort: split
+
+from fairseq2.recipes.common._error import DatasetPathNotFoundError
 
 DatasetT = TypeVar("DatasetT")
 

--- a/src/fairseq2/recipes/common/_evaluator.py
+++ b/src/fairseq2/recipes/common/_evaluator.py
@@ -15,10 +15,13 @@ from fairseq2.datasets import DataReader
 from fairseq2.device import SupportsDeviceTransfer
 from fairseq2.gang import Gangs
 from fairseq2.recipes import Evaluator, EvalUnit
+from fairseq2.recipes.config import CommonSection, EvaluatorSection
+
+# isort: split
+
 from fairseq2.recipes.common._device import create_device_stat_tracker
 from fairseq2.recipes.common._metrics import create_metric_recorder
 from fairseq2.recipes.common._profilers import create_profiler
-from fairseq2.recipes.config import CommonSection, EvaluatorSection
 
 BatchT = TypeVar("BatchT", bound=SupportsDeviceTransfer)
 

--- a/src/fairseq2/recipes/common/_generator.py
+++ b/src/fairseq2/recipes/common/_generator.py
@@ -14,10 +14,13 @@ from fairseq2.datasets import DataReader
 from fairseq2.device import SupportsDeviceTransfer
 from fairseq2.gang import Gangs
 from fairseq2.recipes import Generator, GeneratorUnit
+from fairseq2.recipes.config import CommonSection, GeneratorSection
+
+# isort: split
+
 from fairseq2.recipes.common._device import create_device_stat_tracker
 from fairseq2.recipes.common._metrics import create_metric_recorder
 from fairseq2.recipes.common._profilers import create_profiler
-from fairseq2.recipes.config import CommonSection, GeneratorSection
 
 BatchT = TypeVar("BatchT", bound=SupportsDeviceTransfer)
 

--- a/src/fairseq2/recipes/common/_model.py
+++ b/src/fairseq2/recipes/common/_model.py
@@ -48,13 +48,6 @@ from fairseq2.models import (
 from fairseq2.nn.checkpointing import use_layerwise_activation_checkpointing
 from fairseq2.nn.utils.gradient import clip_gradient_norm
 from fairseq2.recipes import Model, RecipeError
-from fairseq2.recipes.common._distributed import setup_data_parallel_model
-from fairseq2.recipes.common._error import (
-    InvalidCheckpointPathError,
-    ModelCompilationNotSupportedError,
-    ModelParallelismNotSupportedError,
-    ModelPathNotFoundError,
-)
 from fairseq2.recipes.config import ModelSection, TorchCompileSection, TrainerSection
 from fairseq2.recipes.utils.log import log_config, log_model
 from fairseq2.registry import Provider
@@ -62,6 +55,16 @@ from fairseq2.typing import ContextManager, DataClass, is_dataclass_instance
 from fairseq2.utils.merge import MergeError, merge_dataclass
 from fairseq2.utils.structured import StructureError, structure
 from fairseq2.utils.yaml import StandardYamlDumper
+
+# isort: split
+
+from fairseq2.recipes.common._distributed import setup_data_parallel_model
+from fairseq2.recipes.common._error import (
+    InvalidCheckpointPathError,
+    ModelCompilationNotSupportedError,
+    ModelParallelismNotSupportedError,
+    ModelPathNotFoundError,
+)
 
 
 def setup_model(

--- a/src/fairseq2/recipes/common/_ref_model.py
+++ b/src/fairseq2/recipes/common/_ref_model.py
@@ -33,13 +33,16 @@ from fairseq2.models import (
 )
 from fairseq2.nn.utils.module import remove_parametrizations
 from fairseq2.recipes import Model, RecipeError
-from fairseq2.recipes.common._distributed import broadcast_model
-from fairseq2.recipes.common._error import ModelParallelismNotSupportedError
-from fairseq2.recipes.common._model import LocalModel, maybe_compile_model
 from fairseq2.recipes.config import ReferenceModelSection, TorchCompileSection
 from fairseq2.recipes.utils.log import log_model
 from fairseq2.registry import Provider
 from fairseq2.typing import DataType
+
+# isort: split
+
+from fairseq2.recipes.common._distributed import broadcast_model
+from fairseq2.recipes.common._error import ModelParallelismNotSupportedError
+from fairseq2.recipes.common._model import LocalModel, maybe_compile_model
 
 
 def setup_reference_model(

--- a/src/fairseq2/recipes/common/_trainer.py
+++ b/src/fairseq2/recipes/common/_trainer.py
@@ -28,15 +28,18 @@ from fairseq2.recipes import (
     TrainUnit,
     Validator,
 )
-from fairseq2.recipes.common._device import create_device_stat_tracker
-from fairseq2.recipes.common._metrics import create_metric_recorder
-from fairseq2.recipes.common._profilers import create_profiler
 from fairseq2.recipes.config import CommonSection, RegimeSection, TrainerSection
 from fairseq2.utils.gc import (
     CPythonGarbageCollector,
     GarbageCollector,
     NoopGarbageCollector,
 )
+
+# isort: split
+
+from fairseq2.recipes.common._device import create_device_stat_tracker
+from fairseq2.recipes.common._metrics import create_metric_recorder
+from fairseq2.recipes.common._profilers import create_profiler
 
 BatchT = TypeVar("BatchT", bound=SupportsDeviceTransfer)
 

--- a/src/fairseq2/recipes/lm/_loss_eval.py
+++ b/src/fairseq2/recipes/lm/_loss_eval.py
@@ -38,14 +38,17 @@ from fairseq2.recipes.config import (
     ReferenceModelSection,
     TextTokenizerSection,
 )
-from fairseq2.recipes.lm._instruction_finetune import (
-    InstructionFinetuneCriterion,
-    InstructionLossEvalUnit,
-)
 from fairseq2.typing import CPU
 from fairseq2.utils.rng import manual_seed
 from fairseq2.utils.structured import structure
 from fairseq2.utils.validation import validate
+
+# isort: split
+
+from fairseq2.recipes.lm._instruction_finetune import (
+    InstructionFinetuneCriterion,
+    InstructionLossEvalUnit,
+)
 
 
 @dataclass(kw_only=True)

--- a/src/fairseq2/recipes/lm/_preference_finetune/_cpo.py
+++ b/src/fairseq2/recipes/lm/_preference_finetune/_cpo.py
@@ -19,14 +19,17 @@ from fairseq2.gang import Gang, Gangs
 from fairseq2.metrics import Mean
 from fairseq2.models.sequence import SequenceModelOutput, as_auto_regressive_input
 from fairseq2.recipes import Model, TrainUnit
+from fairseq2.utils.structured import structure
+from fairseq2.utils.validation import validate
+
+# isort: split
+
 from fairseq2.recipes.lm._preference_finetune._common import (
     POFinetuneMetricBag,
     _gather_lprobs,
 )
 from fairseq2.recipes.lm._preference_finetune._config import POFinetuneConfig
 from fairseq2.recipes.lm._preference_finetune._handler import POFinetuneUnitHandler
-from fairseq2.utils.structured import structure
-from fairseq2.utils.validation import validate
 
 
 @final

--- a/src/fairseq2/recipes/lm/_preference_finetune/_dpo.py
+++ b/src/fairseq2/recipes/lm/_preference_finetune/_dpo.py
@@ -29,14 +29,17 @@ from fairseq2.nn.utils.module import freeze_parameters
 from fairseq2.recipes import Model, TrainUnit
 from fairseq2.recipes.common import setup_reference_model
 from fairseq2.recipes.config import ReferenceModelSection
+from fairseq2.utils.structured import structure
+from fairseq2.utils.validation import validate
+
+# isort: split
+
 from fairseq2.recipes.lm._preference_finetune._common import (
     POFinetuneMetricBag,
     _gather_lprobs_avg,
 )
 from fairseq2.recipes.lm._preference_finetune._config import POFinetuneConfig
 from fairseq2.recipes.lm._preference_finetune._handler import POFinetuneUnitHandler
-from fairseq2.utils.structured import structure
-from fairseq2.utils.validation import validate
 
 
 @final

--- a/src/fairseq2/recipes/lm/_preference_finetune/_handler.py
+++ b/src/fairseq2/recipes/lm/_preference_finetune/_handler.py
@@ -11,6 +11,9 @@ from abc import ABC, abstractmethod
 from fairseq2.datasets.preference import PreferenceBatch
 from fairseq2.gang import Gangs
 from fairseq2.recipes import Model, TrainUnit
+
+# isort: split
+
 from fairseq2.recipes.lm._preference_finetune._config import POFinetuneConfig
 
 

--- a/src/fairseq2/recipes/lm/_preference_finetune/_orpo.py
+++ b/src/fairseq2/recipes/lm/_preference_finetune/_orpo.py
@@ -19,14 +19,17 @@ from fairseq2.gang import Gang, Gangs
 from fairseq2.metrics import Mean
 from fairseq2.models.sequence import SequenceModelOutput, as_auto_regressive_input
 from fairseq2.recipes import Model, TrainUnit
+from fairseq2.utils.structured import structure
+from fairseq2.utils.validation import validate
+
+# isort: split
+
 from fairseq2.recipes.lm._preference_finetune._common import (
     POFinetuneMetricBag,
     _gather_lprobs,
 )
 from fairseq2.recipes.lm._preference_finetune._config import POFinetuneConfig
 from fairseq2.recipes.lm._preference_finetune._handler import POFinetuneUnitHandler
-from fairseq2.utils.structured import structure
-from fairseq2.utils.validation import validate
 
 
 @final

--- a/src/fairseq2/recipes/lm/_preference_finetune/_recipe.py
+++ b/src/fairseq2/recipes/lm/_preference_finetune/_recipe.py
@@ -31,6 +31,13 @@ from fairseq2.recipes.common import (
     setup_torch,
     setup_training_gangs,
 )
+from fairseq2.typing import CPU
+from fairseq2.utils.rng import manual_seed
+from fairseq2.utils.structured import structure
+from fairseq2.utils.validation import validate
+
+# isort: split
+
 from fairseq2.recipes.lm._preference_finetune._config import (
     POCriterionSection,
     POFinetuneConfig,
@@ -43,10 +50,6 @@ from fairseq2.recipes.lm._preference_finetune._handler import (
     POFinetuneUnitHandler,
     UnknownPOFinetuneUnitError,
 )
-from fairseq2.typing import CPU
-from fairseq2.utils.rng import manual_seed
-from fairseq2.utils.structured import structure
-from fairseq2.utils.validation import validate
 
 
 def register_po_finetune_configs(context: RuntimeContext) -> None:

--- a/src/fairseq2/recipes/lm/_preference_finetune/_simpo.py
+++ b/src/fairseq2/recipes/lm/_preference_finetune/_simpo.py
@@ -19,14 +19,17 @@ from fairseq2.gang import Gang, Gangs
 from fairseq2.metrics import Mean
 from fairseq2.models.sequence import SequenceModelOutput, as_auto_regressive_input
 from fairseq2.recipes import Model, TrainUnit
+from fairseq2.utils.structured import structure
+from fairseq2.utils.validation import validate
+
+# isort: split
+
 from fairseq2.recipes.lm._preference_finetune._common import (
     POFinetuneMetricBag,
     _gather_lprobs_avg,
 )
 from fairseq2.recipes.lm._preference_finetune._config import POFinetuneConfig
 from fairseq2.recipes.lm._preference_finetune._handler import POFinetuneUnitHandler
-from fairseq2.utils.structured import structure
-from fairseq2.utils.validation import validate
 
 
 @final

--- a/src/fairseq2/recipes/mt/_eval.py
+++ b/src/fairseq2/recipes/mt/_eval.py
@@ -56,12 +56,15 @@ from fairseq2.recipes.config import (
     Seq2SeqGeneratorSection,
     TextTokenizerSection,
 )
-from fairseq2.recipes.mt._common import MTCriterion, MTLossSection
 from fairseq2.typing import CPU
 from fairseq2.utils.file import FileMode
 from fairseq2.utils.rng import manual_seed
 from fairseq2.utils.structured import structure
 from fairseq2.utils.validation import validate
+
+# isort: split
+
+from fairseq2.recipes.mt._common import MTCriterion, MTLossSection
 
 
 @dataclass(kw_only=True)

--- a/src/fairseq2/recipes/mt/_train.py
+++ b/src/fairseq2/recipes/mt/_train.py
@@ -55,12 +55,15 @@ from fairseq2.recipes.config import (
     TextTokenizerSection,
     TrainerSection,
 )
-from fairseq2.recipes.mt._common import MTCriterion, MTLossSection
-from fairseq2.recipes.mt._eval import MTBleuChrfEvalUnit, MTLossEvalUnit
 from fairseq2.typing import CPU
 from fairseq2.utils.rng import manual_seed
 from fairseq2.utils.structured import structure
 from fairseq2.utils.validation import validate
+
+# isort: split
+
+from fairseq2.recipes.mt._common import MTCriterion, MTLossSection
+from fairseq2.recipes.mt._eval import MTBleuChrfEvalUnit, MTLossEvalUnit
 
 
 @dataclass(kw_only=True)

--- a/src/fairseq2/recipes/wav2vec2/_eval.py
+++ b/src/fairseq2/recipes/wav2vec2/_eval.py
@@ -39,15 +39,18 @@ from fairseq2.recipes.config import (
     GangSection,
     ReferenceModelSection,
 )
+from fairseq2.typing import CPU
+from fairseq2.utils.rng import manual_seed
+from fairseq2.utils.structured import structure
+from fairseq2.utils.validation import validate
+
+# isort: split
+
 from fairseq2.recipes.wav2vec2._common import (
     Wav2Vec2Criterion,
     Wav2Vec2LossSection,
     Wav2Vec2MetricBag,
 )
-from fairseq2.typing import CPU
-from fairseq2.utils.rng import manual_seed
-from fairseq2.utils.structured import structure
-from fairseq2.utils.validation import validate
 
 
 @dataclass(kw_only=True)

--- a/src/fairseq2/recipes/wav2vec2/_train.py
+++ b/src/fairseq2/recipes/wav2vec2/_train.py
@@ -48,16 +48,19 @@ from fairseq2.recipes.config import (
     RegimeSection,
     TrainerSection,
 )
+from fairseq2.typing import CPU
+from fairseq2.utils.rng import manual_seed
+from fairseq2.utils.structured import structure
+from fairseq2.utils.validation import validate
+
+# isort: split
+
 from fairseq2.recipes.wav2vec2._common import (
     Wav2Vec2Criterion,
     Wav2Vec2LossSection,
     Wav2Vec2MetricBag,
 )
 from fairseq2.recipes.wav2vec2._eval import Wav2Vec2EvalUnit
-from fairseq2.typing import CPU
-from fairseq2.utils.rng import manual_seed
-from fairseq2.utils.structured import structure
-from fairseq2.utils.validation import validate
 
 
 @dataclass(kw_only=True)

--- a/src/fairseq2/setup/_asset.py
+++ b/src/fairseq2/setup/_asset.py
@@ -15,8 +15,11 @@ from fairseq2.assets import (
     WheelPackageFileLister,
 )
 from fairseq2.context import RuntimeContext
-from fairseq2.setup._error import SetupError
 from fairseq2.utils.yaml import StandardYamlLoader
+
+# isort: split
+
+from fairseq2.setup._error import SetupError
 
 
 def register_assets(context: RuntimeContext) -> None:

--- a/src/fairseq2/setup/_metrics.py
+++ b/src/fairseq2/setup/_metrics.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from typing import Any
 
 from fairseq2.context import RuntimeContext
-from fairseq2.metrics._descriptor import (
+from fairseq2.metrics import (
     MetricDescriptor,
     format_as_byte_size,
     format_as_float,

--- a/src/fairseq2/setup/_root.py
+++ b/src/fairseq2/setup/_root.py
@@ -17,6 +17,11 @@ from fairseq2.assets import (
 )
 from fairseq2.context import RuntimeContext
 from fairseq2.extensions import run_extensions
+from fairseq2.utils.file import FileSystem, LocalFileSystem
+from fairseq2.utils.progress import NoopProgressReporter, ProgressReporter
+
+# isort: split
+
 from fairseq2.setup._asset import register_assets
 from fairseq2.setup._chatbots import register_chatbots
 from fairseq2.setup._cluster import register_clusters
@@ -36,8 +41,6 @@ from fairseq2.setup._po_finetune_units import register_po_finetune_units
 from fairseq2.setup._profilers import register_profilers
 from fairseq2.setup._recipes import register_recipes
 from fairseq2.setup._text_tokenizers import register_text_tokenizer_families
-from fairseq2.utils.file import FileSystem, LocalFileSystem
-from fairseq2.utils.progress import NoopProgressReporter, ProgressReporter
 
 
 def setup_library(progress_reporter: ProgressReporter | None = None) -> RuntimeContext:


### PR DESCRIPTION
For better readability this PR splits internal package imports from external ones via `# isort: split`.