### PR TITLE
Introduce FlashAttention3 support

### DIFF
--- a/src/fairseq2/datasets/instruction.py
+++ b/src/fairseq2/datasets/instruction.py
@@ -297,7 +297,9 @@ class GenericInstructionDataset(InstructionDataset):
             "target_mask", pad_value=False
         )
 
-        collater = Collater(pad_value=0, overrides=[target_mask_collate_opts])
+        collater = Collater(
+            pad_value=tokenizer.vocab_info.pad_idx, overrides=[target_mask_collate_opts]
+        )
 
         builder.map(collater, num_parallel_calls=npc)
 

--- a/src/fairseq2/metrics/recorders/_tensorboard.py
+++ b/src/fairseq2/metrics/recorders/_tensorboard.py
@@ -13,6 +13,13 @@ from typing import Final, final
 
 from typing_extensions import override
 
+try:
+    from torch.utils.tensorboard import SummaryWriter  # type: ignore[attr-defined]
+except ImportError:
+    _has_tensorboard = False
+else:
+    _has_tensorboard = True
+
 from fairseq2.logging import log
 from fairseq2.metrics import MetricDescriptor
 from fairseq2.registry import Provider
@@ -27,13 +34,6 @@ from fairseq2.metrics.recorders._recorder import (
     MetricRecordError,
     NoopMetricRecorder,
 )
-
-try:
-    from torch.utils.tensorboard import SummaryWriter  # type: ignore[attr-defined]
-except ImportError:
-    has_tensorboard = False
-else:
-    has_tensorboard = True
 
 
 @final
@@ -51,7 +51,7 @@ class TensorBoardRecorder(MetricRecorder):
         :param output_dir:
             The base directory under which to store the TensorBoard files.
         """
-        if not has_tensorboard:
+        if not _has_tensorboard:
             log.warning("tensorboard not found. Please install it with `pip install tensorboard`.")  # fmt: skip
 
         self._output_dir = output_dir
@@ -94,7 +94,7 @@ class TensorBoardRecorder(MetricRecorder):
             ) from ex
 
     def _get_writer(self, run: str) -> SummaryWriter | None:
-        if not has_tensorboard:
+        if not _has_tensorboard:
             return None
 
         writer = self._writers.get(run)

--- a/src/fairseq2/metrics/recorders/_wandb.py
+++ b/src/fairseq2/metrics/recorders/_wandb.py
@@ -13,6 +13,13 @@ from typing import Final, final
 
 from typing_extensions import override
 
+try:
+    import wandb  # type: ignore[import-not-found]
+except ImportError:
+    _has_wandb = False
+else:
+    _has_wandb = True
+
 from fairseq2.logging import log
 from fairseq2.metrics import MetricDescriptor
 from fairseq2.registry import Provider
@@ -27,13 +34,6 @@ from fairseq2.metrics.recorders._recorder import (
     MetricRecordError,
     NoopMetricRecorder,
 )
-
-try:
-    import wandb  # type: ignore[import-not-found]
-except ImportError:
-    has_wandb = False
-else:
-    has_wandb = True
 
 
 @final
@@ -57,7 +57,7 @@ class WandbRecorder(MetricRecorder):
         In order to use W&B, run `wandb login` from the command line and enter
         the API key when prompted.
         """
-        if not has_wandb:
+        if not _has_wandb:
             log.warning("wandb not found. Please install it with `pip install wandb`.")  # fmt: skip
 
             self._run = None

--- a/src/fairseq2/models/llama/_factory.py
+++ b/src/fairseq2/models/llama/_factory.py
@@ -93,8 +93,9 @@ class LLaMAFactory:
             self._init_truncated_normal(embed.weight, bias=None, std=std)
 
         return StandardEmbedding(
-            num_embeddings=config.vocab_size,
-            embedding_dim=config.model_dim,
+            config.vocab_size,
+            config.model_dim,
+            pad_idx=config.pad_idx,
             init_fn=init_embed,
         )
 

