### PR TITLE
parallel vllm worker init, online dpo ref score fix when bs>1 and reward is binary

### DIFF
--- a/src/fairseq2/recipes/lm/__init__.py
+++ b/src/fairseq2/recipes/lm/__init__.py
@@ -76,8 +76,12 @@ from fairseq2.recipes.lm._online_finetune._recipe import (
 from fairseq2.recipes.lm._online_finetune._recipe import (
     OnlineFinetuneUnitHandler,
     load_online_finetuner,
+)
+
+from fairseq2.recipes.lm._online_finetune._presets import (
     register_online_finetune_configs,
 )
+
 from fairseq2.recipes.lm._online_finetune._remote_model import (
     NoEnvAtheneRewardPipeline as NoEnvAtheneRewardPipeline,
 )

--- a/src/fairseq2/recipes/lm/_online_finetune/_common.py
+++ b/src/fairseq2/recipes/lm/_online_finetune/_common.py
@@ -298,7 +298,7 @@ def prepare_preference_batch_random_pair(
         reference_score_rejected=None,
     )
 
-    return batch, is_bad_batch
+    return batch, is_bad_batch, dummy_batch_ids
 
 
 def prepare_group_dpo_batch(

--- a/src/fairseq2/recipes/lm/_online_finetune/_online_dpo.py
+++ b/src/fairseq2/recipes/lm/_online_finetune/_online_dpo.py
@@ -264,12 +264,18 @@ class OnlineDpoFinetuneUnit(TrainUnit[SequenceBatch]):
         )
         update_logit_entropy(metric_bag, tgt_logit_entropy)
 
+        prompt_lengths = (
+            prompt_batch.prompt_lengths
+            if is_bad_batch
+            else reward_output["prompt_lengths"]
+        )
+
         token_ref_chosen_logps = compute_reference_logps(
             self._gangs,
             self._reference_model,
             chosen_input_batch_seqs,
             chosen_input_batch_layout,
-            prompt_batch.prompt_lengths,
+            prompt_lengths,
         )
 
         token_ref_rejected_logps = compute_reference_logps(
@@ -277,7 +283,7 @@ class OnlineDpoFinetuneUnit(TrainUnit[SequenceBatch]):
             self._reference_model,
             rejected_input_batch_seqs,
             rejected_input_batch_layout,
-            prompt_batch.prompt_lengths,
+            prompt_lengths,
         )
 
         ref_average_chosen_logps = token_ref_chosen_logps.mean(dim=-1)

--- a/src/fairseq2/recipes/lm/_online_finetune/_online_dpo.py
+++ b/src/fairseq2/recipes/lm/_online_finetune/_online_dpo.py
@@ -264,6 +264,7 @@ class OnlineDpoFinetuneUnit(TrainUnit[SequenceBatch]):
         )
         update_logit_entropy(metric_bag, tgt_logit_entropy)
 
