### PR TITLE
Add support for writing out model confidence scores.

### DIFF
--- a/src/fairseq2/datasets/_data_reader.py
+++ b/src/fairseq2/datasets/_data_reader.py
@@ -8,18 +8,18 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Iterator, Mapping
-from typing import TypeVar, final
+from typing import final, TypeVar
 
 import torch
-from typing_extensions import Self, override
 
 from fairseq2.data import DataPipeline, DataPipelineError
-from fairseq2.gang import Gang, GangError, all_sum
-from fairseq2.logging import log
 
 # isort: split
 
 from fairseq2.datasets._config import DataReadOptions, SyncMode
+from fairseq2.gang import all_sum, Gang, GangError
+from fairseq2.logging import log
+from typing_extensions import override, Self
 
 BatchT_co = TypeVar("BatchT_co", covariant=True)
 


### PR DESCRIPTION
**What does this PR do? Please describe:**
Add option to write out ASR model confidence score at the utterance level.
Companion to https://github.com/fairinternal/mms/pull/25.

Fixes #{issue number}

**Does your PR introduce any breaking changes? If yes, please list them:**
List of all backwards-incompatible changes.

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [ ] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
