### PR TITLE
Mutualize audio readings

### DIFF
--- a/src/fairseq2/data/parquet/__init__.py
+++ b/src/fairseq2/data/parquet/__init__.py
@@ -50,12 +50,12 @@ class BasicDataLoadingConfig:
 
     # default trivial config will load all columns
     fragment_load_config: FragmentLoadingConfig = field(
-        default=lambda: FragmentLoadingConfig()
+        default_factory=lambda: FragmentLoadingConfig()
     )
 
     # default trivial config applies NO bucketing
     table_bucketing_config: TableBucketingConfig = field(
-        default=lambda: TableBucketingConfig()
+        default_factory=lambda: TableBucketingConfig()
     )
 
 

--- a/src/fairseq2/data/parquet/fragment_loading/builder.py
+++ b/src/fairseq2/data/parquet/fragment_loading/builder.py
@@ -16,9 +16,7 @@ import pyarrow as pa
 from retrying import retry
 
 from fairseq2.data import DataPipelineBuilder
-from fairseq2.data.parquet.arrow_transform import (
-    apply_filter,
-)
+from fairseq2.data.parquet.arrow_transform import apply_filter
 from fairseq2.data.parquet.fragment_loading.config import FragmentLoadingConfig
 from fairseq2.data.parquet.fragment_streaming.primitives import process_filter
 from fairseq2.data.parquet.utils import (
@@ -48,8 +46,13 @@ class SafeFragment:
 
     def __init__(self, fragment: pa.dataset.ParquetFileFragment):
         self.fragment = fragment
-        pa.jemalloc_set_decay_ms(10)
-        self.je_pool = pa.jemalloc_memory_pool()
+        self.memory_pool = None
+        try:
+            self.memory_pool = pa.jemalloc_memory_pool()
+            pa.jemalloc_set_decay_ms(10)
+        except pa.ArrowNotImplementedError:
+            log.info("jemalloc not available, skipping memory pool init")
+            pass
 
     def __repr__(self) -> str:
         out = ""
@@ -107,7 +110,7 @@ class SafeFragment:
                 columns=fragment_columns,
                 use_threads=use_threads,
                 filter=filters if can_apply_on_phyiscal_schema else None,
-                memory_pool=self.je_pool,
+                memory_pool=self.memory_pool,
             )
 
         if add_partitioning_columns:

--- a/src/fairseq2/data/parquet/fragment_loading/builder.py
+++ b/src/fairseq2/data/parquet/fragment_loading/builder.py
@@ -79,8 +79,6 @@ class SafeFragment:
         # adding technical columns for tracking
         if add_fragment_traces:
             fragment_columns = list(fragment_columns) + [
-                "__batch_index",
-                "__fragment_index",
                 "__filename",
             ]
 

--- a/src/fairseq2/data/parquet/fragment_loading/builder.py
+++ b/src/fairseq2/data/parquet/fragment_loading/builder.py
@@ -79,6 +79,8 @@ class SafeFragment:
         # adding technical columns for tracking
         if add_fragment_traces:
             fragment_columns = list(fragment_columns) + [
+                "__batch_index",
+                "__fragment_index",
                 "__filename",
             ]
 

--- a/src/fairseq2/data/parquet/fragment_loading/builder.py
+++ b/src/fairseq2/data/parquet/fragment_loading/builder.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 from __future__ import annotations
 
-import gc
 import tempfile
 from copy import deepcopy
 from functools import partial
@@ -13,7 +12,6 @@ from pathlib import Path
 from pickle import dumps, loads
 from typing import List, Optional
 
-import numpy as np
 import pyarrow as pa
 from retrying import retry
 

--- a/src/fairseq2/datasets/asr.py
+++ b/src/fairseq2/datasets/asr.py
@@ -154,7 +154,9 @@ class GenericAsrDataset(AsrDataset):
         npc = options.npc
         seed = options.seed
 
-        audio_dir = self._retrieve_data_directory(split)
+        audio_dir = GenericSpeechDataset._retrieve_data_directory(
+            self._manifest_dir, self._name, split
+        )
         builder = self._read_manifest(split)
 
         # Shuffle examples. Must be consistent across all processes.
@@ -204,24 +206,6 @@ class GenericAsrDataset(AsrDataset):
         return DataPipelineReader[Seq2SeqBatch](
             self._name, split, pipeline, gang, options
         )
-
-    def _retrieve_data_directory(self, split: str) -> Path:
-        manifest_file = self._manifest_dir.joinpath(f"{split}.tsv")
-
-        try:
-            with manifest_file.open(encoding="utf-8") as fp:
-                line = fp.readline().rstrip()
-        except OSError as ex:
-            raise DataReadError(
-                self._name, split, f"The {manifest_file} manifest file cannot be read. See the nested exception for details."  # fmt: skip
-            ) from ex
-
-        try:
-            return Path(line)
-        except ValueError:
-            raise DataReadError(
-                self._name, split, f"The first line of the '{manifest_file}' manifest file must point to a data directory."  # fmt: skip
-            ) from None
 
     def _read_manifest(self, split: str) -> DataPipelineBuilder:
         def read_tsv_file() -> DataPipelineBuilder:

--- a/src/fairseq2/datasets/asr.py
+++ b/src/fairseq2/datasets/asr.py
@@ -175,9 +175,8 @@ class GenericAsrDataset(AsrDataset):
         )
         # Read audios
         seed += 1
-        builder = GenericSpeechDataset.add_audio_reading_pipeline(
-            builder, audio_dir, options, seed, max_audio_len
-        )
+        builder = GenericSpeechDataset.add_audio_decoding(builder, options, audio_dir)
+        builder = GenericSpeechDataset.audio_post_process(builder, options)
 
         # Tokenize target text.
         text_encoder = tokenizer.create_encoder()

--- a/src/fairseq2/datasets/asr.py
+++ b/src/fairseq2/datasets/asr.py
@@ -8,17 +8,19 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from functools import partial
-from typing import Any, cast, Dict, Final
+from typing import Any, Dict, Final, cast
+
+from typing_extensions import override
 
 from fairseq2.data import (
     CollateOptionsOverride,
     Collater,
     DataPipeline,
     DataPipelineBuilder,
-    read_sequence,
     SequenceData,
+    read_sequence,
 )
