### PR TITLE
Fix PyPI publish bug

### DIFF
--- a/.github/workflows/_publish.yaml
+++ b/.github/workflows/_publish.yaml
@@ -106,7 +106,7 @@ jobs:
       matrix:
         torch: ['2.8.0']
         py: ['3.10', '3.11', '3.12']
-        variant: ['cu126', 'cu128']
+        variant: ['cu128']
       max-parallel: 1
     with:
       os: 'linux'


### PR DESCRIPTION
This PR fixes the (rather serious) bug in PyPI publish workflow that tries to upload two different package variants to PyPI. As expected the upload of the second variant fails due to name conflict. In this case, unfortunately, CUDA 12.8 was the actual variant we wanted to upload to PyPI, but since CUDA 12.6 was uploaded first, we cannot do that. Since once uploaded PyPI packages are immutable and cannot be overridden, we need to bump v0.5.1 after this fix.