### PR TITLE
Introduce validate_at_start

### DIFF
--- a/src/fairseq2/nn/utils/mask.py
+++ b/src/fairseq2/nn/utils/mask.py
@@ -28,7 +28,7 @@ def apply_mask(
 
     :returns: The input sequences with mask applied. *Shape:* Same as ``seqs``.
     """
-    unsqueeze(mask, dim=-1, count=seqs.ndim - mask.ndim)
+    mask = unsqueeze(mask, dim=-1, count=seqs.ndim - mask.ndim)
 
     return seqs.where(mask, fill_value)
 
@@ -95,7 +95,7 @@ def compute_row_mask(
         )
     else:
         # (N)
-        row_lens = row_lens.view(num_rows)
+        row_lens = row_lens.to(torch.int64).view(num_rows)
 
         # We only mask rows that are longer than the mask span length.
         if (span_len >= row_lens).any():

--- a/src/fairseq2/recipes/_validator.py
+++ b/src/fairseq2/recipes/_validator.py
@@ -538,8 +538,8 @@ class StandardValidator(Validator, Generic[BatchT]):
 @final
 class NoopValidator(Validator):
     @override
-    def run(self, train_step_nr: int, train_data_epoch_nr: int) -> float:
-        return -torch.inf
+    def run(self, train_step_nr: int, train_data_epoch_nr: int) -> float | None:
+        return None
 
     @override
     def reset(self) -> None:

--- a/src/fairseq2/recipes/common/_trainer.py
+++ b/src/fairseq2/recipes/common/_trainer.py
@@ -119,6 +119,7 @@ def create_trainer(
         max_num_steps=regime_section.num_steps,
         max_num_data_epochs=regime_section.num_data_epochs,
         validator=validator,
+        validate_at_start=regime_section.validate_at_start,
         validate_after_n_steps=regime_section.validate_after_n_steps,
         validate_every_n_steps=regime_section.validate_every_n_steps,
         validate_after_n_data_epochs=regime_section.validate_after_n_data_epochs,

--- a/src/fairseq2/recipes/config.py
+++ b/src/fairseq2/recipes/config.py
@@ -234,6 +234,9 @@ class RegimeSection:
     num_data_epochs: int | None = None
     """The maximum number of data epochs to train for."""
 
+    validate_at_start: bool = False
+    """If ``True``, runs validation before starting training."""
+
     validate_after_n_steps: int = 0
     """The number of steps after which to start validating the model."""
 

--- a/src/fairseq2/recipes/wav2vec2/asr/_train.py
+++ b/src/fairseq2/recipes/wav2vec2/asr/_train.py
@@ -105,7 +105,7 @@ class Wav2Vec2AsrTrainConfig:
     regime: RegimeSection = field(
         default_factory=lambda: RegimeSection(
             num_steps=20_000,
-            validate_after_n_steps=10_000,
+            validate_after_n_steps=9999,
             validate_every_n_steps=1_000,
             publish_metrics_every_n_steps=200,
         )


### PR DESCRIPTION
This PR introduces support for a new recipe option called `validate_at_start`. This is in particular useful for finetuning jobs where an initial pre-validation gives baseline metrics for the rest of the finetuning.