### PR TITLE
Jacklanchantin/fix force sync

### DIFF
--- a/src/fairseq2/recipes/lm/_online_finetune/_grpo.py
+++ b/src/fairseq2/recipes/lm/_online_finetune/_grpo.py
@@ -134,7 +134,7 @@ class GrpoFinetuneUnit(TrainUnit[SequenceBatch]):
                     self._vllm_model.sync_weights_with_vllm(train_model=self._model)
                 self._gangs.root.barrier()
 
-        if (
+        if hasattr(self, "_step_nr") and (
             self._sync_ref_model_every_n_steps > 0
             and self._step_nr % self._sync_ref_model_every_n_steps == 0
         ):
@@ -343,9 +343,7 @@ class GrpoFinetuneUnit(TrainUnit[SequenceBatch]):
                 (per_token_loss * target_mask).sum(dim=-1) / target_mask.sum(dim=-1)
             ).mean(dim=1)
         else:
-            per_seq_loss = (
-                (per_token_loss * target_mask).sum(dim=-1)
-            ).mean(dim=1)
+            per_seq_loss = ((per_token_loss * target_mask).sum(dim=-1)).mean(dim=1)
 
         # if self._gangs.root.rank == 0:
         #     from pudb.remote import set_trace

--- a/src/fairseq2/recipes/lm/_online_finetune/_online_dpo.py
+++ b/src/fairseq2/recipes/lm/_online_finetune/_online_dpo.py
@@ -135,7 +135,7 @@ class OnlineDpoFinetuneUnit(TrainUnit[SequenceBatch]):
                     self._vllm_model.sync_weights_with_vllm(train_model=self._model)
                 self._gangs.root.barrier()
 
-        if (
+        if hasattr(self, "_step_nr") and (
             self._sync_ref_model_every_n_steps > 0
             and self._step_nr % self._sync_ref_model_every_n_steps == 0
         ):


### PR DESCRIPTION
**What does this PR do? Please describe:**

Checks if `self._step_nr` exists in the finetuneunit when force syncing vllm models. Need this because when we [first sync vllm models after loading a train unit](https://github.com/facebookresearch/fairseq2/blob/cee96d722b770844f8f89df9ffa6524dbdf92db8/src/fairseq2/recipes/lm/_online_finetune/_recipe.py#L300), the step_nr hasn't been intialized yet.

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [ ] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