-from fairseq2.data.text import read_text, StrSplitter
+from fairseq2.data.text import StrSplitter, read_text
 from fairseq2.data.text.tokenizers import TextTokenizer
 from fairseq2.datasets import (
     DataPipelineReader,
@@ -35,8 +37,6 @@ from fairseq2.gang import Gang
 from fairseq2.models.seq2seq import Seq2SeqBatch
 from fairseq2.nn.padding import get_seqs_and_padding_mask
 from fairseq2.typing import Device
-
-from typing_extensions import override
 
 
 class AsrDataset(ABC):

--- a/src/fairseq2/datasets/asr.py
+++ b/src/fairseq2/datasets/asr.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from functools import partial
-from pathlib import Path
 from typing import Any, cast, Dict, Final
 
 from fairseq2.data import (
@@ -25,7 +24,6 @@ from fairseq2.datasets import (
     DataPipelineReader,
     DataReader,
     DatasetHubAccessor,
-    DatasetLoadError,
     UnknownSplitError,
 )
 from fairseq2.datasets.speech import (

--- a/src/fairseq2/datasets/asr.py
+++ b/src/fairseq2/datasets/asr.py
@@ -24,7 +24,6 @@ from fairseq2.data.text.tokenizers import TextTokenizer
 from fairseq2.datasets import (
     DataPipelineReader,
     DataReader,
-    DataReadError,
     DatasetHubAccessor,
     DatasetLoadError,
     UnknownSplitError,
@@ -176,7 +175,9 @@ class GenericAsrDataset(AsrDataset):
         # Read audios
         seed += 1
         builder = GenericSpeechDataset.add_audio_decoding(builder, options, audio_dir)
-        builder = GenericSpeechDataset.audio_post_process(builder, options)
+        builder = GenericSpeechDataset.audio_post_process(
+            builder, options, GenericSpeechDataset.rename_feature
+        )
 
         # Tokenize target text.
         text_encoder = tokenizer.create_encoder()

--- a/src/fairseq2/datasets/asr.py
+++ b/src/fairseq2/datasets/asr.py
@@ -28,7 +28,11 @@ from fairseq2.datasets import (
     DatasetLoadError,
     UnknownSplitError,
 )
-from fairseq2.datasets.speech import GenericSpeechDataset, SpeechReadOptions
+from fairseq2.datasets.speech import (
+    GenericSpeechDataset,
+    ManifestDatasetInterface,
+    SpeechReadOptions,
+)
 from fairseq2.gang import Gang
 from fairseq2.models.seq2seq import Seq2SeqBatch
 from fairseq2.nn.padding import get_seqs_and_padding_mask
@@ -75,24 +79,11 @@ class AsrDataset(ABC):
 
 GENERIC_ASR_DATASET_FAMILY: Final = "generic_asr"
 
+get_asr_dataset_hub = DatasetHubAccessor(AsrDataset)
 
-class GenericAsrDataset(AsrDataset):
+
+class GenericAsrDataset(ManifestDatasetInterface, AsrDataset):
     """Represents a generic manifest-based ASR dataset."""
-
-    _name: str
-    _manifest_dir: Path
-    _splits: set[str]
-
-    def __init__(self, name: str, manifest_dir: Path, splits: set[str]) -> None:
-        """
-        :param manifest_dir:
-            The directory under which the manifest files resides.
-        :param splits:
-            The available splits.
-        """
-        self._name = name
-        self._manifest_dir = manifest_dir
-        self._splits = splits
 
     @staticmethod
     def to_batch(example: Dict[str, Any], device: Device | None = None) -> Seq2SeqBatch:
@@ -113,22 +104,6 @@ class GenericAsrDataset(AsrDataset):
             target_padding_mask,
             example,
         )
-
-    @staticmethod
-    def from_path(path: Path, name: str) -> GenericAsrDataset:
-        path = path.expanduser().resolve()
-
-        if not path.is_dir():
-            return GenericAsrDataset(name, manifest_dir=path.parent, splits={path.stem})
-
-        try:
-            splits = {f.stem for f in path.glob("*.tsv")}
-        except OSError as ex:
-            raise DatasetLoadError(
-                name, f"The splits under the '{path}' directory of the '{name}' dataset cannot be determined. See the nested exception for details."  # fmt: skip
-            ) from ex
-
-        return GenericAsrDataset(name, path, splits)
 
     @override
     def create_reader(
@@ -238,10 +213,3 @@ class GenericAsrDataset(AsrDataset):
         manifest = list(builder.and_return())
 
         return read_sequence(manifest)
-
-    @override
-    def splits(self) -> set[str]:
-        return self._splits
-
-
-get_asr_dataset_hub = DatasetHubAccessor(AsrDataset)

--- a/src/fairseq2/datasets/asr_parquet.py
+++ b/src/fairseq2/datasets/asr_parquet.py
@@ -1,0 +1,157 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import partial
+from typing import Final, List, final
+
+from typing_extensions import override
+
+from fairseq2.data import (
+    CollateOptionsOverride,
+    Collater,
+)
+from fairseq2.data.parquet import (
+    NamedColumns,
+)
+from fairseq2.data.text.tokenizers import TextTokenizer
+from fairseq2.datasets import (
+    DataPipelineReader,
+    DataReader,
+    UnknownSplitError,
+)
+from fairseq2.datasets.asr import AsrDataset, GenericAsrDataset
+from fairseq2.datasets.speech import (
+    GenericSpeechDataset,
+    SpeechReadOptions,
+)
+from fairseq2.datasets.speech_parquet import (
+    GenericSpeechParquetDataset,
+    ParquetDatasetInterface,
+)
+from fairseq2.gang import Gang
+from fairseq2.logging import log
+from fairseq2.models.seq2seq import Seq2SeqBatch
+
+PARQUET_ASR_DATASET_FAMILY: Final = "generic_parquet_asr"
+
+
+@dataclass
+class DefaultASRSchema(NamedColumns):
+    audio: str = "audio_bytes"
+    length: str = "length"
+    text: str = "text"
+    size: str | None = "size"  # size of the audio in bytes : len(audio_bytes)
+    extra_columns: List[str] | None = None
+
+
+@final
+class GenericAsrParquetDataset(ParquetDatasetInterface, AsrDataset):
+    """Represents a generic parquet-based ASR dataset."""
+
+    @override
+    def create_reader(
+        self,
+        split: str,
+        tokenizer: TextTokenizer,
+        gang: Gang,
+        min_audio_len: int,
+        max_audio_len: int,
+        options: SpeechReadOptions | None = None,
+    ) -> DataReader[Seq2SeqBatch]:
+        assert min_audio_len <= max_audio_len, "min_audio_len must be <= max_audio_len"
+
+        if split not in self._splits:
+            raise UnknownSplitError(self._name, split, self._splits)
+
+        if options is None:
+            options = SpeechReadOptions()
+        npc = options.npc
+        seed = options.seed
+
+        options.batch_shuffle_window = min(
+            options.batch_shuffle_window, self.max_num_batches
+        )
+
+        log.info(
+            f"Creating a reader for the <{split}> split of the <{self._name}>"
+            f" dataset with the following options:/n {options}."
+        )
+
+        builder = GenericSpeechParquetDataset.get_example_loading_builder(
+            self._dataset,
+            options,
+            split,
+            columns=DefaultASRSchema(),
+            seed=seed,
+            rank=gang.rank,
+            world_size=gang.size,
+        )
+        seed += gang.size
+        # truncate length to max_audio_len
+        builder = builder.filter(
+            lambda x: (int(x["length"]) >= min_audio_len)
+            and (int(x["length"]) <= max_audio_len)
+        )
+
+        # shuffle examples in memory
+        if options.example_shuffle_window != 1:
+            # FIXME: make it configurable, we need some upper bound to avoid OOM in cpu
+            example_shuffle_window = min(
+                options.example_shuffle_window, self.max_num_examples
+            )
+            builder = builder.prefetch(int(2 * example_shuffle_window))
+            builder = builder.shuffle(example_shuffle_window, seed=seed)
+            seed += 1
+
+        builder = GenericSpeechDataset.add_bucketing_pipeline(
+            builder,
+            options,
+            max_audio_len=max_audio_len,
+            min_audio_len=min_audio_len,
+            seed=seed,
+            columns="length",
+        )
+        seed += 1
+
+        # Read audios
+        seed += 1
+        builder = GenericSpeechParquetDataset.add_audio_decoding(builder, options)
+        builder = GenericSpeechDataset.audio_post_process(
+            builder, options, GenericSpeechParquetDataset.rename_feature
+        )
+
+        # Tokenize target text.
+        text_encoder = tokenizer.create_encoder()
+        builder.map(text_encoder, selector="[*].text", num_parallel_calls=npc)
+
+        # Collate bucketed examples into a batch.
+        text_collate_opts = CollateOptionsOverride(
+            "text", pad_value=tokenizer.vocab_info.pad_idx
+        )
+
+        collater = Collater(pad_value=0, overrides=[text_collate_opts])
+
+        builder.map(collater, num_parallel_calls=npc)
+
+        # Return only the first `max_num_batches`.
+        if options.max_num_batches is not None:
+            builder.take(options.max_num_batches)
+
+        # Prefetch `num_prefetch` batches in background.
+        builder.prefetch(options.num_prefetch)
+
+        # Wrap examples with `Seq2SeqBatch`.
+
+        pipeline = builder.map(
+            partial(GenericAsrDataset.to_batch, device=gang.device)
+        ).and_return()
+
+        return DataPipelineReader[Seq2SeqBatch](
+            self._name, split, pipeline, gang, options
+        )

--- a/src/fairseq2/datasets/asr_parquet.py
+++ b/src/fairseq2/datasets/asr_parquet.py
@@ -153,5 +153,5 @@ class GenericAsrParquetDataset(ParquetDatasetInterface, AsrDataset):
         ).and_return()
 
         return DataPipelineReader[Seq2SeqBatch](
-            self._name, split, pipeline, gang, options
+            self._name, split, pipeline, gang, options, strict_state=False
         )

--- a/src/fairseq2/datasets/asr_parquet.py
+++ b/src/fairseq2/datasets/asr_parquet.py
@@ -44,9 +44,9 @@ PARQUET_ASR_DATASET_FAMILY: Final = "generic_parquet_asr"
 @dataclass
 class DefaultASRSchema(NamedColumns):
     audio: str = "audio_bytes"
-    length: str = "length"
+    length: str = "audio_size"
     text: str = "text"
-    size: str | None = "size"  # size of the audio in bytes : len(audio_bytes)
+    # size: str | None = "size"  # size of the audio in bytes : len(audio_bytes)
     extra_columns: List[str] | None = None
 
 
@@ -123,7 +123,7 @@ class GenericAsrParquetDataset(ParquetDatasetInterface, AsrDataset):
         seed += 1
         builder = GenericSpeechParquetDataset.add_audio_decoding(builder, options)
         builder = GenericSpeechDataset.audio_post_process(
-            builder, options, GenericSpeechParquetDataset.rename_feature
+            builder, options, GenericSpeechDataset.rename_feature
         )
 
         # Tokenize target text.

--- a/src/fairseq2/datasets/asr_parquet.py
+++ b/src/fairseq2/datasets/asr_parquet.py
@@ -104,7 +104,6 @@ class GenericAsrParquetDataset(ParquetDatasetInterface, AsrDataset):
             example_shuffle_window = min(
                 options.example_shuffle_window, self.max_num_examples
             )
-            builder = builder.prefetch(int(2 * example_shuffle_window))
             builder = builder.shuffle(example_shuffle_window, seed=seed)
             seed += 1
 

--- a/src/fairseq2/datasets/speech.py
+++ b/src/fairseq2/datasets/speech.py
@@ -315,6 +315,7 @@ class GenericSpeechDataset(SpeechDataset):
         try:
             audio_dir = Path(header)
             if audio_dir.exists():
+                log.info(f"Using the data directory: {audio_dir}")
                 return audio_dir
             return None
         except ValueError:

--- a/src/fairseq2/datasets/speech.py
+++ b/src/fairseq2/datasets/speech.py
@@ -14,10 +14,13 @@ from typing import Any, Callable, Dict, Final, List
 
 import numpy as np
 import torch
+from torch import Tensor
+from torch.nn.functional import layer_norm
+from typing_extensions import override
 
-from fairseq2.data import Collater, create_bucket_sizes, DataPipelineBuilder, FileMapper
+from fairseq2.data import Collater, DataPipelineBuilder, FileMapper, create_bucket_sizes
 from fairseq2.data.audio import AudioDecoder, WaveformToFbankConverter
-from fairseq2.data.text import read_text, StrSplitter
+from fairseq2.data.text import StrSplitter, read_text
 from fairseq2.datasets import (
     DataPipelineReader,
     DataReader,
@@ -35,9 +38,6 @@ from fairseq2.logging import log
 from fairseq2.models.sequence import SequenceBatch
 from fairseq2.nn.padding import get_seqs_and_padding_mask
 from fairseq2.typing import DataType, Device
-from torch import Tensor
-from torch.nn.functional import layer_norm
-from typing_extensions import override
 
 
 @torch.no_grad()

--- a/src/fairseq2/datasets/speech.py
+++ b/src/fairseq2/datasets/speech.py
@@ -391,6 +391,10 @@ class GenericSpeechDataset(ManifestDatasetInterface, SpeechDataset):
             raise NotSupportedError(f"`{batching}` is not supported.")
 
         # Shuffle buckets.
+        assert (
+            options.batch_shuffle_window > 0
+        ), "can apply full batch shuffling which may result in OOM"
+
         if options.batch_shuffle_window != 1:
             builder.shuffle(options.batch_shuffle_window, seed)
         return builder

--- a/src/fairseq2/datasets/speech.py
+++ b/src/fairseq2/datasets/speech.py
@@ -86,15 +86,6 @@ class AudioCropper:
         return batch
 
 
-def rename_feature(batch: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-    for example in batch:
-        if "fbank" in example["audio"]["data"]:
-            example["audio_feature"] = example["audio"]["data"].pop("fbank")
-        elif "waveform" in example["audio"]["data"]:
-            example["audio_feature"] = example["audio"]["data"].pop("waveform")
-    return batch
-
-
 @dataclass(kw_only=True)
 class SpeechReadOptions(DataReadOptions):
 
@@ -185,6 +176,15 @@ class GenericSpeechDataset(SpeechDataset):
         return SequenceBatch(seqs, padding_mask, example=example)
 
     @staticmethod
+    def rename_feature(batch: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        for example in batch:
+            if "fbank" in example["audio"]["data"]:
+                example["audio_feature"] = example["audio"]["data"].pop("fbank")
+            elif "waveform" in example["audio"]["data"]:
+                example["audio_feature"] = example["audio"]["data"].pop("waveform")
+        return batch
+
+    @staticmethod
     def from_path(path: Path, name: str) -> GenericSpeechDataset:
         path = path.expanduser().resolve()
 
@@ -234,9 +234,7 @@ class GenericSpeechDataset(SpeechDataset):
     def audio_post_process(
         builder: DataPipelineBuilder,
         options: SpeechReadOptions,
-        renaming: Callable[
-            [List[Dict[str, Any]]], List[Dict[str, Any]]
-        ] = rename_feature,
+        renaming: Callable[[List[Dict[str, Any]]], List[Dict[str, Any]]],
     ) -> DataPipelineBuilder:
         if options.use_fbank:
             fbank_converter = WaveformToFbankConverter(
@@ -280,22 +278,6 @@ class GenericSpeechDataset(SpeechDataset):
             crop_to_batch_minimal_size=options.no_padding,
         )
         builder.map(audio_cropper.crop_audios_in_batch)
-        return builder
-
-    @staticmethod
-    def add_audio_reading_pipeline(
-        builder: DataPipelineBuilder,
-        audio_dir: Path | None,
-        options: SpeechReadOptions,
-        seed: int,
-        max_audio_len: int,
-    ) -> DataPipelineBuilder:
-
-        builder = GenericSpeechDataset.add_audio_decoding(builder, options, audio_dir)
-        builder = GenericSpeechDataset.audio_post_process(builder, options)
-        builder = GenericSpeechDataset.add_audio_cropping(
-            builder, options, seed, max_audio_len
-        )
         return builder
 
     @staticmethod
@@ -460,9 +442,14 @@ class GenericSpeechDataset(SpeechDataset):
             columns="audio_size",
         )
         seed += 1
-        builder = GenericSpeechDataset.add_audio_reading_pipeline(
-            builder, audio_dir, options, seed=seed, max_audio_len=max_audio_len
+        builder = GenericSpeechDataset.add_audio_decoding(builder, options, audio_dir)
+        builder = GenericSpeechDataset.audio_post_process(
+            builder, options, GenericSpeechDataset.rename_feature
         )
+        builder = GenericSpeechDataset.add_audio_cropping(
+            builder, options, seed=seed, max_audio_len=max_audio_len
+        )
+
         # Collate batched examples into a batch.
         collater = Collater(pad_value=None if no_padding else 0)
         builder.map(collater)

--- a/src/fairseq2/datasets/speech.py
+++ b/src/fairseq2/datasets/speech.py
@@ -298,22 +298,30 @@ class GenericSpeechDataset(SpeechDataset):
         )
         return builder
 
-    def _retrieve_data_directory(self, split: str) -> Path:
-        manifest_file = self._manifest_dir.joinpath(f"{split}.tsv")
+    @staticmethod
+    def _retrieve_data_directory(
+        manifest_dir: Path, name: str, split: str
+    ) -> Path | None:
+        manifest_file = manifest_dir.joinpath(f"{split}.tsv")
 
         try:
             with manifest_file.open(encoding="utf-8") as fp:
-                line = fp.readline().rstrip()
+                header = fp.readline().rstrip()
         except OSError as ex:
             raise DataReadError(
-                self._name, split, f"The {manifest_file} manifest file cannot be read. See the nested exception for details."  # fmt: skip
+                name, split, f"The {manifest_file} manifest file cannot be read. See the nested exception for details."  # fmt: skip
             ) from ex
 
         try:
-            return Path(line)
+            audio_dir = Path(header)
+            if audio_dir.exists():
+                return audio_dir
+            return None
         except ValueError:
             raise DataReadError(
-                self._name, split, f"The first line of the '{manifest_file}' manifest file must point to a data directory."  # fmt: skip
+                name,
+                split,
+                f"The first line of {manifest_file} must point to a data directory.",
             ) from None
 
     def _read_manifest(
@@ -428,7 +436,9 @@ class GenericSpeechDataset(SpeechDataset):
         seed = options.seed
         no_padding = options.no_padding
 
-        audio_dir = self._retrieve_data_directory(split)
+        audio_dir = GenericSpeechDataset._retrieve_data_directory(
+            self._manifest_dir, self._name, split
+        )
         builder = self._read_manifest(split, max_audio_len, min_audio_len, audio_dir)
 
         if options.example_shuffle_window != 1:

--- a/src/fairseq2/datasets/speech.py
+++ b/src/fairseq2/datasets/speech.py
@@ -144,8 +144,7 @@ GENERIC_SPEECH_DATASET_FAMILY: Final = "generic_speech"
 get_speech_dataset_hub = DatasetHubAccessor(SpeechDataset)
 
 
-class GenericSpeechDataset(SpeechDataset):
-    """Represents a generic manifest-based Speech dataset."""
+class ManifestDatasetInterface:
 
     _name: str
     _manifest_dir: Path
@@ -161,6 +160,29 @@ class GenericSpeechDataset(SpeechDataset):
         self._name = name
         self._manifest_dir = manifest_dir
         self._splits = splits
+
+    @classmethod
+    def from_path(cls, path: Path, name: str) -> "ManifestDatasetInterface":
+        path = path.expanduser().resolve()
+
+        if not path.is_dir():
+            return cls(name, manifest_dir=path.parent, splits={path.stem})
+
+        try:
+            splits = {f.stem for f in path.glob("*.tsv")}
+        except OSError as ex:
+            raise DatasetLoadError(
+                name, f"The splits under the '{path}' directory of the '{name}' dataset cannot be determined. See the nested exception for details."  # fmt: skip
+            ) from ex
+
+        return cls(name, path, splits)
+
+    def splits(self) -> set[str]:
+        return self._splits
+
+
+class GenericSpeechDataset(ManifestDatasetInterface, SpeechDataset):
+    """Represents a generic manifest-based Speech dataset."""
 
     @staticmethod
     def to_batch(
@@ -183,28 +205,6 @@ class GenericSpeechDataset(SpeechDataset):
             elif "waveform" in example["audio"]["data"]:
                 example["audio_feature"] = example["audio"]["data"].pop("waveform")
         return batch
-
-    @staticmethod
-    def from_path(path: Path, name: str) -> GenericSpeechDataset:
-        path = path.expanduser().resolve()
-
-        if not path.is_dir():
-            return GenericSpeechDataset(
-                name, manifest_dir=path.parent, splits={path.stem}
-            )
-
-        try:
-            splits = {f.stem for f in path.glob("*.tsv")}
-        except OSError as ex:
-            raise DatasetLoadError(
-                name, f"The splits under the '{path}' directory of the '{name}' dataset cannot be determined. See the nested exception for details."  # fmt: skip
-            ) from ex
-
-        return GenericSpeechDataset(name, path, splits)
-
-    @override
-    def splits(self) -> set[str]:
-        return self._splits
 
     @staticmethod
     def add_audio_decoding(

--- a/src/fairseq2/datasets/speech_parquet.py
+++ b/src/fairseq2/datasets/speech_parquet.py
@@ -66,8 +66,8 @@ class ParquetDatasetInterface:
     _splits: set[str]
     split_column: str = "split"
 
-    max_num_batches: int = 500
-    max_num_examples: int = 1_000_000
+    max_num_batches: int = 2000
+    max_num_examples: int = 100_000
 
     def __init__(self, name: str, dataset: pq.ParquetDataset, splits: set[str]) -> None:
         self._dataset = dataset
@@ -241,7 +241,6 @@ class GenericSpeechParquetDataset(ParquetDatasetInterface, SpeechDataset):
             example_shuffle_window = min(
                 options.example_shuffle_window, self.max_num_examples
             )
-            builder = builder.prefetch(int(2 * example_shuffle_window))
             builder = builder.shuffle(example_shuffle_window, seed=seed)
             seed += 1
 

--- a/src/fairseq2/datasets/speech_parquet.py
+++ b/src/fairseq2/datasets/speech_parquet.py
@@ -136,7 +136,6 @@ class GenericSpeechParquetDataset(ParquetDatasetInterface, SpeechDataset):
         rank: int,
         world_size: int,
         pa_cpu_count: int = 20,
-        nb_samples_per_fragment: int = 1000,
     ) -> DataPipelineBuilder:
 
         npc = options.npc
@@ -155,7 +154,7 @@ class GenericSpeechParquetDataset(ParquetDatasetInterface, SpeechDataset):
             split_to_row_groups=True,
             files_circular_shift=True,
             seed=seed,
-            fragment_shuffle_window=-1,
+            fragment_shuffle_window=-1 if split == "train" else 0,
         )
         fragment_config = fragment_config.add_partition_filter(
             pa.compute.field("split") == split

--- a/src/fairseq2/datasets/speech_parquet.py
+++ b/src/fairseq2/datasets/speech_parquet.py
@@ -249,6 +249,9 @@ class GenericSpeechParquetDataset(ParquetDatasetInterface, SpeechDataset):
             example_shuffle_window = min(
                 options.example_shuffle_window, self.max_num_examples
             )
+            assert (
+                example_shuffle_window > 0
+            ), "can apply full example shuffling which may result in OOM"
             builder = builder.shuffle(example_shuffle_window, seed=seed)
             seed += 1
 

--- a/src/fairseq2/datasets/speech_parquet.py
+++ b/src/fairseq2/datasets/speech_parquet.py
@@ -194,9 +194,16 @@ class GenericSpeechParquetDataset(ParquetDatasetInterface, SpeechDataset):
         builder = ParquetFragmentLoader(config=loading_config).apply(fragement_builder)
 
         # dispatch table into examples
+        try:
+            memory_pool = pa.jemalloc_memory_pool()
+            pa.jemalloc_set_decay_ms(0)
+        except pa.ArrowNotImplementedError:
+            memory_pool = pa.default_memory_pool()
         builder = builder.yield_from(
             lambda table: read_sequence(
-                table.to_pandas().to_dict(orient="records")
+                table.to_pandas(memory_pool=memory_pool, self_destruct=True).to_dict(
+                    orient="records"
+                )
             ).and_return()
         )
         return builder

--- a/src/fairseq2/datasets/speech_parquet.py
+++ b/src/fairseq2/datasets/speech_parquet.py
@@ -194,11 +194,12 @@ class GenericSpeechParquetDataset(ParquetDatasetInterface, SpeechDataset):
         builder = ParquetFragmentLoader(config=loading_config).apply(fragement_builder)
 
         # dispatch table into examples
+        memory_pool = pa.default_memory_pool()
         try:
             memory_pool = pa.jemalloc_memory_pool()
             pa.jemalloc_set_decay_ms(0)
         except pa.ArrowNotImplementedError:
-            memory_pool = pa.default_memory_pool()
+            pass
         builder = builder.yield_from(
             lambda table: read_sequence(
                 table.to_pandas(memory_pool=memory_pool, self_destruct=True).to_dict(

--- a/src/fairseq2/datasets/speech_parquet.py
+++ b/src/fairseq2/datasets/speech_parquet.py
@@ -18,16 +18,8 @@ import torch
 from numpy.typing import NDArray
 from typing_extensions import override
 
-from fairseq2.data import (
-    Collater,
-    DataPipelineBuilder,
-    MemoryBlock,
-    read_sequence,
-)
-from fairseq2.data.audio import (
-    AudioDecoder,
-    AudioDecoderOutput,
-)
+from fairseq2.data import Collater, DataPipelineBuilder, MemoryBlock, read_sequence
+from fairseq2.data.audio import AudioDecoder, AudioDecoderOutput
 from fairseq2.data.parquet import (
     FragmentLoadingConfig,
     FragmentStreamingConfig,
@@ -35,10 +27,7 @@ from fairseq2.data.parquet import (
     ParquetFragmentLoader,
     ParquetFragmentStreamer,
 )
-from fairseq2.datasets import (
-    DataPipelineReader,
-    UnknownSplitError,
-)
+from fairseq2.datasets import DataPipelineReader, UnknownSplitError
 from fairseq2.datasets.speech import (
     GenericSpeechDataset,
     SpeechDataset,
@@ -184,13 +173,21 @@ class GenericSpeechParquetDataset(ParquetDatasetInterface, SpeechDataset):
         columns = options.extras.get("columns", columns)  # type: ignore
         assert columns is None or isinstance(columns, NamedColumns)
 
+        cache = options.extras.get("cache", False)
+        assert isinstance(cache, bool)
+
+        add_fragment_traces = options.extras.get("add_fragment_traces", False)
+        assert isinstance(add_fragment_traces, bool)
+
         loading_config = FragmentLoadingConfig(
             columns=columns,
-            add_fragment_traces=False,
+            add_fragment_traces=add_fragment_traces,
             num_parallel_fragments=num_parallel_fragments,
             nb_prefetch=options.num_prefetch,
-            non_deterministic_read=True,
+            non_deterministic_read=False,
+            cache=cache,
             drop_null=False,
+            filters=None,
         )
 
         # load data in memory

--- a/src/fairseq2/datasets/speech_parquet.py
+++ b/src/fairseq2/datasets/speech_parquet.py
@@ -55,8 +55,8 @@ class ParquetDatasetInterface:
     _splits: set[str]
     split_column: str = "split"
 
-    max_num_batches: int = 2000
-    max_num_examples: int = 100_000
+    max_num_batches: int = 10_000
+    max_num_examples: int = 400_000
 
     def __init__(self, name: str, dataset: pq.ParquetDataset, splits: set[str]) -> None:
         self._dataset = dataset
@@ -73,23 +73,23 @@ class ParquetDatasetInterface:
 
         # from stopes.fb_config import get_filesystem_from_path
         # path, filesystem = get_filesystem_from_path(path)  # type: ignore
-        datasest = pq.ParquetDataset(path, filesystem=filesystem)  # type: ignore
+        dataset = pq.ParquetDataset(path, filesystem=filesystem)  # type: ignore
 
-        assert isinstance(datasest, pq.ParquetDataset)
+        assert isinstance(dataset, pq.ParquetDataset)
         partition_columns: List[str] = []
-        if datasest.partitioning is not None:
-            partition_columns = datasest.partitioning.schema.names
+        if dataset.partitioning is not None:
+            partition_columns = dataset.partitioning.schema.names
 
         splits: Set[str] = set()
-        if datasest.partitioning is not None and cls.split_column in partition_columns:
+        if dataset.partitioning is not None and cls.split_column in partition_columns:
             idx = partition_columns.index(cls.split_column)
-            _splits = datasest.partitioning.dictionaries[idx]
+            _splits = dataset.partitioning.dictionaries[idx]
             if _splits is None:
                 splits = set()
             else:
                 splits = set(_splits.to_pylist())
 
-        return cls(name, datasest, splits)
+        return cls(name, dataset, splits)
 
     def splits(self) -> set[str]:
         return self._splits

--- a/src/fairseq2/datasets/speech_parquet.py
+++ b/src/fairseq2/datasets/speech_parquet.py
@@ -37,8 +37,6 @@ from fairseq2.data.parquet import (
 )
 from fairseq2.datasets import (
     DataPipelineReader,
-    LengthBatching,
-    StaticBatching,
     UnknownSplitError,
 )
 from fairseq2.datasets.speech import (

--- a/src/fairseq2/datasets/speech_parquet.py
+++ b/src/fairseq2/datasets/speech_parquet.py
@@ -9,12 +9,14 @@ from __future__ import annotations
 from dataclasses import dataclass
 from functools import partial
 from pathlib import Path
-from typing import Any, Dict, Final, final, List, Set
+from typing import Any, Dict, Final, List, Set, final
 
 import numpy as np
 import pyarrow as pa
 import pyarrow.parquet as pq
 import torch
+from numpy.typing import NDArray
+from typing_extensions import override
 
 from fairseq2.data import Collater, DataPipelineBuilder, MemoryBlock, read_sequence
 from fairseq2.data.audio import AudioDecoder, AudioDecoderOutput
@@ -34,8 +36,6 @@ from fairseq2.datasets.speech import (
 from fairseq2.gang import Gang
 from fairseq2.logging import log
 from fairseq2.models.sequence import SequenceBatch
-from numpy.typing import NDArray
-from typing_extensions import override
 
 PARQUET_SPEECH_DATASET_FAMILY: Final = "generic_parquet_speech"
 

--- a/src/fairseq2/metrics/recorders/_wandb.py
+++ b/src/fairseq2/metrics/recorders/_wandb.py
@@ -13,7 +13,6 @@ from typing import Final, final
 
 from fairseq2.logging import log
 from fairseq2.metrics import MetricDescriptor
-
 from fairseq2.metrics.recorders._handler import MetricRecorderHandler
 from fairseq2.metrics.recorders._recorder import (
     MetricRecorder,
@@ -22,7 +21,7 @@ from fairseq2.metrics.recorders._recorder import (
 )
 from fairseq2.registry import Provider
 from fairseq2.utils.structured import structure
-from fairseq2.utils.validation import validate, ValidationError, ValidationResult
+from fairseq2.utils.validation import ValidationError, ValidationResult, validate
 
 # isort: split
 

--- a/src/fairseq2/models/asr/_model.py
+++ b/src/fairseq2/models/asr/_model.py
@@ -24,8 +24,7 @@ class AsrModel(Module, ABC):
     """Represents an Automatic Speech Recognition model."""
 
     @abstractmethod
-    def forward(self, batch: SequenceBatch | Seq2SeqBatch) -> AsrModelOutput:
-        ...
+    def forward(self, batch: SequenceBatch | Seq2SeqBatch) -> AsrModelOutput: ...
 
 
 @dataclass

--- a/src/fairseq2/models/wav2vec2/asr/_model.py
+++ b/src/fairseq2/models/wav2vec2/asr/_model.py
@@ -8,6 +8,9 @@ from __future__ import annotations
 
 from typing import final
 
+from torch.nn import Dropout
+from typing_extensions import override
+
 from fairseq2.models.asr import AsrModel, AsrModelOutput
 from fairseq2.models.seq2seq import Seq2SeqBatch
 from fairseq2.models.sequence import SequenceBatch
@@ -15,9 +18,6 @@ from fairseq2.models.transformer import TransformerEncoder
 from fairseq2.models.wav2vec2 import Wav2Vec2Frontend, Wav2Vec2Masker
 from fairseq2.nn import Projection
 from fairseq2.typing import DataType, Device
-
-from torch.nn import Dropout
-from typing_extensions import override
 
 
 @final

--- a/src/fairseq2/recipes/asr/_common.py
+++ b/src/fairseq2/recipes/asr/_common.py
@@ -7,9 +7,11 @@
 from __future__ import annotations
 
 import math
-from typing import Any, Dict, final, TextIO
+from typing import Any, Dict, TextIO, final
 
 import torch
+from torch import Tensor
+from typing_extensions import override
 
 from fairseq2.data.text.tokenizers import TextTokenDecoder, TextTokenizer
 from fairseq2.gang import Gang
@@ -20,8 +22,6 @@ from fairseq2.models.seq2seq import Seq2SeqBatch
 from fairseq2.models.sequence import SequenceBatch
 from fairseq2.models.wav2vec2.asr import Wav2Vec2AsrModel
 from fairseq2.recipes import BaseMetricBag, Model, UnitError
-from torch import Tensor
-from typing_extensions import override
 
 
 @final

--- a/src/fairseq2/recipes/asr/_eval.py
+++ b/src/fairseq2/recipes/asr/_eval.py
@@ -14,7 +14,7 @@ import torch
 
 from fairseq2.context import RuntimeContext
 from fairseq2.datasets import LengthBatching, SyncMode
-from fairseq2.datasets.asr import AsrDataset, GENERIC_ASR_DATASET_FAMILY
+from fairseq2.datasets.asr import GENERIC_ASR_DATASET_FAMILY, AsrDataset
 from fairseq2.datasets.speech import SpeechReadOptions
 from fairseq2.gang import Gangs
 from fairseq2.models.asr import AsrModel
@@ -22,6 +22,8 @@ from fairseq2.models.seq2seq import Seq2SeqBatch
 from fairseq2.recipes import Evaluator, EvalUnit, Model, RecipeError, UnitError
 
 # isort: split
+
+from typing_extensions import override
 
 from fairseq2.recipes.asr._common import AsrCriterion, AsrMetricBag, AsrScorer
 from fairseq2.recipes.common import (
@@ -46,7 +48,6 @@ from fairseq2.utils.file import FileMode
 from fairseq2.utils.rng import manual_seed
 from fairseq2.utils.structured import structure
 from fairseq2.utils.validation import validate
-from typing_extensions import override
 
 
 @dataclass(kw_only=True)

--- a/src/fairseq2/recipes/asr/_eval.py
+++ b/src/fairseq2/recipes/asr/_eval.py
@@ -14,7 +14,8 @@ import torch
 
 from fairseq2.context import RuntimeContext
 from fairseq2.datasets import LengthBatching, SyncMode
-from fairseq2.datasets.asr import AsrDataset, AsrReadOptions, GENERIC_ASR_DATASET_FAMILY
+from fairseq2.datasets.asr import AsrDataset, GENERIC_ASR_DATASET_FAMILY
+from fairseq2.datasets.speech import SpeechReadOptions
 from fairseq2.gang import Gangs
 from fairseq2.models.asr import AsrModel
 from fairseq2.models.seq2seq import Seq2SeqBatch
@@ -190,7 +191,7 @@ def load_asr_evaluator(
 
     batching = LengthBatching(config.dataset.max_num_elements)
 
-    read_options = AsrReadOptions(
+    read_options = SpeechReadOptions(
         batching=batching,
         dtype=config.evaluator.dtype,
         normalize_audio=config.dataset.normalize_audio,

--- a/src/fairseq2/recipes/wav2vec2/asr/_train.py
+++ b/src/fairseq2/recipes/wav2vec2/asr/_train.py
@@ -16,7 +16,11 @@ from typing_extensions import override
 
 from fairseq2.context import RuntimeContext
 from fairseq2.datasets import LengthBatching, SyncMode
-from fairseq2.datasets.asr import GENERIC_ASR_DATASET_FAMILY, AsrDataset, AsrReadOptions
+from fairseq2.datasets.asr import (
+    GENERIC_ASR_DATASET_FAMILY,
+    AsrDataset,
+)
+from fairseq2.datasets.speech import SpeechReadOptions
 from fairseq2.gang import Gang, GangError
 from fairseq2.logging import log
 from fairseq2.models.asr import AsrModel
@@ -380,7 +384,7 @@ def load_wav2vec2_asr_trainer(
 
     batching = LengthBatching(config.dataset.max_num_elements)
 
-    read_options = AsrReadOptions(
+    read_options = SpeechReadOptions(
         batching=batching,
         dtype=config.trainer.dtype,
         normalize_audio=config.dataset.normalize_audio,
@@ -420,7 +424,7 @@ def load_wav2vec2_asr_trainer(
 
         valid_criterion = AsrCriterion(model, valid_scorer)
 
-        read_options = AsrReadOptions(
+        read_options = SpeechReadOptions(
             batching=batching,
             dtype=config.trainer.dtype,
             normalize_audio=config.dataset.normalize_audio,

--- a/src/fairseq2/recipes/wav2vec2/asr/_train.py
+++ b/src/fairseq2/recipes/wav2vec2/asr/_train.py
@@ -8,13 +8,15 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import cast, final, Literal
+from typing import Literal, cast, final
 
 import torch
+from torch import Tensor
+from typing_extensions import override
 
 from fairseq2.context import RuntimeContext
 from fairseq2.datasets import LengthBatching, SyncMode
-from fairseq2.datasets.asr import AsrDataset, GENERIC_ASR_DATASET_FAMILY
+from fairseq2.datasets.asr import GENERIC_ASR_DATASET_FAMILY, AsrDataset
 from fairseq2.datasets.speech import SpeechReadOptions
 from fairseq2.gang import Gang, GangError
 from fairseq2.logging import log
@@ -58,15 +60,13 @@ from fairseq2.recipes.config import (
 )
 from fairseq2.recipes.utils.log import log_model
 from fairseq2.recipes.wav2vec2.batch_weighted_datareader import (
-    BatchMixtureDataset,
     MIXTURE_DATASET_FAMILY,
+    BatchMixtureDataset,
 )
 from fairseq2.typing import CPU
 from fairseq2.utils.rng import manual_seed
 from fairseq2.utils.structured import structure
 from fairseq2.utils.validation import validate
-from torch import Tensor
-from typing_extensions import override
 
 
 @dataclass(kw_only=True)

--- a/src/fairseq2/recipes/wav2vec2/asr/_train.py
+++ b/src/fairseq2/recipes/wav2vec2/asr/_train.py
@@ -275,11 +275,11 @@ def load_wav2vec2_asr_trainer(
 
         pt_module = cast(Wav2Vec2Model, pt_model.module)
 
-        share_parameters(pt_module.encoder_frontend, module.encoder_frontend)
-        share_parameters(pt_module.encoder, module.encoder)
+        share_parameters(pt_module.encoder_frontend, module.encoder_frontend)  # type: ignore
+        share_parameters(pt_module.encoder, module.encoder)  # type: ignore
 
         if module.masker is not None:
-            share_parameters(pt_module.masker, module.masker)
+            share_parameters(pt_module.masker, module.masker)  # type: ignore
 
         del pt_model
 
@@ -336,7 +336,7 @@ def load_wav2vec2_asr_trainer(
             mp=config.trainer.mixed_precision != "off",
         )
         pt_module = pt_model.module  # type: ignore[assignment]
-        share_parameters(pt_module.decoder, module.llama_decoder)
+        share_parameters(pt_module.decoder, module.llama_decoder)  # type: ignore
         del pt_model
 
         # Make sure that the final projection layer is instantiated along with
@@ -355,7 +355,7 @@ def load_wav2vec2_asr_trainer(
         module = wrap_lora(module, get_llama_lora_config())  # type: ignore[assignment]
 
     # We never train the feature extractor.
-    freeze_parameters(module.encoder_frontend.feature_extractor)
+    freeze_parameters(module.encoder_frontend.feature_extractor)  # type: ignore
 
     prepare_model(context, config.trainer, model)
 
@@ -531,11 +531,11 @@ class Wav2Vec2AsrTrainUnit(TrainUnit[Seq2SeqBatch]):
             if step_nr == 1:
                 log.info("Freezing the encoder for the first {} steps.", self._freeze_encoder_for_n_steps)  # fmt: skip
 
-            freeze_parameters(module.encoder_frontend)
-            freeze_parameters(module.encoder)
+            freeze_parameters(module.encoder_frontend)  # type: ignore
+            freeze_parameters(module.encoder)  # type: ignore
 
             if module.masker is not None:
-                freeze_parameters(module.masker)
+                freeze_parameters(module.masker)  # type: ignore
 
             self._frozen = True
         else:
@@ -548,7 +548,7 @@ class Wav2Vec2AsrTrainUnit(TrainUnit[Seq2SeqBatch]):
             freeze_parameters(module, False)
 
             # We never train the feature extractor.
-            freeze_parameters(module.encoder_frontend.feature_extractor)
+            freeze_parameters(module.encoder_frontend.feature_extractor)  # type: ignore
 
             self._frozen = False
 

--- a/src/fairseq2/recipes/wav2vec2/asr/_train.py
+++ b/src/fairseq2/recipes/wav2vec2/asr/_train.py
@@ -166,6 +166,9 @@ class Wav2Vec2AsrTrainDatasetSection(DatasetSection):
     num_prefetch: int = 4
     """The number of batches to prefetch in background."""
 
+    npc: int = 10
+    """The number of parallel calls to use in the pipeline."""
+
     extras: dict[str, object] = field(default_factory=dict)
     """The dataset-specific extra options."""
 
@@ -394,6 +397,7 @@ def load_wav2vec2_asr_trainer(
         num_prefetch=config.dataset.num_prefetch,
         seed=seed,
         extras=config.dataset.extras,
+        npc=config.dataset.npc,
     )
 
     dataset: AsrDataset | BatchMixtureDataset

--- a/src/fairseq2/recipes/wav2vec2/asr/_train.py
+++ b/src/fairseq2/recipes/wav2vec2/asr/_train.py
@@ -8,18 +8,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Literal, cast, final
+from typing import cast, final, Literal
 
 import torch
-from torch import Tensor
-from typing_extensions import override
 
 from fairseq2.context import RuntimeContext
 from fairseq2.datasets import LengthBatching, SyncMode
-from fairseq2.datasets.asr import (
-    GENERIC_ASR_DATASET_FAMILY,
-    AsrDataset,
-)
+from fairseq2.datasets.asr import AsrDataset, GENERIC_ASR_DATASET_FAMILY
 from fairseq2.datasets.speech import SpeechReadOptions
 from fairseq2.gang import Gang, GangError
 from fairseq2.logging import log
@@ -63,13 +58,15 @@ from fairseq2.recipes.config import (
 )
 from fairseq2.recipes.utils.log import log_model
 from fairseq2.recipes.wav2vec2.batch_weighted_datareader import (
-    MIXTURE_DATASET_FAMILY,
     BatchMixtureDataset,
+    MIXTURE_DATASET_FAMILY,
 )
 from fairseq2.typing import CPU
 from fairseq2.utils.rng import manual_seed
 from fairseq2.utils.structured import structure
 from fairseq2.utils.validation import validate
+from torch import Tensor
+from typing_extensions import override
 
 
 @dataclass(kw_only=True)

--- a/src/fairseq2/recipes/wav2vec2/batch_weighted_datareader.py
+++ b/src/fairseq2/recipes/wav2vec2/batch_weighted_datareader.py
@@ -13,10 +13,8 @@ from typing import Dict, Final, List, Tuple
 from fairseq2.context import RuntimeContext
 from fairseq2.data import DataPipeline
 from fairseq2.data.text.tokenizers import TextTokenizer
-from fairseq2.datasets import (
-    DataPipelineReader,
-)
-from fairseq2.datasets.asr import AsrDataset, AsrReadOptions
+from fairseq2.datasets import DataPipelineReader
+from fairseq2.datasets.asr import AsrDataset, SpeechReadOptions
 from fairseq2.gang import Gang, Gangs
 from fairseq2.models.seq2seq import Seq2SeqBatch
 from fairseq2.recipes.common import load_dataset
@@ -141,11 +139,11 @@ class BatchMixtureDataset:
         gang: Gang,
         min_audio_len: int,
         max_audio_len: int,
-        options: AsrReadOptions | None = None,
+        options: SpeechReadOptions | None = None,
     ) -> DataPipelineReader[Seq2SeqBatch]:
 
         if options is None:
-            options = AsrReadOptions()
+            options = SpeechReadOptions()
 
         splits = self.parse_split_config(split)
 

--- a/src/fairseq2/recipes/wav2vec2/batch_weighted_datareader.py
+++ b/src/fairseq2/recipes/wav2vec2/batch_weighted_datareader.py
@@ -144,11 +144,12 @@ class BatchMixtureDataset:
         min_audio_len: int,
         max_audio_len: int,
         options: SpeechReadOptions | None = None,
-        mixing_level: Literal["batch", "example"] = "batch",
     ) -> DataPipelineReader[Seq2SeqBatch]:
 
         if options is None:
             options = SpeechReadOptions()
+        mixing_level = options.extras.get("mixing_level", "batch")
+        assert mixing_level in ["batch", "example"]
 
         splits = self.parse_split_config(split)
         if mixing_level == "batch":

--- a/src/fairseq2/recipes/wav2vec2/batch_weighted_datareader.py
+++ b/src/fairseq2/recipes/wav2vec2/batch_weighted_datareader.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import re
 from copy import deepcopy
-from typing import Dict, Final, List, Literal, Tuple
+from typing import Dict, Final, List, Tuple
 
 from fairseq2.context import RuntimeContext
 from fairseq2.data import DataPipeline

--- a/src/fairseq2/setup/_datasets.py
+++ b/src/fairseq2/setup/_datasets.py
@@ -11,6 +11,10 @@ from typing import final
 from fairseq2.context import RuntimeContext
 from fairseq2.datasets import DatasetHandler, DatasetLoader, StandardDatasetHandler
 from fairseq2.datasets.asr import GENERIC_ASR_DATASET_FAMILY, GenericAsrDataset
+from fairseq2.datasets.asr_parquet import (
+    PARQUET_ASR_DATASET_FAMILY,
+    GenericAsrParquetDataset,
+)
 from fairseq2.datasets.instruction import (
     GENERIC_INSTRUCTION_DATASET_FAMILY,
     GenericInstructionDataset,
@@ -70,6 +74,12 @@ def register_dataset_families(context: RuntimeContext) -> None:
         PARQUET_SPEECH_DATASET_FAMILY,
         GenericSpeechParquetDataset,
         GenericSpeechParquetDataset.from_path,
+    )
+
+    registrar.register_family(
+        PARQUET_ASR_DATASET_FAMILY,
+        GenericAsrParquetDataset,
+        GenericAsrParquetDataset.from_path,
     )
 
     registrar.register_family(


### PR DESCRIPTION
**What does this PR do? Please describe:**
- This PR mutualizes the code between different Speech and ASR dataloaders with static method and subclassing
 - It also introduces parquet speech and asr dataloaders family (to load audio directly from binary inside parquets)
 - It enables batch and example level dataset (static) weighted mixture for all ASR dataloaders (it can be next generized on all other type of dataloading)

Minor points :
 - using `pa.jemalloc_memory_pool()` for faster memory release when loading parquet
 - using `SpeechReadOptions` for both Asr and Speech datasets


Some other important behavior changes:
- for train splits (detected with "train" in split) we do infinite loop in datapipeline to avoid resets
- this is also coherent with mixture type dataloading (infinite loop)
- for non-train splits, we do one epoch only


## Tests
- reaching parity on ASR finetuning metrics
- currently running pretraining (there's some different behavior in diversity loss, -> i'll play more with shuffling window)
- running some mixture recipes to verify the integration

## Config considerations

- To enable data mixture one needs to use the following pattern the preset:
```python
        config.dataset.name = "dataset1:7,dataset2:1"
        config.dataset.family = "weighted_dataset_mixture"
        config.dataset.train_split = "dataset1=train,dataset2=train"
        config.dataset.valid_split = "dataset1=[dev,test],dataset2=[dev,test]"
        config.dataset.extras = {"mixing_level": "batch"}  # {"mixing_level": "example"}
```
- For parquet dataloader, several params are passed through `config.extras`, in particular :
    - fragment_shuffle_window ( default = -1, global fragments shuffling)
    - columns (possibility to pass custom column config)
    - pa_cpu_count (default to 20)
    - partition_filters (default to None)
    - files_circular_shift (default to False)

- For parquet dataloader, the examples and batch shuffling happens in memory, having very large window will result in higher cpu memory footprint. As dummy protection mechanics, we added upper some reasonable boundaries and not allow global window=0 any more.