### PR TITLE
Main parquet text loader

### DIFF
--- a/src/fairseq2/datasets/_config.py
+++ b/src/fairseq2/datasets/_config.py
@@ -97,6 +97,9 @@ class DataReadOptions:
     num_prefetch: int = 1
     """The number of batches to prefetch in background."""
 
+    npc: int = 10
+    """The reference number of parallel calls that data reader can do."""
+
     seed: int = 2
     """The seed to initialize the random number generators used internally."""
 

--- a/src/fairseq2/datasets/jsonl.py
+++ b/src/fairseq2/datasets/jsonl.py
@@ -14,10 +14,7 @@ from typing import Any, Final, final
 from torch import Tensor
 from typing_extensions import override
 
-from fairseq2.data import (
-    DataPipeline,
-    read_sequence,
-)
+from fairseq2.data import DataPipeline, DataPipelineBuilder, read_sequence
 from fairseq2.data.text import read_text
 from fairseq2.data.text.tokenizers import TextTokenEncoder
 from fairseq2.datasets import (
@@ -27,14 +24,11 @@ from fairseq2.datasets import (
     LengthBatching,
     SequenceBatch,
 )
-from fairseq2.datasets.text import TextDataset, TextReadOptions
+from fairseq2.datasets.text import GenericTextDataset, TextDataset, TextReadOptions
 from fairseq2.error import NotSupportedError
 from fairseq2.gang import Gang
+from fairseq2.logging import log
 from fairseq2.nn import BatchLayout
-
-# TODO: FIX, INFER
-npc = 10
-
 
 JSONL_DATASET_FAMILY: Final = "jsonl"
 
@@ -75,20 +69,32 @@ class JsonlDataset(TextDataset):
         min_seq_len: int,
         max_seq_len: int,
         options: TextReadOptions | None = None,
+        split: str | None = None,
     ) -> DataReader[SequenceBatch]:
         if options is None:
             options = TextReadOptions()
 
         file_rank = gang.rank
-
         file_world_size = gang.size
 
-        if len(self._files) < file_world_size:
+        text_column_name = options.extras.get("text_column_name", "text")
+        assert isinstance(text_column_name, str)
+
+        if min_seq_len > 0:
+            log.warning(
+                f"The `min_seq_len={min_seq_len}`  is ignored for JSONL datasets because of packing."
+            )
+
+        split_files = GenericTextDataset.filter_split(
+            self._files, split, extention="jsonl"
+        )
+
+        if len(split_files) < file_world_size:
             raise NotSupportedError(
                 "The number of dataset files must be greater than or equal to the number of world size."
             )
 
-        builder = read_sequence(self._files)
+        builder = read_sequence(split_files)
 
         if file_world_size > 1:
             builder.shard(file_rank, file_world_size, allow_uneven=True)
@@ -98,9 +104,37 @@ class JsonlDataset(TextDataset):
 
         builder.yield_from(read_file)
 
+        pipeline = JsonlDataset.build_pipeline_backend(
+            builder,
+            options,
+            text_encoder,
+            pad_idx=pad_idx,
+            max_seq_len=max_seq_len,
+            text_column_name=text_column_name,
+        )
+        return DataPipelineReader[SequenceBatch](
+            self._name, "default", pipeline, gang, options
+        )
+
+    @staticmethod
+    def build_pipeline_backend(
+        builder: DataPipelineBuilder,
+        options: TextReadOptions,
+        text_encoder: TextTokenEncoder,
+        max_seq_len: int,
+        pad_idx: int | None,
+        text_column_name: str,
+    ):
+        if pad_idx is None:
+            pad_idx = 0
+
+        seed = options.seed
+        if options.example_shuffle_window != 1:
+            builder.shuffle(options.example_shuffle_window, seed)
+
         # Tokenize.
         def encode(example: dict[str, Any]) -> Tensor:
-            return text_encoder(example["text"])
+            return text_encoder(example[text_column_name])
 
         builder.map(encode, num_parallel_calls=1)
 
@@ -110,19 +144,19 @@ class JsonlDataset(TextDataset):
             max_num_elements = batching.max_num_elements
 
             builder.pack(
-                max_num_elements + 1, max_seq_len, truncate=True, pinned_memory=True
+                max_num_elements + 1,
+                max_seq_len,
+                pad_value=pad_idx,
+                truncate=True,
+                pinned_memory=True,
             )
