### PR TITLE
Record rollouts in logs, update num examples, separate train/valid in wandb

### DIFF
--- a/src/fairseq2/metrics/recorders/_wandb.py
+++ b/src/fairseq2/metrics/recorders/_wandb.py
@@ -78,12 +78,6 @@ class WandbRecorder(MetricRecorder):
         if self._run is None:
             return
 
-        # try:
-        #     self._run.log({"_step": step_nr})  # Log to the specific step
-        #     self._run.step = step_nr  # Directly update the internal step counter
-        # except:
-        #     ...
-
         for name, value in values.items():
             try:
                 descriptor = self._metric_descriptors.get(name)

--- a/src/fairseq2/recipes/lm/_online_finetune/_common.py
+++ b/src/fairseq2/recipes/lm/_online_finetune/_common.py
@@ -38,6 +38,7 @@ from fairseq2.gang import Gang
 from fairseq2.models.sequence import SequenceBatch, SequenceModelOutput
 from fairseq2.nn.padding import get_seqs_and_padding_mask
 from fairseq2.recipes.metrics import SequenceMetricBag
+from fairseq2.logging import log
 
 
 @dataclass
@@ -540,3 +541,19 @@ def compute_token_level_entropy(logits: torch.Tensor, target_mask: torch.Tensor)
     entropy_per_seq = entropy_target_only.sum(dim=-1) / target_mask.sum(dim=-1)
 
     return entropy_per_seq
+
+
+def log_rollouts(prompt_batch: PromptBatch, rollouts, split_name, num_rollouts=1):
+    """
+    log the first num_rollouts rollouts for first prompt in the batch
+    """
+    if "prompt_raw" in prompt_batch.meta_info:
+        prompt = prompt_batch.meta_info.get("prompt_raw")[0]
+    else:
+        # raw text prompt doesn't exist for this dataset
+        prompt = "DUMMY PROMPT"
+
+    log.info(f"{split_name} Prompt: {prompt}")
+    for rollout in rollouts[0].outputs[:num_rollouts]:
+        rollout_text = rollout.text
+        log.info(f"{split_name} Rollout: {rollout_text}")

--- a/src/fairseq2/recipes/lm/_online_finetune/_grpo.py
+++ b/src/fairseq2/recipes/lm/_online_finetune/_grpo.py
@@ -166,7 +166,8 @@ class GrpoFinetuneUnit(TrainUnit[SequenceBatch]):
             vllm_model=self._vllm_model,
             sampling_params=policy_sampling_params,
         )
-        log_rollouts(prompt_batch, rollouts, "Valid")
+        if self._loss_config.log_rollouts:
+            log_rollouts(prompt_batch, rollouts, "Valid")
         reward_output = self._reward.process_rollouts(rollouts, prompt_batch)
         avg_reward = torch.tensor(reward_output["rewards"]).float().mean()
         self._metric_bag.update_avg_reward(avg_reward)
@@ -214,8 +215,8 @@ class GrpoFinetuneUnit(TrainUnit[SequenceBatch]):
         rollouts = generate_rollouts(
             prompt_batch.prompts, dp_gang=self._gangs.dp, vllm_model=self._vllm_model
         )
-
-        log_rollouts(prompt_batch, rollouts, "Train")
+        if self._loss_config.log_rollouts:
+            log_rollouts(prompt_batch, rollouts, "Train")
 
         reward_output = self._reward.process_rollouts(rollouts, prompt_batch)
 
@@ -430,7 +431,7 @@ class GrpoLossConfig:
     """The coefficient of regularization towards the reference model."""
     entropy_regularizer_scale: float = 0.0
 
-    log_rollouts: bool = True
+    log_rollouts: bool = False
     """Log rollouts during training/validation"""
 
 

--- a/src/fairseq2/recipes/lm/_online_finetune/_grpo.py
+++ b/src/fairseq2/recipes/lm/_online_finetune/_grpo.py
@@ -171,6 +171,7 @@ class GrpoFinetuneUnit(TrainUnit[SequenceBatch]):
         reward_output = self._reward.process_rollouts(rollouts, prompt_batch)
         avg_reward = torch.tensor(reward_output["rewards"]).float().mean()
         self._metric_bag.update_avg_reward(avg_reward)
+        self._metric_bag.update_batch_metrics(prompt_batch)
         # returning dummy loss since trainer expects it
         return torch.tensor(0.0, device=self._gangs.dp.device), prompt_batch.batch_size
 

--- a/src/fairseq2/recipes/lm/_online_finetune/_grpo.py
+++ b/src/fairseq2/recipes/lm/_online_finetune/_grpo.py
@@ -420,6 +420,14 @@ class GrpoFinetuneMetricBag(SequenceMetricBag):
     def update_avg_reward(self, avg_reward):
         self.avg_reward.update(avg_reward, weight=1)
 
+    @torch.inference_mode()
+    def update_batch_metrics(self, batch: PreferenceBatch):
+        num_examples = batch.batch_size
+        self.num_examples.update(num_examples)
+        if self._train:
+            assert self.total_num_examples is not None
+            self.total_num_examples.update(num_examples)
+
 
 GRPO_FINETUNE_UNIT: Final = "grpo"
 

