### PR TITLE
Introduce mmap configuration

### DIFF
--- a/src/fairseq2/models/_handler.py
+++ b/src/fairseq2/models/_handler.py
@@ -69,7 +69,13 @@ class ModelHandler(ABC):
 
     @abstractmethod
     def load(
-        self, card: AssetCard, gangs: Gangs, dtype: DataType, config: object
+        self,
+        card: AssetCard,
+        gangs: Gangs,
+        dtype: DataType,
+        config: object,
+        *,
+        mmap: bool = False,
     ) -> Module: ...
 
     @abstractmethod
@@ -81,7 +87,8 @@ class ModelHandler(ABC):
         gangs: Gangs,
         dtype: DataType,
         *,
-        restrict: bool = True,
+        restrict: bool | None = None,
+        mmap: bool = False,
     ) -> Module: ...
 
     @abstractmethod
@@ -284,7 +291,13 @@ class StandardModelHandler(ModelHandler):
 
     @override
     def load(
-        self, card: AssetCard, gangs: Gangs, dtype: DataType, config: object
+        self,
+        card: AssetCard,
+        gangs: Gangs,
+        dtype: DataType,
+        config: object,
+        *,
+        mmap: bool = False,
     ) -> Module:
         model_name = card.name
 
@@ -336,7 +349,7 @@ class StandardModelHandler(ModelHandler):
 
         try:
             return self.load_from_path(
-                path, model_name, config, gangs, dtype, restrict=restrict
+                path, model_name, config, gangs, dtype, restrict=restrict, mmap=mmap
             )
         except FileNotFoundError:
             raise ModelLoadError(
@@ -360,6 +373,7 @@ class StandardModelHandler(ModelHandler):
         dtype: DataType,
         *,
         restrict: bool | None = None,
+        mmap: bool = False,
     ) -> Module:
         if gangs.root.device.type == "meta":
             raise ValueError(
@@ -384,7 +398,7 @@ class StandardModelHandler(ModelHandler):
         with load_with_sdp_gang(gangs):  # Required for ShardedTensor
             try:
                 checkpoint = self._tensor_loader.load(
-                    path, map_location=CPU, restrict=restrict
+                    path, map_location=CPU, restrict=restrict, mmap=mmap
                 )
             except TensorLoadError as ex:
                 raise ModelLoadError(

--- a/src/fairseq2/models/_hub.py
+++ b/src/fairseq2/models/_hub.py
@@ -108,6 +108,7 @@ class ModelHub(Generic[ModelT, ModelConfigT]):
         device: Device | None = None,
         dtype: DataType | None = None,
         config: ModelConfigT | None = None,
+        mmap: bool = False,
     ) -> ModelT:
         if gangs is not None and device is not None:
             raise ValueError(
@@ -159,7 +160,7 @@ class ModelHub(Generic[ModelT, ModelConfigT]):
         if dtype is None:
             dtype = torch.get_default_dtype()
 
-        model = handler.load(card, gangs, dtype, config=config)
+        model = handler.load(card, gangs, dtype, config, mmap=mmap)
 
         return cast(ModelT, model)
 

--- a/src/fairseq2/recipes/_trainer.py
+++ b/src/fairseq2/recipes/_trainer.py
@@ -741,7 +741,7 @@ class Trainer(Recipe, Generic[BatchT]):
                     if log.is_enabled_for_error():
                         s = pretty_repr(batch, max_width=88, max_string=128)
 
-                        log.error("CUDA out of memory. Note that CUDA operations are async. Dumping the likely input batch information. Use the `CUDA_LAUNCH_BLOCKING=1` environment variable for debugging:\n{}", s)  # fmt: skip
+                        log.error("CUDA out of memory. Note that CUDA operations are async. Dumping the likely input batch. Use `CUDA_LAUNCH_BLOCKING=1` for debugging:\n{}", s)  # fmt: skip
 
                     raise
 

--- a/src/fairseq2/recipes/common/_model.py
+++ b/src/fairseq2/recipes/common/_model.py
@@ -123,7 +123,7 @@ def load_base_model(
 
     model_loader: ModelLoader
 
-    if model_section.checkpoint is not None:
+    if model_section.path is not None:
         model_loader = PathBasedModelLoader(
             kls, model_handlers, model_card_saver, checkpoint_manager
         )
@@ -262,14 +262,21 @@ class CardBasedModelLoader(ModelLoader):
 
                     try:
                         module = handler.load_from_path(
-                            model_path, model_name, model_config, gangs, dtype
+                            model_path,
+                            model_name,
+                            model_config,
+                            gangs,
+                            dtype,
+                            mmap=model_section.mmap,
                         )
                     except FileNotFoundError:
                         raise ModelLoadError(
                             model_name, f"The '{model_name}' model cannot be found at the '{model_path}' path."  # fmt: skip
                         ) from None
                 else:
-                    module = handler.load(card, gangs, dtype, model_config)
+                    module = handler.load(
+                        card, gangs, dtype, model_config, mmap=model_section.mmap
+                    )
             else:
                 module = handler.create(
                     model_config, gangs, dtype, meta=handler.supports_meta
@@ -322,9 +329,9 @@ class PathBasedModelLoader(ModelLoader):
         if model_family is None:
             raise ValueError("`recipe_config.model.family` must be specified.")
 
-        model_path = model_section.checkpoint
+        model_path = model_section.path
         if model_path is None:
-            raise ValueError("`recipe_config.model.checkpoint` must be specified.")
+            raise ValueError("`recipe_config.model.path` must be specified.")
 
         model_path = self._format_as_sharded_path(model_path, gangs)
 
@@ -392,7 +399,12 @@ class PathBasedModelLoader(ModelLoader):
 
                     try:
                         module = handler.load_from_path(
-                            model_path, model_name, model_config, gangs, dtype
+                            model_path,
+                            model_name,
+                            model_config,
+                            gangs,
+                            dtype,
+                            mmap=model_section.mmap,
                         )
                     except FileNotFoundError:
                         raise ModelLoadError(
@@ -401,7 +413,12 @@ class PathBasedModelLoader(ModelLoader):
                 else:
                     try:
                         module = handler.load_from_path(
-                            model_path, model_name, model_config, gangs, dtype
+                            model_path,
+                            model_name,
+                            model_config,
+                            gangs,
+                            dtype,
+                            mmap=model_section.mmap,
                         )
                     except FileNotFoundError:
                         raise ModelPathNotFoundError(model_name, model_path) from None
@@ -530,7 +547,12 @@ class ModelCreator(ModelLoader):
 
                     try:
                         module = handler.load_from_path(
-                            model_path, model_name, model_config, gangs, dtype
+                            model_path,
+                            model_name,
+                            model_config,
+                            gangs,
+                            dtype,
+                            mmap=model_section.mmap,
                         )
                     except FileNotFoundError:
                         raise ModelLoadError(

--- a/src/fairseq2/recipes/common/_ref_model.py
+++ b/src/fairseq2/recipes/common/_ref_model.py
@@ -153,7 +153,9 @@ class ReferenceModelLoader:
 
         try:
             if gangs.dp.rank == 0:
-                module = handler.load(card, gangs, dtype, model_config)
+                module = handler.load(
+                    card, gangs, dtype, model_config, mmap=model_section.mmap
+                )
             else:
                 module = handler.create(
                     model_config, gangs, dtype, meta=handler.supports_meta

--- a/src/fairseq2/recipes/config.py
+++ b/src/fairseq2/recipes/config.py
@@ -45,16 +45,16 @@ class ModelSection:
 
     config: object = None
 
-    checkpoint: Path | None = None
+    path: Path | None = None
+
+    mmap: bool = False
 
     def validate(self) -> None:
         result = ValidationResult()
 
-        if self.checkpoint is not None:
+        if self.path is not None:
             if self.family is None:
-                result.add_error(
-                    "`family` must be specified when `checkpoint` is specified."
-                )
+                result.add_error("`family` must be specified when `path` is specified.")
         elif self.name is None and self.family is None:
             result.add_error("Either `name` or `family` must be specified.")
 
@@ -67,6 +67,8 @@ class ModelSection:
 @dataclass
 class ReferenceModelSection:
     name: str
+
+    mmap: bool = False
 
 
 @dataclass(kw_only=True)


### PR DESCRIPTION
This PR renames `model.checkpoint` recipe configuration to `recipe.path` for better wording and adds a new `model.mmap` setting to allow the use of memory-mapped checkpoint loading.