### PR TITLE
Improve metric value handling in recorders

### DIFF
--- a/src/fairseq2/metrics/formatters.py
+++ b/src/fairseq2/metrics/formatters.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import math
+from collections.abc import Sequence
 from functools import partial
 from typing import Final
 
@@ -22,6 +23,8 @@ def format_as_int(value: object, *, postfix: str | None = None) -> str:
             i = int(value)
         except ValueError:
             return f"{value}"
+    elif isinstance(value, Sequence):
+        return ", ".join(format_as_int(e) for e in value)
     else:
         return f"{value}"
 
@@ -46,6 +49,8 @@ def format_as_float(value: object, *, postfix: str | None = None) -> str:
             f = float(value)
         except ValueError:
             return f"{value}"
+    elif isinstance(value, Sequence):
+        return ", ".join(format_as_float(e) for e in value)
     else:
         return f"{value}"
 
@@ -66,6 +71,8 @@ def format_as_percentage(value: object) -> str:
             f = float(value)
         except ValueError:
             return f"{value}"
+    elif isinstance(value, Sequence):
+        return ", ".join(format_as_percentage(e) for e in value)
     else:
         return f"{value}"
 
@@ -86,6 +93,8 @@ def format_as_byte_size(value: object) -> str:
             size = float(value)
         except ValueError:
             return f"{value}"
+    elif isinstance(value, Sequence):
+        return ", ".join(format_as_byte_size(e) for e in value)
     else:
         return f"{value}"
 


### PR DESCRIPTION
This PR includes two improvements in existing `MetricRecorder` classes:

(1) Beyond scalars, provided metric values can also be sequences of scalars (recursively). This is in particular needed for use cases like having multiple learning rates under a single metric.
(2) Instead of failing with a recorder specific (typically non-user friendly) error, all recorders check that the provided metric values are either scalar (i.e. int, float, Tensor, str) or a sequence of them before attempting to write them.

All four recorders (log, jsonl, tb, wandb) have been tested with various metric types to verify correctness. In the future, we should ideally cover these cases with some proper integration tests.