--- a/src/fairseq2/recipes/lm/_online_finetune/_grpo.py
+++ b/src/fairseq2/recipes/lm/_online_finetune/_grpo.py
@@ -19,7 +19,10 @@ from torch.nn import Module
 from torcheval.metrics import Mean
 from typing_extensions import override
 from vllm.distributed.device_communicators.pynccl import PyNcclCommunicator
-from fairseq2.recipes.lm._online_finetune._common import compute_token_level_entropy
+from fairseq2.recipes.lm._online_finetune._common import (
+    compute_token_level_entropy,
+    log_rollouts,
+)
 
 from fairseq2.context import RuntimeContext
 from fairseq2.datasets.preference import PreferenceBatch
@@ -163,6 +166,7 @@ class GrpoFinetuneUnit(TrainUnit[SequenceBatch]):
             vllm_model=self._vllm_model,
             sampling_params=policy_sampling_params,
         )
+        log_rollouts(prompt_batch, rollouts, "Valid")
         reward_output = self._reward.process_rollouts(rollouts, prompt_batch)
         avg_reward = torch.tensor(reward_output["rewards"]).float().mean()
         self._metric_bag.update_avg_reward(avg_reward)
@@ -210,6 +214,8 @@ class GrpoFinetuneUnit(TrainUnit[SequenceBatch]):
         rollouts = generate_rollouts(
             prompt_batch.prompts, dp_gang=self._gangs.dp, vllm_model=self._vllm_model
         )
+
+        log_rollouts(prompt_batch, rollouts, "Train")
 
         reward_output = self._reward.process_rollouts(rollouts, prompt_batch)
 
@@ -423,6 +429,9 @@ class GrpoLossConfig:
     beta: float = 0.1
     """The coefficient of regularization towards the reference model."""
     entropy_regularizer_scale: float = 0.0
+
+    log_rollouts: bool = True
+    """Log rollouts during training/validation"""
 
 
 @dataclass(kw_only=True)

--- a/src/fairseq2/recipes/lm/_online_finetune/_online_dpo.py
+++ b/src/fairseq2/recipes/lm/_online_finetune/_online_dpo.py
@@ -463,7 +463,7 @@ class DpoLossConfig:
 
     entropy_regularizer_scale: float = 0.0
 
-    log_rollouts: bool = True
+    log_rollouts: bool = False
     """Log rollouts during training/validation"""
 
 

--- a/src/fairseq2/recipes/lm/_online_finetune/_online_dpo.py
+++ b/src/fairseq2/recipes/lm/_online_finetune/_online_dpo.py
@@ -445,6 +445,15 @@ class OnlineDpoFinetuneMetricBag(POFinetuneMetricBag):
     def update_avg_zeroed_loss(self, avg_zeroed_loss):
         self.avg_zeroed_loss.update(avg_zeroed_loss, weight=1)
 
+    
+    @torch.inference_mode()
+    def update_batch_metrics(self, batch: PreferenceBatch):
+        num_examples = batch.batch_size
+        self.num_examples.update(num_examples)
+        if self._train:
+            assert self.total_num_examples is not None
+            self.total_num_examples.update(num_examples)
+
 
 ONLINE_DPO_FINETUNE_UNIT: Final = "online_dpo"
 

--- a/src/fairseq2/recipes/lm/_online_finetune/_online_dpo.py
+++ b/src/fairseq2/recipes/lm/_online_finetune/_online_dpo.py
@@ -175,6 +175,7 @@ class OnlineDpoFinetuneUnit(TrainUnit[SequenceBatch]):
         avg_reward = torch.tensor(reward_output["rewards"]).float().mean()
 
         self._metric_bag.update_avg_reward(avg_reward)
+        self._metric_bag.update_batch_metrics(prompt_batch)
         # returning dummy loss since trainer expects it
         return torch.tensor(0.0, device=self._gangs.dp.device), prompt_batch.batch_size
 
@@ -445,7 +446,6 @@ class OnlineDpoFinetuneMetricBag(POFinetuneMetricBag):
     def update_avg_zeroed_loss(self, avg_zeroed_loss):
         self.avg_zeroed_loss.update(avg_zeroed_loss, weight=1)
 
-    
     @torch.inference_mode()
     def update_batch_metrics(self, batch: PreferenceBatch):
         num_examples = batch.batch_size


### PR DESCRIPTION
**What does this PR do? Please describe:**
A summary of the change or the issue that is fixed.

Adds three things:
1.  Logging rollouts during online training and validation (see below for how to turn on)
2. Adds logging `num_examples` and `total_num_examples` in metrics loggers for online_dpo and grpo.
3. Updates [src/fairseq2/metrics/recorders/_wandb.py](src/fairseq2/metrics/recorders/_wandb.py) to separate train/valid in wandb logs

add the following to config to turn on logging rollouts
```
criterion:
  config:
    _set_:
      loss_config:
        log_rollouts: True
 ```


**Does your PR introduce any breaking changes? If yes, please list them:**
List of all backwards-incompatible changes.

**Check list:**
- [x] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [ ] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
