### PR TITLE
Add tied weights for llama3.2 3B

### DIFF
--- a/src/fairseq2/models/llama/_config.py
+++ b/src/fairseq2/models/llama/_config.py
@@ -250,6 +250,7 @@ def register_llama_configs(context: RuntimeContext) -> None:
         config = llama3_1_8b()
 
         config.model_dim = 3072
+        config.tied_embeddings = True
         config.ffn_inner_dim = 3072 * 4
         config.ffn_inner_dim_multiplier = 1.0
         config.ffn_inner_dim_multiple_of = 256


### PR DESCRIPTION
**What does this PR do? Please describe:**

Currently the LLaMA 3.2 1B model config is using tied weights between the embedding lookup table and the final projection layer, but this is missing from the 3B model version. Confirmed below that the 3B model is using tied weights:

```
In [1]: from fairseq2.models.llama import get_llama_model_hub
In [2]: llama = get_llama_model_hub().load("llama3_2_3b")
In [3]: (llama.decoder_frontend.embed.weight == llama.final_proj.weight).all()
Out[3]: tensor(True)
```

Fixes #1102 

**Does your PR introduce any breaking changes? If yes, please list them:**
List of all backwards-incompatible changes.

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
