### PR TITLE
Jacklanchantin/no offline sync

### DIFF
--- a/src/fairseq2/recipes/lm/_online_finetune/_recipe.py
+++ b/src/fairseq2/recipes/lm/_online_finetune/_recipe.py
@@ -297,7 +297,8 @@ def load_online_finetuner(
 
     unit = unit_handler.create(model, gangs, config, vllm_actors)
     try:
-        unit.maybe_sync_models(force_sync_vllm=True)
+        if unit._sync_vllm_model_every_n_steps >= 0:
+            unit.maybe_sync_models(force_sync_vllm=True)
     except AttributeError:
         raise RuntimeError("Train unit does not support maybe_sync_models")
 


### PR DESCRIPTION
**What does this PR do? Please describe:**
If we want to simulate offline training in online pipeline, then we can't force sync vllm rollout model

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
