### PR TITLE
Improve non-blocking host-to-device transfer

### DIFF
--- a/src/fairseq2/chatbots/llama.py
+++ b/src/fairseq2/chatbots/llama.py
@@ -26,6 +26,7 @@ from fairseq2.generation import SequenceGenerator
 from fairseq2.models.decoder import DecoderModel
 from fairseq2.models.llama import LLAMA_MODEL_FAMILY
 from fairseq2.nn.utils.module import infer_device
+from fairseq2.utils.tensor import to_tensor
 
 
 @final
@@ -48,8 +49,8 @@ class LLaMA1DialogEncoder(ChatDialogEncoder):
                 "The device of `generator.model` is not valid. See the nested exception for details."
             ) from ex
 
-        self._bos_idx = torch.tensor([bos_idx], device=device)
-        self._eos_idx = torch.tensor([eos_idx], device=device)
+        self._bos_idx = to_tensor([bos_idx], device=device)
+        self._eos_idx = to_tensor([eos_idx], device=device)
 
         self._text_encoder = tokenizer.create_raw_encoder(device=device)
 
@@ -119,10 +120,10 @@ class LLaMA3DialogEncoder(ChatDialogEncoder):
                 "The device of `generator.model` is not valid. See the nested exception for details."
             ) from ex
 
-        self._bos_idx = torch.tensor([bos_idx], device=device)
-        self._eos_idx = torch.tensor([eos_idx], device=device)
-        self._boh_idx = torch.tensor([boh_idx], device=device)
-        self._eoh_idx = torch.tensor([eoh_idx], device=device)
+        self._bos_idx = to_tensor([bos_idx], device=device)
+        self._eos_idx = to_tensor([eos_idx], device=device)
+        self._boh_idx = to_tensor([boh_idx], device=device)
+        self._eoh_idx = to_tensor([eoh_idx], device=device)
 
         self._text_encoder = tokenizer.create_raw_encoder(device=device)
 

--- a/src/fairseq2/chatbots/mistral.py
+++ b/src/fairseq2/chatbots/mistral.py
@@ -24,6 +24,7 @@ from fairseq2.generation import SequenceGenerator
 from fairseq2.models.decoder import DecoderModel
 from fairseq2.models.mistral import MISTRAL_MODEL_FAMILY
 from fairseq2.nn.utils.module import infer_device
+from fairseq2.utils.tensor import to_tensor
 
 
 @final
@@ -46,8 +47,8 @@ class MistralDialogEncoder(ChatDialogEncoder):
                 "The device of `generator.model` is not valid. See the nested exception for details."
             ) from ex
 
-        self._bos_idx = torch.tensor([bos_idx], device=device)
-        self._eos_idx = torch.tensor([eos_idx], device=device)
+        self._bos_idx = to_tensor([bos_idx], device=device)
+        self._eos_idx = to_tensor([eos_idx], device=device)
 
         self._text_encoder = tokenizer.create_raw_encoder(device=device)
 

--- a/src/fairseq2/checkpoint/_manager.py
+++ b/src/fairseq2/checkpoint/_manager.py
@@ -15,21 +15,21 @@ from pathlib import Path
 from shutil import Error
 from typing import Protocol, TypeAlias, cast, final, runtime_checkable
 
-import torch
 from torch import Tensor
 from typing_extensions import override
 
+from fairseq2.device import CPU
 from fairseq2.error import InternalError
 from fairseq2.file_system import FileMode, FileSystem
 from fairseq2.gang import Gang, GangError, Gangs, all_sum
 from fairseq2.nn.data_parallel import load_with_sdp_gang
-from fairseq2.typing import CPU
 from fairseq2.utils.io import (
     TensorDumper,
     TensorDumpError,
     TensorLoader,
     TensorLoadError,
 )
+from fairseq2.utils.tensor import to_tensor
 from fairseq2.utils.threading import ThreadPool
 
 
@@ -174,8 +174,8 @@ class FileCheckpointManager(CheckpointManager):
         self._op = None
         self._step_nr = None
 
