### PR TITLE
Rename TransformerDecoderModel to TransformerLanguageModel

### DIFF
--- a/src/fairseq2/models/llama/__init__.py
+++ b/src/fairseq2/models/llama/__init__.py
@@ -28,6 +28,6 @@ from fairseq2.models.llama._shard import shard_llama_model as shard_llama_model
 # isort: split
 
 from fairseq2.models import ModelHubAccessor
-from fairseq2.models.transformer_decoder import TransformerDecoderModel
+from fairseq2.models.transformer_lm import TransformerLanguageModel
 
-get_llama_model_hub = ModelHubAccessor(TransformerDecoderModel, LLaMAConfig)
+get_llama_model_hub = ModelHubAccessor(TransformerLanguageModel, LLaMAConfig)

--- a/src/fairseq2/models/llama/_compile.py
+++ b/src/fairseq2/models/llama/_compile.py
@@ -8,10 +8,10 @@ from __future__ import annotations
 
 from typing import Any
 
-from fairseq2.models.transformer_decoder import TransformerDecoderModel
+from fairseq2.models.transformer_lm import TransformerLanguageModel
 
 
-def compile_llama_model(model: TransformerDecoderModel, **kwargs: Any) -> None:
+def compile_llama_model(model: TransformerLanguageModel, **kwargs: Any) -> None:
     for layer in model.decoder.layers:
         layer.compile(**kwargs)
 

--- a/src/fairseq2/models/llama/_factory.py
+++ b/src/fairseq2/models/llama/_factory.py
@@ -17,7 +17,7 @@ from fairseq2.models.transformer import (
     TransformerEmbeddingFrontend,
     TransformerFrontend,
 )
