### PR TITLE
Add a basic flatten operator for data pipelines

### DIFF
--- a/native/python/src/fairseq2n/bindings/data/data_pipeline.cc
+++ b/native/python/src/fairseq2n/bindings/data/data_pipeline.cc
@@ -558,6 +558,15 @@ def_data_pipeline(py::module_ &data_module)
             },
             py::arg("num_examples"))
         .def(
+            "flatten",
+            [](data_pipeline_builder &self, std::optional<std::string> maybe_selector) -> data_pipeline_builder &
+            {
+                self = std::move(self).flatten(maybe_selector);
+
+                return self;
+            },
+            py::arg("selector") = std::nullopt)
+        .def(
             "repeat",
             [](
                 data_pipeline_builder &self,

--- a/native/src/fairseq2n/CMakeLists.txt
+++ b/native/src/fairseq2n/CMakeLists.txt
@@ -32,6 +32,7 @@ target_sources(fairseq2n
         data/file_mapper.cc
         data/file_stream.cc
         data/filter_data_source.cc
+        data/flatten_data_source.cc
         data/immutable_string.cc
         data/list_data_source.cc
         data/map_data_source.cc

--- a/native/src/fairseq2n/data/data_pipeline.cc
+++ b/native/src/fairseq2n/data/data_pipeline.cc
@@ -21,6 +21,7 @@
 #include "fairseq2n/data/detail/file_system.h"
 #include "fairseq2n/data/dynamic_bucket_data_source.h"
 #include "fairseq2n/data/filter_data_source.h"
+#include "fairseq2n/data/flatten_data_source.h"
 #include "fairseq2n/data/list_data_source.h"
 #include "fairseq2n/data/map_data_source.h"
 #include "fairseq2n/data/prefetch_data_source.h"
@@ -478,6 +479,17 @@ data_pipeline_builder::prefetch(std::size_t num_examples) &&
     factory_ = [=, inner = std::move(factory_)]
     {
         return std::make_unique<prefetch_data_source>(inner(), num_examples);
+    };
+
+    return std::move(*this);
+}
+
+data_pipeline_builder
+data_pipeline_builder::flatten(std::optional<std::string> selector) &&
+{
+    factory_ = [selector = std::move(selector), inner = std::move(factory_)]
+    {
+        return std::make_unique<flatten_data_source>(inner(), selector);
     };
 
     return std::move(*this);

--- a/native/src/fairseq2n/data/data_pipeline.h
+++ b/native/src/fairseq2n/data/data_pipeline.h
@@ -173,6 +173,9 @@ public:
     prefetch(std::size_t num_examples) &&;
 
     data_pipeline_builder
+    flatten(std::optional<std::string> selector = std::nullopt) &&;
+
+    data_pipeline_builder
     repeat(std::optional<std::size_t> num_repeats = std::nullopt, bool reset_rng = false) &&;
 
     data_pipeline_builder

--- a/native/src/fairseq2n/data/flatten_data_source.cc
+++ b/native/src/fairseq2n/data/flatten_data_source.cc
@@ -1,0 +1,122 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "fairseq2n/data/flatten_data_source.h"
+
+#include <queue>
+#include <string>
+#include <utility>
+
+#include "fairseq2n/data/data.h"
+#include "fairseq2n/data/detail/exception.h"
+
+namespace fairseq2n::detail {
+
+std::optional<data>
+flatten_data_source::next()
+{
+    // If we have elements in the queue, return the next one
+    if (!elements_queue_.empty()) {
+        data element = std::move(elements_queue_.front());
+        elements_queue_.pop();
+        return element;
+    }
+
+    // Get the next example from the inner data source
+    std::optional<data> maybe_example = inner_->next();
+    if (!maybe_example)
+        return std::nullopt;
+
+    // Extract elements from the example and add them to the queue
+    elements_queue_ = extract_elements(*maybe_example);
+
+    // If the queue is empty (no elements could be extracted), recursively call next()
+    if (elements_queue_.empty())
+        return next();
+
+    // Return the first element from the queue
+    data element = std::move(elements_queue_.front());
+    elements_queue_.pop();
+    return element;
+}
+
+void
+flatten_data_source::reset(bool reset_rng)
+{
+    // Clear the queue and reset the inner data source
+    while (!elements_queue_.empty())
+        elements_queue_.pop();
+
+    inner_->reset(reset_rng);
+}
+
+void
+flatten_data_source::record_position(tape &t, bool strict) const
+{
+    // Record the size of the queue and its contents
+    t.record(elements_queue_.size());
+
+    // Make a copy to preserve the original queue
+    std::queue<data> queue_copy = elements_queue_;
+    
+    while (!queue_copy.empty()) {
+        t.record(queue_copy.front());
+        queue_copy.pop();
+    }
+
+    // Record the inner data source position
+    inner_->record_position(t, strict);
+}
+
+void
+flatten_data_source::reload_position(tape &t, bool strict)
+{
+    // Clear the current queue
+    while (!elements_queue_.empty())
+        elements_queue_.pop();
+
+    // Reload the queue size
+    std::size_t queue_size = t.read<std::size_t>();
+    
+    // Reload the queue elements
+    for (std::size_t i = 0; i < queue_size; ++i)
+        elements_queue_.push(t.read<data>());
+
+    // Reload the inner data source position
+    inner_->reload_position(t, strict);
+}
+
+data_source_finitude_type
+flatten_data_source::finitude_type() const noexcept
+{
+    // The finitude type of a flattened data source is the same as its inner source
+    return inner_->finitude_type();
+}
+
+std::queue<data>
+flatten_data_source::extract_elements(const data &example)
+{
+    std::queue<data> elements;
+
+    // If selector is provided, use it to extract elements
+    if (selector_) {
+        std::string error_msg = "Cannot use selector with flatten.";
+        std::cerr << error_msg << std::endl;
+        std::terminate();  // Force immediate program termination
+    }
+    // If no selector is provided, assume the example itself is a list
+    else if (example.is_list()) {
+        auto example_list = example.as_list();
+        for (size_t i = 0; i < example_list.size(); ++i) {
+            elements.push(example_list.at(i));
+        }
+    }
+    // If no valid elements were found, the queue remains empty
+    
+    return elements;
+}
+
+}  // namespace fairseq2n::detail

--- a/native/src/fairseq2n/data/flatten_data_source.h
+++ b/native/src/fairseq2n/data/flatten_data_source.h
@@ -1,0 +1,57 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <queue>
+#include <string>
+#include <utility>
+
+#include "fairseq2n/data/data_source.h"
+#include "fairseq2n/data/data.h"
+
+namespace fairseq2n::detail {
+
+class flatten_data_source final : public data_source {
+public:
+    explicit
+    flatten_data_source(
+        std::unique_ptr<data_source> &&inner,
+        std::optional<std::string> selector) noexcept
+      : inner_{std::move(inner)}, selector_{std::move(selector)}
+    {}
+
+    std::optional<data>
+    next() override;
+
+    void
+    reset(bool reset_rng) override;
+
+    void
+    record_position(tape &t, bool strict) const override;
+
+    void
+    reload_position(tape &t, bool strict) override;
+
+    data_source_finitude_type
+    finitude_type() const noexcept override;
+
+private:
+    // Extracts elements from a data object based on the selector.
+    // Returns a queue of elements to be returned by next().
+    std::queue<data>
+    extract_elements(const data &example);
+
+    std::unique_ptr<data_source> inner_;
+    std::optional<std::string> selector_;
+    std::queue<data> elements_queue_;
+    //std::exception_ptr exception_ptr_{};
+};
+
+}  // namespace fairseq2n::detail

--- a/src/fairseq2/data/_data_pipeline.py
+++ b/src/fairseq2/data/_data_pipeline.py
@@ -325,6 +325,29 @@ if TYPE_CHECKING or DOC_MODE:
                 The number of examples to prefetch.
             """
 
+        def flatten(self, selector: str | None = None) -> Self:
+            """Flatten the examples in the data pipeline.
+
+            Three layouts of initial examples will be supported, but at the
+            moment only the first is implemented:
+
+            - If no selector is specified, the input can be a list,
+              and the outputs will be the flattened individual elements.
+            - If no selector is specified, the input can be a dictionary with
+              all values being lists with n elements,
+              and the output will be n examples, each being a dictionary
+              with the same keys, but with the values being the value of
+              the i-th element.
+            - If a selector is specified, the example should be a dictionary with
+              the selected column as a key, and the value should be a list,
+              and this is the list that will be flattened.
+              All other columns will be copied as-is to each example.
+
+            :param selector:
+                The column to flatten. See :ref:`basics/data-pipeline/column-selection`
+                for details. Not supported for the moment.
+            """
+
         def repeat(
             self, num_repeats: int | None = None, reset_rng: bool = False
         ) -> Self:

--- a/tests/unit/data/data_pipeline/test_flatten.py
+++ b/tests/unit/data/data_pipeline/test_flatten.py
@@ -1,0 +1,112 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import pytest
+
+from fairseq2.data import read_sequence
+
+
+class TestFlattenOp:
+    def test_op_works_without_selector(self) -> None:
+        # Test flattening a list of lists without a selector
+        seq = [[1, 2, 3], [4, 5], [6, 7, 8, 9]]
+
+        pipeline = read_sequence(seq).flatten().and_return()
+
+        # Expected output is a flattened list
+        expected_output = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+        for _ in range(2):
+            assert list(pipeline) == expected_output
+
+            pipeline.reset()
+
+    def test_op_works_when_pipeline_is_empty(self) -> None:
+        # Test flattening an empty sequence
+        pipeline = read_sequence([]).flatten().and_return()
+
+        for _ in range(2):
+            assert list(pipeline) == []
+
+            pipeline.reset()
+
+    def test_op_works_with_empty_lists(self) -> None:
+        # Test behavior with empty lists
+        seq = [[1, 2, 3], [], [4, 5], [], []]
+
+        pipeline = read_sequence(seq).flatten().and_return()
+
+        # Expected output is the flattened non-empty lists
+        expected_output = [1, 2, 3, 4, 5]
+
+        for _ in range(2):
+            assert list(pipeline) == expected_output
+
+            pipeline.reset()
+
+    def test_op_saves_and_restores_its_state(self) -> None:
+        # Test state saving and restoration
+        seq = [[1, 2, 3], [4, 5], [6, 7, 8, 9]]
+
+        pipeline = read_sequence(seq).flatten().and_return()
+
+        d = None
+
+        it = iter(pipeline)
+
+        # Move to the fifth example.
+        for _ in range(5):
+            d = next(it)
+
+        assert d == 5
+
+        state_dict = pipeline.state_dict()
+
+        # Read a few examples before we roll back.
+        for _ in range(2):
+            d = next(it)
+
+        assert d == 7
+
+        # Expected to roll back to the fifth example.
+        pipeline.load_state_dict(state_dict)
+
+        # Move to EOD.
+        for _ in range(4):
+            d = next(it)
+
+        assert d == 9
+
+        state_dict = pipeline.state_dict()
+
+        pipeline.reset()
+
+        # Expected to be EOD.
+        pipeline.load_state_dict(state_dict)
+
+        with pytest.raises(StopIteration):
+            next(iter(pipeline))
+
+    def test_nested_flattening(self) -> None:
+        # Test flattening nested structures
+        seq = [[[1, 2], [3, 4]], [[5, 6]], [[7, 8, 9]]]
+
+        # First flatten the outer lists
+        pipeline = read_sequence(seq).flatten().and_return()
+        
+        # The first flatten gives us [[1, 2], [3, 4], [5, 6], [7, 8, 9]]
+        intermediate = list(pipeline)
+        
+        pipeline.reset()
+        
+        # Now flatten the result again
+        pipeline2 = read_sequence(intermediate).flatten().and_return()
+        
+        expected_output = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        
+        assert list(pipeline2) == expected_output


### PR DESCRIPTION
**What does this PR do? Please describe:**
Adds an operator turning a pipeline of lists into a pipeline of their flattened elements.


**Does your PR introduce any breaking changes? If yes, please list them:**
None

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [ ] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
