### PR TITLE
Adding test presets for mms + support for any encoder in reference model

### DIFF
--- a/src/fairseq2/models/wav2vec2/asr/_config.py
+++ b/src/fairseq2/models/wav2vec2/asr/_config.py
@@ -163,6 +163,12 @@ def register_wav2vec2_asr_configs(context: RuntimeContext) -> None:
         config.vocab_info.size = 3335
         return config
 
+    @wav2vec2_asr_arch("300m_bib1143_3292")
+    def bib1143_300m_3292() -> Wav2Vec2AsrConfig:
+        config = bib1143_300m()
+        config.vocab_info.size = 3292
+        return config
+
     @wav2vec2_asr_arch("1b_bib61")
     def bib61_1b() -> Wav2Vec2AsrConfig:
         config = base_10h()

--- a/src/fairseq2/recipes/wav2vec2/asr/_train.py
+++ b/src/fairseq2/recipes/wav2vec2/asr/_train.py
@@ -173,6 +173,9 @@ class Wav2Vec2AsrTrainDatasetSection(DatasetSection):
     extras: dict[str, object] = field(default_factory=dict)
     """The dataset-specific extra options."""
 
+    max_num_batches: int | None = None
+    """The maximum number of batches for the dataloader to return."""
+
     # Upsampling
     beta_corpus: float | None = None
     beta_language: float | None = None
@@ -288,7 +291,7 @@ def load_wav2vec2_asr_trainer(
 
     # If we start the training with an empty ASR model, use the weights of a
     # pretrained wav2vec 2.0 model.
-    if model.is_empty_initialized:
+    if model.is_empty_initialized and config.pretrained_encoder.name:
         tp = AsrModel if config.pretrained_encoder_is_ctc else Wav2Vec2Model
         pt_model = load_reference_model(
             tp,
@@ -427,6 +430,7 @@ def load_wav2vec2_asr_trainer(
         spec_aug_p=config.dataset.spec_aug_p,
         spec_aug_freq_mask_param=config.dataset.spec_aug_freq_mask_param,
         spec_aug_time_mask_param=config.dataset.spec_aug_time_mask_param,
+        max_num_batches=config.dataset.max_num_batches,
         n_context_examples=config.dataset.n_context_examples,
         bucket_size=config.dataset.bucket_size_train,
         deterministic_context=False,
@@ -472,6 +476,7 @@ def load_wav2vec2_asr_trainer(
             sync_mode=SyncMode.UNTIL_LAST,
             num_prefetch=config.dataset.num_prefetch,
             seed=seed,
+            max_num_batches=config.dataset.max_num_batches,
             extras=config.dataset.extras,
             n_context_examples=config.dataset.n_context_examples,
             bucket_size=config.dataset.bucket_size_eval,


### PR DESCRIPTION
**What does this PR do? Please describe:**
As discussed in the meeting, adding two test presets for mms that can be quickly run (10 mins) to verify PRs are not breaking training. One preset for llm-asr and another for ctc. 

those two tests are passing right now:
test_ctc_seed2_test_presets
test_llm_asr_seed2_test_presets

Fixes #{issue number}
n/a

**Does your PR introduce any breaking changes? If yes, please list them:**
No

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [ ] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)

All ok