### PR TITLE
Introduce register_in_memory_assets

### DIFF
--- a/src/fairseq2/assets/__init__.py
+++ b/src/fairseq2/assets/__init__.py
@@ -49,6 +49,9 @@ from fairseq2.assets.metadata_provider import (
     FileAssetMetadataSource as FileAssetMetadataSource,
 )
 from fairseq2.assets.metadata_provider import (
+    InMemoryAssetMetadataSource as InMemoryAssetMetadataSource,
+)
+from fairseq2.assets.metadata_provider import (
     PackageAssetMetadataLoader as PackageAssetMetadataLoader,
 )
 from fairseq2.assets.metadata_provider import (

--- a/src/fairseq2/composition/__init__.py
+++ b/src/fairseq2/composition/__init__.py
@@ -11,6 +11,9 @@ from fairseq2.composition.assets import (
 )
 from fairseq2.composition.assets import register_file_assets as register_file_assets
 from fairseq2.composition.assets import (
+    register_in_memory_assets as register_in_memory_assets,
+)
+from fairseq2.composition.assets import (
     register_package_assets as register_package_assets,
 )
 from fairseq2.composition.datasets import (

--- a/src/fairseq2/composition/assets.py
+++ b/src/fairseq2/composition/assets.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Iterator
+from typing import Iterator, Sequence
 
 from fairseq2.assets import (
     AssetDirectoryAccessor,
@@ -21,6 +21,7 @@ from fairseq2.assets import (
     FileAssetMetadataLoader,
     FileAssetMetadataSource,
     HuggingFaceHub,
+    InMemoryAssetMetadataSource,
     LocalAssetDownloadManager,
     PackageAssetMetadataLoader,
     PackageAssetMetadataSource,
@@ -56,6 +57,17 @@ def register_file_assets(
 def register_package_assets(container: DependencyContainer, package: str) -> None:
     def create_source(resolver: DependencyResolver) -> AssetMetadataSource:
         return wire_object(resolver, PackageAssetMetadataSource, package=package)
+
+    container.collection.register(AssetMetadataSource, create_source)
+
+
+def register_in_memory_assets(
+    container: DependencyContainer, source: str, entries: Sequence[dict[str, object]]
+) -> None:
+    def create_source(resolver: DependencyResolver) -> AssetMetadataSource:
+        return wire_object(
+            resolver, InMemoryAssetMetadataSource, name=source, entries=entries
+        )
 
     container.collection.register(AssetMetadataSource, create_source)
 


### PR DESCRIPTION
This PR introduces a helper `register_in_memory_assets` composition function similar to `register_file_assets` and `register_package_assets`. It is used the same way as the latter two functions:

```python
from fairseq2.composition import register_in_memory_assets

entries = [
  {"name": "foo1", "model_family": "foo"},
  {"name": "foo2", "model_family": "foo"},
]

def setup_fs2_extension(container: DependencyContainer) -> None:
  register_in_memory_assets(container, source="my_in_mem_source", entries=entries)

init_fairseq2(extras=setup_fs2_extension)
```

Tested manually with a toy script. Ideally should have proper test coverage (like may other parts of the code base) once we have proper bandwidth.