--- a/src/fairseq2/models/mistral/_factory.py
+++ b/src/fairseq2/models/mistral/_factory.py
@@ -84,7 +84,7 @@ class MistralFactory:
         config = self._config
 
         return StandardEmbedding(
-            num_embeddings=config.vocab_size, embedding_dim=config.model_dim
+            config.vocab_size, config.model_dim, pad_idx=config.pad_idx
         )
 
     def create_decoder(self) -> TransformerLMDecoder:

--- a/src/fairseq2/models/s2t_transformer/_factory.py
+++ b/src/fairseq2/models/s2t_transformer/_factory.py
@@ -232,8 +232,8 @@ class S2TTransformerFactory:
         config = self._config
 
         return StandardEmbedding(
-            num_embeddings=config.target_vocab_size,
-            embedding_dim=config.model_dim,
+            config.target_vocab_size,
+            config.model_dim,
             pad_idx=config.pad_idx,
             init_fn=init_scaled_embedding,
         )

--- a/src/fairseq2/models/transformer/__init__.py
+++ b/src/fairseq2/models/transformer/__init__.py
@@ -142,6 +142,8 @@ from fairseq2.models.transformer._sdpa._default import (
 from fairseq2.models.transformer._sdpa._default import (
     set_default_sdpa_factory as set_default_sdpa_factory,
 )
+from fairseq2.models.transformer._sdpa._flash2 import Flash2SDPA as Flash2SDPA
+from fairseq2.models.transformer._sdpa._flash3 import Flash3SDPA as Flash3SDPA
 from fairseq2.models.transformer._sdpa._naive import NaiveSDPA as NaiveSDPA
 from fairseq2.models.transformer._sdpa._naive import (
     naive_scaled_dot_product_attention as naive_scaled_dot_product_attention,

--- a/src/fairseq2/models/transformer/_factory.py
+++ b/src/fairseq2/models/transformer/_factory.py
@@ -96,8 +96,8 @@ class TransformerFactory:
         config = self._config
 
         return StandardEmbedding(
-            num_embeddings=config.vocab_size,
-            embedding_dim=config.model_dim,
+            config.vocab_size,
+            config.model_dim,
             pad_idx=config.pad_idx,
             init_fn=init_scaled_embedding,
         )

--- a/src/fairseq2/models/transformer/_sdpa/_base.py
+++ b/src/fairseq2/models/transformer/_sdpa/_base.py
@@ -68,7 +68,6 @@ class SDPA(Module, ABC):
         """
 
     @final
-    @torch.compiler.disable
     def _maybe_get_attention_bias_tensor(
         self,
         seqs: Tensor,
@@ -88,6 +87,19 @@ class SDPA(Module, ABC):
                 if seqs_layout.max_seq_len == 1:
                     return None
 
+        return self._get_attention_bias_tensor(  # type: ignore[no-any-return]
+            seqs, seqs_layout, keys_layout, bias_cache
+        )
+
+    @final
+    @torch.compiler.disable
+    def _get_attention_bias_tensor(
+        self,
+        seqs: Tensor,
+        seqs_layout: BatchLayout,
+        keys_layout: BatchLayout,
+        bias_cache: AttentionBiasCache,
+    ) -> Tensor:
         impl = "tensor"
 
         bias = bias_cache.maybe_get(self.bias, impl, kls=Tensor)

--- a/src/fairseq2/models/transformer/_sdpa/_flash2.py
+++ b/src/fairseq2/models/transformer/_sdpa/_flash2.py
@@ -1,0 +1,123 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from typing import cast, final
+
+from torch import Tensor
+from typing_extensions import override
+
+try:
+    from flash_attn import (  # type: ignore[import-not-found, import-untyped]
+        flash_attn_func,
+        flash_attn_varlen_func,
+    )
+except ImportError:
+    _has_flash_attn_2 = False
+else:
+    _has_flash_attn_2 = True
+
+from fairseq2.error import NotSupportedError
+from fairseq2.nn import BatchLayout
+
+# isort: split
+
+from fairseq2.models.transformer._attention_bias import (
+    AttentionBias,
+    AttentionBiasCache,
+    CausalAttentionBias,
+    IdentityBias,
+)
+from fairseq2.models.transformer._sdpa._base import SDPA
+
+
+@final
+class Flash2SDPA(SDPA):
+    """Computes scaled dot-product attention using FlashAttention2."""
+
+    dropout_p: float
+
+    def __init__(self, bias: AttentionBias, *, dropout_p: float = 0.0) -> None:
+        """
+        :param dropout_p: The dropout probability on attention weights.
+        """
+        super().__init__(bias)
+
+        self.dropout_p = dropout_p
+
+    @override
+    def forward(
+        self,
+        seqs: Tensor,
+        seqs_layout: BatchLayout,
+        keys: Tensor,
+        keys_layout: BatchLayout,
+        values: Tensor,
+        bias_cache: AttentionBiasCache,
+        *,
+        needs_weights: bool = False,
+    ) -> tuple[Tensor, Tensor | None]:
+        if not _has_flash_attn_2:
+            raise RuntimeError(
+                "FlashAttention is not found in your Python environment. Use `pip install flash-attn`."
+            )
+
+        if seqs_layout.padded or keys_layout.padded:
+            raise NotSupportedError(f"`{Flash2SDPA}` does not support padded batches.")
+
+        if isinstance(self.bias, IdentityBias):
+            causal = False
+
+            window_size = (-1, -1)
+        elif isinstance(self.bias, CausalAttentionBias):
+            causal = True
+
+            attn_window_len = self.bias.attn_window_len
+            if attn_window_len is not None:
+                left_window = attn_window_len
+            else:
+                left_window = -1
+
+            window_size = (left_window, -1)
+        else:
+            raise NotSupportedError(f"`{Flash2SDPA}` does not support `{self.bias}`.")
+
+        if not self.training:
+            dropout_p = 0.0
+        else:
+            dropout_p = self.dropout_p
+
+        if seqs_layout.packed ^ keys_layout.packed:
+            raise ValueError("`seqs_layout` and `keys_layout` must be both packed.")
+
+        if seqs_layout.packed:
+            attns = flash_attn_varlen_func(
+                seqs,
+                keys,
+                values,
+                seqs_layout.seq_begin_indices_pt,
+                keys_layout.seq_begin_indices_pt,
+                seqs_layout.max_seq_len,
+                keys_layout.max_seq_len,
+                dropout_p,
+                causal=causal,
+                window_size=window_size,
+            )
+        else:
+            attns = flash_attn_func(
+                seqs, keys, values, dropout_p, causal=causal, window_size=window_size
+            )
+
+        attns = cast(Tensor, attns)
+
+        return attns, None
+
+    def extra_repr(self) -> str:
+        """:meta private:"""
+        s = super().extra_repr()
+
+        return f"{s}, dropout_p={self.dropout_p:G}"

--- a/src/fairseq2/models/transformer/_sdpa/_flash3.py
+++ b/src/fairseq2/models/transformer/_sdpa/_flash3.py
@@ -1,0 +1,522 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from typing import Any, cast, final
+
+import torch
+from torch import Tensor
+from typing_extensions import override
+
+try:
+    import flash_attn_3_cuda  # type: ignore[import-not-found]
+except ImportError:
+    _has_flash_attn_3 = False
+else:
+    _has_flash_attn_3 = True
+
+from fairseq2.error import NotSupportedError
+from fairseq2.nn import BatchLayout
+
+# isort: split
+
+from fairseq2.models.transformer._attention_bias import (
+    AttentionBias,
+    AttentionBiasCache,
+    CausalAttentionBias,
+    IdentityBias,
+)
+from fairseq2.models.transformer._sdpa._base import SDPA
+
+
+@final
+class Flash3SDPA(SDPA):
+    """Computes scaled dot-product attention using FlashAttention3."""
+
+    dropout_p: float
+
+    def __init__(self, bias: AttentionBias, *, dropout_p: float = 0.0) -> None:
+        """
+        :param dropout_p: The dropout probability on attention weights.
+        """
+        super().__init__(bias)
+
+        self.dropout_p = dropout_p
+
+    @override
+    def forward(
+        self,
+        seqs: Tensor,
+        seqs_layout: BatchLayout,
+        keys: Tensor,
+        keys_layout: BatchLayout,
+        values: Tensor,
+        bias_cache: AttentionBiasCache,
+        *,
+        needs_weights: bool = False,
+    ) -> tuple[Tensor, Tensor | None]:
+        if not _has_flash_attn_3:
+            raise RuntimeError(
+                "FlashAttention3 is not found in your Python environment. Follow instructions at https://github.com/Dao-AILab/flash-attention to install."
+            )
+
+        if seqs_layout.padded or keys_layout.padded:
+            raise NotSupportedError(f"`{Flash3SDPA}` does not support padded batches.")
+
+        if isinstance(self.bias, IdentityBias):
+            causal = False
+
+            lhs_window_size = -1
+        elif isinstance(self.bias, CausalAttentionBias):
+            causal = True
+
+            attn_window_len = self.bias.attn_window_len
+            if attn_window_len is not None:
+                lhs_window_size = attn_window_len
+            else:
+                lhs_window_size = -1
+        else:
+            raise NotSupportedError(f"`{Flash3SDPA}` does not support `{self.bias}`.")
+
+        if not self.training:
+            dropout_p = 0.0
+        else:
+            dropout_p = self.dropout_p
+
+        if dropout_p != 0.0:
+            raise NotSupportedError(f"`{Flash3SDPA}` does not support dropout.")
+
+        if seqs_layout.packed ^ keys_layout.packed:
+            raise ValueError("`seqs_layout` and `keys_layout` must be both packed.")
+
+        if seqs_layout.packed:
+            attns = flash_attn_3_varlen(
+                seqs,
+                keys,
+                values,
+                seqs_layout.seq_begin_indices_pt,
+                keys_layout.seq_begin_indices_pt,
+                seqs_layout.max_seq_len,
+                keys_layout.max_seq_len,
+                causal=causal,
+                lhs_window_size=lhs_window_size,
+            )
+        else:
+            attns = flash_attn_3(
+                seqs, keys, values, causal=causal, lhs_window_size=lhs_window_size
+            )
+
+        return attns, None
+
+    def extra_repr(self) -> str:
+        """:meta private:"""
+        s = super().extra_repr()
+
+        return f"{s}, dropout_p={self.dropout_p:G}"
+
+
+def flash_attn_3(
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    *,
+    softmax_scale: float | None = None,
+    causal: bool = False,
+    lhs_window_size: int = -1,
+    rhs_window_size: int = -1,
+) -> Tensor:
+    if softmax_scale is None:
+        softmax_scale = q.shape[-1] ** -0.5
+
+    attns, _ = _flash_attn_3_op(
+        q, k, v, softmax_scale, causal, lhs_window_size, rhs_window_size
+    )
+
+    return cast(Tensor, attns)
+
+
+@torch.library.custom_op(
+    "fairseq2::_flash_attn_3", mutates_args=(), device_types="cuda"
+)
+def _flash_attn_3_op(
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    softmax_scale: float | None,
+    causal: bool,
+    lhs_window_size: int,
+    rhs_window_size: int,
+) -> tuple[Tensor, Tensor]:
+    q = _contiguous(q)
+    k = _contiguous(k)
+    v = _contiguous(v)
+
+    # fmt: off
+    out, softmax_lse, *_ = flash_attn_3_cuda.fwd(
+        q,
+        k,
+        v,
+        None, # k_new
+        None, # v_new
+        None, # qv
+        None, # out
+        None, # cu_seqlens_q
+        None, # cu_seqlens_k
+        None, # cu_seqlens_k_new
+        None, # seqused_q
+        None, # seqused_k
+        None, # max_seqlen_q
+        None, # max_seqlen_k
+        None, # page_table
+        None, # kv_batch_idx
+        None, # leftpad_k
+        None, # rotary_cos
+        None, # rotary_sin
+        None, # seqlens_rotary
+        None, # q_descale
+        None, # k_descale
+        None, # v_descale
+        softmax_scale,
+        causal,
+        lhs_window_size,
+        rhs_window_size,
+        0,    # attention_chunk
+        0.0,  # softcap
+        True, # rotary_interleaved
+        None, # scheduler_metadata
+        1,    # num_splits
+        None, # pack_gqa
+        0,    # sm_margin
+    )
+    # fmt: on
+
+    return out, softmax_lse
+
+
+@_flash_attn_3_op.register_fake
+def _flash_attn_3_fake(
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    softmax_scale: float | None,
+    causal: bool,
+    lhs_window_size: int,
+    rhs_window_size: int,
+) -> tuple[Tensor, Tensor]:
+    out = torch.empty_like(q)
+
+    batch_size, seqlen_q, num_heads, head_size = q.shape
+
+    softmax_shp = (batch_size, num_heads, seqlen_q)
+
+    softmax_lse = torch.empty(
+        softmax_shp, dtype=torch.float32, device=q.device, layout=q.layout
+    )
+
+    return out, softmax_lse
+
+
+def _flash_attn_3_ctx(ctx: Any, inputs: tuple[Any, ...], output: Any) -> None:
+    q, k, v, softmax_scale, causal, lhs_window_size, rhs_window_size = inputs
+
+    out, softmax_lse = output
+
+    ctx.save_for_backward(q, k, v, out, softmax_lse)
+
+    ctx.mark_non_differentiable(softmax_lse)
+
+    ctx.softmax_scale = softmax_scale
+    ctx.causal = causal
+    ctx.lhs_window_size = lhs_window_size
+    ctx.rhs_window_size = rhs_window_size
+
+
+def _flash_attn_3_bwd(ctx: Any, dout: Tensor, *_: Any) -> Any:
+    q, k, v, out, softmax_lse = ctx.saved_tensors
+
+    dq = torch.empty_like(q)
+    dk = torch.empty_like(k)
+    dv = torch.empty_like(q)
+
+    dout = _contiguous(dout)
+
+    _flash_attn_3_bwd_op(
+        dout,
+        q,
+        k,
+        v,
+        out,
+        softmax_lse,
+        dq,
+        dk,
+        dv,
+        None,  # cu_seqlens_q
+        None,  # cu_seqlens_k
+        None,  # max_seqlen_q
+        None,  # max_seqlen_k
+        ctx.softmax_scale,
+        ctx.causal,
+        ctx.lhs_window_size,
+        ctx.rhs_window_size,
+    )
+
+    dq = dq[..., : q.shape[-1]]
+    dk = dk[..., : k.shape[-1]]
+    dv = dv[..., : v.shape[-1]]
+
+    return dq, dk, dv, None, None, None, None
+
+
+_flash_attn_3_op.register_autograd(_flash_attn_3_bwd, setup_context=_flash_attn_3_ctx)
+
+
+def flash_attn_3_varlen(
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    cu_seqlens_q: Tensor,
+    cu_seqlens_k: Tensor,
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+    *,
+    softmax_scale: float | None = None,
+    causal: bool = False,
+    lhs_window_size: int = -1,
+    rhs_window_size: int = -1,
+) -> Tensor:
+    if softmax_scale is None:
+        softmax_scale = q.shape[-1] ** -0.5
+
+    attns, _ = _flash_attn_3_varlen_op(
+        q,
+        k,
+        v,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        max_seqlen_q,
+        max_seqlen_k,
+        softmax_scale,
+        causal,
+        lhs_window_size,
+        rhs_window_size,
+    )
+
+    return cast(Tensor, attns)
+
+
+@torch.library.custom_op(
+    "fairseq2::_flash_attn_3_varlen", mutates_args=(), device_types="cuda"
+)
+def _flash_attn_3_varlen_op(
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    cu_seqlens_q: Tensor,
+    cu_seqlens_k: Tensor,
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+    softmax_scale: float | None,
+    causal: bool,
+    lhs_window_size: int,
+    rhs_window_size: int,
+) -> tuple[Tensor, Tensor]:
+    q = _contiguous(q)
+    k = _contiguous(k)
+    v = _contiguous(v)
+
+    cu_seqlens_q = _contiguous(cu_seqlens_q)
+    cu_seqlens_k = _contiguous(cu_seqlens_k)
+
+    # fmt: off
+    out, softmax_lse, *_ = flash_attn_3_cuda.fwd(
+        q,
+        k,
+        v,
+        None, # k_new
+        None, # v_new
+        None, # qv
+        None, # out
+        cu_seqlens_q,
+        cu_seqlens_k,
+        None, # cu_seqlens_k_new
+        None, # seqused_q
+        None, # seqused_k
+        max_seqlen_q,
+        max_seqlen_k,
+        None, # page_table
+        None, # kv_batch_idx
+        None, # leftpad_k
+        None, # rotary_cos
+        None, # rotary_sin
+        None, # seqlens_rotary
+        None, # q_descale
+        None, # k_descale
+        None, # v_descale
+        softmax_scale,
+        causal,
+        lhs_window_size,
+        rhs_window_size,
+        0,    # attention_chunk
+        0.0,  # softcap
+        True, # rotary_interleaved
+        None, # scheduler_metadata
+        1,    # num_splits
+        None, # pack_gqa
+        0,    # sm_margin
+    )
+    # fmt: on
+
+    return out, softmax_lse
+
+
+@_flash_attn_3_varlen_op.register_fake
+def _flash_attn_3_varlen_fake(
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    cu_seqlens_q: Tensor,
+    cu_seqlens_k: Tensor,
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+    softmax_scale: float | None,
+    causal: bool,
+    lhs_window_size: int,
+    rhs_window_size: int,
+) -> tuple[Tensor, Tensor]:
+    out = torch.empty_like(q)
+
+    seqlen_q, num_heads, head_size = q.shape
+
+    softmax_lse = torch.empty(
+        (num_heads, seqlen_q), dtype=torch.float32, device=q.device, layout=q.layout
+    )
+
+    return out, softmax_lse
+
+
+def _flash_attn_3_varlen_ctx(ctx: Any, inputs: tuple[Any, ...], output: Any) -> None:
+    (
+        q,
+        k,
+        v,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        max_seqlen_q,
+        max_seqlen_k,
+        softmax_scale,
+        causal,
+        lhs_window_size,
+        rhs_window_size,
+    ) = inputs
+
+    out, softmax_lse = output
+
+    ctx.save_for_backward(q, k, v, cu_seqlens_q, cu_seqlens_k, out, softmax_lse)
+
+    ctx.mark_non_differentiable(softmax_lse)
+
+    ctx.max_seqlen_q = max_seqlen_q
+    ctx.max_seqlen_k = max_seqlen_k
+    ctx.softmax_scale = softmax_scale
+    ctx.causal = causal
+    ctx.lhs_window_size = lhs_window_size
+    ctx.rhs_window_size = rhs_window_size
+
+
+def _flash_attn_3_varlen_bwd(ctx: Any, dout: Tensor, *_: Any) -> Any:
+    q, k, v, cu_seqlens_q, cu_seqlens_k, out, softmax_lse = ctx.saved_tensors
+
+    dq = torch.empty_like(q)
+    dk = torch.empty_like(k)
+    dv = torch.empty_like(q)
+
+    dout = _contiguous(dout)
+
+    _flash_attn_3_bwd_op(
+        dout,
+        q,
+        k,
+        v,
+        out,
+        softmax_lse,
+        dq,
+        dk,
+        dv,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        ctx.max_seqlen_q,
+        ctx.max_seqlen_k,
+        ctx.softmax_scale,
+        ctx.causal,
+        ctx.lhs_window_size,
+        ctx.rhs_window_size,
+    )
+
+    dq = dq[..., : q.shape[-1]]
+    dk = dk[..., : k.shape[-1]]
+    dv = dv[..., : v.shape[-1]]
+
+    return dq, dk, dv, None, None, None, None, None, None, None, None
+
+
+_flash_attn_3_varlen_op.register_autograd(
+    _flash_attn_3_varlen_bwd, setup_context=_flash_attn_3_varlen_ctx
+)
+
+
+@torch.library.custom_op(
+    "fairseq2::_flash_attn_3_bwd", mutates_args=("dq", "dk", "dv"), device_types="cuda"
+)
+def _flash_attn_3_bwd_op(
+    dout: Tensor,
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    out: Tensor,
+    softmax_lse: Tensor,
+    dq: Tensor,
+    dk: Tensor,
+    dv: Tensor,
+    cu_seqlens_q: Tensor | None,
+    cu_seqlens_k: Tensor | None,
+    max_seqlen_q: int | None,
+    max_seqlen_k: int | None,
+    softmax_scale: float,
+    causal: bool,
+    lhs_window_size: int,
+    rhs_window_size: int,
+) -> None:
+    # fmt: off
+    flash_attn_3_cuda.bwd(
+        dout,
+        q,
+        k,
+        v,
+        out,
+        softmax_lse,
+        dq,
+        dk,
+        dv,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        None, # seqused_q
+        None, # seqused_k
+        max_seqlen_q,
+        max_seqlen_k,
+        softmax_scale,
+        causal,
+        lhs_window_size,
+        rhs_window_size,
+        0.0,   # softcap
+        False, # deterministic,
+        0,     # sm_margin,
+    )
+    # fmt: on
+
+
+def _contiguous(x: Tensor) -> Tensor:
+    return x.contiguous() if x.stride(-1) != 1 else x

--- a/src/fairseq2/nn/_normalization.py
+++ b/src/fairseq2/nn/_normalization.py
@@ -17,15 +17,15 @@ from torch.nn import Module, Parameter
 from torch.nn.functional import layer_norm
 from typing_extensions import override
 
-from fairseq2.data_type import DataType
-from fairseq2.device import Device
-
 try:
     from torch.nn.functional import rms_norm as torch_rms_norm  # type: ignore[import]
-
-    _has_torch_rms_norm = True
 except ImportError:
     _has_torch_rms_norm = False
+else:
+    _has_torch_rms_norm = True
+
+from fairseq2.data_type import DataType
+from fairseq2.device import Device
 
 
 class LayerNorm(Module, ABC):

--- a/src/fairseq2/nn/_position_encoder.py
+++ b/src/fairseq2/nn/_position_encoder.py
@@ -76,19 +76,18 @@ class PositionEncoder(Module, ABC):
         :returns: The input sequences with positional information encoded.
             *Shape:* Same as ``seqs``.
         """
-        if not torch.compiler.is_compiling():
-            if self.max_seq_len is not None:
-                if not self.training and state_bag is not None:
-                    start_step = state_bag.step_nr
-                else:
-                    start_step = 0
+        if self.max_seq_len is not None:
+            if not self.training and state_bag is not None:
+                start_step = state_bag.step_nr
+            else:
+                start_step = 0
 
-                max_seq_len = start_step + seqs_layout.max_seq_len
+            max_seq_len = start_step + seqs_layout.max_seq_len
 
-                if max_seq_len > self.max_seq_len:
-                    raise ValueError(
-                        f"The lengths of all sequences in `seqs` must be less than or equal to the maximum sequence length ({self.max_seq_len}), but at least one sequence has a length of {max_seq_len} instead."
-                    )
+            if max_seq_len > self.max_seq_len:
+                raise ValueError(
+                    f"The lengths of all sequences in `seqs` must be less than or equal to the maximum sequence length ({self.max_seq_len}), but at least one sequence has a length of {max_seq_len} instead."
+                )
 
         return self._do_forward(seqs, seqs_layout, state_bag)
 

--- a/src/fairseq2/recipes/common/_model.py
+++ b/src/fairseq2/recipes/common/_model.py
@@ -697,6 +697,8 @@ def prepare_model(
     model_section: ModelSection,
     trainer_section: TrainerSection,
 ) -> Model:
+    # Apply AC before torch.compile() so that min-cut partitioner can see the AC
+    # information and avoid recomputing twice.
     if trainer_section.activation_checkpointing == "layerwise":
         if not model.handler.supports_activation_checkpointing:
             raise ActivationCheckpointingNotSupportedError(model.name)
@@ -715,7 +717,7 @@ def compile_model(model: Model, options_section: CompileOptionsSection) -> None:
     if not model.handler.supports_compilation:
         raise ModelCompilationNotSupportedError(model.name)
 
-    log.info("Compiling '{}' model.", model.name)
+    log.info("Applying torch.compile() to '{}' model.", model.name)
 
     try:
         model.handler.compile(

--- a/src/fairseq2/recipes/common/_torch.py
+++ b/src/fairseq2/recipes/common/_torch.py
@@ -13,7 +13,13 @@ import torch
 
 from fairseq2.context import RuntimeContext
 from fairseq2.logging import log
-from fairseq2.models.transformer import NaiveSDPA, TorchSDPA, set_default_sdpa_factory
+from fairseq2.models.transformer import (
+    Flash2SDPA,
+    Flash3SDPA,
+    NaiveSDPA,
+    TorchSDPA,
+    set_default_sdpa_factory,
+)
 from fairseq2.recipes import RecipeError
 from fairseq2.recipes.config import TorchSection
 from fairseq2.utils.env import get_rank
@@ -131,6 +137,10 @@ def _set_default_sdpa_variant(name: str) -> None:
                 _set_torch_sdpa_backend(backend)
             except (ImportError, AttributeError):
                 log.warning("PyTorch SDPA kernel cannot be set to '{}'. Falling back to auto mode.", backend)  # fmt: skip
+        case "flash2":
+            set_default_sdpa_factory(Flash2SDPA)
+        case "flash3":
+            set_default_sdpa_factory(Flash3SDPA)
         case "naive":
             set_default_sdpa_factory(NaiveSDPA)
         case _:

--- a/src/fairseq2/recipes/config.py
+++ b/src/fairseq2/recipes/config.py
@@ -424,6 +424,8 @@ SDPAVariant: TypeAlias = Literal[
     "torch_math",
     "torch_mem_efficient",
     "torch_flash",
+    "flash2",
+    "flash3",
     "naive",
 ]
 

--- a/src/fairseq2/recipes/lm/_train.py
+++ b/src/fairseq2/recipes/lm/_train.py
@@ -67,7 +67,7 @@ class LMTrainConfig:
             family="llama",
             arch="llama3_8b",
             compile=True,
-            compile_options=CompileOptionsSection(fullgraph=False, dynamic=False),
+            compile_options=CompileOptionsSection(fullgraph=True, dynamic=False),
         )
     )
 
@@ -121,7 +121,7 @@ class LMTrainConfig:
     common: CommonSection = field(
         default_factory=lambda: CommonSection(
             torch=TorchSection(
-                default_sdpa="torch", compiled_region_activation_memory_budget=0.9
+                default_sdpa="flash2", compiled_region_activation_memory_budget=0.9
             )
         )
     )

--- a/src/fairseq2/utils/tensor.py
+++ b/src/fairseq2/utils/tensor.py
@@ -19,12 +19,12 @@ TensorData: TypeAlias = int | float | Sequence[int] | Sequence[float]
 
 
 def to_tensor(
-    data: TensorData, device: Device | None = None, dtype: DataType | None = None
+    data: TensorData, *, dtype: DataType | None = None, device: Device | None = None
 ) -> Tensor:
     if device is None or device.type != "cuda":
         return torch.tensor(data, dtype=dtype, device=device)
 
-    t = torch.tensor(data, device=CPU, pin_memory=True)
+    t = torch.tensor(data, dtype=dtype, device=CPU, pin_memory=True)
 
     return t.to(device, non_blocking=True)
 


### PR DESCRIPTION
This PR introduces support for FlashAttention3 with some smaller related changes. The implementation uses the new custom op APIs of PyTorch and integrates well with torch.compile (unlike the Python API in the official flash_attn repo)