### PR TITLE
replicas support added to vllm models

### DIFF
--- a/src/fairseq2/recipes/lm/_online_finetune/_group_dpo.py
+++ b/src/fairseq2/recipes/lm/_online_finetune/_group_dpo.py
@@ -418,11 +418,11 @@ class GroupDpoFinetuneUnit(TrainUnit[SequenceBatch]):
                     ref_rejected_logps_i[rejected_ii],
                 )
                 batch_loss.append(dpo_single_pair)
-            loss_to_sum.append(sum(batch_loss)/len(batch_loss))
+            loss_to_sum.append(sum(batch_loss) / len(batch_loss))
 
         if len(loss_to_sum) == 0:
             # dummy batch
-            loss_to_sum = [logps.sum()*0.0]  # dummy loss to zero out
+            loss_to_sum = [logps.sum() * 0.0]  # dummy loss to zero out
             loss_zeroer = 0.0
         else:
             loss_zeroer = 1.0

--- a/src/fairseq2/recipes/lm/_online_finetune/_online_dpo.py
+++ b/src/fairseq2/recipes/lm/_online_finetune/_online_dpo.py
@@ -336,10 +336,7 @@ class OnlineDpoFinetuneUnit(TrainUnit[SequenceBatch]):
             )
 
         loss = (
-            dpo_loss
-            + self._loss_config.nll_scale
-            * nll_loss
-            + max_entropy_regularizer
+            dpo_loss + self._loss_config.nll_scale * nll_loss + max_entropy_regularizer
         )  # nll normalization applied locally per-rank
 
         loss = loss * loss_zeroer  # zero loss if entire batch was dummy batch
@@ -557,7 +554,7 @@ class OnlineDpoFinetuneUnitHandler(OnlineFinetuneUnitHandler):
             reference_model = vllm_actors[config.reference_model]
             reference_offload = True
             if config.sync_ref_model_every_n_steps != -1:
-                if reference_model and reference_model.update_process_group is None:
+                if reference_model and reference_model.update_process_groups is None:
                     raise ValueError(
                         f"Reference model actor must have update process group if we sync weights"
                     )

--- a/src/fairseq2/recipes/lm/_online_finetune/_recipe.py
+++ b/src/fairseq2/recipes/lm/_online_finetune/_recipe.py
@@ -296,6 +296,7 @@ def load_online_finetuner(
         raise UnknownOnlineFinetuneUnitError(config.criterion.name) from None
 
     unit = unit_handler.create(model, gangs, config, vllm_actors)
+
     try:
         if unit._sync_vllm_model_every_n_steps >= 0:
             unit.maybe_sync_models(force_sync_vllm=True)


### PR DESCRIPTION
**What does this PR do? Please describe:**

RemoteVllmModel is now capable of having nun_replicas number of vllm actors. Rollout generation and weight sync is all done internally, i.e., recipe code does not require any changes. Default setting is 1 replica i.e. existing configs expected to be working as is.