+            BatchLayout.compiled_max_seq_len = max_seq_len
         else:
             raise NotSupportedError(f"`{batching}` is not supported.")
-
-        BatchLayout.compiled_max_seq_len = max_seq_len
 
         # Return only the first `max_num_batches`.
         if options.max_num_batches is not None:
             builder.take(options.max_num_batches)
-
-        # Prefetch `num_prefetch` batches in background.
-        builder.prefetch(options.num_prefetch)
 
         # Convert to `SequenceBatch`.
         def to_batch(example: dict[str, Any]) -> SequenceBatch:
@@ -130,8 +164,6 @@ class JsonlDataset(TextDataset):
 
             return SequenceBatch(seqs, seq_lens, packed=True)
 
-        pipeline = builder.map(to_batch).and_return()
+        pipeline = builder.map(to_batch).prefetch(options.num_prefetch).and_return()
 
-        return DataPipelineReader[SequenceBatch](
-            self._name, "default", pipeline, gang, options
-        )
+        return pipeline

--- a/src/fairseq2/datasets/parallel_text.py
+++ b/src/fairseq2/datasets/parallel_text.py
@@ -105,10 +105,6 @@ class ParallelTextDataset(ABC):
         """Return the directions included ``split``."""
 
 
-# TODO: FIX, INFER
-npc = 10
-
-
 GENERIC_PARALLEL_TEXT_DATASET_FAMILY: Final = "generic_parallel_text"
 
 
@@ -335,7 +331,7 @@ class GenericParallelTextDataset(ParallelTextDataset):
 
             return example
 
-        builder.map(encode, num_parallel_calls=npc)
+        builder.map(encode, num_parallel_calls=1)
 
         batching = options.batching
 
@@ -393,7 +389,7 @@ class GenericParallelTextDataset(ParallelTextDataset):
             ]
         )
 
-        builder.map(collater, num_parallel_calls=npc)
+        builder.map(collater, num_parallel_calls=options.npc)
 
         # Return only the first `max_num_batches`.
         if options.max_num_batches is not None:

--- a/src/fairseq2/datasets/preference.py
+++ b/src/fairseq2/datasets/preference.py
@@ -121,10 +121,6 @@ class PreferenceDataset(ABC):
         """
 
 
-# TODO: FIX, INFER
-npc = 10
-
-
 GENERIC_PREFERENCE_DATASET_FAMILY: Final = "generic_preference"
 
 
@@ -209,9 +205,9 @@ class GenericPreferenceDataset(PreferenceDataset):
         source_encoder = tokenizer.create_encoder(mode=options.source_encode_mode)
         target_encoder = tokenizer.create_encoder(mode=options.target_encode_mode)
 
-        builder.map(source_encoder, selector="src", num_parallel_calls=npc)
-        builder.map(target_encoder, selector="tgt_chosen", num_parallel_calls=npc)
-        builder.map(target_encoder, selector="tgt_rejected", num_parallel_calls=npc)
+        builder.map(source_encoder, selector="src", num_parallel_calls=1)
+        builder.map(target_encoder, selector="tgt_chosen", num_parallel_calls=1)
+        builder.map(target_encoder, selector="tgt_rejected", num_parallel_calls=1)
 
         def cat_source_and_target(example: dict[str, Any]) -> dict[str, Any]:
             id_ = example.get("id", None)
@@ -264,7 +260,7 @@ class GenericPreferenceDataset(PreferenceDataset):
                 "keep_jsonl_keys": jsonl_content,
             }
 
-        builder.map(cat_source_and_target, num_parallel_calls=npc)
+        builder.map(cat_source_and_target, num_parallel_calls=1)
 
         batching = options.batching
 
@@ -315,7 +311,7 @@ class GenericPreferenceDataset(PreferenceDataset):
 
         collater = Collater(pad_value=0, overrides=target_mask_collate_opts)
 
-        builder.map(collater, num_parallel_calls=npc)
+        builder.map(collater, num_parallel_calls=options.npc)
 
         # Return only the first `max_num_batches`.
         if options.max_num_batches is not None:
@@ -387,7 +383,7 @@ class GenericPreferenceDataset(PreferenceDataset):
             for line in fp:
                 lines.append(line)
 
-        return read_sequence(lines).map(json.loads, num_parallel_calls=npc)
+        return read_sequence(lines).map(json.loads, num_parallel_calls=1)
 
 
 get_preference_dataset_hub = DatasetHubAccessor(PreferenceDataset)

--- a/src/fairseq2/datasets/text.py
+++ b/src/fairseq2/datasets/text.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import fnmatch
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -54,6 +55,7 @@ class TextDataset(ABC):
         min_seq_len: int,
         max_seq_len: int,
         options: TextReadOptions | None = None,
+        split: str | None = None,
     ) -> DataReader[SequenceBatch]:
         """Create a dataset reader.
 
