### PR TITLE
update fsdp1/2 state dict - save replicated items on all shards

### DIFF
--- a/src/fairseq2/nn/data_parallel/_fsdp1.py
+++ b/src/fairseq2/nn/data_parallel/_fsdp1.py
@@ -13,7 +13,6 @@ from contextlib import contextmanager
 from typing import TypeAlias
 
 import torch
-import torch.distributed as dist
 from torch import Tensor
 from torch.distributed import ProcessGroup
 from torch.distributed._shard.sharded_tensor import ShardedTensor
@@ -209,22 +208,17 @@ def fsdp1_local_state_dict(module: FSDP1) -> dict[str, object]:
             action="ignore", message=r".*Please use DTensor instead.*"
         )
 
-        sdp_rank = dist.get_rank(module.process_group)
-
         for name, item in module.state_dict().items():
             if isinstance(item, ShardedTensor):
                 local_shards = item.local_shards()
                 if not local_shards:
                     continue  # means the tensor is sharded unevenly.
 
-                state_dict[name] = item.local_tensor().detach()
-            # Save replicated items only on the first intra-node (i.e. sharded)
-            # gang.
-            elif sdp_rank == 0:
-                if isinstance(item, Tensor):
-                    item = item.detach()
+                item = item.local_tensor().detach()
+            elif isinstance(item, Tensor):
+                item = item.detach()
 
-                state_dict[name] = item
+            state_dict[name] = item
 
     return state_dict
 


### PR DESCRIPTION
**What does this PR do? Please describe:**

When using fsdp1/2, replicated items (e.g. model buffer) are only saved to rank 0 ([fsdp1](https://github.com/facebookresearch/fairseq2/blob/main/src/fairseq2/nn/data_parallel/_fsdp1.py#L221-L227), [fsdp2](https://github.com/facebookresearch/fairseq2/blob/main/src/fairseq2/nn/data_parallel/_fsdp2.py#L221-L227)). However, when continue training from sharded model checkpoints from fsdp1/2, we don't retrieve and load those replicated items from sdp_00.pt. This PR fixes the subtle bug by retiring the small optimization of model buffer de-dup.

Does your PR introduce any breaking changes? If yes, please list them:
N/A

**Does your PR introduce any breaking changes? If yes, please list them:**
List of all backwards-incompatible changes.

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
