### PR TITLE
adding head dim since 3.2 has it

### DIFF
--- a/src/fairseq2/models/llama/_hg.py
+++ b/src/fairseq2/models/llama/_hg.py
@@ -115,4 +115,5 @@ def _convert_to_hg_config(config: LLaMAConfig) -> dict[str, object]:
         "rope_theta": config.rope_theta,
         "tie_word_embeddings": config.tied_embeddings,
         "vocab_size": config.vocab_size,
+        "head_dim": config.model_dim // config.num_attn_heads,
     }


### PR DESCRIPTION
**What does this PR do? Please describe:**

Our llama config does not have the head dim since we compute it dynamically and default 8B / 70B models didnt have it in HG configs too. However, smaller 3.2 models introduced it so we must save head dim in HG config in order to override the default head dim that is 128.

Prior to this fix the vllm loading of 1B model didnt work due to config bug.