-        self._f_flag = torch.tensor(0, device=gangs.root.device)
-        self._t_flag = torch.tensor(1, device=gangs.root.device)
+        self._f_flag = to_tensor(0, device=gangs.root.device)
+        self._t_flag = to_tensor(1, device=gangs.root.device)
 
     @override
     def save_checkpoint(
@@ -249,7 +249,7 @@ class FileCheckpointManager(CheckpointManager):
                 state = self._move_state_to_cpu(state)
             except (RuntimeError, ValueError, TypeError) as ex:
                 raise CheckpointSaveError(
-                    step_nr, f"The checkpoint state of step {step_nr} cannot be moved to CPU. See the nested exception for details."  # fmt: skip
+                    step_nr, f"The checkpoint state of step {step_nr} cannot be transferred to the host memory. See the nested exception for details."  # fmt: skip
                 ) from ex
 
         if state_processor is not None:

--- a/src/fairseq2/cli/commands/chatbot.py
+++ b/src/fairseq2/cli/commands/chatbot.py
@@ -22,6 +22,7 @@ from fairseq2.cli.utils.cluster import set_torch_distributed_variables
 from fairseq2.cli.utils.rich import get_console
 from fairseq2.context import RuntimeContext
 from fairseq2.data.text.tokenizers import TextTokenDecoder, TextTokenizer
+from fairseq2.device import CPU
 from fairseq2.error import InternalError
 from fairseq2.gang import Gang, GangError
 from fairseq2.generation import (
@@ -44,7 +45,6 @@ from fairseq2.recipes.config import (
     TextTokenizerSection,
     TorchSection,
 )
-from fairseq2.typing import CPU
 from fairseq2.utils.rng import RngBag
 
 

--- a/src/fairseq2/cli/utils/argparse.py
+++ b/src/fairseq2/cli/utils/argparse.py
@@ -18,7 +18,7 @@ from typing import Any, final
 
 import torch
 
-from fairseq2.typing import DataType
+from fairseq2.data_type import DataType
 from fairseq2.utils.yaml import YamlError, read_yaml
 
 

--- a/src/fairseq2/data/audio.py
+++ b/src/fairseq2/data/audio.py
@@ -13,7 +13,8 @@ from torch import Tensor
 from typing_extensions import NotRequired
 
 from fairseq2.data import MemoryBlock
-from fairseq2.typing import DataType, Device
+from fairseq2.data_type import DataType
+from fairseq2.device import Device
 
 if TYPE_CHECKING or DOC_MODE:
 

--- a/src/fairseq2/data/image.py
+++ b/src/fairseq2/data/image.py
@@ -12,7 +12,7 @@ from fairseq2n import DOC_MODE
 from torch import Tensor
 
 from fairseq2.data import MemoryBlock
-from fairseq2.typing import Device
+from fairseq2.device import Device
 
 if TYPE_CHECKING or DOC_MODE:
 

--- a/src/fairseq2/data/text/_converters.py
+++ b/src/fairseq2/data/text/_converters.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, final
 from fairseq2n import DOC_MODE
 from torch import Tensor
 
-from fairseq2.typing import DataType
+from fairseq2.data_type import DataType
 
 if TYPE_CHECKING or DOC_MODE:
 

--- a/src/fairseq2/data/text/tokenizers/_tokenizer.py
+++ b/src/fairseq2/data/text/tokenizers/_tokenizer.py
@@ -12,7 +12,7 @@ from collections.abc import Sequence
 from torch import Tensor
 
 from fairseq2.data import VocabularyInfo
-from fairseq2.typing import Device
+from fairseq2.device import Device
 
 
 class TextTokenizer(ABC):

--- a/src/fairseq2/data/text/tokenizers/llama.py
+++ b/src/fairseq2/data/text/tokenizers/llama.py
@@ -24,7 +24,7 @@ from fairseq2.data.text.tokenizers.tiktoken import (
     TiktokenEncoder,
     TiktokenModel,
 )
-from fairseq2.typing import Device
+from fairseq2.device import Device
 
 
 @final

--- a/src/fairseq2/data/text/tokenizers/nllb.py
+++ b/src/fairseq2/data/text/tokenizers/nllb.py
@@ -25,7 +25,7 @@ from fairseq2.data.text.tokenizers.sentencepiece import (
     SentencePieceModel,
     get_sentencepiece_vocabulary_info,
 )
-from fairseq2.typing import Device
+from fairseq2.device import Device
 
 
 @final

--- a/src/fairseq2/data/text/tokenizers/s2t_transformer.py
+++ b/src/fairseq2/data/text/tokenizers/s2t_transformer.py
@@ -24,7 +24,7 @@ from fairseq2.data.text.tokenizers.sentencepiece import (
     SentencePieceModel,
     get_sentencepiece_vocabulary_info,
 )
-from fairseq2.typing import Device
+from fairseq2.device import Device
 
 
 @final

--- a/src/fairseq2/data/text/tokenizers/sentencepiece.py
+++ b/src/fairseq2/data/text/tokenizers/sentencepiece.py
@@ -22,7 +22,7 @@ from fairseq2.data.text.tokenizers import (
     TextTokenizer,
     TextTokenizerLoadError,
 )
-from fairseq2.typing import Device
+from fairseq2.device import Device
 
 if TYPE_CHECKING or DOC_MODE:
 

--- a/src/fairseq2/data/text/tokenizers/tiktoken.py
+++ b/src/fairseq2/data/text/tokenizers/tiktoken.py
@@ -21,7 +21,8 @@ from fairseq2.data.text.tokenizers import (
     TextTokenDecoder,
     TextTokenEncoder,
 )
-from fairseq2.typing import Device
+from fairseq2.device import Device
+from fairseq2.utils.tensor import to_tensor
 
 
 @final
@@ -113,8 +114,8 @@ class TiktokenEncoder(TextTokenEncoder):
     _encoding: Encoding
     _prefix_indices: list[int]
     _suffix_indices: list[int]
-    _prefix_index_tensor: Tensor | None
-    _suffix_index_tensor: Tensor | None
+    _prefix_indices_pt: Tensor | None
+    _suffix_indices_pt: Tensor | None
     _device: Device | None
     _pin_memory: bool
 
@@ -147,13 +148,13 @@ class TiktokenEncoder(TextTokenEncoder):
                 self._encoding.encode_single_token(t) for t in prefix_tokens
             ]
 
-            self._prefix_index_tensor = torch.tensor(
+            self._prefix_indices_pt = to_tensor(
                 self._prefix_indices, dtype=torch.int64, device=device
             )
         else:
             self._prefix_indices = []
 
-            self._prefix_index_tensor = None
+            self._prefix_indices_pt = None
 
         # Suffix
         if suffix_tokens:
@@ -161,13 +162,13 @@ class TiktokenEncoder(TextTokenEncoder):
                 self._encoding.encode_single_token(t) for t in suffix_tokens
             ]
 
-            self._suffix_index_tensor = torch.tensor(
+            self._suffix_indices_pt = to_tensor(
                 self._suffix_indices, dtype=torch.int64, device=device
             )
         else:
             self._suffix_indices = []
 
-            self._suffix_index_tensor = None
+            self._suffix_indices_pt = None
 
         self._device = device
         self._pin_memory = pin_memory
@@ -197,12 +198,12 @@ class TiktokenEncoder(TextTokenEncoder):
     @property
     @override
     def prefix_indices(self) -> Tensor | None:
-        return self._prefix_index_tensor
+        return self._prefix_indices_pt
 
     @property
     @override
     def suffix_indices(self) -> Tensor | None:
-        return self._suffix_index_tensor
+        return self._suffix_indices_pt
 
 
 @final

--- a/src/fairseq2/data_type.py
+++ b/src/fairseq2/data_type.py
@@ -1,0 +1,27 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import TypeAlias
+
+import torch
+
+DataType: TypeAlias = torch.dtype
+
+
+@contextmanager
+def default_dtype(dtype: DataType) -> Iterator[None]:
+    original_dtype = torch.get_default_dtype()
+
+    torch.set_default_dtype(dtype)
+
+    try:
+        yield
+    finally:
+        torch.set_default_dtype(original_dtype)

--- a/src/fairseq2/datasets/_data_reader.py
+++ b/src/fairseq2/datasets/_data_reader.py
@@ -16,6 +16,7 @@ from typing_extensions import Self, override
 from fairseq2.data import DataPipeline, DataPipelineError
 from fairseq2.gang import Gang, GangError, all_sum
 from fairseq2.logging import log
+from fairseq2.utils.tensor import to_tensor
 
 # isort: split
 
@@ -200,9 +201,9 @@ class DataPipelineReader(DataReader[BatchT]):
 def _min_num_batches(num_batches: int, gang: Gang) -> int:
     all_num_batches = torch.zeros((gang.size,), device=gang.device, dtype=torch.int64)
 
-    input_ = torch.tensor([num_batches], device=gang.device)
+    num_batches_pt = to_tensor([num_batches], device=gang.device)
 
-    gang.all_gather(all_num_batches, input_)
+    gang.all_gather(all_num_batches, num_batches_pt)
 
     min_num_batches = int(all_num_batches.min())
     if min_num_batches != 0:

--- a/src/fairseq2/datasets/asr.py
+++ b/src/fairseq2/datasets/asr.py
@@ -29,6 +29,7 @@ from fairseq2.data import (
 from fairseq2.data.audio import AudioDecoder
 from fairseq2.data.text import StrSplitter, read_text
 from fairseq2.data.text.tokenizers import TextTokenizer
+from fairseq2.data_type import DataType
 from fairseq2.datasets import (
     DataPipelineReader,
     DataReader,
@@ -44,7 +45,6 @@ from fairseq2.error import NotSupportedError
 from fairseq2.gang import Gang
 from fairseq2.models.seq2seq import Seq2SeqBatch
 from fairseq2.nn.padding import get_seqs_and_padding_mask
-from fairseq2.typing import DataType
 
 
 @dataclass(kw_only=True)

--- a/src/fairseq2/datasets/preference.py
+++ b/src/fairseq2/datasets/preference.py
@@ -33,12 +33,11 @@ from fairseq2.datasets import (
     LengthBatching,
     StaticBatching,
 )
-from fairseq2.device import SupportsDeviceTransfer
+from fairseq2.device import Device, SupportsDeviceTransfer
 from fairseq2.error import NotSupportedError
 from fairseq2.gang import Gang
 from fairseq2.models.sequence import SequenceBatch
 from fairseq2.nn.padding import get_seqs_and_padding_mask
-from fairseq2.typing import Device
 
 # isort: split
 

--- a/src/fairseq2/datasets/speech.py
+++ b/src/fairseq2/datasets/speech.py
@@ -14,6 +14,7 @@ from typing import Final, final
 import torch
 from typing_extensions import override
 
+from fairseq2.data_type import DataType
 from fairseq2.datasets import (
     DataPipelineReader,
     DataReader,
@@ -23,7 +24,6 @@ from fairseq2.datasets import (
 from fairseq2.error import NotSupportedError
 from fairseq2.gang import Gang
 from fairseq2.models.sequence import SequenceBatch
-from fairseq2.typing import DataType
 
 
 @dataclass(kw_only=True)

--- a/src/fairseq2/generation/_beam_search/_generator.py
+++ b/src/fairseq2/generation/_beam_search/_generator.py
@@ -25,6 +25,7 @@ from fairseq2.models.sequence import SequenceModelOutput
 from fairseq2.nn import IncrementalStateBag
 from fairseq2.nn.padding import PaddingMask
 from fairseq2.utils.stopwatch import Stopwatch
+from fairseq2.utils.tensor import to_tensor
 
 # isort: split
 
@@ -786,7 +787,7 @@ class _AbstractBeamSearchSequenceGeneratorOp(ABC):
                 if len(lprobs) != 1:
                     raise InternalError(f"The length of `lprobs` is {len(lprobs)}.")
 
-                seq_idx = torch.tensor([batch_offset], device=lprobs.device)
+                seq_idx = to_tensor([batch_offset], device=lprobs.device)
 
                 # We just extract the prompt step along with its score and treat
                 # it as the next beam step. So we keep a beam of size 1 until we

--- a/src/fairseq2/metrics/_aggregation.py
+++ b/src/fairseq2/metrics/_aggregation.py
@@ -6,13 +6,15 @@
 
 from __future__ import annotations
 
-import torch
 from torch import Tensor
 from torcheval.metrics import Max as MaxBase
 from torcheval.metrics import Mean as MeanBase
 from torcheval.metrics import Min as MinBase
 from torcheval.metrics import Sum as SumBase
 from typing_extensions import Self, override
+
+from fairseq2.device import CPU
+from fairseq2.utils.tensor import to_tensor
 
 
 class Min(MinBase):
@@ -21,7 +23,7 @@ class Min(MinBase):
     @override
     def update(self, input_: int | float | Tensor) -> Self:
         if isinstance(input_, (int, float)):
-            input_ = torch.tensor(input_)
+            input_ = to_tensor(input_, device=CPU)
 
         super().update(input_)
 
@@ -34,7 +36,7 @@ class Max(MaxBase):
     @override
     def update(self, input_: int | float | Tensor) -> Self:
         if isinstance(input_, (int, float)):
-            input_ = torch.tensor(input_)
+            input_ = to_tensor(input_, device=CPU)
 
         super().update(input_)
 
@@ -52,7 +54,7 @@ class Mean(MeanBase):
         weight: int | float | Tensor = 1.0,
     ) -> Self:
         if isinstance(input_, (int, float)):
-            input_ = torch.tensor(input_)
+            input_ = to_tensor(input_, device=CPU)
 
         super().update(input_, weight=weight)
 
@@ -70,7 +72,7 @@ class Sum(SumBase):
         weight: int | float | Tensor = 1.0,
     ) -> Self:
         if isinstance(input_, (int, float)):
-            input_ = torch.tensor(input_)
+            input_ = to_tensor(input_, device=CPU)
 
         super().update(input_, weight=weight)
 

--- a/src/fairseq2/metrics/text/_bleu.py
+++ b/src/fairseq2/metrics/text/_bleu.py
@@ -16,7 +16,8 @@ from torch import Tensor
 from torcheval.metrics import Metric
 from typing_extensions import Self, override
 
-from fairseq2.typing import Device
+from fairseq2.device import Device
+from fairseq2.utils.tensor import to_tensor
 
 DEFAULT_BLEU_TOKENIZER: Final = BLEU.TOKENIZER_DEFAULT
 
@@ -70,8 +71,8 @@ class BleuMetric(Metric[Tensor]):
         self.sys_len += bleu.sys_len
         self.ref_len += bleu.ref_len
 
-        self.valid_ngrams += torch.tensor(bleu.counts, device=self.device)
-        self.total_ngrams += torch.tensor(bleu.totals, device=self.device)
+        self.valid_ngrams += to_tensor(bleu.counts, device=self.device)
+        self.total_ngrams += to_tensor(bleu.totals, device=self.device)
 
         return self
 
@@ -86,7 +87,7 @@ class BleuMetric(Metric[Tensor]):
 
         score_output = BLEU.compute_bleu(valid_ngrams, total_ngrams, sys_len, ref_len)
 
-        return torch.tensor(score_output.score, device=self.device)
+        return to_tensor(score_output.score, device=self.device)
 
     @override
     @torch.inference_mode()

--- a/src/fairseq2/metrics/text/_chrf.py
+++ b/src/fairseq2/metrics/text/_chrf.py
@@ -15,7 +15,8 @@ from torch import Tensor
 from torcheval.metrics import Metric
 from typing_extensions import Self, override
 
-from fairseq2.typing import Device
+from fairseq2.device import Device
+from fairseq2.utils.tensor import to_tensor
 
 
 @final
@@ -50,7 +51,7 @@ class ChrfMetric(Metric[Tensor]):
         all_stats = chrf._extract_corpus_statistics(hyps, [refs])
 
         for stats in all_stats:
-            self.stats += torch.tensor(stats, device=self.device, dtype=torch.int64)
+            self.stats += to_tensor(stats, device=self.device, dtype=torch.int64)
 
         return self
 
@@ -61,7 +62,7 @@ class ChrfMetric(Metric[Tensor]):
 
         score_output = chrf._compute_score_from_stats(self.stats.tolist())
 
-        return torch.tensor(score_output.score, device=self.device)
+        return to_tensor(score_output.score, device=self.device)
 
     @override
     @torch.inference_mode()

--- a/src/fairseq2/metrics/text/_wer.py
+++ b/src/fairseq2/metrics/text/_wer.py
@@ -15,8 +15,9 @@ from torch import Tensor
 from torcheval.metrics import Metric
 from typing_extensions import Self, override
 
+from fairseq2.device import Device
 from fairseq2.nn.padding import PaddingMask, get_seq_lens
-from fairseq2.typing import Device
+from fairseq2.utils.tensor import to_tensor
 
 
 @final
@@ -104,8 +105,8 @@ class WerMetric(Metric[tuple[Tensor, Tensor]]):
             uer = self.unit_err * 100.0 / self.unit_len
             wer = self.word_err * 100.0 / self.word_len
         else:
-            uer = torch.tensor(-1.0, dtype=torch.float32)
-            wer = torch.tensor(-1.0, dtype=torch.float32)
+            uer = to_tensor(-1.0, dtype=torch.float32)
+            wer = to_tensor(-1.0, dtype=torch.float32)
 
         return uer, wer
 

--- a/src/fairseq2/models/_hub.py
+++ b/src/fairseq2/models/_hub.py
@@ -19,9 +19,10 @@ from fairseq2.assets import (
     AssetCardNotFoundError,
     AssetStore,
 )
+from fairseq2.data_type import DataType
+from fairseq2.device import Device
 from fairseq2.gang import Gangs, fake_gangs
 from fairseq2.registry import Provider
-from fairseq2.typing import DataType, Device
 
 # isort: split
 

--- a/src/fairseq2/models/conformer/_block.py
+++ b/src/fairseq2/models/conformer/_block.py
@@ -12,6 +12,8 @@ from torch import Tensor
 from torch.nn import Dropout
 from typing_extensions import override
 
+from fairseq2.data_type import DataType
+from fairseq2.device import Device
 from fairseq2.models.transformer import (
     AttentionMask,
     FeedForwardNetwork,
@@ -22,7 +24,6 @@ from fairseq2.models.transformer import (
 )
 from fairseq2.nn import LayerNorm
 from fairseq2.nn.padding import PaddingMask
-from fairseq2.typing import DataType, Device
 
 # isort: split
 

--- a/src/fairseq2/models/conformer/_convolution.py
+++ b/src/fairseq2/models/conformer/_convolution.py
@@ -12,10 +12,11 @@ from torch import Tensor
 from torch.nn import GLU, BatchNorm1d, Conv1d, Module, SiLU
 from torch.nn.functional import pad
 
+from fairseq2.data_type import DataType
+from fairseq2.device import Device
 from fairseq2.error import InternalError
 from fairseq2.nn import LayerNorm, StandardLayerNorm
 from fairseq2.nn.padding import PaddingMask, apply_padding_mask
-from fairseq2.typing import DataType, Device
 
 
 @final

--- a/src/fairseq2/models/jepa/_factory.py
+++ b/src/fairseq2/models/jepa/_factory.py
@@ -13,6 +13,8 @@ import torch.nn as nn
 from torch import Tensor
 from torch.nn import GELU, Conv2d, Conv3d
 
+from fairseq2.data_type import DataType
+from fairseq2.device import Device
 from fairseq2.models.transformer import (
     FeedForwardNetwork,
     MultiheadAttention,
@@ -41,7 +43,6 @@ from fairseq2.nn import (
     Sinusoidal3dPositionEncoder,
     StandardLayerNorm,
 )
-from fairseq2.typing import DataType, Device
 
 # isort: split
 

--- a/src/fairseq2/models/jepa/classifier/_model.py
+++ b/src/fairseq2/models/jepa/classifier/_model.py
@@ -13,6 +13,8 @@ import torch.nn as nn
 from torch import Tensor
 from torch.nn import Module, Parameter
 
+from fairseq2.data_type import DataType
+from fairseq2.device import Device
 from fairseq2.models.sequence import SequenceBatch
 from fairseq2.models.transformer import (
     FeedForwardNetwork,
@@ -23,7 +25,6 @@ from fairseq2.models.transformer import (
     create_standard_layer_norm,
 )
 from fairseq2.nn import LayerNorm, Projection
-from fairseq2.typing import DataType, Device
 
 
 @final

--- a/src/fairseq2/models/llama/_factory.py
+++ b/src/fairseq2/models/llama/_factory.py
@@ -13,6 +13,8 @@ import torch
 import torch.nn as nn
 from torch import Tensor
 
+from fairseq2.data_type import DataType
+from fairseq2.device import Device
 from fairseq2.models.transformer import (
     FeedForwardNetwork,
     GLUFeedForwardNetwork,
@@ -41,7 +43,7 @@ from fairseq2.nn import (
     StandardEmbedding,
     TiedProjection,
 )
-from fairseq2.typing import DataType, Device
+from fairseq2.utils.tensor import to_tensor
 
 # isort: split
 
@@ -310,4 +312,4 @@ def init_llama_rope_freqs(
 
         new_freqs.append((1 - smooth) * freq / scale_factor + smooth * freq)
 
-    return torch.tensor(new_freqs, dtype=freqs.dtype, device=device)
+    return to_tensor(new_freqs, dtype=freqs.dtype, device=device)

--- a/src/fairseq2/models/mistral/_factory.py
+++ b/src/fairseq2/models/mistral/_factory.py
@@ -6,6 +6,8 @@
 
 from __future__ import annotations
 
+from fairseq2.data_type import DataType
+from fairseq2.device import Device
 from fairseq2.models.transformer import (
     CausalAttentionMaskFactory,
     FeedForwardNetwork,
@@ -36,7 +38,6 @@ from fairseq2.nn import (
     RotaryEncoder,
     StandardEmbedding,
 )
-from fairseq2.typing import DataType, Device
 
 # isort: split
 

--- a/src/fairseq2/models/s2t_transformer/_feature_extractor.py
+++ b/src/fairseq2/models/s2t_transformer/_feature_extractor.py
@@ -13,9 +13,10 @@ from torch import Tensor
 from torch.nn import GLU, Conv1d, Sequential
 from typing_extensions import override
 
+from fairseq2.data_type import DataType
+from fairseq2.device import Device
 from fairseq2.models.feature_extractor import SequenceFeatureExtractor
 from fairseq2.nn.padding import PaddingMask
-from fairseq2.typing import DataType, Device
 
 
 @final

--- a/src/fairseq2/models/s2t_transformer/_frontend.py
+++ b/src/fairseq2/models/s2t_transformer/_frontend.py
@@ -13,12 +13,13 @@ from torch import Tensor
 from torch.nn import Dropout
 from typing_extensions import override
 
+from fairseq2.data_type import DataType
+from fairseq2.device import Device
 from fairseq2.error import NotSupportedError
 from fairseq2.models.feature_extractor import SequenceFeatureExtractor
 from fairseq2.models.transformer import TransformerFrontend
 from fairseq2.nn import IncrementalStateBag, Linear, PositionEncoder, Projection
 from fairseq2.nn.padding import PaddingMask
-from fairseq2.typing import DataType, Device
 
 
 @final

--- a/src/fairseq2/models/seq2seq.py
+++ b/src/fairseq2/models/seq2seq.py
@@ -13,10 +13,9 @@ from torch import Tensor
 from torch.nn import Module
 from typing_extensions import override
 
-from fairseq2.device import SupportsDeviceTransfer
+from fairseq2.device import Device, SupportsDeviceTransfer
 from fairseq2.models.sequence import SequenceBatch, SequenceModelOutput
 from fairseq2.nn.padding import PaddingMask
-from fairseq2.typing import Device
 
 
 class Seq2SeqModel(Module, ABC):

--- a/src/fairseq2/models/sequence.py
+++ b/src/fairseq2/models/sequence.py
@@ -14,10 +14,9 @@ from torch import Tensor
 from torch.nn import Module
 from typing_extensions import override
 
-from fairseq2.device import SupportsDeviceTransfer
+from fairseq2.device import Device, SupportsDeviceTransfer
 from fairseq2.nn.ops import CrossEntropy, cross_entropy
 from fairseq2.nn.padding import PaddingMask
-from fairseq2.typing import Device
 
 
 class SequenceModel(Module, ABC):

--- a/src/fairseq2/models/transformer/_attention_mask.py
+++ b/src/fairseq2/models/transformer/_attention_mask.py
@@ -13,8 +13,9 @@ import torch
 from torch import Tensor
 from typing_extensions import override
 
+from fairseq2.data_type import DataType
+from fairseq2.device import Device
 from fairseq2.nn import IncrementalStateBag
-from fairseq2.typing import DataType, Device
 
 
 class AttentionMask(ABC):

--- a/src/fairseq2/models/transformer/_decoder.py
+++ b/src/fairseq2/models/transformer/_decoder.py
@@ -17,10 +17,11 @@ from torch.nn import Dropout, Module
 from torch.utils.hooks import RemovableHandle
 from typing_extensions import override
 
+from fairseq2.data_type import DataType
+from fairseq2.device import CPU, Device
 from fairseq2.error import InvalidOperationError
 from fairseq2.nn import IncrementalStateBag, LayerNorm, LayerStack
 from fairseq2.nn.padding import PaddingMask
-from fairseq2.typing import CPU, DataType, Device
 
 # isort: split
 

--- a/src/fairseq2/models/transformer/_decoder_layer.py
+++ b/src/fairseq2/models/transformer/_decoder_layer.py
@@ -13,6 +13,8 @@ from torch import Tensor
 from torch.nn import Dropout, Module
 from typing_extensions import override
 
+from fairseq2.data_type import DataType
+from fairseq2.device import Device
 from fairseq2.nn import (
     IncrementalStateBag,
     LayerNorm,
@@ -20,7 +22,6 @@ from fairseq2.nn import (
     StandardResidualConnect,
 )
 from fairseq2.nn.padding import PaddingMask
-from fairseq2.typing import DataType, Device
 
 # isort: split
 

--- a/src/fairseq2/models/transformer/_encoder.py
+++ b/src/fairseq2/models/transformer/_encoder.py
@@ -18,10 +18,11 @@ from torch.nn import Dropout, Module
 from torch.utils.hooks import RemovableHandle
 from typing_extensions import override
 
+from fairseq2.data_type import DataType
+from fairseq2.device import CPU, Device
 from fairseq2.error import InvalidOperationError
 from fairseq2.nn import LayerNorm, LayerStack
 from fairseq2.nn.padding import PaddingMask
-from fairseq2.typing import CPU, DataType, Device
 
 # isort: split
 

--- a/src/fairseq2/models/transformer/_encoder_layer.py
+++ b/src/fairseq2/models/transformer/_encoder_layer.py
@@ -13,9 +13,10 @@ from torch import Tensor
 from torch.nn import Dropout, Module
 from typing_extensions import override
 
+from fairseq2.data_type import DataType
+from fairseq2.device import Device
 from fairseq2.nn import LayerNorm, ResidualConnect, StandardResidualConnect
 from fairseq2.nn.padding import PaddingMask
-from fairseq2.typing import DataType, Device
 
 # isort: split
 

--- a/src/fairseq2/models/transformer/_ffn.py
+++ b/src/fairseq2/models/transformer/_ffn.py
@@ -14,8 +14,9 @@ from torch import Tensor
 from torch.nn import Dropout, Module, ReLU, Sigmoid, SiLU
 from typing_extensions import override
 
+from fairseq2.data_type import DataType
+from fairseq2.device import Device
 from fairseq2.nn import LayerNorm, Linear, Projection
-from fairseq2.typing import DataType, Device
 
 
 class FeedForwardNetwork(Module, ABC):

--- a/src/fairseq2/models/transformer/_frontend.py
+++ b/src/fairseq2/models/transformer/_frontend.py
@@ -14,9 +14,10 @@ from torch import Tensor
 from torch.nn import Dropout, Module
 from typing_extensions import override
 
+from fairseq2.data_type import DataType
+from fairseq2.device import Device
 from fairseq2.nn import Embedding, IncrementalStateBag, LayerNorm, PositionEncoder
 from fairseq2.nn.padding import PaddingMask
-from fairseq2.typing import DataType, Device
 
 # isort: split
 

--- a/src/fairseq2/models/transformer/_multihead_attention.py
+++ b/src/fairseq2/models/transformer/_multihead_attention.py
@@ -18,6 +18,8 @@ from torch.nn import Module
 from torch.utils.hooks import RemovableHandle
 from typing_extensions import override
 
+from fairseq2.data_type import DataType
+from fairseq2.device import Device
 from fairseq2.error import NotSupportedError
 from fairseq2.nn import (
     IncrementalState,
@@ -28,7 +30,6 @@ from fairseq2.nn import (
 )
 from fairseq2.nn.ops import repeat_interleave
 from fairseq2.nn.padding import PaddingMask
-from fairseq2.typing import DataType, Device
 
 # isort: split
 

--- a/src/fairseq2/models/transformer/_normalization.py
+++ b/src/fairseq2/models/transformer/_normalization.py
@@ -8,8 +8,9 @@ from __future__ import annotations
 
 from typing import Protocol
 
+from fairseq2.data_type import DataType
+from fairseq2.device import Device
 from fairseq2.nn import LayerNorm, StandardLayerNorm
-from fairseq2.typing import DataType, Device
 
 
 class LayerNormFactory(Protocol):

--- a/src/fairseq2/models/transformer/_relative_attention.py
+++ b/src/fairseq2/models/transformer/_relative_attention.py
@@ -16,9 +16,10 @@ from torch.nn import Module, Parameter
 from torch.nn.functional import pad
 from typing_extensions import override
 
+from fairseq2.data_type import DataType
+from fairseq2.device import Device
 from fairseq2.nn import Linear
 from fairseq2.nn.padding import PaddingMask
-from fairseq2.typing import DataType, Device
 
 # isort: split
 

--- a/src/fairseq2/models/transformer/_shaw_attention.py
+++ b/src/fairseq2/models/transformer/_shaw_attention.py
@@ -13,10 +13,11 @@ import torch.nn as nn
 from torch import Tensor
 from typing_extensions import override
 
+from fairseq2.data_type import DataType
+from fairseq2.device import Device
 from fairseq2.error import InternalError
 from fairseq2.nn import StandardEmbedding
 from fairseq2.nn.padding import PaddingMask
-from fairseq2.typing import DataType, Device
 
 # isort: split
 

--- a/src/fairseq2/models/transformer_lm/_decoder.py
+++ b/src/fairseq2/models/transformer_lm/_decoder.py
@@ -16,6 +16,8 @@ from torch.nn import Dropout
 from torch.utils.hooks import RemovableHandle
 from typing_extensions import override
 
+from fairseq2.data_type import DataType
+from fairseq2.device import Device
 from fairseq2.models.transformer import (
     LayerNormFactory,
     TransformerNormOrder,
@@ -27,7 +29,6 @@ from fairseq2.models.transformer._attention_mask import (
 )
 from fairseq2.nn import IncrementalStateBag, LayerNorm, LayerStack
 from fairseq2.nn.padding import PaddingMask
-from fairseq2.typing import DataType, Device
 
 # isort: split
 

--- a/src/fairseq2/models/transformer_lm/_decoder_layer.py
+++ b/src/fairseq2/models/transformer_lm/_decoder_layer.py
@@ -13,6 +13,8 @@ from torch import Tensor
 from torch.nn import Dropout, Module
 from typing_extensions import override
 
+from fairseq2.data_type import DataType
+from fairseq2.device import Device
 from fairseq2.models.transformer import (
     AttentionMask,
     FeedForwardNetwork,
@@ -28,7 +30,6 @@ from fairseq2.nn import (
     StandardResidualConnect,
 )
 from fairseq2.nn.padding import PaddingMask
-from fairseq2.typing import DataType, Device
 
 
 class TransformerLMDecoderLayer(Module, ABC):

--- a/src/fairseq2/models/vit/_feature_extractor.py
+++ b/src/fairseq2/models/vit/_feature_extractor.py
@@ -14,7 +14,8 @@ from torch import Tensor
 from torch.nn import Conv2d, Conv3d, Module
 from typing_extensions import override
 
-from fairseq2.typing import DataType, Device
+from fairseq2.data_type import DataType
+from fairseq2.device import Device
 
 
 class PatchFeatureExtractor(Module, ABC):

--- a/src/fairseq2/models/w2vbert/_checkpoint.py
+++ b/src/fairseq2/models/w2vbert/_checkpoint.py
@@ -12,8 +12,8 @@ import torch
 from torch import Tensor
 from torch.nn.modules.utils import consume_prefix_in_state_dict_if_present
 
+from fairseq2.device import CPU
 from fairseq2.models.utils.checkpoint import convert_fairseq_checkpoint
-from fairseq2.typing import CPU
 
 # isort: split
 

--- a/src/fairseq2/models/w2vbert/_model.py
+++ b/src/fairseq2/models/w2vbert/_model.py
@@ -13,6 +13,8 @@ from torch import Tensor
 from torch.nn import Module
 from torch.nn.functional import cross_entropy
 
+from fairseq2.data_type import DataType
+from fairseq2.device import Device
 from fairseq2.models.sequence import SequenceBatch
 from fairseq2.models.wav2vec2 import (
     Wav2Vec2Loss,
@@ -22,7 +24,6 @@ from fairseq2.models.wav2vec2 import (
 )
 from fairseq2.nn import Linear
 from fairseq2.nn.padding import PaddingMask
-from fairseq2.typing import DataType, Device
 
 
 @final

--- a/src/fairseq2/models/wav2vec2/_checkpoint.py
+++ b/src/fairseq2/models/wav2vec2/_checkpoint.py
@@ -12,9 +12,9 @@ import torch
 from torch import Tensor
 from torch.nn.modules.utils import consume_prefix_in_state_dict_if_present
 
+from fairseq2.device import CPU
 from fairseq2.models.transformer import TransformerNormOrder
 from fairseq2.models.utils.checkpoint import convert_fairseq_checkpoint
-from fairseq2.typing import CPU
 
 # isort: split
 

--- a/src/fairseq2/models/wav2vec2/_feature_extractor.py
+++ b/src/fairseq2/models/wav2vec2/_feature_extractor.py
@@ -16,11 +16,12 @@ from torch.nn import GELU, Conv1d, Dropout, GroupNorm, Module, Sequential
 from torch.nn.functional import group_norm, layer_norm
 from typing_extensions import override
 
+from fairseq2.data_type import DataType
+from fairseq2.device import Device
 from fairseq2.models.feature_extractor import SequenceFeatureExtractor
 from fairseq2.nn import LayerNorm
 from fairseq2.nn.padding import PaddingMask
 from fairseq2.nn.utils.gradient import scale_gradient
-from fairseq2.typing import DataType, Device
 
 
 @final

--- a/src/fairseq2/models/wav2vec2/_frontend.py
+++ b/src/fairseq2/models/wav2vec2/_frontend.py
@@ -12,6 +12,8 @@ from torch import Tensor
 from torch.nn import Dropout
 from typing_extensions import override
 
+from fairseq2.data_type import DataType
+from fairseq2.device import Device
 from fairseq2.error import NotSupportedError
 from fairseq2.models.feature_extractor import SequenceFeatureExtractor
 from fairseq2.models.transformer import TransformerFrontend
@@ -23,7 +25,6 @@ from fairseq2.nn import (
     StandardLayerNorm,
 )
 from fairseq2.nn.padding import PaddingMask
-from fairseq2.typing import DataType, Device
 
 # isort: split
 

--- a/src/fairseq2/models/wav2vec2/_masker.py
+++ b/src/fairseq2/models/wav2vec2/_masker.py
@@ -15,10 +15,11 @@ from torch import Tensor
 from torch.nn import Module, Parameter
 from typing_extensions import override
 
+from fairseq2.data_type import DataType
+from fairseq2.device import Device
 from fairseq2.error import InternalError
 from fairseq2.nn.padding import PaddingMask
 from fairseq2.nn.utils.mask import RowMaskFactory, compute_row_mask
-from fairseq2.typing import DataType, Device
 
 
 class Wav2Vec2Masker(Module, ABC):

--- a/src/fairseq2/models/wav2vec2/_model.py
+++ b/src/fairseq2/models/wav2vec2/_model.py
@@ -14,13 +14,14 @@ from torch import Tensor
 from torch.nn import Module
 from torch.nn.functional import cross_entropy
 
+from fairseq2.data_type import DataType
+from fairseq2.device import Device
 from fairseq2.error import InternalError
 from fairseq2.models.sequence import SequenceBatch
 from fairseq2.models.transformer import TransformerEncoder
 from fairseq2.nn import Linear
 from fairseq2.nn.ops import repeat_interleave
 from fairseq2.nn.padding import PaddingMask
-from fairseq2.typing import DataType, Device
 
 # isort: split
 

--- a/src/fairseq2/models/wav2vec2/_position_encoder.py
+++ b/src/fairseq2/models/wav2vec2/_position_encoder.py
@@ -15,6 +15,8 @@ from torch.nn import GELU, Conv1d, Module, Sequential
 from torch.nn.utils import remove_weight_norm, weight_norm  # type: ignore[attr-defined]
 from typing_extensions import override
 
+from fairseq2.data_type import DataType
+from fairseq2.device import Device
 from fairseq2.error import NotSupportedError
 from fairseq2.nn import (
     IncrementalStateBag,
@@ -23,7 +25,6 @@ from fairseq2.nn import (
     StandardLayerNorm,
 )
 from fairseq2.nn.padding import PaddingMask, apply_padding_mask
-from fairseq2.typing import DataType, Device
 
 
 @final

--- a/src/fairseq2/models/wav2vec2/_vector_quantizer.py
+++ b/src/fairseq2/models/wav2vec2/_vector_quantizer.py
@@ -16,8 +16,9 @@ from torch.nn import Module, Parameter
 from torch.nn.functional import gumbel_softmax
 from typing_extensions import override
 
+from fairseq2.data_type import DataType
+from fairseq2.device import Device
 from fairseq2.nn import Linear
-from fairseq2.typing import DataType, Device
 
 
 class VectorQuantizer(Module, ABC):

--- a/src/fairseq2/models/wav2vec2/asr/_model.py
+++ b/src/fairseq2/models/wav2vec2/asr/_model.py
@@ -11,12 +11,13 @@ from typing import final
 from torch.nn import Dropout
 from typing_extensions import override
 
+from fairseq2.data_type import DataType
+from fairseq2.device import Device
 from fairseq2.models.asr import AsrModel, AsrModelOutput
 from fairseq2.models.sequence import SequenceBatch
 from fairseq2.models.transformer import TransformerEncoder
 from fairseq2.models.wav2vec2 import Wav2Vec2Frontend, Wav2Vec2Masker
 from fairseq2.nn import Projection
-from fairseq2.typing import DataType, Device
 
 
 @final

--- a/src/fairseq2/nn/_embedding.py
+++ b/src/fairseq2/nn/_embedding.py
@@ -18,11 +18,12 @@ from torch.nn.functional import embedding
 from torch.nn.parameter import Parameter
 from typing_extensions import override
 
+from fairseq2.data_type import DataType
+from fairseq2.device import META_DEVICE, Device
 from fairseq2.error import InternalError
 from fairseq2.gang import Gang
 from fairseq2.nn.utils.module import to_empty
 from fairseq2.tensor_parallel import gather, reduce, reduce_on_backward
-from fairseq2.typing import META, DataType, Device
 
 
 class Embedding(Module, ABC):
@@ -177,7 +178,7 @@ class VocabShardedEmbedding(Embedding):
             embed.embedding_dim,
             embed.pad_idx,
             init_fn=embed.init_fn,
-            device=META,
+            device=META_DEVICE,
             dtype=embed.weight.dtype,
         )
 
@@ -313,7 +314,7 @@ class VocabShardedEmbedding(Embedding):
 
     def to_embedding(self, device: Device | None = None) -> StandardEmbedding:
         """Convert this instance to a :class:`StandardEmbedding`."""
-        embed = self._embedding_like(META)
+        embed = self._embedding_like(device=META_DEVICE)
 
         to_empty(embed, device or self.gang.device)
 
@@ -380,7 +381,7 @@ class ShardedEmbedding(Embedding):
             embed.embedding_dim,
             embed.pad_idx,
             init_fn=embed.init_fn,
-            device=META,
+            device=META_DEVICE,
             dtype=embed.weight.dtype,
         )
 
@@ -491,7 +492,7 @@ class ShardedEmbedding(Embedding):
 
     def to_embedding(self, device: Device | None = None) -> StandardEmbedding:
         """Convert this instance to a :class:`StandardEmbedding`."""
-        embed = self._embedding_like(META)
+        embed = self._embedding_like(device=META_DEVICE)
 
         to_empty(embed, device or self.gang.device)
 

--- a/src/fairseq2/nn/_normalization.py
+++ b/src/fairseq2/nn/_normalization.py
@@ -17,7 +17,8 @@ from torch.nn import Module, Parameter
 from torch.nn.functional import layer_norm
 from typing_extensions import override
 
-from fairseq2.typing import DataType, Device
+from fairseq2.data_type import DataType
+from fairseq2.device import Device
 
 try:
     from torch.nn.functional import rms_norm as torch_rms_norm  # type: ignore[import]

--- a/src/fairseq2/nn/_position_encoder.py
+++ b/src/fairseq2/nn/_position_encoder.py
@@ -19,9 +19,10 @@ from torch.nn.functional import embedding, interpolate
 from torch.nn.parameter import Parameter
 from typing_extensions import override
 
+from fairseq2.data_type import DataType
+from fairseq2.device import Device
 from fairseq2.error import InternalError
 from fairseq2.nn.padding import PaddingMask
-from fairseq2.typing import DataType, Device
 
 # isort: split
 

--- a/src/fairseq2/nn/_projection.py
+++ b/src/fairseq2/nn/_projection.py
@@ -19,11 +19,12 @@ from torch.nn.functional import linear
 from torch.nn.parameter import Parameter
 from typing_extensions import override
 
+from fairseq2.data_type import DataType
+from fairseq2.device import META_DEVICE, Device
 from fairseq2.error import InternalError
 from fairseq2.gang import Gang
 from fairseq2.nn.utils.module import to_empty
 from fairseq2.tensor_parallel import gather, reduce, reduce_on_backward, scatter
-from fairseq2.typing import META, DataType, Device
 
 
 class Projection(Module, ABC):
@@ -177,7 +178,7 @@ class ColumnShardedLinear(Projection):
             bias=linear.bias is not None,
             gather_output=gather_output,
             init_fn=linear.init_fn,
-            device=META,
+            device=META_DEVICE,
             dtype=linear.weight.dtype,
         )
 
@@ -323,7 +324,7 @@ class ColumnShardedLinear(Projection):
 
     def to_linear(self, device: Device | None = None) -> Linear:
         """Convert this instance to a :class:`Linear`."""
-        linear = self._linear_like(META)
+        linear = self._linear_like(device=META_DEVICE)
 
         to_empty(linear, device or self.gang.device)
 
@@ -417,7 +418,7 @@ class RowShardedLinear(Projection):
             bias=linear.bias is not None,
             scatter_input=scatter_input,
             init_fn=linear.init_fn,
-            device=META,
+            device=META_DEVICE,
             dtype=linear.weight.dtype,
         )
 
@@ -550,7 +551,7 @@ class RowShardedLinear(Projection):
 
     def to_linear(self, device: Device | None = None) -> Linear:
         """Convert this instance to a :class:`Linear`."""
-        linear = self._linear_like(META)
+        linear = self._linear_like(device=META_DEVICE)
 
         to_empty(linear, device or self.gang.device)
 

--- a/src/fairseq2/nn/data_parallel/_common.py
+++ b/src/fairseq2/nn/data_parallel/_common.py
@@ -13,6 +13,7 @@ from torch import Tensor
 from torch.distributed._shard import load_with_process_group
 from torch.nn import Module
 
+from fairseq2.device import Device
 from fairseq2.error import NotSupportedError
 from fairseq2.gang import Gangs
 from fairseq2.nn.utils.module import (
@@ -20,7 +21,7 @@ from fairseq2.nn.utils.module import (
     reset_parameters,
     to_empty,
 )
-from fairseq2.typing import ContextManager, Device
+from fairseq2.typing import ContextManager
 
 FsdpGranularity: TypeAlias = Literal["layer", "stack"]
 

--- a/src/fairseq2/nn/data_parallel/_fsdp.py
+++ b/src/fairseq2/nn/data_parallel/_fsdp.py
@@ -10,8 +10,9 @@ from typing import TYPE_CHECKING, Literal
 
 from torch.nn import Module
 
+from fairseq2.data_type import DataType
 from fairseq2.gang import Gangs
-from fairseq2.typing import ContextManager, DataType
+from fairseq2.typing import ContextManager
 from fairseq2.utils.version import torch_greater_or_equal
 
 # isort: split

--- a/src/fairseq2/nn/data_parallel/_fsdp1.py
+++ b/src/fairseq2/nn/data_parallel/_fsdp1.py
@@ -29,13 +29,13 @@ from torch.distributed.fsdp.api import (
 )
 from torch.nn import Module, Parameter, SyncBatchNorm
 
+from fairseq2.data_type import DataType
 from fairseq2.error import NotSupportedError
 from fairseq2.gang import Gangs
 from fairseq2.nn.utils.module import (
     apply_to_parameters,
     infer_device,
 )
-from fairseq2.typing import DataType
 
 # isort: split
 

--- a/src/fairseq2/nn/data_parallel/_fsdp2.py
+++ b/src/fairseq2/nn/data_parallel/_fsdp2.py
@@ -25,10 +25,10 @@ from torch.distributed.fsdp import (
 from torch.distributed.tensor import DTensor
 from torch.nn import Module, Parameter, SyncBatchNorm
 
+from fairseq2.data_type import DataType
 from fairseq2.error import InvalidOperationError, NotSupportedError
 from fairseq2.gang import Gangs
 from fairseq2.nn.utils.module import apply_to_parameters, broadcast_module, infer_device
-from fairseq2.typing import DataType
 
 # isort: split
 

--- a/src/fairseq2/nn/data_parallel/_fsdp2_compat.py
+++ b/src/fairseq2/nn/data_parallel/_fsdp2_compat.py
@@ -10,9 +10,10 @@ from typing import NoReturn, final
 
 from torch.nn import Module
 
+from fairseq2.data_type import DataType
 from fairseq2.error import NotSupportedError
 from fairseq2.gang import Gangs
-from fairseq2.typing import ContextManager, DataType
+from fairseq2.typing import ContextManager
 
 # isort: split
 

--- a/src/fairseq2/nn/lora.py
+++ b/src/fairseq2/nn/lora.py
@@ -19,8 +19,9 @@ from torch.nn import Dropout
 from torch.nn.functional import embedding, linear
 from torch.nn.parameter import Parameter
 
+from fairseq2.data_type import DataType
+from fairseq2.device import Device
 from fairseq2.nn import Embedding, Projection
-from fairseq2.typing import DataType, Device
 
 
 @dataclass

--- a/src/fairseq2/nn/padding.py
+++ b/src/fairseq2/nn/padding.py
@@ -13,7 +13,7 @@ import torch
 from torch import Tensor
 
 from fairseq2.data import Collater, SequenceData
-from fairseq2.typing import Device
+from fairseq2.device import Device
 
 
 @final

--- a/src/fairseq2/nn/utils/mask.py
+++ b/src/fairseq2/nn/utils/mask.py
@@ -11,8 +11,9 @@ from typing import Protocol
 import torch
 from torch import Tensor
 
+from fairseq2.data_type import DataType
+from fairseq2.device import Device
 from fairseq2.nn.ops import repeat_interleave
-from fairseq2.typing import DataType, Device
 
 
 def to_float_mask(mask: Tensor, dtype: DataType | None = None) -> Tensor:

--- a/src/fairseq2/nn/utils/module.py
+++ b/src/fairseq2/nn/utils/module.py
@@ -17,9 +17,9 @@ from torch import Tensor
 from torch.nn import Module, Parameter
 from torch.nn.utils import remove_weight_norm  # type: ignore[attr-defined]
 
+from fairseq2.device import CPU, Device
 from fairseq2.gang import Gang
 from fairseq2.logging import log
-from fairseq2.typing import CPU, Device
 from fairseq2.utils.version import torch_greater_or_equal
 
 

--- a/src/fairseq2/optim/_dynamic_loss_scaler.py
+++ b/src/fairseq2/optim/_dynamic_loss_scaler.py
@@ -19,10 +19,10 @@ from torch.distributed.fsdp.sharded_grad_scaler import ShardedGradScaler
 from torch.optim import Optimizer
 from typing_extensions import override
 
+from fairseq2.device import Device
 from fairseq2.error import InvalidOperationError
 from fairseq2.gang import Gang
 from fairseq2.logging import log
-from fairseq2.typing import Device
 
 
 @final

--- a/src/fairseq2/recipes/_evaluator.py
+++ b/src/fairseq2/recipes/_evaluator.py
@@ -15,15 +15,16 @@ import torch
 from torch.profiler import record_function
 from typing_extensions import override
 
+from fairseq2.data_type import DataType
 from fairseq2.datasets import DataReader, DataReadError
-from fairseq2.device import SupportsDeviceTransfer
+from fairseq2.device import CPU, SupportsDeviceTransfer
 from fairseq2.error import InternalError, InvalidOperationError
 from fairseq2.gang import GangError, Gangs
 from fairseq2.logging import log
 from fairseq2.metrics import MetricBag, MetricBagError
 from fairseq2.metrics.recorders import MetricRecorder, MetricRecordError
 from fairseq2.profilers import Profiler
-from fairseq2.typing import CPU, ContextManager, DataType
+from fairseq2.typing import ContextManager
 from fairseq2.utils.device_stat import DeviceStatTracker
 from fairseq2.utils.progress import ProgressReporter, ProgressTask
 from fairseq2.utils.rng import RngBag

--- a/src/fairseq2/recipes/_generator.py
+++ b/src/fairseq2/recipes/_generator.py
@@ -14,15 +14,16 @@ import torch
 from torch.profiler import record_function
 from typing_extensions import override
 
+from fairseq2.data_type import DataType
 from fairseq2.datasets import DataReader, DataReadError
-from fairseq2.device import SupportsDeviceTransfer
+from fairseq2.device import CPU, SupportsDeviceTransfer
 from fairseq2.error import InternalError, InvalidOperationError
 from fairseq2.gang import GangError, Gangs
 from fairseq2.logging import log
 from fairseq2.metrics import MetricBag, MetricBagError
 from fairseq2.metrics.recorders import MetricRecorder, MetricRecordError
 from fairseq2.profilers import Profiler
-from fairseq2.typing import CPU, ContextManager, DataType
+from fairseq2.typing import ContextManager
 from fairseq2.utils.device_stat import DeviceStatTracker
 from fairseq2.utils.progress import ProgressReporter, ProgressTask
 from fairseq2.utils.rng import RngBag

--- a/src/fairseq2/recipes/_trainer.py
+++ b/src/fairseq2/recipes/_trainer.py
@@ -28,8 +28,9 @@ from fairseq2.checkpoint import (
     CheckpointState,
     Stateful,
 )
+from fairseq2.data_type import DataType
 from fairseq2.datasets import DataReader, DataReadError
-from fairseq2.device import SupportsDeviceTransfer
+from fairseq2.device import CPU, SupportsDeviceTransfer
 from fairseq2.error import InternalError, InvalidOperationError
 from fairseq2.gang import GangError, Gangs, broadcast_flag
 from fairseq2.logging import log
@@ -39,7 +40,7 @@ from fairseq2.nn.utils.gradient import check_gradient_norms, normalize_gradients
 from fairseq2.optim import DynamicLossScaler
 from fairseq2.optim.lr_scheduler import LRScheduler, get_effective_lr
 from fairseq2.profilers import Profiler
-from fairseq2.typing import CPU, ContextManager, DataType
+from fairseq2.typing import ContextManager
 from fairseq2.utils.device_stat import DeviceStatTracker
 from fairseq2.utils.gc import GarbageCollector
 from fairseq2.utils.progress import ProgressReporter, ProgressTask

--- a/src/fairseq2/recipes/_validator.py
+++ b/src/fairseq2/recipes/_validator.py
@@ -17,15 +17,16 @@ from torch.profiler import record_function
 from typing_extensions import override
 
 from fairseq2.checkpoint import CheckpointError, CheckpointManager, CheckpointSaveError
+from fairseq2.data_type import DataType
 from fairseq2.datasets import DataReader, DataReadError
-from fairseq2.device import SupportsDeviceTransfer
+from fairseq2.device import CPU, SupportsDeviceTransfer
 from fairseq2.error import ContractError, InternalError, InvalidOperationError
 from fairseq2.gang import GangError, Gangs
 from fairseq2.logging import log
 from fairseq2.metrics import MetricBagError, MetricDescriptor
 from fairseq2.metrics.recorders import MetricRecorder, MetricRecordError
 from fairseq2.profilers import Profiler
-from fairseq2.typing import CPU, ContextManager, DataType
+from fairseq2.typing import ContextManager
 from fairseq2.utils.device_stat import DeviceStatTracker
 from fairseq2.utils.progress import ProgressReporter, ProgressTask
 from fairseq2.utils.rng import RngBag

--- a/src/fairseq2/recipes/asr/_eval.py
+++ b/src/fairseq2/recipes/asr/_eval.py
@@ -16,6 +16,7 @@ from typing_extensions import override
 from fairseq2.context import RuntimeContext
 from fairseq2.datasets import LengthBatching, SyncMode
 from fairseq2.datasets.asr import GENERIC_ASR_DATASET_FAMILY, AsrDataset, AsrReadOptions
+from fairseq2.device import CPU
 from fairseq2.file_system import FileMode
 from fairseq2.gang import Gangs
 from fairseq2.metrics import MetricBag
@@ -39,7 +40,6 @@ from fairseq2.recipes.config import (
     ReferenceModelSection,
     TextTokenizerSection,
 )
-from fairseq2.typing import CPU
 from fairseq2.utils.rng import manual_seed
 from fairseq2.utils.structured import structure
 from fairseq2.utils.validation import validate

--- a/src/fairseq2/recipes/common/_gang.py
+++ b/src/fairseq2/recipes/common/_gang.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 from datetime import timedelta
 
 from fairseq2.context import RuntimeContext
-from fairseq2.device import DeviceDetectionError, determine_default_device
 from fairseq2.gang import (
     GangError,
     Gangs,
@@ -25,6 +24,7 @@ from fairseq2.recipes.config import (
     TrainerSection,
 )
 from fairseq2.recipes.utils.log import log_environment_info, log_ranks
+from fairseq2.utils.device import DeviceDetectionError, determine_default_device
 from fairseq2.utils.env import InvalidEnvironmentVariableError, get_local_world_size
 
 

--- a/src/fairseq2/recipes/common/_ref_model.py
+++ b/src/fairseq2/recipes/common/_ref_model.py
@@ -18,6 +18,7 @@ from fairseq2.assets import (
     AssetStore,
 )
 from fairseq2.context import RuntimeContext
+from fairseq2.data_type import DataType
 from fairseq2.error import NotSupportedError
 from fairseq2.gang import GangError, Gangs
 from fairseq2.logging import log
@@ -36,7 +37,6 @@ from fairseq2.recipes import Model, RecipeError
 from fairseq2.recipes.config import ReferenceModelSection
 from fairseq2.recipes.utils.log import log_model
 from fairseq2.registry import Provider
-from fairseq2.typing import DataType
 
 # isort: split
 

--- a/src/fairseq2/recipes/config.py
+++ b/src/fairseq2/recipes/config.py
@@ -12,6 +12,7 @@ from typing import Literal, TypeAlias
 
 import torch
 
+from fairseq2.data_type import DataType
 from fairseq2.generation import (
     BEAM_SEARCH_GENERATOR,
     SAMPLING_GENERATOR,
@@ -31,7 +32,6 @@ from fairseq2.metrics.recorders import (
 from fairseq2.nn.data_parallel import FsdpGranularity
 from fairseq2.optim import ADAMW_OPTIMIZER, AdamWConfig
 from fairseq2.profilers import TORCH_PROFILER, TorchProfilerConfig
-from fairseq2.typing import DataType
 from fairseq2.utils.validation import ValidationError, ValidationResult
 
 

--- a/src/fairseq2/recipes/lm/_instruction_finetune.py
+++ b/src/fairseq2/recipes/lm/_instruction_finetune.py
@@ -22,6 +22,7 @@ from fairseq2.datasets.instruction import (
     InstructionDataset,
     InstructionReadOptions,
 )
+from fairseq2.device import CPU
 from fairseq2.gang import Gangs
 from fairseq2.metrics import MetricBag
 from fairseq2.models.decoder import DecoderModel
@@ -58,7 +59,6 @@ from fairseq2.recipes.config import (
     TorchSection,
     TrainerSection,
 )
-from fairseq2.typing import CPU
 from fairseq2.utils.rng import manual_seed
 from fairseq2.utils.structured import structure
 from fairseq2.utils.validation import validate

--- a/src/fairseq2/recipes/lm/_loss_eval.py
+++ b/src/fairseq2/recipes/lm/_loss_eval.py
@@ -18,6 +18,7 @@ from fairseq2.datasets.instruction import (
     InstructionDataset,
     InstructionReadOptions,
 )
+from fairseq2.device import CPU
 from fairseq2.models.decoder import DecoderModel
 from fairseq2.models.sequence import SequenceBatch
 from fairseq2.recipes import Evaluator
@@ -38,7 +39,6 @@ from fairseq2.recipes.config import (
     ReferenceModelSection,
     TextTokenizerSection,
 )
-from fairseq2.typing import CPU
 from fairseq2.utils.rng import manual_seed
 from fairseq2.utils.structured import structure
 from fairseq2.utils.validation import validate

--- a/src/fairseq2/recipes/lm/_preference_finetune/_recipe.py
+++ b/src/fairseq2/recipes/lm/_preference_finetune/_recipe.py
@@ -15,6 +15,7 @@ from fairseq2.datasets.preference import (
     PreferenceDataset,
     PreferenceReadOptions,
 )
+from fairseq2.device import CPU
 from fairseq2.models.decoder import DecoderModel
 from fairseq2.optim import AdamWConfig
 from fairseq2.optim.lr_scheduler import CosineAnnealingLRConfig
@@ -31,7 +32,6 @@ from fairseq2.recipes.common import (
     setup_torch,
     setup_training_gangs,
 )
-from fairseq2.typing import CPU
 from fairseq2.utils.rng import manual_seed
 from fairseq2.utils.structured import structure
 from fairseq2.utils.validation import validate

--- a/src/fairseq2/recipes/lm/_text_generate.py
+++ b/src/fairseq2/recipes/lm/_text_generate.py
@@ -22,6 +22,7 @@ from fairseq2.datasets.instruction import (
     InstructionDataset,
     InstructionPromptReadOptions,
 )
+from fairseq2.device import CPU
 from fairseq2.error import InternalError
 from fairseq2.file_system import FileMode
 from fairseq2.gang import Gangs
@@ -56,7 +57,6 @@ from fairseq2.recipes.config import (
     SequenceGeneratorSection,
     TextTokenizerSection,
 )
-from fairseq2.typing import CPU
 from fairseq2.utils.rng import manual_seed
 from fairseq2.utils.structured import structure
 from fairseq2.utils.validation import validate

--- a/src/fairseq2/recipes/mt/_eval.py
+++ b/src/fairseq2/recipes/mt/_eval.py
@@ -22,6 +22,7 @@ from fairseq2.datasets.parallel_text import (
     ParallelTextDataset,
     ParallelTextReadOptions,
 )
+from fairseq2.device import CPU
 from fairseq2.file_system import FileMode
 from fairseq2.gang import Gangs
 from fairseq2.generation import BeamSearchConfig, Seq2SeqGenerator
@@ -58,7 +59,6 @@ from fairseq2.recipes.config import (
     Seq2SeqGeneratorSection,
     TextTokenizerSection,
 )
-from fairseq2.typing import CPU
 from fairseq2.utils.rng import manual_seed
 from fairseq2.utils.structured import structure
 from fairseq2.utils.validation import validate

--- a/src/fairseq2/recipes/mt/_train.py
+++ b/src/fairseq2/recipes/mt/_train.py
@@ -21,6 +21,7 @@ from fairseq2.datasets.parallel_text import (
     ParallelTextDataset,
     ParallelTextReadOptions,
 )
+from fairseq2.device import CPU
 from fairseq2.gang import Gangs
 from fairseq2.generation import BeamSearchConfig
 from fairseq2.metrics import MetricBag
@@ -56,7 +57,6 @@ from fairseq2.recipes.config import (
     TextTokenizerSection,
     TrainerSection,
 )
-from fairseq2.typing import CPU
 from fairseq2.utils.rng import manual_seed
 from fairseq2.utils.structured import structure
 from fairseq2.utils.validation import validate

--- a/src/fairseq2/recipes/mt/_translate.py
+++ b/src/fairseq2/recipes/mt/_translate.py
@@ -21,6 +21,7 @@ from fairseq2.datasets.text import (
     TextDataset,
     TextReadOptions,
 )
+from fairseq2.device import CPU
 from fairseq2.file_system import FileMode
 from fairseq2.gang import Gangs
 from fairseq2.generation import BeamSearchConfig, Seq2SeqGenerator
@@ -55,7 +56,6 @@ from fairseq2.recipes.config import (
     Seq2SeqGeneratorSection,
     TextTokenizerSection,
 )
-from fairseq2.typing import CPU
 from fairseq2.utils.rng import manual_seed
 from fairseq2.utils.structured import structure
 from fairseq2.utils.validation import validate

--- a/src/fairseq2/recipes/utils/log.py
+++ b/src/fairseq2/recipes/utils/log.py
@@ -18,11 +18,11 @@ from torch.nn import Module
 
 import fairseq2
 from fairseq2.data.text.tokenizers import TextTokenizer
+from fairseq2.device import Device
 from fairseq2.gang import Gangs
 from fairseq2.logging import LogWriter
 from fairseq2.metrics import format_as_byte_size
 from fairseq2.nn.utils.module import get_module_size_info
-from fairseq2.typing import Device
 
 
 def log_config(log: LogWriter, title: str, config: object) -> None:

--- a/src/fairseq2/recipes/wav2vec2/_eval.py
+++ b/src/fairseq2/recipes/wav2vec2/_eval.py
@@ -20,6 +20,7 @@ from fairseq2.datasets.speech import (
     SpeechDataset,
     SpeechReadOptions,
 )
+from fairseq2.device import CPU
 from fairseq2.gang import Gangs
 from fairseq2.metrics import MetricBag
 from fairseq2.models.sequence import SequenceBatch
@@ -40,7 +41,6 @@ from fairseq2.recipes.config import (
     GangSection,
     ReferenceModelSection,
 )
-from fairseq2.typing import CPU
 from fairseq2.utils.rng import manual_seed
 from fairseq2.utils.structured import structure
 from fairseq2.utils.validation import validate

--- a/src/fairseq2/recipes/wav2vec2/_train.py
+++ b/src/fairseq2/recipes/wav2vec2/_train.py
@@ -21,6 +21,7 @@ from fairseq2.datasets.speech import (
     SpeechDataset,
     SpeechReadOptions,
 )
+from fairseq2.device import CPU
 from fairseq2.gang import Gangs
 from fairseq2.metrics import MetricBag
 from fairseq2.models.sequence import SequenceBatch
@@ -49,7 +50,6 @@ from fairseq2.recipes.config import (
     RegimeSection,
     TrainerSection,
 )
-from fairseq2.typing import CPU
 from fairseq2.utils.rng import manual_seed
 from fairseq2.utils.structured import structure
 from fairseq2.utils.validation import validate

--- a/src/fairseq2/recipes/wav2vec2/asr/_train.py
+++ b/src/fairseq2/recipes/wav2vec2/asr/_train.py
@@ -17,6 +17,7 @@ from typing_extensions import override
 from fairseq2.context import RuntimeContext
 from fairseq2.datasets import LengthBatching, SyncMode
 from fairseq2.datasets.asr import GENERIC_ASR_DATASET_FAMILY, AsrDataset, AsrReadOptions
+from fairseq2.device import CPU
 from fairseq2.gang import Gang, GangError
 from fairseq2.logging import log
 from fairseq2.metrics import MetricBag
@@ -56,7 +57,6 @@ from fairseq2.recipes.config import (
     TrainerSection,
 )
 from fairseq2.recipes.utils.log import log_model
-from fairseq2.typing import CPU
 from fairseq2.utils.rng import manual_seed
 from fairseq2.utils.structured import structure
 from fairseq2.utils.validation import validate

--- a/src/fairseq2/typing.py
+++ b/src/fairseq2/typing.py
@@ -9,17 +9,22 @@ from __future__ import annotations
 from collections.abc import MutableMapping
 from contextlib import AbstractContextManager
 from dataclasses import Field, is_dataclass
-from typing import Any, ClassVar, Final, Protocol, TypeAlias, TypeGuard
+from typing import Any, ClassVar, Protocol, TypeAlias, TypeGuard
 
-from torch import device, dtype
 from typing_extensions import Self
-from typing_extensions import override as override  # noqa: F401
+
+ContextManager: TypeAlias = AbstractContextManager[None]
 
 
 class DataClass(Protocol):
     """Represents a data class object."""
 
     __dataclass_fields__: ClassVar[dict[str, Field[Any]]]
+
+
+def is_dataclass_instance(obj: object) -> TypeGuard[DataClass]:
+    """Return ``True`` if ``obj`` is of type :class:`DataClass`."""
+    return is_dataclass(obj) and not isinstance(obj, type)
 
 
 class _EmptyType:
@@ -37,21 +42,4 @@ class _EmptyType:
 
 
 EMPTY = _EmptyType()
-"""A sentinel signifying no value for a dataclass field."""
-
-
-def is_dataclass_instance(obj: object) -> TypeGuard[DataClass]:
-    """Return ``True`` if ``obj`` is of type :class:`DataClass`."""
-    return is_dataclass(obj) and not isinstance(obj, type)
-
-
-ContextManager: TypeAlias = AbstractContextManager[None]
-
-
-Device: TypeAlias = device
-
-DataType: TypeAlias = dtype
-
-CPU: Final = Device("cpu")
-
-META: Final = Device("meta")
+"""A sentinel signifying no value."""

--- a/src/fairseq2/utils/cuda.py
+++ b/src/fairseq2/utils/cuda.py
@@ -12,7 +12,7 @@ from typing import final
 import torch
 from typing_extensions import override
 
-from fairseq2.typing import Device
+from fairseq2.device import Device
 
 
 class CudaContext(ABC):

--- a/src/fairseq2/utils/device.py
+++ b/src/fairseq2/utils/device.py
@@ -1,0 +1,122 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import final
+
+from fairseq2.context import RuntimeContext
+from fairseq2.device import CPU, Device
+from fairseq2.error import InternalError
+from fairseq2.utils.cuda import CudaContext, TorchCudaContext
+from fairseq2.utils.env import (
+    InvalidEnvironmentVariableError,
+    get_device_from_env,
+    get_int_from_env,
+)
+
+
+def determine_default_device(context: RuntimeContext) -> Device:
+    cuda_context = TorchCudaContext()
+
+    device_accessor = DefaultDeviceAccessor(context.env, cuda_context)
+
+    return device_accessor.get()
+
+
+@final
+class DefaultDeviceAccessor:
+    _env: Mapping[str, str]
+    _cuda_context: CudaContext
+
+    def __init__(self, env: Mapping[str, str], cuda_context: CudaContext) -> None:
+        self._env = env
+        self._cuda_context = cuda_context
+
+    def get(self) -> Device:
+        try:
+            device = get_device_from_env(self._env, "FAIRSEQ2_DEVICE")
+        except InvalidEnvironmentVariableError as ex:
+            raise DeviceDetectionError(
+                "The default device cannot be set using the `FAIRSEQ2_DEVICE` environment variable. See the nested exception for details."
+            ) from ex
+
+        if device is None:
+            device = self._determine_default_cuda_device()
+
+        if device is None:
+            device = CPU
+
+        if device.type == "cuda":
+            self._cuda_context.set_default_device(device)
+
+        return device
+
+    def _determine_default_cuda_device(self) -> Device | None:
+        if not self._cuda_context.is_available():
+            return None
+
+        num_devices = self._cuda_context.device_count()
+        if num_devices == 0:
+            return None
+
+        visible_devices = self._env.get("CUDA_VISIBLE_DEVICES")
+        if visible_devices is not None:
+            try:
+                int(visible_devices)
+            except ValueError:
+                # If we are here, it means CUDA_VISIBLE_DEVICES is a list instead of
+                # a single device index.
+                device = None
+            else:
+                device = Device("cuda", index=0)
+        else:
+            device = None
+
+        if device is None:
+            try:
+                idx = self._get_device_index(num_devices, device_type="cuda")
+            except InvalidEnvironmentVariableError as ex:
+                raise DeviceDetectionError(
+                    "The default `cuda` device index cannot be inferred from the environment. See the nested exception for details."
+                ) from ex
+
+            device = Device("cuda", index=idx)
+
+        return device
+
+    def _get_device_index(self, num_devices: int, device_type: str) -> int:
+        if num_devices <= 0:
+            raise InternalError(f"`num_devices` is {num_devices}.")
+
+        # We use the `LOCAL_RANK` environment variable to determine which device to
+        # pick in case the process has more than one available.
+        device_idx = get_int_from_env(self._env, "LOCAL_RANK", allow_zero=True)
+        if device_idx is None:
+            num_procs = get_int_from_env(self._env, "LOCAL_WORLD_SIZE")
+            if num_procs is not None and num_procs > 1 and num_devices > 1:
+                raise InvalidEnvironmentVariableError(
+                    "LOCAL_RANK", f"The default `{device_type}` device cannot be determined. There are {num_devices} devices available, but the `LOCAL_RANK` environment variable is not set."  # fmt: skip
+                )
+
+            return 0
+
+        if device_idx < 0:
+            raise InvalidEnvironmentVariableError(
+                "LOCAL_RANK", f"The value of the `LOCAL_RANK` environment variable is expected to be greater than or equal to 0, but is {device_idx} instead."  # fmt: skip
+            )
+
+        if device_idx >= num_devices:
+            raise InvalidEnvironmentVariableError(
+                "LOCAL_RANK", f"The value of the `LOCAL_RANK` environment variable is expected to be less than the number of available `{device_type}` devices ({num_devices}), but is {device_idx} instead."  # fmt: skip
+            )
+
+        return device_idx
+
+
+class DeviceDetectionError(Exception):
+    pass

--- a/src/fairseq2/utils/device_stat.py
+++ b/src/fairseq2/utils/device_stat.py
@@ -12,7 +12,7 @@ from typing import final
 import torch
 from typing_extensions import override
 
-from fairseq2.typing import Device
+from fairseq2.device import Device
 
 
 class DeviceStatTracker(ABC):

--- a/src/fairseq2/utils/env.py
+++ b/src/fairseq2/utils/env.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from pathlib import Path
 
-from fairseq2.typing import Device
+from fairseq2.device import Device
 
 
 def get_int_from_env(

--- a/src/fairseq2/utils/io.py
+++ b/src/fairseq2/utils/io.py
@@ -18,9 +18,9 @@ import torch
 from torch import Tensor
 from typing_extensions import override
 
+from fairseq2.device import Device
 from fairseq2.error import NotSupportedError
 from fairseq2.file_system import FileMode, FileSystem
-from fairseq2.typing import Device
 
 MapLocation: TypeAlias = (
     Callable[[Tensor, str], Tensor] | Device | str | dict[str, str] | None

--- a/src/fairseq2/utils/rng.py
+++ b/src/fairseq2/utils/rng.py
@@ -13,7 +13,8 @@ from typing import final
 import torch
 from torch import Generator, Tensor
 
-from fairseq2.typing import ContextManager, Device
+from fairseq2.device import Device
+from fairseq2.typing import ContextManager
 
 
 def use_deterministic(value: bool, warn_only: bool = False) -> None:

--- a/src/fairseq2/utils/stopwatch.py
+++ b/src/fairseq2/utils/stopwatch.py
@@ -12,8 +12,8 @@ from typing import Any, final
 import torch
 from typing_extensions import Self
 
+from fairseq2.device import CPU, Device
 from fairseq2.error import InvalidOperationError
-from fairseq2.typing import CPU, Device
 
 
 @final

--- a/src/fairseq2/utils/structured.py
+++ b/src/fairseq2/utils/structured.py
@@ -25,7 +25,9 @@ from typing import (
 
 import torch
 
-from fairseq2.typing import EMPTY, DataClass, DataType, Device
+from fairseq2.data_type import DataType
+from fairseq2.device import Device
+from fairseq2.typing import EMPTY, DataClass
 
 
 class _Structurer(Protocol):

--- a/src/fairseq2/utils/tensor.py
+++ b/src/fairseq2/utils/tensor.py
@@ -1,0 +1,29 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TypeAlias
+
+import torch
+from torch import Tensor
+
+from fairseq2.data_type import DataType
+from fairseq2.device import CPU, Device
+
+TensorData: TypeAlias = int | float | Sequence[int] | Sequence[float]
+
+
+def to_tensor(
+    data: TensorData, device: Device | None = None, dtype: DataType | None = None
+) -> Tensor:
+    if device is None or device.type != "cuda":
+        return torch.tensor(data, device=device, dtype=dtype)
+
+    t = torch.tensor(data, device=CPU, pin_memory=True)
+
+    return t.to(device, non_blocking=True)

--- a/src/fairseq2/utils/threading.py
+++ b/src/fairseq2/utils/threading.py
@@ -85,7 +85,7 @@ def _get_num_cpus(num_procs: int) -> int:
 
     if num_cpus is None or affinity_mask is None:
         raise ThreadingError(
-            "The number of CPUs of the host machine cannot be determined."
+            "The number of CPUs on the host machine cannot be determined."
         )
 
     # We should not exceed the number of cores available in the affinity mask.

--- a/tests/common.py
+++ b/tests/common.py
@@ -11,11 +11,11 @@ from typing import Any
 import torch
 from torch import Tensor
 
-from fairseq2.typing import Device
+from fairseq2.device import CPU
 
 # The default device that tests should use. Note that pytest can change it based
 # on the provided command line arguments.
-device = Device("cpu")
+device = CPU
 
 
 def assert_close(a: Tensor, b: Tensor | list[Any]) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ from pytest import Config, Parser, Session
 
 import tests.common
 from fairseq2 import setup_fairseq2
-from fairseq2.typing import Device
+from fairseq2.device import Device
 
 
 def pytest_addoption(parser: Parser) -> None:

--- a/tests/unit/data/text/test_sentencepiece.py
+++ b/tests/unit/data/text/test_sentencepiece.py
@@ -19,7 +19,7 @@ from fairseq2.data.text.tokenizers.sentencepiece import (
     SentencePieceEncoder,
     SentencePieceModel,
 )
-from fairseq2.typing import DataType
+from fairseq2.data_type import DataType
 from tests.common import assert_equal, device
 
 TEST_SPM_PATH: Final = Path(__file__).parent.joinpath("test.spm")

--- a/tests/unit/data/text/test_str_to_tensor_converter.py
+++ b/tests/unit/data/text/test_str_to_tensor_converter.py
@@ -13,7 +13,7 @@ import pytest
 import torch
 
 from fairseq2.data.text import StrToTensorConverter
-from fairseq2.typing import DataType
+from fairseq2.data_type import DataType
 from tests.common import assert_equal
 
 

--- a/tests/unit/nn/utils/test_module.py
+++ b/tests/unit/nn/utils/test_module.py
@@ -9,9 +9,9 @@ from __future__ import annotations
 from torch.nn import Parameter
 
 from fairseq2 import get_runtime_context
+from fairseq2.device import META_DEVICE
 from fairseq2.models.transformer import TransformerConfig, TransformerFactory
 from fairseq2.nn.utils.module import select_parameters
-from fairseq2.typing import META
 
 
 def test_select_parameters() -> None:
@@ -23,7 +23,7 @@ def test_select_parameters() -> None:
 
     model_factory = TransformerFactory(model_config)
 
-    with META:
+    with META_DEVICE:
         model = model_factory.create_model()
 
     output = select_parameters(model, [r".*\.encoder_decoder_attn_layer_norm\.bias$"])
@@ -45,7 +45,7 @@ def test_select_parameters_when_exclude_is_true() -> None:
 
     model_factory = TransformerFactory(model_config)
 
-    with META:
+    with META_DEVICE:
         model = model_factory.create_model()
 
     names = [r".*\.encoder_decoder_attn_layer_norm\.bias$", "decoder.layer_norm.weight"]

--- a/tests/unit/utils/test_structured.py
+++ b/tests/unit/utils/test_structured.py
@@ -13,7 +13,8 @@ from pathlib import Path
 import pytest
 import torch
 
-from fairseq2.typing import EMPTY, DataType
+from fairseq2.data_type import DataType
+from fairseq2.typing import EMPTY
 from fairseq2.utils.structured import (
     StructureError,
     is_unstructured,


### PR DESCRIPTION
This PR introduces a `to_tensor` utility function as a non-blocking alternative to `torch.tensor`. It also reorganizes the device and data type related APIs into their own files.