### PR TITLE
Respect content-disposition while downloading assets

### DIFF
--- a/src/fairseq2/assets/download_manager.py
+++ b/src/fairseq2/assets/download_manager.py
@@ -632,12 +632,21 @@ class _AssetDownloadOp:
 
             fp.close()
 
-            try:
-                filename = Path(urlparse(response.geturl()).path).name
+            filename = None
 
-                filename = unquote(filename)
-            except ValueError:
-                filename = "asset"
+            content_disposition = response.headers.get("Content-Disposition")
+            if content_disposition is not None:
+                match = re.search(r"filename=\"?([^\"\n]+)\"?", content_disposition)
+                if match:
+                    filename = match.group(1)
+
+            if filename is None:
+                try:
+                    filename = Path(urlparse(response.geturl()).path).name
+
+                    filename = unquote(filename)
+                except ValueError:
+                    filename = "asset"
 
             asset_file = tmp_dir.joinpath(filename)
 


### PR DESCRIPTION
This PR improves filename handling when downloading files via redirection. In particular Hugging Face Hub recently started returning the actual filename in `Content-Disposition` header instead of within the URL which causes checkpoint loading to fail.