### PR TITLE
qwen: fix export keymap by reusing and reversing existing importing key map

### DIFF
--- a/src/fairseq2/models/qwen/_checkpoint.py
+++ b/src/fairseq2/models/qwen/_checkpoint.py
@@ -12,13 +12,8 @@ from fairseq2.models.utils.checkpoint import convert_checkpoint
 
 from fairseq2.models.qwen._config import QwenConfig
 
-
-def convert_qwen_checkpoint(
-    checkpoint: dict[str, object], config: QwenConfig
-) -> dict[str, object]:
-    if "model.embed_tokens.weight" in checkpoint:  # Hugging Face
-        key_map = {
-            # fmt: off
+QWEN_KEY_MAP = {
+    # fmt: off
             r"^model\.layers\.([0-9]+)\.self_attn\.q_proj\.":        r"decoder.layers.\1.self_attn.q_proj.",
             r"^model\.layers\.([0-9]+)\.self_attn\.k_proj\.":        r"decoder.layers.\1.self_attn.k_proj.",
             r"^model\.layers\.([0-9]+)\.self_attn\.v_proj\.":        r"decoder.layers.\1.self_attn.v_proj.",
@@ -33,10 +28,15 @@ def convert_qwen_checkpoint(
             r"^model\.norm\.":                                       r"decoder.layer_norm.",
             r"^model\.embed_tokens\.":                               r"decoder_frontend.embed.",
             r"^lm_head\.":                                           r"final_proj.",
-            # fmt: on
-        }
+    # fmt: on
+}
 
-        checkpoint = convert_checkpoint(checkpoint, key_map)
+
+def convert_qwen_checkpoint(
+    checkpoint: dict[str, object], config: QwenConfig
+) -> dict[str, object]:
+    if "model.embed_tokens.weight" in checkpoint:  # Hugging Face
+        checkpoint = convert_checkpoint(checkpoint, QWEN_KEY_MAP)
 
     if config.tied_embeddings:
         checkpoint["final_proj.weight"] = checkpoint["decoder_frontend.embed.weight"]

--- a/src/fairseq2/models/qwen/_hg.py
+++ b/src/fairseq2/models/qwen/_hg.py
@@ -6,11 +6,12 @@
 
 from __future__ import annotations
 
-from fairseq2.models.utils.checkpoint import convert_checkpoint
+from fairseq2.models.utils.checkpoint import convert_checkpoint, create_reverse_key_map
 
 # isort: split
 
 from fairseq2.models.qwen._config import QwenConfig
+from fairseq2.models.qwen._checkpoint import QWEN_KEY_MAP
 
 
 def export_qwen_checkpoint(
@@ -40,24 +41,8 @@ def _convert_config(config: QwenConfig) -> dict[str, object]:
 def _convert_checkpoint(
     checkpoint: dict[str, object], config: QwenConfig
 ) -> dict[str, object]:
-    key_map = {
-        # fmt: off
-        r"^decoder\.layers\.([0-9]+)\.self_attn\.q_proj\.":      r"model.layers.\1.self_attn.q_proj.",
-        r"^decoder\.layers\.([0-9]+)\.self_attn\.k_proj\.":      r"model.layers.\1.self_attn.k_proj.",
-        r"^decoder\.layers\.([0-9]+)\.self_attn\.v_proj\.":      r"model.layers.\1.self_attn.v_proj.",
-        r"^decoder\.layers\.([0-9]+)\.self_attn\.output_proj\.": r"model.layers.\1.self_attn.o_proj.",
-        r"^decoder\.layers\.([0-9]+)\.ffn_layer_norm\.":         r"model.layers.\1.post_attention_layernorm.",
-        r"^decoder\.layers\.([0-9]+)\.ffn\.gate_proj\.":         r"model.layers.\1.mlp.gate_proj.",
-        r"^decoder\.layers\.([0-9]+)\.ffn\.output_proj\.":       r"model.layers.\1.mlp.down_proj.",
-        r"^decoder\.layers\.([0-9]+)\.ffn\.inner_proj\.":        r"model.layers.\1.mlp.up_proj.",
-        r"^decoder\.layers\.([0-9]+)\.self_attn_layer_norm\.":   r"model.layers.\1.input_layernorm.",
-        r"^decoder\.layer_norm\.":                               r"model.norm.",
-        r"^decoder_frontend\.embed\.":                           r"model.embed_tokens.",
-        r"^final_proj\.":                                        r"lm_head.",
-        # fmt: on
-    }
 
-    checkpoint = convert_checkpoint(checkpoint, key_map)
+    checkpoint = convert_checkpoint(checkpoint, create_reverse_key_map(QWEN_KEY_MAP))
 
     if config.tied_embeddings:
         del checkpoint["lm_head.weight"]

--- a/src/fairseq2/models/utils/checkpoint.py
+++ b/src/fairseq2/models/utils/checkpoint.py
@@ -144,3 +144,32 @@ def convert_fairseq_checkpoint(
         pass
 
     return fs2_checkpoint
+
+
+def create_reverse_key_map(key_map):
+    """Create a reversed version of a regex-based key map."""
+    reversed_map = {}
+
+    for pattern, replacement in key_map.items():
+        # Strip ^ from pattern if present
+        pattern_without_anchor = pattern[1:] if pattern.startswith("^") else pattern
+
+        # Create new pattern from the original replacement
+        # 1. Escape dots
+        # 2. Replace backreferences with capture groups
+        new_pattern = "^" + replacement.replace(".", r"\.").replace(r"\1", r"([0-9]+)")
+
+        # Create new replacement from original pattern
+        # Instead of string manipulation, use a simpler approach
+        # The key insight: we need \1 as a literal in the output string
+        if "([0-9]+)" in pattern_without_anchor:
+            # This is the literal representation we want in the final string
+            new_replacement = pattern_without_anchor.replace(r"([0-9]+)", r"\1")
+            # Remove escaping from dots
+            new_replacement = new_replacement.replace(r"\.", ".")
+        else:
+            new_replacement = pattern_without_anchor.replace(r"\.", ".")
+
+        reversed_map[new_pattern] = new_replacement
+
+    return reversed_map


### PR DESCRIPTION
**What does this PR do? Please describe:**

exporting logic key map had some missing maps. Now we make one source of truth keymap in checkpoint and then reverse it in the export using the reverse function from common ckpt utils.

For now this is only in QWEN, but can be adopted in llama as well if needed?
