### PR TITLE
Update end_to_end_fine_tuning.rst

### DIFF
--- a/doc/source/tutorials/end_to_end_fine_tuning.rst
+++ b/doc/source/tutorials/end_to_end_fine_tuning.rst
@@ -146,7 +146,6 @@ Read more about this recipe in :ref:`tutorial-preference-optimization`.
                 path: /datasets/facebook/fairseq2-lm-gsm8k/sft
                 max_seq_len: 4096
                 max_num_tokens: 4096
-                max_seq_len: 4096
         model:
             _set_:
                 name: llama3_2_1b


### PR DESCRIPTION
Removed duplicate parameter in DPO configuration which otherwise leads to an error.

Trace for visibility:
```
> fairseq2 lm instruction_finetune $OUTPUT_DIR --config-file $CONFIG_FILE
(...)
 File "/Users/aerben/miniconda3/envs/fairseq2/lib/python3.12/site-packages/ruamel/yaml/constructor.py", line 281, in check_mapping_key
                                 raise DuplicateKeyError(*args)
                             ruamel.yaml.constructor.DuplicateKeyError: while constructing a mapping
                               in "temp.config", line 3, column 9
                             found duplicate key "max_seq_len" with value "4096" (original value: "4096")
                               in "temp.config", line 6, column 9
```

**What does this PR do? Please describe:**
A summary of the change or the issue that is fixed.

Fixes #{issue number}

**Does your PR introduce any breaking changes? If yes, please list them:**
List of all backwards-incompatible changes.

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [X] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [X] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ X Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
