### PR TITLE
Move torch_compile recipe settings to model section

### DIFF
--- a/src/fairseq2/cli/commands/chatbot.py
+++ b/src/fairseq2/cli/commands/chatbot.py
@@ -42,7 +42,6 @@ from fairseq2.recipes.config import (
     GangSection,
     ReferenceModelSection,
     TextTokenizerSection,
-    TorchCompileSection,
     TorchSection,
 )
 from fairseq2.typing import CPU
@@ -141,10 +140,6 @@ class RunChatbotHandler(CliCommandHandler):
 
         model_section = ReferenceModelSection(name=args.model_name)
 
-        mp = False
-
-        torch_compile_section = TorchCompileSection()
-
         try:
             model = setup_reference_model(
                 DecoderModel,
@@ -152,8 +147,7 @@ class RunChatbotHandler(CliCommandHandler):
                 model_section,
                 gangs,
                 args.dtype,
-                mp,
-                torch_compile_section,
+                mp=False,
             )
         except RecipeError as ex:
             raise CliCommandError(

--- a/src/fairseq2/recipes/asr/_eval.py
+++ b/src/fairseq2/recipes/asr/_eval.py
@@ -137,7 +137,6 @@ def load_asr_evaluator(
         gangs,
         config.evaluator.dtype,
         config.evaluator.amp,
-        config.evaluator.torch_compile,
     )
 
     dataset = load_dataset(AsrDataset, context, config.dataset, gangs)

--- a/src/fairseq2/recipes/common/__init__.py
+++ b/src/fairseq2/recipes/common/__init__.py
@@ -57,10 +57,8 @@ from fairseq2.recipes.common._generator import create_generator as create_genera
 from fairseq2.recipes.common._metrics import (
     create_metric_recorder as create_metric_recorder,
 )
+from fairseq2.recipes.common._model import compile_model as compile_model
 from fairseq2.recipes.common._model import load_base_model as load_base_model
-from fairseq2.recipes.common._model import (
-    maybe_torch_compile_model as maybe_torch_compile_model,
-)
 from fairseq2.recipes.common._model import prepare_model as prepare_model
 from fairseq2.recipes.common._model import setup_model as setup_model
 from fairseq2.recipes.common._optim import create_lr_scheduler as create_lr_scheduler

--- a/src/fairseq2/recipes/common/_ref_model.py
+++ b/src/fairseq2/recipes/common/_ref_model.py
@@ -33,7 +33,7 @@ from fairseq2.models import (
 )
 from fairseq2.nn.utils.module import remove_parametrizations
 from fairseq2.recipes import Model, RecipeError
-from fairseq2.recipes.config import ReferenceModelSection, TorchCompileSection
+from fairseq2.recipes.config import ReferenceModelSection
 from fairseq2.recipes.utils.log import log_model
 from fairseq2.registry import Provider
 from fairseq2.typing import DataType
@@ -42,7 +42,7 @@ from fairseq2.typing import DataType
 
 from fairseq2.recipes.common._distributed import broadcast_model
 from fairseq2.recipes.common._error import ModelParallelismNotSupportedError
-from fairseq2.recipes.common._model import BasicModel, maybe_torch_compile_model
+from fairseq2.recipes.common._model import BasicModel, compile_model
 
 
 def setup_reference_model(
@@ -52,13 +52,12 @@ def setup_reference_model(
     gangs: Gangs,
     dtype: DataType,
     mp: bool,
-    torch_compile_section: TorchCompileSection,
 ) -> Model:
     model = load_reference_model(kls, context, model_section, gangs, dtype, mp)
 
     broadcast_model(model, gangs)
 
-    model = prepare_reference_model(context, model, torch_compile_section)
+    model = prepare_reference_model(context, model, model_section)
 
     log_model(log, model.module, gangs)
 
@@ -180,10 +179,11 @@ class ReferenceModelLoader:
 
 
 def prepare_reference_model(
-    context: RuntimeContext, model: Model, torch_compile_section: TorchCompileSection
+    context: RuntimeContext, model: Model, model_section: ReferenceModelSection
 ) -> Model:
     remove_parametrizations(model.module)
 
-    maybe_torch_compile_model(model, torch_compile_section)
+    if model_section.compile:
+        compile_model(model, model_section.compile_options)
 
     return model

--- a/src/fairseq2/recipes/common/_torch.py
+++ b/src/fairseq2/recipes/common/_torch.py
@@ -37,7 +37,7 @@ def setup_torch(
     _set_default_sdpa_variant(torch_section.default_sdpa)
 
     torch._functorch.config.activation_memory_budget = (
-        torch_section.torch_compile_activation_budget
+        torch_section.compiled_region_activation_memory_budget
     )
 
 

--- a/src/fairseq2/recipes/lm/_loss_eval.py
+++ b/src/fairseq2/recipes/lm/_loss_eval.py
@@ -137,7 +137,6 @@ def load_lm_loss_evaluator(
         gangs,
         config.evaluator.dtype,
         config.evaluator.amp,
-        config.evaluator.torch_compile,
     )
 
     dataset = load_dataset(InstructionDataset, context, config.dataset, gangs)

--- a/src/fairseq2/recipes/lm/_preference_finetune/_dpo.py
+++ b/src/fairseq2/recipes/lm/_preference_finetune/_dpo.py
@@ -272,16 +272,13 @@ class DpoFinetuneUnitHandler(POFinetuneUnitHandler):
         if config.reference_model is not None:
             log.info("Setting up DPO with reference model.")
 
-            mp = False
-
             reference_model = setup_reference_model(
                 DecoderModel,
                 self._context,
                 config.reference_model,
                 gangs,
                 recipe_config.trainer.dtype,
-                mp,
-                recipe_config.trainer.torch_compile,
+                mp=False,
             )
 
             freeze_parameters(reference_model.module)

--- a/src/fairseq2/recipes/lm/_text_generate.py
+++ b/src/fairseq2/recipes/lm/_text_generate.py
@@ -175,7 +175,6 @@ def load_text_generator(
         gangs,
         config.generator.dtype,
         config.generator.amp,
-        config.generator.torch_compile,
     )
 
     dataset = load_dataset(InstructionDataset, context, config.dataset, gangs)

--- a/src/fairseq2/recipes/mt/_eval.py
+++ b/src/fairseq2/recipes/mt/_eval.py
@@ -170,7 +170,6 @@ def load_mt_evaluator(
         gangs,
         config.evaluator.dtype,
         config.evaluator.amp,
-        config.evaluator.torch_compile,
     )
 
     dataset = load_dataset(ParallelTextDataset, context, config.dataset, gangs)

--- a/src/fairseq2/recipes/mt/_translate.py
+++ b/src/fairseq2/recipes/mt/_translate.py
@@ -160,7 +160,6 @@ def load_text_translator(
         gangs,
         config.generator.dtype,
         config.generator.amp,
-        config.generator.torch_compile,
     )
 
     dataset = load_dataset(TextDataset, context, config.dataset, gangs)

--- a/src/fairseq2/recipes/wav2vec2/_eval.py
+++ b/src/fairseq2/recipes/wav2vec2/_eval.py
@@ -140,7 +140,6 @@ def load_wav2vec2_evaluator(
         gangs,
         config.evaluator.dtype,
         config.evaluator.amp,
-        config.evaluator.torch_compile,
     )
 
     dataset = load_dataset(SpeechDataset, context, config.dataset, gangs)

--- a/src/fairseq2/recipes/wav2vec2/asr/_train.py
+++ b/src/fairseq2/recipes/wav2vec2/asr/_train.py
@@ -279,7 +279,7 @@ def load_wav2vec2_asr_trainer(
     # We never train the feature extractor.
     freeze_parameters(module.encoder_frontend.feature_extractor)
 
-    prepare_model(context, config.trainer, model)
+    model = prepare_model(context, model, config.model, config.trainer)
 
     static_graph = config.trainer.freeze_encoder_for_n_steps == 0
 


### PR DESCRIPTION
This PR moves `torch_compile` recipe sub-section from `trainer` to `model`.
