### PR TITLE
Raise jsonl key error

### DIFF
--- a/src/fairseq2/datasets/preference.py
+++ b/src/fairseq2/datasets/preference.py
@@ -224,7 +224,13 @@ class GenericPreferenceDataset(PreferenceDataset):
                     and all(isinstance(i, str) for i in jsonl_keys)
                 ):
                     raise ValueError(f"{jsonl_keys} must be a list of strings")
-                jsonl_content = {k: example.get(k, None) for k in jsonl_keys}
+                jsonl_content = {}
+                for k in jsonl_keys:
+                    if k not in example:
+                        raise KeyError(
+                            f"Required key '{k}' not found in example dictionary."
+                        )
+                    jsonl_content[k] = example[k]
             else:
                 jsonl_content = None
 

--- a/src/fairseq2/datasets/prompt.py
+++ b/src/fairseq2/datasets/prompt.py
@@ -247,7 +247,13 @@ class GenericPromptDataset(PromptDataset):
                     and all(isinstance(i, str) for i in jsonl_keys)
                 ):
                     raise ValueError(f"{jsonl_keys} must be a list of strings")
-                jsonl_content = {k: example.get(k, None) for k in jsonl_keys}
+                jsonl_content = {}
+                for k in jsonl_keys:
+                    if k not in example:
+                        raise KeyError(
+                            f"Required key '{k}' not found in example dictionary."
+                        )
+                    jsonl_content[k] = example[k]
             else:
                 jsonl_content = None
 


### PR DESCRIPTION
**What does this PR do? Please describe:**

- We use the `keep_jsonl_keys` config arg to specify the key in the data jsonl that we want to use for input to the reward model.
- The problem is that it will not raise an error if this key is not present in each data sample
- This PR changes the code so that a KeyError is raised if each `keep_jsonl_keys` is not found in each data sample


**Check list:**
- [x] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [ ] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