@@ -71,11 +73,10 @@ class TextDataset(ABC):
             this value will be dropped.
         :param options:
             The read options.
+        :param split:
+            The split to read (based on files names pattern).
+            If ``None``, read files will be taken.
         """
-
-
-# TODO: FIX, INFER
-npc = 10
 
 
 GENERIC_TEXT_DATASET_FAMILY: Final = "generic_text"
@@ -114,6 +115,31 @@ class GenericTextDataset(TextDataset):
 
         return GenericTextDataset(name, files)
 
+    @staticmethod
+    def filter_split(
+        files: Sequence[Path], split: str | None, extention: str
+    ) -> Sequence[Path]:
+        """Filter the dataset files by split.
+
+        :param split:
+            The split to filter by.
+        """
+        if split is None:
+            return files
+
+        # filtering based on two following patterns:
+        pattern1 = f"**/*{split}*.{extention}"
+        pattern2 = f"*{split}*/*.{extention}"
+
+        # Filter the file paths using the patterns
+        filtered_paths = [
+            path
+            for path in files
+            if fnmatch.fnmatch(str(path), pattern1)
+            or fnmatch.fnmatch(str(path), pattern2)
+        ]
+        return filtered_paths
+
     @override
     def create_reader(
         self,
@@ -123,16 +149,20 @@ class GenericTextDataset(TextDataset):
         min_seq_len: int,
         max_seq_len: int,
         options: TextReadOptions | None = None,
+        split: str | None = None,
     ) -> DataReader[SequenceBatch]:
         if options is None:
             options = TextReadOptions()
 
         seed = options.seed
+        split_files = GenericTextDataset.filter_split(
+            self._files, split, extention="txt"
+        )
 
-        if len(self._files) == 1:
-            builder = read_text(self._files[0], key="text", rtrim=True)
+        if len(split_files) == 1:
+            builder = read_text(split_files[0], key="text", rtrim=True)
         else:
-            builder = read_sequence(self._files)
+            builder = read_sequence(split_files)
 
             def read_file(file: Path) -> DataPipeline:
                 return read_text(file, key="text", rtrim=True).and_return()
@@ -155,7 +185,7 @@ class GenericTextDataset(TextDataset):
 
             return example
 
-        builder.map(encode, num_parallel_calls=npc)
+        builder.map(encode)
 
         batching = options.batching
 
@@ -198,7 +228,7 @@ class GenericTextDataset(TextDataset):
         # Collate bucketed examples into a batch.
         collater = Collater(pad_value=pad_idx)
 
-        builder.map(collater, num_parallel_calls=npc)
+        builder.map(collater, num_parallel_calls=options.npc)
 
         # Return only the first `max_num_batches`.
         if options.max_num_batches is not None:

--- a/src/fairseq2/datasets/text_parquet.py
+++ b/src/fairseq2/datasets/text_parquet.py
@@ -1,0 +1,222 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Final, List, Set, final, override
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+from torch import Tensor
+
+from fairseq2.data import DataPipelineBuilder, read_sequence
+from fairseq2.data.parquet import (
+    FragmentLoadingConfig,
+    FragmentStreamingConfig,
+    NamedColumns,
+    ParquetFragmentLoader,
+    ParquetFragmentStreamer,
+)
+from fairseq2.data.text.tokenizers import TextTokenEncoder
+from fairseq2.datasets import DataPipelineReader, DataReader, SequenceBatch, SyncMode
+from fairseq2.datasets.jsonl import JsonlDataset
+from fairseq2.datasets.text import TextDataset, TextReadOptions
+from fairseq2.gang import Gang
+from fairseq2.logging import log
+from fairseq2.nn import BatchLayout
+
+PARQUET_TEXT_DATASET_FAMILY: Final = "parquet_text"
+
+
+@dataclass
+class DefaultTextSchema(NamedColumns):
+    """Default schema for parquet text datasets.
+    One should pass an different `text` value here if the parquet file has a different column name.
+
+    Or, alternatively, one can pass it with
+    options.extras["columns"] = DefaultTextSchema(text="my_text_column_name")
+    """
+
+    text: str = "text"
+    extra_columns: List[str] | None = None
+
+
+class ParquetDatasetInterface:
+
+    _name: str
+    _dataset: pq.ParquetDataset
+    _splits: set[str]
+    split_column: str = "split"
+
+    def __init__(self, name: str, dataset: pq.ParquetDataset, splits: set[str]) -> None:
+        self._dataset = dataset
+        self._splits = splits
+        self._name = name
+
+    @classmethod
+    def from_path(
+        cls,
+        path: Path | str | List[str | Path],
+        name: str,
+        filesystem: Any | None = None,
+    ) -> "ParquetDatasetInterface":
+
+        # from stopes.fb_config import get_filesystem_from_path
+        # if filesystem is None:
+        #     path, filesystem = get_filesystem_from_path(path)
+        dataset = pq.ParquetDataset(path, filesystem=filesystem)  # type: ignore
+
+        assert isinstance(dataset, pq.ParquetDataset)
+        partition_columns: List[str] = []
+        if dataset.partitioning is not None:
+            partition_columns = dataset.partitioning.schema.names
+
+        splits: Set[str] = set()
+        if dataset.partitioning is not None and cls.split_column in partition_columns:
+            idx = partition_columns.index(cls.split_column)
+            _splits = dataset.partitioning.dictionaries[idx]
+            if _splits is None:
+                splits = set()
+            else:
+                splits = set(_splits.to_pylist())
+
+        return cls(name, dataset, splits)
+
+    def splits(self) -> set[str]:
+        return self._splits
+
+
+@final
+class ParquetTextDataset(ParquetDatasetInterface, TextDataset):
+
+    @staticmethod
+    def get_example_loading_builder(
+        dataset: pq.ParquetDataset,
+        options: TextReadOptions,
+        split: str | None,
+        columns: NamedColumns | None,
+        rank: int,
+        world_size: int,
+        pa_cpu_count: int = 20,
+    ) -> DataPipelineBuilder:
+
+        npc = options.npc
+        pa_cpu_count = int(options.extras.get("pa_cpu_count", pa_cpu_count))  # type: ignore
+        pa.set_cpu_count(pa_cpu_count)
+        pa.set_io_thread_count(pa_cpu_count)
+
+        # Streaming
+        partition_filters = options.extras.get("partition_filters", None)
+        parquet_files: List[str] = dataset.files  # type: ignore
+
+        is_train_streaming = (split is not None) and (
+            "train" in split and options.sync_mode == SyncMode.UNTIL_FIRST
+        )  # FIXME: make it configurable
+
+        files_circular_shift = options.extras.get("files_circular_shift", False)
+        assert isinstance(files_circular_shift, bool)
+
+        fragment_shuffle_window = options.extras.get(
+            "fragment_shuffle_window", -1 if is_train_streaming else 0
+        )
+        assert isinstance(fragment_shuffle_window, int)
+
+        fragment_config = FragmentStreamingConfig(
+            parquet_path=parquet_files,
+            filesystem=dataset.filesystem,
+            nb_epochs=(None if is_train_streaming else 1),
+            partition_filters=partition_filters,  # type: ignore
+            split_to_row_groups=True,
+            files_circular_shift=files_circular_shift,
+            seed=options.seed,
+            fragment_shuffle_window=fragment_shuffle_window,
+        )
+
+        if split is not None:
+            fragment_config = fragment_config.add_partition_filter(
+                pa.compute.field("split") == split
+            )
+        fragement_builder = ParquetFragmentStreamer(
+            config=fragment_config
+        ).build_pipeline(rank=rank, world_size=world_size)
+
+        num_parallel_fragments = options.extras.get("num_parallel_fragments", npc)
+        assert isinstance(num_parallel_fragments, int)
+        assert num_parallel_fragments > 0, "num_parallel_fragments must be > 0"
+
+        columns = options.extras.get("columns", columns)  # type: ignore
+        assert columns is None or isinstance(columns, NamedColumns)
+
+        cache = options.extras.get("cache", False)
+        assert isinstance(cache, bool)
+
+        add_fragment_traces = options.extras.get("add_fragment_traces", False)
+        assert isinstance(add_fragment_traces, bool)
+
+        loading_config = FragmentLoadingConfig(
+            columns=columns,
+            add_fragment_traces=add_fragment_traces,
+            num_parallel_fragments=num_parallel_fragments,
+            nb_prefetch=options.num_prefetch,
+            non_deterministic_read=True,
+            cache=cache,
+            drop_null=False,
+            filters=None,
+        )
+
+        # load data in memory
+        builder = ParquetFragmentLoader(config=loading_config).apply(fragement_builder)
+
+        builder = builder.yield_from(
+            lambda table: read_sequence(table.to_pylist()).and_return()
+        )
+        return builder
+
+    @override
+    def create_reader(
+        self,
+        text_encoder: TextTokenEncoder,
+        pad_idx: int | None,
+        gang: Gang,
+        min_seq_len: int,
+        max_seq_len: int,
+        options: TextReadOptions | None = None,
+        split: str | None = None,
+    ) -> DataReader[SequenceBatch]:
+        if options is None:
+            options = TextReadOptions()
+        else:
+            options = deepcopy(options)
+
+        if min_seq_len > 0:
+            log.warning(
+                f"The `min_seq_len={min_seq_len}`  is ignored for JSONL datasets because of packing."
+            )
+
+        builder = ParquetTextDataset.get_example_loading_builder(
+            self._dataset,
+            options,
+            split=split,
+            columns=DefaultTextSchema(),
+            rank=gang.rank,
+            world_size=gang.size,
+        )
+        options.seed += gang.rank
+
+        pipeline = JsonlDataset.build_pipeline_backend(
+            builder,
+            options,
+            text_encoder,
+            pad_idx=pad_idx,
+            max_seq_len=max_seq_len,
+            text_column_name="text",
+        )
+        return DataPipelineReader[SequenceBatch](
+            self._name, "default", pipeline, gang, options
+        )

--- a/src/fairseq2/recipes/lm/_train.py
+++ b/src/fairseq2/recipes/lm/_train.py
@@ -128,7 +128,7 @@ class CausalLMTrainConfig:
 class TextDatasetSection(DatasetSection):
     name: str = "foo"  # TODO: change!
 
-    family: str = JSONL_DATASET_FAMILY
+    family: str = JSONL_DATASET_FAMILY  # PARQUET_TEXT_DATASET_FAMILY
 
     path: Path | None = None
 

--- a/src/fairseq2/setup/_datasets.py
+++ b/src/fairseq2/setup/_datasets.py
@@ -26,6 +26,10 @@ from fairseq2.datasets.preference import (
 )
 from fairseq2.datasets.speech import GENERIC_SPEECH_DATASET_FAMILY, GenericSpeechDataset
 from fairseq2.datasets.text import GENERIC_TEXT_DATASET_FAMILY, GenericTextDataset
+from fairseq2.datasets.text_parquet import (
+    PARQUET_TEXT_DATASET_FAMILY,
+    ParquetTextDataset,
+)
 from fairseq2.registry import Registry
 
 
@@ -73,6 +77,11 @@ def _register_dataset_families(context: RuntimeContext) -> None:
         JSONL_DATASET_FAMILY,
         JsonlDataset,
         JsonlDataset.from_path,
+    )
+    registrar.register_family(
+        PARQUET_TEXT_DATASET_FAMILY,
+        ParquetTextDataset,
+        ParquetTextDataset.from_path,
     )
     # fmt: on
 


### PR DESCRIPTION
**What does this PR do? Please describe:**
* Enable text dataloading from parquet dataset (shared at row groups levels)
* adding split to text and jsonl dataloader reader to unify the interface
* fixing npc at other different dataloader


**Does your PR introduce any breaking changes? If yes, please list them:**
No BC, only new feature

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [ ] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
