### PR TITLE
Fix CTC model and batch type issue

### DIFF
--- a/src/fairseq2/models/wav2vec2/asr/_model.py
+++ b/src/fairseq2/models/wav2vec2/asr/_model.py
@@ -8,6 +8,9 @@ from __future__ import annotations
 
 from typing import final
 
+from torch.nn import Dropout
+from typing_extensions import override
+
 from fairseq2.models.asr import AsrModel, AsrModelOutput
 from fairseq2.models.seq2seq import Seq2SeqBatch
 from fairseq2.models.sequence import SequenceBatch
@@ -15,9 +18,6 @@ from fairseq2.models.transformer import TransformerEncoder
 from fairseq2.models.wav2vec2 import Wav2Vec2Frontend, Wav2Vec2Masker
 from fairseq2.nn import Projection
 from fairseq2.typing import DataType, Device
-
-from torch.nn import Dropout
-from typing_extensions import override
 
 
 @final
@@ -71,7 +71,13 @@ class Wav2Vec2AsrModel(AsrModel):
         :param batch:
             The batch of sequences to process.
         """
-        assert isinstance(batch, SequenceBatch)
+        if isinstance(batch, Seq2SeqBatch):
+            batch = SequenceBatch(
+                seqs=batch.source_seqs,
+                padding_mask=batch.source_padding_mask,
+                example=batch.example,
+            )
+
         seqs, padding_mask, _ = self.encoder_frontend.extract_features(
             batch.seqs, batch.padding_mask
         )

--- a/src/fairseq2/recipes/asr/_common.py
+++ b/src/fairseq2/recipes/asr/_common.py
@@ -7,9 +7,11 @@
 from __future__ import annotations
 
 import math
-from typing import Any, Dict, final, TextIO
+from typing import Any, Dict, TextIO, final
 
 import torch
+from torch import Tensor
+from typing_extensions import override
 
 from fairseq2.data.text.tokenizers import TextTokenDecoder, TextTokenizer
 from fairseq2.gang import Gang
@@ -18,10 +20,7 @@ from fairseq2.metrics.text import WerMetric
 from fairseq2.models.asr import AsrModel, AsrModelOutput
 from fairseq2.models.seq2seq import Seq2SeqBatch
 from fairseq2.models.sequence import SequenceBatch
-from fairseq2.models.wav2vec2.asr import Wav2Vec2AsrModel
 from fairseq2.recipes import BaseMetricBag, Model, UnitError
-from torch import Tensor
-from typing_extensions import override
 
 
 @final
@@ -42,14 +41,7 @@ class AsrCriterion:
     def __call__(
         self, batch: Seq2SeqBatch, metric_bag: AsrMetricBag
     ) -> tuple[Tensor, int]:
-        if isinstance(self._model.module, Wav2Vec2AsrModel):
-            input_batch: SequenceBatch | Seq2SeqBatch = SequenceBatch(
-                batch.source_seqs, batch.source_padding_mask
-            )
-        else:
-            input_batch = batch
-
-        output = self._forward(input_batch)
+        output = self._forward(batch)
 
         loss, extra_metrics = output.compute_loss(
             batch.target_seqs, batch.target_padding_mask


### PR DESCRIPTION
Fix issue in CTC training that was caused by github.com/facebookresearch/fairseq2/pull/1140

Now we always send a Seq2SeqBatch to the model forward, and the CTC model converts it to a SequenceBatch. 