-from fairseq2.models.transformer_decoder import TransformerDecoderModel
+from fairseq2.models.transformer_lm import TransformerLanguageModel
 from fairseq2.nn import (
     Embedding,
     LayerNorm,
@@ -48,7 +48,7 @@ from fairseq2.typing import DataType, Device
 from fairseq2.models.llama._config import LLaMAConfig, LLaMARopeScalingConfig
 
 
-def create_llama_model(config: LLaMAConfig) -> TransformerDecoderModel:
+def create_llama_model(config: LLaMAConfig) -> TransformerLanguageModel:
     return LLaMAFactory(config).create_model()
 
 
@@ -58,7 +58,7 @@ class LLaMAFactory:
     def __init__(self, config: LLaMAConfig) -> None:
         self._config = config
 
-    def create_model(self) -> TransformerDecoderModel:
+    def create_model(self) -> TransformerLanguageModel:
         config = self._config
 
         embed = self.create_embedding()
@@ -69,7 +69,7 @@ class LLaMAFactory:
 
         final_proj = self.create_final_projection(embed)
 
-        return TransformerDecoderModel(
+        return TransformerLanguageModel(
             decoder_frontend,
             decoder,
             final_proj,

--- a/src/fairseq2/models/llama/_shard.py
+++ b/src/fairseq2/models/llama/_shard.py
@@ -7,9 +7,9 @@
 from __future__ import annotations
 
 from fairseq2.gang import Gangs
-from fairseq2.models.transformer_decoder import (
-    TransformerDecoderModel,
-    shard_transformer_decoder_model,
+from fairseq2.models.transformer_lm import (
+    TransformerLanguageModel,
+    shard_transformer_language_model,
 )
 
 # isort: split
@@ -18,8 +18,8 @@ from fairseq2.models.llama._config import LLaMAConfig
 
 
 def shard_llama_model(
-    model: TransformerDecoderModel, config: LLaMAConfig, gangs: Gangs
+    model: TransformerLanguageModel, config: LLaMAConfig, gangs: Gangs
 ) -> None:
     shard_embed_dim = config.max_seq_len < 8192  # LLaMA 1 or 2
 
-    shard_transformer_decoder_model(model, gangs, shard_embed_dim)
+    shard_transformer_language_model(model, gangs, shard_embed_dim)

--- a/src/fairseq2/models/mistral/__init__.py
+++ b/src/fairseq2/models/mistral/__init__.py
@@ -22,6 +22,6 @@ from fairseq2.models.mistral._factory import (
 # isort: split
 
 from fairseq2.models import ModelHubAccessor
-from fairseq2.models.transformer_decoder import TransformerDecoderModel
+from fairseq2.models.transformer_lm import TransformerLanguageModel
 
-get_mistral_model_hub = ModelHubAccessor(TransformerDecoderModel, MistralConfig)
+get_mistral_model_hub = ModelHubAccessor(TransformerLanguageModel, MistralConfig)

--- a/src/fairseq2/models/mistral/_factory.py
+++ b/src/fairseq2/models/mistral/_factory.py
@@ -11,7 +11,7 @@ from fairseq2.models.transformer import (
     TransformerFrontend,
     init_transformer_final_projection,
 )
-from fairseq2.models.transformer_decoder import TransformerDecoderModel
+from fairseq2.models.transformer_lm import TransformerLanguageModel
 from fairseq2.nn import (
     Embedding,
     LayerNorm,
@@ -43,7 +43,7 @@ from fairseq2.typing import DataType, Device
 from fairseq2.models.mistral._config import MistralConfig
 
 
-def create_mistral_model(config: MistralConfig) -> TransformerDecoderModel:
+def create_mistral_model(config: MistralConfig) -> TransformerLanguageModel:
     return MistralFactory(config).create_model()
 
 
@@ -53,7 +53,7 @@ class MistralFactory:
     def __init__(self, config: MistralConfig) -> None:
         self._config = config
 
-    def create_model(self) -> TransformerDecoderModel:
+    def create_model(self) -> TransformerLanguageModel:
         config = self._config
 
         decoder_frontend = self.create_decoder_frontend()
@@ -62,7 +62,7 @@ class MistralFactory:
 
         final_proj = self.create_final_projection()
 
-        return TransformerDecoderModel(
+        return TransformerLanguageModel(
             decoder_frontend,
             decoder,
             final_proj,

--- a/src/fairseq2/models/transformer_lm/__init__.py
+++ b/src/fairseq2/models/transformer_lm/__init__.py
@@ -6,9 +6,9 @@
 
 from __future__ import annotations
 
-from fairseq2.models.transformer_decoder._model import (
-    TransformerDecoderModel as TransformerDecoderModel,
+from fairseq2.models.transformer_lm._model import (
+    TransformerLanguageModel as TransformerLanguageModel,
 )
-from fairseq2.models.transformer_decoder._sharder import (
-    shard_transformer_decoder_model as shard_transformer_decoder_model,
+from fairseq2.models.transformer_lm._sharder import (
+    shard_transformer_language_model as shard_transformer_language_model,
 )

--- a/src/fairseq2/models/transformer_lm/_model.py
+++ b/src/fairseq2/models/transformer_lm/_model.py
@@ -22,8 +22,8 @@ from fairseq2.nn.transformer import TransformerDecoder
 
 
 @final
-class TransformerDecoderModel(DecoderModel):
-    """Represents a Transformer-based decoder model."""
+class TransformerLanguageModel(DecoderModel):
+    """Represents a Transformer-based language model."""
 
     decoder_frontend: TransformerFrontend
     decoder: TransformerDecoder

--- a/src/fairseq2/models/transformer_lm/_sharder.py
+++ b/src/fairseq2/models/transformer_lm/_sharder.py
@@ -24,13 +24,13 @@ from fairseq2.nn.transformer import (
 
 # isort: split
 
-from fairseq2.models.transformer_decoder._model import TransformerDecoderModel
+from fairseq2.models.transformer_lm._model import TransformerLanguageModel
 
 # mypy: disable-error-code="arg-type"
 
 
-def shard_transformer_decoder_model(
-    model: TransformerDecoderModel, gangs: Gangs, shard_embed_dim: bool
+def shard_transformer_language_model(
+    model: TransformerLanguageModel, gangs: Gangs, shard_embed_dim: bool
 ) -> None:
     """Shard ``model`` over ``gangs`` for tensor parallelism.
 

--- a/src/fairseq2/setup/_models.py
+++ b/src/fairseq2/setup/_models.py
@@ -66,7 +66,7 @@ from fairseq2.models.transformer import (
     create_transformer_model,
     register_transformer_configs,
 )
-from fairseq2.models.transformer_decoder import TransformerDecoderModel
+from fairseq2.models.transformer_lm import TransformerLanguageModel
 from fairseq2.models.w2vbert import (
     W2VBERT_MODEL_FAMILY,
     W2VBertConfig,
@@ -131,7 +131,7 @@ def register_model_families(context: RuntimeContext) -> None:
 
     registrar.register_family(
         LLAMA_MODEL_FAMILY,
-        TransformerDecoderModel,
+        TransformerLanguageModel,
         LLaMAConfig,
         default_arch,
         create_llama_model,
@@ -147,7 +147,7 @@ def register_model_families(context: RuntimeContext) -> None:
 
     registrar.register_family(
         MISTRAL_MODEL_FAMILY,
-        TransformerDecoderModel,
+        TransformerLanguageModel,
         MistralConfig,
         default_arch,
         create_mistral_model,


### PR DESCRIPTION
This PR renames `TransformerDecoderModel` to `TransformerLanguageModel`.