### PR TITLE
safetensor loader speedup

### DIFF
--- a/src/fairseq2/models/_checkpoint.py
+++ b/src/fairseq2/models/_checkpoint.py
@@ -354,7 +354,7 @@ class ShardedCheckpointLoader(CheckpointLoader):
                 for dp_file in dp_files:
                     try:
                         dp_checkpoint = self._tensor_loader.load(
-                            dp_file, restrict=restrict, mmap=True
+                            dp_file, restrict=restrict, map_location=CPU, mmap=True
                         )
                     except (FileNotFoundError, TensorLoadError) as ex:
                         raise CheckpointError(
@@ -564,7 +564,7 @@ class LLaMACheckpointLoader(CheckpointLoader):
         for tp_file in tp_files:
             try:
                 tp_checkpoint = self._tensor_loader.load(
-                    tp_file, restrict=restrict, mmap=True
+                    tp_file, restrict=restrict, map_location=CPU, mmap=True
                 )
             except (FileNotFoundError, TensorLoadError) as ex:
                 raise CheckpointError(

--- a/src/fairseq2/utils/io.py
+++ b/src/fairseq2/utils/io.py
@@ -168,8 +168,8 @@ class HuggingFaceSafetensorsLoader(SafetensorsLoader):
         try:
             with open(file, "rb") as f:
                 tensors = safetensors_torch.load(f.read())
-                for key, tensor in tensors.items():
-                    tensors[key] = tensor.to(str(device))
+            for key, tensor in tensors.items():
+                tensors[key] = tensor.to(str(device))
 
         except FileNotFoundError:
             raise

--- a/src/fairseq2/utils/io.py
+++ b/src/fairseq2/utils/io.py
@@ -18,7 +18,7 @@ from torch import Tensor
 from typing_extensions import override
 
 try:
-    from safetensors import torch as safetensors_torch
+    from safetensors import torch as safetensors_torch  # type: ignore[import-not-found]
 except ImportError:
     _has_safetensors = False
 else:

--- a/src/fairseq2/utils/io.py
+++ b/src/fairseq2/utils/io.py
@@ -18,7 +18,6 @@ from torch import Tensor
 from typing_extensions import override
 
 try:
-    import safetensors  # type: ignore[import-not-found]
     from safetensors import torch as safetensors_torch
 except ImportError:
     _has_safetensors = False

--- a/src/fairseq2/utils/io.py
+++ b/src/fairseq2/utils/io.py
@@ -168,7 +168,7 @@ class HuggingFaceSafetensorsLoader(SafetensorsLoader):
             with open(file, "rb") as f:
                 tensors = safetensors_torch.load(f.read())
             for key, tensor in tensors.items():
-                tensors[key] = tensor.to(str(device))
+                tensors[key] = tensor.to(device)
 
         except FileNotFoundError:
             raise

--- a/src/fairseq2/utils/io.py
+++ b/src/fairseq2/utils/io.py
@@ -19,6 +19,7 @@ from typing_extensions import override
 
 try:
     import safetensors  # type: ignore[import-not-found]
+    from safetensors import torch as safetensors_torch
 except ImportError:
     _has_safetensors = False
 else:
@@ -165,9 +166,11 @@ class HuggingFaceSafetensorsLoader(SafetensorsLoader):
         tensors = {}
 
         try:
-            with safetensors.safe_open(file, framework="pt", device=str(device)) as f:
-                for key in f.keys():
-                    tensors[key] = f.get_tensor(key)
+            with open(file, "rb") as f:
+                tensors = safetensors_torch.load(f.read())
+                for key, tensor in tensors.items():
+                    tensors[key] = tensor.to(str(device))
+
         except FileNotFoundError:
             raise
         except (RuntimeError, OSError, PickleError) as ex:


### PR DESCRIPTION
**What does this PR do? Please describe:**

existing safetensor loader has some issues with loading shards from network filesystems. More discussion here: https://github.com/huggingface/safetensors/issues/562

So we will follow the standard fix approach where we first load shard to RAM entirely and then operate as we wish. From testing this substantially speeds up ckpt loading time.