### PR TITLE
validate before training

### DIFF
--- a/src/fairseq2/recipes/common/_trainer.py
+++ b/src/fairseq2/recipes/common/_trainer.py
@@ -96,7 +96,7 @@ def create_trainer(
         valid_data_readers=valid_data_readers,
         validate_after_n_steps=regime_section.validate_after_n_steps,
         validate_every_n_steps=regime_section.validate_every_n_steps,
-        validate_step_0=regime_section.validate_step_0,
+        validate_before_training=regime_section.validate_before_training,
         validate_after_n_data_epochs=regime_section.validate_after_n_data_epochs,
         validate_every_n_data_epochs=regime_section.validate_every_n_data_epochs,
         checkpoint_manager=checkpoint_manager,

--- a/src/fairseq2/recipes/common/_trainer.py
+++ b/src/fairseq2/recipes/common/_trainer.py
@@ -96,6 +96,7 @@ def create_trainer(
         valid_data_readers=valid_data_readers,
         validate_after_n_steps=regime_section.validate_after_n_steps,
         validate_every_n_steps=regime_section.validate_every_n_steps,
+        validate_step_0=regime_section.validate_step_0,
         validate_after_n_data_epochs=regime_section.validate_after_n_data_epochs,
         validate_every_n_data_epochs=regime_section.validate_every_n_data_epochs,
         checkpoint_manager=checkpoint_manager,

--- a/src/fairseq2/recipes/config.py
+++ b/src/fairseq2/recipes/config.py
@@ -219,7 +219,7 @@ class RegimeSection:
     validate_every_n_steps: int | None = None
     """The step interval at which to validate the model."""
 
-    validate_step_0: bool = False
+    validate_before_training: bool = False
     """Validate before training"""
 
     validate_after_n_data_epochs: int = 0

--- a/src/fairseq2/recipes/config.py
+++ b/src/fairseq2/recipes/config.py
@@ -219,6 +219,9 @@ class RegimeSection:
     validate_every_n_steps: int | None = None
     """The step interval at which to validate the model."""
 
+    validate_step_0: bool = False
+    """Validate before training"""
+
     validate_after_n_data_epochs: int = 0
 
     validate_every_n_data_epochs: int | None = None

--- a/src/fairseq2/recipes/lm/_online_finetune/_recipe.py
+++ b/src/fairseq2/recipes/lm/_online_finetune/_recipe.py
@@ -211,6 +211,7 @@ def register_online_finetune_configs(context: RuntimeContext) -> None:
         config = OnlineFinetuneConfig()
 
         config.model.config = DropoutConfig()
+        config.regime.validate_step_0 = True
 
         return config
 

--- a/src/fairseq2/recipes/lm/_online_finetune/_recipe.py
+++ b/src/fairseq2/recipes/lm/_online_finetune/_recipe.py
@@ -211,7 +211,7 @@ def register_online_finetune_configs(context: RuntimeContext) -> None:
         config = OnlineFinetuneConfig()
 
         config.model.config = DropoutConfig()
-        config.regime.validate_step_0 = True
+        config.regime.validate_before_training = True
 
         return config
 

--- a/src/fairseq2/recipes/trainer.py
+++ b/src/fairseq2/recipes/trainer.py
@@ -118,7 +118,7 @@ class Trainer(StatefulObjectBag, Generic[BatchT]):
     _valid_data_readers: Sequence[DataReader[BatchT]]
     _validate_after_n_steps: int
     _validate_every_n_steps: int | None
-    _validate_step_0: bool
+    _validate_before_training: bool
     _validate_after_n_data_epochs: int
     _validate_every_n_data_epochs: int | None
     _checkpoint_manager: CheckpointManager
@@ -178,7 +178,7 @@ class Trainer(StatefulObjectBag, Generic[BatchT]):
         valid_data_readers: Sequence[DataReader[BatchT]] | None = None,
         validate_after_n_steps: int = 0,
         validate_every_n_steps: int | None = None,
-        validate_step_0: bool = False,
+        validate_before_training: bool = False,
         validate_after_n_data_epochs: int = 0,
         validate_every_n_data_epochs: int | None = None,
         checkpoint_after_n_steps: int = 0,
@@ -237,7 +237,7 @@ class Trainer(StatefulObjectBag, Generic[BatchT]):
             The number of steps after which to start validating the model.
         :param validate_every_n_steps:
             The step interval at which to validate the model.
-        :param validate_step_0:
+        :param validate_before_training:
             Validate before training
         :param validate_after_n_data_epochs:
             The number of data epochs after which to start validating the model.
@@ -394,7 +394,7 @@ class Trainer(StatefulObjectBag, Generic[BatchT]):
 
         self._validate_after_n_data_epochs = validate_after_n_data_epochs
         self._validate_every_n_data_epochs = validate_every_n_data_epochs
-        self._validate_step_0 = validate_step_0
+        self._validate_before_training = validate_before_training
 
         self._checkpoint_manager = checkpoint_manager
 
@@ -599,7 +599,7 @@ class Trainer(StatefulObjectBag, Generic[BatchT]):
 
             first_iter = True
 
-            if self._validate_step_0:
+            if self._validate_before_training:
                 self._validate()
 
             while self._should_run_step():

--- a/src/fairseq2/recipes/trainer.py
+++ b/src/fairseq2/recipes/trainer.py
@@ -118,6 +118,7 @@ class Trainer(StatefulObjectBag, Generic[BatchT]):
     _valid_data_readers: Sequence[DataReader[BatchT]]
     _validate_after_n_steps: int
     _validate_every_n_steps: int | None
+    _validate_step_0: bool
     _validate_after_n_data_epochs: int
     _validate_every_n_data_epochs: int | None
     _checkpoint_manager: CheckpointManager
@@ -177,6 +178,7 @@ class Trainer(StatefulObjectBag, Generic[BatchT]):
         valid_data_readers: Sequence[DataReader[BatchT]] | None = None,
         validate_after_n_steps: int = 0,
         validate_every_n_steps: int | None = None,
+        validate_step_0: bool = False,
         validate_after_n_data_epochs: int = 0,
         validate_every_n_data_epochs: int | None = None,
         checkpoint_after_n_steps: int = 0,
@@ -235,6 +237,8 @@ class Trainer(StatefulObjectBag, Generic[BatchT]):
             The number of steps after which to start validating the model.
         :param validate_every_n_steps:
             The step interval at which to validate the model.
+        :param validate_step_0:
+            Validate before training
         :param validate_after_n_data_epochs:
             The number of data epochs after which to start validating the model.
         :param validate_every_n_data_epochs:
@@ -390,6 +394,7 @@ class Trainer(StatefulObjectBag, Generic[BatchT]):
 
         self._validate_after_n_data_epochs = validate_after_n_data_epochs
         self._validate_every_n_data_epochs = validate_every_n_data_epochs
+        self._validate_step_0 = validate_step_0
 
         self._checkpoint_manager = checkpoint_manager
 
@@ -594,7 +599,11 @@ class Trainer(StatefulObjectBag, Generic[BatchT]):
 
             first_iter = True
 
+            if self._validate_step_0:
+                self._validate()
+
             while self._should_run_step():
+
                 self._maybe_advance_data_epoch()
 
                 self._step_nr += 1
@@ -614,7 +623,6 @@ class Trainer(StatefulObjectBag, Generic[BatchT]):
 
                 if self._should_validate():
                     self._validate()
-
                     self._maybe_request_early_stop()
 
                 if self._should_checkpoint():

--- a/src/fairseq2/recipes/trainer.py
+++ b/src/fairseq2/recipes/trainer.py
@@ -603,7 +603,6 @@ class Trainer(StatefulObjectBag, Generic[BatchT]):
                 self._validate()
 
             while self._should_run_step():
-
                 self._maybe_advance_data_epoch()
 
                 self._step_nr += 1


### PR DESCRIPTION
**What does this PR do? Please describe:**

Adds boolean arg to run validation before training begins.

To use, add the following to your config (set to `True` [by default](https://github.com/facebookresearch/fairseq2/blob/f545da358dd5adc5bca1c073fba7052f01c1135b/src/fairseq2/recipes/lm/_online_finetune/_recipe.py#L214) in preset `llama3_1_instruct`):

```
regime:
  _set_:
    validate_before_training : True
```




**Check list:**
- [x] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [ ] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