+        # reward_output["prompt_lengths"] excludes lengths that correspond to examples that we filter out due to no preference signal.
         prompt_lengths = (
             prompt_batch.prompt_lengths
             if is_bad_batch

--- a/src/fairseq2/recipes/lm/_online_finetune/_presets.py
+++ b/src/fairseq2/recipes/lm/_online_finetune/_presets.py
@@ -66,7 +66,7 @@ def register_online_finetune_configs(context: RuntimeContext) -> None:
 
         dataset_config = OnlineFinetuneDatasetSection(
             name="wildchat",
-            path="/checkpoint/ram/chenxwh/data/online_dpo/wildchat_1k",
+            path="./wildchat_1k",
             train_split="train",
             valid_split="valid",
             batch_size=1,
@@ -80,8 +80,8 @@ def register_online_finetune_configs(context: RuntimeContext) -> None:
             num_replicas=2,
             init_update_process_group=True,
             vllm_engine_args=VllmEngineArgs(
-                model="/datasets/pretrained-llms/Qwen3-4B/",
-                tokenizer="/datasets/pretrained-llms/Qwen3-4B/",
+                model="./Qwen3-4B/",
+                tokenizer="./Qwen3-4B/",
                 tensor_parallel_size=2,
                 enforce_eager=False,
                 gpu_memory_utilization=0.7,
@@ -101,8 +101,8 @@ def register_online_finetune_configs(context: RuntimeContext) -> None:
             num_replicas=1,
             init_update_process_group=True,
             vllm_engine_args=VllmEngineArgs(
-                model="/datasets/pretrained-llms/Qwen3-4B/",
-                tokenizer="/datasets/pretrained-llms/Qwen3-4B/",
+                model="./Qwen3-4B/",
+                tokenizer="./Qwen3-4B/",
                 tensor_parallel_size=2,
                 enforce_eager=False,
                 gpu_memory_utilization=0.7,

--- a/src/fairseq2/recipes/lm/_online_finetune/_presets.py
+++ b/src/fairseq2/recipes/lm/_online_finetune/_presets.py
@@ -1,0 +1,178 @@
+from fairseq2.context import RuntimeContext
+from fairseq2.recipes.lm import OnlineFinetuneConfig
+from fairseq2.recipes.lm._online_finetune._recipe import (
+    VllmActorsSection,
+    OnlineFinetuneDatasetSection,
+)
+from fairseq2.recipes.lm._online_finetune._grpo import (
+    GrpoFinetuneConfig,
+    GrpoLossConfig,
+)
+
+from fairseq2.recipes.lm._online_finetune._remote_model import (
+    HFRayActorConfig,
+    RemoteRayModelHandler,
+    VllmRayActorConfig,
+    VllmEngineArgs,
+)
+from dataclasses import replace
+
+from fairseq2.recipes.lm._online_finetune._rewards import (
+    RewardSection,
+    RewardModelConfig,
+    VLLMOutputReward,
+    VLLMOutputRewardHandler,
+)
+from fairseq2.recipes.lm._online_finetune._common import OnlineCriterionSection
+from fairseq2.optim import AdamWConfig
+
+from fairseq2.recipes.config import (
+    ActivationCheckpointingSection,
+    CommonSection,
+    DatasetSection,
+    FSDPSection,
+    GangSection,
+    LRSchedulerSection,
+    ModelSection,
+    OptimizerSection,
+    RegimeSection,
+    TextTokenizerSection,
+    TrainerSection,
+    GradAccumulationSection,
+)
+
+
+def register_online_finetune_configs(context: RuntimeContext) -> None:
+    """
+    Here we keep some wildchat presets that are known to work well
+    """
+
+    registry = context.get_config_registry(OnlineFinetuneConfig)
+
+    preset = registry.decorator
+
+    @preset("llama3_1_instruct")
+    def llama3_1_instruct() -> OnlineFinetuneConfig:
+        config = OnlineFinetuneConfig()
+        config.regime.validate_before_training = True
+
+        return config
+
+    @preset("qwen3_4b_wildchat_grpo")
+    def qwen3_4b_wildchat_grpo() -> OnlineFinetuneConfig:
+
+        model_config = ModelSection(name="qwen3_4b")
+        tokenizer_config = TextTokenizerSection(name="qwen3_4b")
+
+        dataset_config = OnlineFinetuneDatasetSection(
+            name="wildchat",
+            path="/checkpoint/ram/chenxwh/data/online_dpo/wildchat_1k",
+            train_split="train",
+            valid_split="valid",
+            batch_size=1,
+            src_key="qwen3_src",
+            extras={"keep_jsonl_keys": ["prompt_raw"]},
+        )
+
+        policy_vllm_config = VllmRayActorConfig(
+            ray_actor_name="vllm_policy",
+            backend="vllm",
+            num_replicas=2,
+            init_update_process_group=True,
+            vllm_engine_args=VllmEngineArgs(
+                model="/datasets/pretrained-llms/Qwen3-4B/",
+                tokenizer="/datasets/pretrained-llms/Qwen3-4B/",
+                tensor_parallel_size=2,
+                enforce_eager=False,
+                gpu_memory_utilization=0.7,
+                enable_chunked_prefill=True,
+            ),
+            vllm_sampling_params={
+                "n": 1,
+                "temperature": 1.0,
+                "max_tokens": 8196,
+                "logprobs": 0,
+            },
+        )
+
+        reference_vllm_config = VllmRayActorConfig(
+            ray_actor_name="vllm_reference",
+            backend="vllm",
+            num_replicas=1,
+            init_update_process_group=True,
+            vllm_engine_args=VllmEngineArgs(
+                model="/datasets/pretrained-llms/Qwen3-4B/",
+                tokenizer="/datasets/pretrained-llms/Qwen3-4B/",
+                tensor_parallel_size=2,
+                enforce_eager=False,
+                gpu_memory_utilization=0.7,
+                enable_chunked_prefill=True,
+            ),
+            vllm_sampling_params={
+                "n": 1,
+                "temperature": 1.0,
+                "max_tokens": 1,
+                "prompt_logprobs": 0,
+                "detokenize": False,
+            },
+        )
+
+        reward_hf_config = HFRayActorConfig(
+            ray_actor_name="hf_reward",
+            num_replicas=2,
+            backend="hf",
+            pipeline_name="athene_reward_pipeline",
+            tensor_parallel_size=1,
+            init_update_process_group=False,
+        )
+
+        crit_config = OnlineCriterionSection(
+            name="grpo",
+            config=GrpoFinetuneConfig(
+                loss_config=GrpoLossConfig(
+                    beta=0.001,
+                    group_size=8,
+                    log_rollouts=True,
+                    forward_group_size=4,
+                    validation_vllm_sampling_params={
+                        "n": 1,
+                        "temperature": 0.6,
+                        "top_p": 0.9,
+                    },
+                ),
+                vllm_model_actor_name="vllm_policy",
+                vllm_reference_model_actor_name="vllm_reference",
+                vllm_reward_model_actor_name="hf_reward",
+                reward=RewardSection(
+                    name="athene_verifier",
+                    config=RewardModelConfig(prompt_key="prompt_raw"),
+                ),
+            ),
+        )
+
+        vllm_config = VllmActorsSection(
+            ray_cluster_ip_address="tobechanged_via_cli",
+            ray_actors=[policy_vllm_config, reference_vllm_config, reward_hf_config],
+        )
+
+        regime_updates = {
+            "num_data_epochs": 30,
+            "validate_at_start": True,
+            "validate_every_n_steps": 50,
+            "checkpoint_every_n_steps": 100,
+            "keep_best_n_checkpoints": 100,
+            "save_model_only": False,  # set to False if willing to resume interrupted training
+            "save_as_hugging_face": True,
+        }
+
+        config = OnlineFinetuneConfig()
+        config.model = model_config
+        config.dataset = dataset_config
+        config.tokenizer = tokenizer_config
+        config.trainer.max_grad_norm = 1.0
+        config.vllm = vllm_config
+        config.criterion = crit_config
+        config.optimizer.config.lr = 1e-6
+        config.regime = replace(config.regime, **regime_updates)
+
+        return config

--- a/src/fairseq2/recipes/lm/_online_finetune/_recipe.py
+++ b/src/fairseq2/recipes/lm/_online_finetune/_recipe.py
@@ -206,41 +206,6 @@ class DropoutConfig:
     dropout_p: float = 0.0
 
 
-# def register_online_finetune_configs(context: RuntimeContext) -> None:
-#     registry = context.get_config_registry(OnlineFinetuneConfig)
-
-#     preset = registry.decorator
-
-#     @preset("llama3_1_instruct")
-#     def llama3_1_instruct() -> OnlineFinetuneConfig:
-#         config = OnlineFinetuneConfig()
-
-#         config.model.config = DropoutConfig()
-#         config.regime.validate_before_training = True
-
-#         return config
-
-#     @preset("llama3_1_instruct_grpo")
-#     def llama3_1_instruct() -> OnlineFinetuneConfig:
-#         config = OnlineFinetuneConfig()
-
-#         config.model.config = DropoutConfig()
-#         config.criterion.config = GrpoFinetuneConfig()
-
-#         return config
-
-#     @preset("llama3_1_instruct_constant_lr")
-#     def llama3_1_instruct_constant_lr() -> OnlineFinetuneConfig:
-#         config = llama3_1_instruct()
-
-#         assert isinstance(config.optimizer.config, AdamWConfig)
-#         assert isinstance(config.lr_scheduler.config, CosineAnnealingLRConfig)
-
-#         config.lr_scheduler.config.final_lr = config.optimizer.config.lr
-
-#         return config
-
-
 def load_online_finetuner(
     context: RuntimeContext, config: object, output_dir: Path
 ) -> Trainer[PreferenceBatch]:

--- a/src/fairseq2/recipes/lm/_online_finetune/_rewards.py
+++ b/src/fairseq2/recipes/lm/_online_finetune/_rewards.py
@@ -150,9 +150,16 @@ class GSM8kVerifier(VLLMOutputReward):
 
         reward_output = self.process_rollouts(rollouts, prompt_batch)
 
-        batch, is_bad_batch = prepare_preference_batch_random_pair(
+        batch, is_bad_batch, dummy_batch_ids = prepare_preference_batch_random_pair(
             prompt_batch=prompt_batch, reward_output=reward_output, gangs=self._gangs
         )
+
+        prompt_lengths = [
+            l
+            for idx, l in enumerate(prompt_batch.prompt_lengths)
+            if idx not in dummy_batch_ids
+        ]
+        reward_output["prompt_lengths"] = prompt_lengths
 
         return batch, is_bad_batch, reward_output
 
@@ -269,9 +276,16 @@ class MathVerifyVerifier(VLLMOutputReward):
 
         reward_output = self.process_rollouts(rollouts, prompt_batch)
 
-        batch, is_bad_batch = prepare_preference_batch_random_pair(
+        batch, is_bad_batch, dummy_batch_ids = prepare_preference_batch_random_pair(
             prompt_batch=prompt_batch, reward_output=reward_output, gangs=self._gangs
         )
+
+        prompt_lengths = [
+            l
+            for idx, l in enumerate(prompt_batch.prompt_lengths)
+            if idx not in dummy_batch_ids
+        ]
+        reward_output["prompt_lengths"] = prompt_lengths
 
         return batch, is_bad_batch, reward_output
 

--- a/src/fairseq2/setup/_metrics.py
+++ b/src/fairseq2/setup/_metrics.py
@@ -87,6 +87,7 @@ def _register_metric_descriptors(context: RuntimeContext) -> None:
     register("rollout_lengths",    "Rollout Length",                      70, format_as_float)
     register("chosen_lengths",     "Chosen Sequence Length",              70, format_as_float)
     register("rejected_lengths",   "Rejected Sequence Length",            70, format_as_float)
+    register("avg_rollout_length", "Average Rollout Length",              70, format_as_float)
 
     # Memory
     register("peak_active_mem_bytes",   "Peak Active Device Memory",       920, format_as_byte_size)


### PR DESCRIPTION
as title says

tested with GRPO and online DPO
spinning up 16 vllm actors over 2 Ray nodes take couple mins now. thanks @a-paulus for first implementation and testing this out :) 

> online dpo ref score fix

our online dpo ref score was buggy when we filtered out some items from batch due to no preference signal. This got introduced during refactor in the first week of June and only show itself when we use math-verify (i.e. 0/1 reward alone) and batch size > 1. Otherwise (batch size = 1), entire batch loss is zeroed out anyway.

also we added _presets.py where we show one example of a preset done programmatically