### PR TITLE
Support multiple parameter groups in LR scheduler factories

### DIFF
--- a/doc/source/reference/api/fairseq2.recipe.optim.rst
+++ b/doc/source/reference/api/fairseq2.recipe.optim.rst
@@ -1,0 +1,5 @@
+=====================
+fairseq2.recipe.optim
+=====================
+
+.. automodule:: fairseq2.recipe.optim

--- a/doc/source/reference/api/index.rst
+++ b/doc/source/reference/api/index.rst
@@ -58,3 +58,4 @@ Utilities
    device
    logging
    metrics
+   fairseq2.recipe.optim

--- a/src/fairseq2/optim/lr_schedulers/lr_scheduler.py
+++ b/src/fairseq2/optim/lr_schedulers/lr_scheduler.py
@@ -54,7 +54,7 @@ def get_per_param_group(
 
     if len(value) != num_param_groups:
         raise ValueError(
-            f"The length of `{name}` must be equal to the number of parameter groups ({num_param_groups}), but is {len(value)} instead."
+            f"The length of `{name}` must match the number of parameter groups ({num_param_groups}), but is {len(value)} instead."
         )
 
     return value

--- a/src/fairseq2/optim/lr_schedulers/myle.py
+++ b/src/fairseq2/optim/lr_schedulers/myle.py
@@ -20,7 +20,8 @@ from fairseq2.optim.lr_schedulers.lr_scheduler import (
 
 @final
 class MyleLR(AbstractLRScheduler):
-    """Represents a scaled version of :class:`NoamLR` that preserves the base
+    """
+    Represents a scaled version of :class:`NoamLR` that preserves the base
     learning rate of the associated optimizer.
 
     .. math::
@@ -35,6 +36,7 @@ class MyleLR(AbstractLRScheduler):
     it thereafter proportionally to the inverse square root of the step number.
 
     .. note::
+
         This scheduler is not chainable.
     """
 
@@ -47,22 +49,18 @@ class MyleLR(AbstractLRScheduler):
         last_epoch: int = -1,
     ) -> None:
         """
-        :param optimizer:
-            The optimizer to associate.
-        :param num_warmup_steps:
-            The number of warmup steps.
-        :param start_lr:
-            The initial warmup learning rate of all parameter groups, or of each
-            parameter group respectively.
-        :param last_epoch:
-            The index of the last epoch.
+        :param optimizer: The optimizer to associate.
+        :param num_warmup_steps: The number of warmup steps.
+        :param start_lr: The initial warmup learning rate of all parameter
+            groups or each group respectively.
+        :param last_epoch: The index of the last epoch.
         """
         if num_warmup_steps == 0:
             raise ValueError("`num_warmup_steps` must be greater than 0.")
 
-        self._num_warmup_steps = num_warmup_steps
+        self.num_warmup_steps = num_warmup_steps
 
-        self._start_lrs = get_per_param_group(optimizer, "start_lr", start_lr)
+        self.start_lrs = get_per_param_group(optimizer, "start_lr", start_lr)
 
         super().__init__(optimizer, last_epoch)
 
@@ -71,13 +69,13 @@ class MyleLR(AbstractLRScheduler):
         base_lrs = self.base_lrs
 
         # Linearly increase the learning rate to its base value during warmup.
-        if self.last_epoch < self._num_warmup_steps:
-            c = self.last_epoch / self._num_warmup_steps
+        if self.last_epoch < self.num_warmup_steps:
+            c = self.last_epoch / self.num_warmup_steps
 
-            return [s + (b - s) * c for b, s in zip(base_lrs, self._start_lrs)]
+            return [s + (b - s) * c for b, s in zip(base_lrs, self.start_lrs)]
 
         # After the warmup, decay the learning rate proportional to the inverse
         # square root of the step number.
-        c = (self._num_warmup_steps / self.last_epoch) ** 0.5
+        c = (self.num_warmup_steps / self.last_epoch) ** 0.5
 
         return [b * c for b in base_lrs]

--- a/src/fairseq2/optim/lr_schedulers/noam.py
+++ b/src/fairseq2/optim/lr_schedulers/noam.py
@@ -16,7 +16,8 @@ from fairseq2.optim.lr_schedulers.lr_scheduler import AbstractLRScheduler
 
 @final
 class NoamLR(AbstractLRScheduler):
-    """Represents the learning rate schedule described in Section 5.3 of
+    """
+    Represents the learning rate schedule described in Section 5.3 of
     :cite:t:`https://doi.org/10.48550/arxiv.1706.03762`.
 
     .. math::
@@ -32,6 +33,7 @@ class NoamLR(AbstractLRScheduler):
     the paper, Noam Shazeer.
 
     .. note::
+
         This scheduler is not chainable.
     """
 
@@ -43,22 +45,19 @@ class NoamLR(AbstractLRScheduler):
         last_epoch: int = -1,
     ) -> None:
         """
-        :param optimizer:
-            The optimizer to associate.
-        :param num_warmup_steps:
-            The number of warmup steps.
-        :param last_epoch:
-            The index of the last epoch.
+        :param optimizer: The optimizer to associate.
+        :param num_warmup_steps: The number of warmup steps.
+        :param last_epoch: The index of the last epoch.
         """
-        self._num_warmup_steps = num_warmup_steps
+        self.num_warmup_steps = num_warmup_steps
 
         super().__init__(optimizer, last_epoch)
 
     @override
     def _compute_lrs(self) -> list[float]:
         # Linearly increase the learning rate during warmup.
-        if self.last_epoch < self._num_warmup_steps:
-            c = self.last_epoch * self._num_warmup_steps**-1.5
+        if self.last_epoch < self.num_warmup_steps:
+            c = self.last_epoch * self.num_warmup_steps**-1.5
 
         # No warmup requested, decay from the base learning rate.
         elif self.last_epoch == 0:

--- a/src/fairseq2/optim/lr_schedulers/tri_stage.py
+++ b/src/fairseq2/optim/lr_schedulers/tri_stage.py
@@ -21,10 +21,11 @@ from fairseq2.optim.lr_schedulers.lr_scheduler import (
 
 @final
 class TriStageLR(AbstractLRScheduler):
-    """Represents the tri-stage learning rate schedule as described in Section
+    """
+    Represents the tri-stage learning rate schedule as described in Section
     3.2 of :cite:t:`https://doi.org/10.48550/arxiv.1706.03762`.
 
-     The learning rate schedule employs three stages:
+    The learning rate schedule employs three stages:
 
        - The warm-up stage where the learning rate is linearly increased to its
          maximum value (i.e. `base_lr`)
@@ -34,6 +35,7 @@ class TriStageLR(AbstractLRScheduler):
          final value.
 
     .. note::
+
         This scheduler is not chainable.
     """
 
@@ -48,16 +50,15 @@ class TriStageLR(AbstractLRScheduler):
         last_epoch: int = -1,
     ) -> None:
         """
-        :param optimizer:
-            The optimizer to associate.
-        :param num_steps:
-            The total number of steps over which to adjust the learning rate.
-        :param stage_ratio:
-            The ratios of warmup, hold, and decay stages. Must add up to 1.
-        :param start_lr_scale:
-            The scale of the initial warm-up learning rate.
-        :param final_lr_scale:
-            The scale of the final learning rate.
+        :param optimizer: The optimizer to associate.
+        :param num_steps: The total number of steps over which to adjust the
+            learning rate.
+        :param stage_ratio: The ratios of warmup, hold, and decay stages, must
+            add up to 1.
+        :param start_lr_scale: The scale of the initial warm-up learning rate of
+            all parameter groups or each group respectively.
+        :param final_lr_scale: The scale of the final learning rate of all
+            parameter groups or each group respectively.
         """
         ratio_sum = sum(stage_ratio)
         if not math.isclose(ratio_sum, 1.0):
@@ -65,21 +66,17 @@ class TriStageLR(AbstractLRScheduler):
                 f"The sum of `stage_ratio` values must be 1.0, but is {ratio_sum} instead."
             )
 
-        self._num_steps = num_steps
+        start_lr_scales = get_per_param_group(optimizer, "start_lr", start_lr_scale)
+        final_lr_scales = get_per_param_group(optimizer, "final_lr", final_lr_scale)
 
-        self._start_lr_scales = get_per_param_group(
-            optimizer, "start_lr", start_lr_scale
-        )
-        self._final_lr_scales = get_per_param_group(
-            optimizer, "final_lr", final_lr_scale
-        )
+        num_stage_steps = [int(r * num_steps) for r in stage_ratio]
 
-        self._start_lrs: Sequence[float] | None = None
-        self._final_lrs: Sequence[float] | None = None
-
-        self._num_stage1_steps = int(stage_ratio[0] * num_steps)
-        self._num_stage2_steps = int(stage_ratio[1] * num_steps)
-        self._num_stage3_steps = int(stage_ratio[2] * num_steps)
+        self.num_steps = num_steps
+        self.start_lrs: Sequence[float] | None = None
+        self.final_lrs: Sequence[float] | None = None
+        self.start_lr_scales = start_lr_scales
+        self.final_lr_scales = final_lr_scales
+        self.num_stage_steps = num_stage_steps
 
         super().__init__(optimizer, last_epoch)
 
@@ -89,31 +86,31 @@ class TriStageLR(AbstractLRScheduler):
 
         # Due to `LRScheduler`'s constructor quirks, we delay the initialization
         # of `start_lrs` and `final_lrs` to here.
-        if self._start_lrs is None:
-            self._start_lrs = [s * b for s, b in zip(self._start_lr_scales, base_lrs)]
+        if self.start_lrs is None:
+            self.start_lrs = [s * b for s, b in zip(self.start_lr_scales, base_lrs)]
 
-        if self._final_lrs is None:
-            self._final_lrs = [s * b for s, b in zip(self._final_lr_scales, base_lrs)]
+        if self.final_lrs is None:
+            self.final_lrs = [s * b for s, b in zip(self.final_lr_scales, base_lrs)]
 
         num_steps = self.last_epoch
 
         # Linearly increase the learning rate to its base value during warmup.
-        if num_steps < self._num_stage1_steps:
-            c = num_steps / self._num_stage1_steps
+        if num_steps < self.num_stage_steps[0]:
+            c = num_steps / self.num_stage_steps[0]
 
-            return [s + (b - s) * c for b, s in zip(base_lrs, self._start_lrs)]
+            return [s + (b - s) * c for b, s in zip(base_lrs, self.start_lrs)]
 
-        num_steps -= self._num_stage1_steps
+        num_steps -= self.num_stage_steps[0]
 
         # Keep the learning rate constant during second stage.
-        if num_steps < self._num_stage2_steps:
+        if num_steps < self.num_stage_steps[1]:
             return list(base_lrs)
 
-        num_steps -= self._num_stage2_steps
+        num_steps -= self.num_stage_steps[1]
 
-        if num_steps < self._num_stage3_steps:
-            c = num_steps / self._num_stage3_steps
+        if num_steps < self.num_stage_steps[2]:
+            c = num_steps / self.num_stage_steps[2]
 
-            return [b * math.exp(math.log(f) * c) for b, f in zip(base_lrs, self._final_lr_scales)]  # fmt: skip
+            return [b * math.exp(math.log(f) * c) for b, f in zip(base_lrs, self.final_lr_scales)]  # fmt: skip
 
-        return list(self._final_lrs)
+        return list(self.final_lrs)

--- a/src/fairseq2/recipe/config.py
+++ b/src/fairseq2/recipe/config.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import math
 from abc import ABC, abstractmethod
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Final, Literal, TypeAlias, TypeVar, final
@@ -683,7 +684,7 @@ class TorchProfilerConfig(Validatable):
 
 @dataclass(kw_only=True)
 class AssetsConfig:
-    extra_paths: list[Path] = field(default_factory=list)
+    extra_paths: Sequence[Path] = field(default_factory=list)
 
     prev_checkpoint_dir: Path | None = None
     """If not ``None``, adds the specified path to the default asset store."""
@@ -809,9 +810,13 @@ class LRSchedulerSection(SupportsStructure):
 
 @dataclass(kw_only=True)
 class CosineAnnealingLRConfig(Validatable):
+    """Represents the configuration of :class:`CosineAnnealingLR`."""
+
     cycle_len: int | None = None
-    """The number of steps within the first cycle. If ``None``, will be set to
-    ``num_steps - num_warmup_steps``."""
+    """
+    The number of steps within the first cycle. If ``None``, will be set to
+    ``num_steps - num_warmup_steps``.
+    """
 
     num_warmup_steps: int = 0
     """The number of warmup steps."""
@@ -820,22 +825,31 @@ class CosineAnnealingLRConfig(Validatable):
     """The factor to grow the length of each cycle."""
 
     lr_mul: float = 1.0
-    """The factor to scale the base and final learning rate at the end of each
-    cycle."""
-
-    start_lr: float = 0.0
-    """The initial warmup learning rate."""
-
-    final_lr: float | None = None
-    """The final learning rate. If ``None``, :attr:`final_lr_scale` will be used."""
-
-    final_lr_scale: float | None = 0.2
     """
-    The optimizer learning rate will be scaled by this value to determine the
-    final learning rate. If ``None``, :attr:`final_lr` will be used.
+    The factor to scale the base and final learning rate at the end of each cycle.
+    """
+
+    start_lr: float | Sequence[float] = 0.0
+    """
+    The initial warmup learning rate of all optimizer parameter groups or each
+    group respectively.
+    """
+
+    final_lr: float | Sequence[float] | None = None
+    """
+    The final learning rate of all optimizer parameter groups or each group
+    respectively. If ``None``, :attr:`final_lr_scale` will be used.
+    """
+
+    final_lr_scale: float | Sequence[float] | None = 0.2
+    """
+    The default learning rate of all optimizer parameter groups or each group
+    respectively will be scaled by this value to determine the final learning
+    rate. If ``None``, :attr:`final_lr` will be used.
     """
 
     def validate(self) -> ValidationResult:
+        """:meta private:"""
         result = ValidationResult()
 
         if self.num_warmup_steps < 0:
@@ -854,13 +868,19 @@ class CosineAnnealingLRConfig(Validatable):
 
 @dataclass(kw_only=True)
 class MyleLRConfig(Validatable):
+    """Represents the configuration of :class:`MyleLR`."""
+
     num_warmup_steps: int = 1
     """The number of warmup steps."""
 
-    start_lr: float = 0.0
-    """The initial warmup learning rate."""
+    start_lr: float | Sequence[float] = 0.0
+    """
+    The initial warmup learning rate of all optimizer parameter groups or each
+    group respectively.
+    """
 
     def validate(self) -> ValidationResult:
+        """:meta private:"""
         result = ValidationResult()
 
         if self.num_warmup_steps < 1:
@@ -871,10 +891,13 @@ class MyleLRConfig(Validatable):
 
 @dataclass(kw_only=True)
 class NoamLRConfig(Validatable):
+    """Represents the configuration of :class:`NoamLR`."""
+
     num_warmup_steps: int = 0
     """The number of warmup steps."""
 
     def validate(self) -> ValidationResult:
+        """:meta private:"""
         result = ValidationResult()
 
         if self.num_warmup_steps < 0:
@@ -885,19 +908,28 @@ class NoamLRConfig(Validatable):
 
 @dataclass(kw_only=True)
 class PolynomialDecayLRConfig(Validatable):
+    """Represents the configuration of :class:`PolynomialDecayLR`."""
+
     num_warmup_steps: int = 0
     """The number of warmup steps."""
 
     power: float = 1.0
     """The exponent of the polynomial used for decay."""
 
-    start_lr: float = 0.0
-    """The initial warmup learning rate."""
+    start_lr: float | Sequence[float] = 0.0
+    """
+    The initial warmup learning rate of all optimizer parameter groups or each
+    group respectively.
+    """
 
-    final_lr: float = 0.0
-    """The final learning rate."""
+    final_lr: float | Sequence[float] = 0.0
+    """
+    The final learning rate of all optimizer parameter groups or each group
+    respectively.
+    """
 
     def validate(self) -> ValidationResult:
+        """:meta private:"""
         result = ValidationResult()
 
         if self.num_warmup_steps < 0:
@@ -908,16 +940,25 @@ class PolynomialDecayLRConfig(Validatable):
 
 @dataclass(kw_only=True)
 class TriStageLRConfig(Validatable):
+    """Represents the configuration of :class:`TriStageLRConfig`."""
+
     stage_ratio: tuple[float, float, float] = (0.0, 0.0, 1.0)
-    """The ratios of warmup, hold, and decay stages. Must add up to 1."""
+    """The ratios of warmup, hold, and decay stages, must add up to 1."""
 
-    start_lr_scale: float = 0.01
-    """The scale of the initial warm-up learning rate."""
+    start_lr_scale: float | Sequence[float] = 0.01
+    """
+    The scale of the initial warm-up learning rate of all optimizer parameter
+    groups or each group respectively.
+    """
 
-    final_lr_scale: float = 0.01
-    """The scale of the final learning rate."""
+    final_lr_scale: float | Sequence[float] = 0.01
+    """
+    The scale of the final learning rate of all optimizer parameter groups or
+    each group respectively.
+    """
 
     def validate(self) -> ValidationResult:
+        """:meta private:"""
         result = ValidationResult()
 
         ratio_sum = sum(self.stage_ratio)

--- a/src/fairseq2/recipe/config.py
+++ b/src/fairseq2/recipe/config.py
@@ -940,7 +940,7 @@ class PolynomialDecayLRConfig(Validatable):
 
 @dataclass(kw_only=True)
 class TriStageLRConfig(Validatable):
-    """Represents the configuration of :class:`TriStageLRConfig`."""
+    """Represents the configuration of :class:`TriStageLR`."""
 
     stage_ratio: tuple[float, float, float] = (0.0, 0.0, 1.0)
     """The ratios of warmup, hold, and decay stages, must add up to 1."""

--- a/src/fairseq2/recipe/optim.py
+++ b/src/fairseq2/recipe/optim.py
@@ -1,0 +1,57 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+This module provides helper functions to add support for new optimizers and
+learning rate schedulers in recipes.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from fairseq2.utils.validation import ValidationError
+
+
+def maybe_raise_param_group_length_error(
+    field: str, value: Sequence[object], num_param_groups: int
+) -> None:
+    """
+    A helper function that raises :class:`~fairseq2.utils.validation.ValidationError`
+    if the length of a learning rate scheduler configuration field (``len(value)``)
+    does not match the number of optimizer parameter groups (``num_param_groups``).
+
+    :param field: The name of the configuration field that holds ``value``.
+    :param value: The value whose length to check.
+    :param num_param_groups: The number of optimizer parameter groups.
+
+    :raises ~fairseq2.utils.validation.ValidationError: if ``len(value)`` does
+        not match ``num_param_groups``.
+
+    .. code-block:: python
+        :caption: A basic use of ``maybe_raise_param_group_length_error``
+
+        from torch.optim import Optimizer
+
+        from fairseq2.recipe.config import MyleLRConfig
+        from fairseq2.recipe.optim import maybe_raise_param_group_length_error
+
+        def get_start_lr(config: MyleLRConfig, optimizer: Optimizer) -> list[float]:
+            num_param_groups = len(optimizer.param_groups)
+
+            start_lr: float | list[float] = config.start_lr
+
+            if isinstance(start_lr, float):
+                return [start_lr] * num_param_groups
+
+            maybe_raise_param_group_length_error("start_lr", start_lr, num_param_groups)
+
+            return start_lr
+    """
+    if len(value) != num_param_groups:
+        raise ValidationError(
+            f"The length of `{field}` must match the number of optimizer parameter groups ({num_param_groups}), but is {len(value)} instead.", field="lr_scheduler.config"  # fmt: skip
+        )

--- a/src/fairseq2/recipe/trainer.py
+++ b/src/fairseq2/recipe/trainer.py
@@ -883,6 +883,8 @@ class Trainer(Task):
 
             self._unit.process_metric_values(values)
 
+            # If the optimizer has a single parameter group, report the learning
+            # rate as a scalar.
             if len(self._last_lrs) == 1:
                 values["lr"] = self._last_lrs[0]
             else:

--- a/src/fairseq2/recipe/trainer.py
+++ b/src/fairseq2/recipe/trainer.py
@@ -41,7 +41,7 @@ from fairseq2.optim.fp16_loss_scaler import (
     Float16LossScaler,
     Float16LossScaleResult,
 )
-from fairseq2.optim.lr_schedulers import LRScheduler, get_effective_lr
+from fairseq2.optim.lr_schedulers import LRScheduler
 from fairseq2.profilers import Profiler
 from fairseq2.recipe.error import MinimumLossScaleReachedError
 from fairseq2.recipe.model import RecipeModel
@@ -309,6 +309,8 @@ class Trainer(Task):
                 "`publish_metrics_every_n_data_epochs` must be greater than or equal to 1."
             )
 
+        last_lrs = [0.0] * len(optimizer.param_groups)
+
         self._state = _TrainerState.NOT_STARTED
         self._step_nr = 0
         self._data_epoch_nr = 1
@@ -364,7 +366,7 @@ class Trainer(Task):
         self._batches: list[Any] | None = None
         self._stop_requested = False
         self._num_batches_read = 0
-        self._last_lr = 0.0
+        self._last_lrs = last_lrs
 
         self._metric_bag.add("grad_norm", Mean())
 
@@ -655,7 +657,7 @@ class Trainer(Task):
 
             return _TrainerState.GRAD_OVERFLOW
 
-        self._last_lr = get_effective_lr(self._lr_scheduler)
+        self._last_lrs = self._lr_scheduler.get_last_lr()
 
         self._lr_scheduler.step()
 
@@ -881,7 +883,10 @@ class Trainer(Task):
 
             self._unit.process_metric_values(values)
 
-            values["lr"] = self._last_lr
+            if len(self._last_lrs) == 1:
+                values["lr"] = self._last_lrs[0]
+            else:
+                values["lr"] = self._last_lrs
 
             values["data_epoch"] = self._data_epoch_nr
 

--- a/tests/unit/optim/test_lr_scheduler.py
+++ b/tests/unit/optim/test_lr_scheduler.py
@@ -278,13 +278,13 @@ class TestLRSchedulers:
     def test_myle_raises_error_if_number_of_start_lrs_is_wrong(self) -> None:
         with pytest.raises(
             ValueError,
-            match=r"^The length of `start_lr` must be equal to the number of parameter groups \(2\), but is 1 instead\.$",
+            match=r"^The length of `start_lr` must match the number of parameter groups \(2\), but is 1 instead\.$",
         ):
             MyleLR(self.opt, num_warmup_steps=10, start_lr=[0])
 
         with pytest.raises(
             ValueError,
-            match=r"^The length of `start_lr` must be equal to the number of parameter groups \(2\), but is 3 instead\.$",
+            match=r"^The length of `start_lr` must match the number of parameter groups \(2\), but is 3 instead\.$",
         ):
             MyleLR(self.opt, num_warmup_steps=10, start_lr=(0, 2, 3))
 

--- a/tests/unit/recipe/internal/test_lr_schedulers.py
+++ b/tests/unit/recipe/internal/test_lr_schedulers.py
@@ -1,0 +1,671 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+from torch.optim import SGD
+
+from fairseq2.error import InternalError
+from fairseq2.nn import Linear
+from fairseq2.recipe.config import (
+    CosineAnnealingLRConfig,
+    MyleLRConfig,
+    NoamLRConfig,
+    PolynomialDecayLRConfig,
+    RegimeSection,
+    TriStageLRConfig,
+)
+from fairseq2.recipe.internal.lr_schedulers import (
+    _CosineAnnealingLRFactory,
+    _MyleLRFactory,
+    _NoamLRFactory,
+    _PolynomialDecayLRFactory,
+    _TriStageLRFactory,
+)
+from fairseq2.utils.validation import ValidationError
+
+
+class TestCosineAnnealingLRFactory:
+    def test_create_works(self) -> None:
+        proj = Linear(10, 10, bias=True)
+
+        optimizer = SGD(proj.parameters(), lr=1.0)
+
+        regime_section = RegimeSection()
+
+        config = CosineAnnealingLRConfig(
+            cycle_len=2,
+            num_warmup_steps=100,
+            cycle_mul=2.0,
+            lr_mul=3.0,
+            start_lr=0.5,
+            final_lr=0.3,
+            final_lr_scale=None,
+        )
+
+        factory = _CosineAnnealingLRFactory(optimizer, regime_section)
+
+        scheduler = factory.create(config)
+
+        start_lrs = [config.start_lr]
+        final_lrs = [config.final_lr]
+
+        assert scheduler.cycle_len == config.cycle_len
+        assert scheduler.num_warmup_steps == config.num_warmup_steps
+        assert scheduler.cycle_mul == config.cycle_mul
+        assert scheduler.lr_mul == config.lr_mul
+        assert scheduler.start_lrs == start_lrs
+        assert scheduler.final_lrs == final_lrs
+
+    def test_create_works_when_cycle_len_is_none(self) -> None:
+        proj = Linear(10, 10, bias=True)
+
+        optimizer = SGD(proj.parameters(), lr=1.0)
+
+        num_steps = 1000
+
+        regime_section = RegimeSection(num_steps=num_steps)
+
+        config = CosineAnnealingLRConfig(
+            cycle_len=None,
+            num_warmup_steps=100,
+            cycle_mul=2.0,
+            lr_mul=3.0,
+            start_lr=0.5,
+            final_lr=0.3,
+            final_lr_scale=None,
+        )
+
+        factory = _CosineAnnealingLRFactory(optimizer, regime_section)
+
+        scheduler = factory.create(config)
+
+        cycle_len = num_steps - config.num_warmup_steps
+
+        start_lrs = [config.start_lr]
+        final_lrs = [config.final_lr]
+
+        assert scheduler.cycle_len == cycle_len
+        assert scheduler.num_warmup_steps == config.num_warmup_steps
+        assert scheduler.cycle_mul == config.cycle_mul
+        assert scheduler.lr_mul == config.lr_mul
+        assert scheduler.start_lrs == start_lrs
+        assert scheduler.final_lrs == final_lrs
+
+    @pytest.mark.parametrize(
+        "start_lrs,final_lrs", [[0.5, 0.3], [[0.5, 0.3], [0.3, 0.4]]]
+    )
+    def test_create_works_with_param_groups(
+        self, start_lrs: float | list[float], final_lrs: float | list[float]
+    ) -> None:
+        proj = Linear(10, 10, bias=True)
+
+        optimizer = SGD([{"params": proj.weight}, {"params": proj.bias}], lr=1.0)  # type: ignore[arg-type]
+
+        regime_section = RegimeSection()
+
+        config = CosineAnnealingLRConfig(
+            cycle_len=2,
+            num_warmup_steps=100,
+            cycle_mul=2.0,
+            lr_mul=3.0,
+            start_lr=start_lrs,
+            final_lr=final_lrs,
+            final_lr_scale=None,
+        )
+
+        factory = _CosineAnnealingLRFactory(optimizer, regime_section)
+
+        scheduler = factory.create(config)
+
+        num_param_groups = len(optimizer.param_groups)
+
+        if isinstance(start_lrs, float):
+            start_lrs = [start_lrs] * num_param_groups
+
+        if isinstance(final_lrs, float):
+            final_lrs = [final_lrs] * num_param_groups
+
+        assert scheduler.cycle_len == config.cycle_len
+        assert scheduler.num_warmup_steps == config.num_warmup_steps
+        assert scheduler.cycle_mul == config.cycle_mul
+        assert scheduler.lr_mul == config.lr_mul
+        assert scheduler.start_lrs == start_lrs
+        assert scheduler.final_lrs == final_lrs
+
+    def test_create_works_when_final_scale_specified(self) -> None:
+        lr = 1.0
+
+        proj = Linear(10, 10, bias=True)
+
+        optimizer = SGD(proj.parameters(), lr=lr)
+
+        regime_section = RegimeSection()
+
+        final_lr_scale = 0.1
+
+        config = CosineAnnealingLRConfig(
+            cycle_len=2,
+            num_warmup_steps=100,
+            cycle_mul=2.0,
+            lr_mul=3.0,
+            start_lr=0.5,
+            final_lr=None,
+            final_lr_scale=final_lr_scale,
+        )
+
+        factory = _CosineAnnealingLRFactory(optimizer, regime_section)
+
+        scheduler = factory.create(config)
+
+        start_lrs = [config.start_lr]
+        final_lrs = [lr * final_lr_scale]
+
+        assert scheduler.cycle_len == config.cycle_len
+        assert scheduler.num_warmup_steps == config.num_warmup_steps
+        assert scheduler.cycle_mul == config.cycle_mul
+        assert scheduler.lr_mul == config.lr_mul
+        assert scheduler.start_lrs == start_lrs
+        assert scheduler.final_lrs == final_lrs
+
+    @pytest.mark.parametrize(
+        "start_lrs,final_lr_scales", [[0.5, 0.1], [[0.5, 0.3], [0.1, 0.2]]]
+    )
+    def test_create_works_with_param_groups_when_final_scale_specified(
+        self, start_lrs: float | list[float], final_lr_scales: float | list[float]
+    ) -> None:
+        lr = 1.0
+
+        proj = Linear(10, 10, bias=True)
+
+        optimizer = SGD([{"params": proj.weight}, {"params": proj.bias}], lr=lr)  # type: ignore[arg-type]
+
+        regime_section = RegimeSection(num_steps=100)
+
+        config = CosineAnnealingLRConfig(
+            cycle_len=2,
+            num_warmup_steps=100,
+            cycle_mul=2.0,
+            lr_mul=3.0,
+            start_lr=start_lrs,
+            final_lr=None,
+            final_lr_scale=final_lr_scales,
+        )
+
+        factory = _CosineAnnealingLRFactory(optimizer, regime_section)
+
+        scheduler = factory.create(config)
+
+        num_param_groups = len(optimizer.param_groups)
+
+        if isinstance(start_lrs, float):
+            start_lrs = [start_lrs] * num_param_groups
+
+        if isinstance(final_lr_scales, float):
+            final_lr_scales = [final_lr_scales] * num_param_groups
+
+        final_lrs = [lr * scale for scale in final_lr_scales]
+
+        assert scheduler.cycle_len == config.cycle_len
+        assert scheduler.num_warmup_steps == config.num_warmup_steps
+        assert scheduler.cycle_mul == config.cycle_mul
+        assert scheduler.lr_mul == config.lr_mul
+        assert scheduler.start_lrs == start_lrs
+        assert scheduler.final_lrs == final_lrs
+
+    def test_create_raises_error_when_cycle_len_and_num_steps_are_both_none(
+        self,
+    ) -> None:
+        proj = Linear(10, 10, bias=True)
+
+        optimizer = SGD(proj.parameters(), lr=1.0)
+
+        regime_section = RegimeSection(num_steps=None)
+
+        config = CosineAnnealingLRConfig(cycle_len=None)
+
+        factory = _CosineAnnealingLRFactory(optimizer, regime_section)
+
+        with pytest.raises(
+            ValidationError, match=r"^`regime.num_steps` must be specified when `lr_scheduler` is 'cosine_annealing' and `lr_scheduler\.config\.cycle_len` is not specified\.$"  # fmt: skip
+        ):
+            factory.create(config)
+
+    def test_create_raises_error_when_start_lrs_do_not_match_param_groups(self) -> None:
+        proj = Linear(10, 10, bias=True)
+
+        optimizer = SGD([{"params": proj.weight}, {"params": proj.bias}], lr=1.0)  # type: ignore[arg-type]
+
+        regime_section = RegimeSection(num_steps=100)
+
+        config = CosineAnnealingLRConfig(
+            start_lr=[1.0, 2.0, 3.0], final_lr=[1.0, 2.0], final_lr_scale=None
+        )
+
+        factory = _CosineAnnealingLRFactory(optimizer, regime_section)
+
+        with pytest.raises(
+            ValidationError, match=r"^`lr_scheduler.config` is not valid: The length of `start_lr` must match the number of optimizer parameter groups \(2\), but is 3 instead\.$"  # fmt: skip
+        ):
+            factory.create(config)
+
+    def test_create_raises_error_when_final_lrs_do_not_match_param_groups(self) -> None:
+        proj = Linear(10, 10, bias=True)
+
+        optimizer = SGD([{"params": proj.weight}, {"params": proj.bias}], lr=1.0)  # type: ignore[arg-type]
+
+        regime_section = RegimeSection(num_steps=100)
+
+        config = CosineAnnealingLRConfig(
+            start_lr=[1.0, 2.0], final_lr=[1.0, 2.0, 3.0, 4.0], final_lr_scale=None
+        )
+
+        factory = _CosineAnnealingLRFactory(optimizer, regime_section)
+
+        with pytest.raises(
+            ValidationError, match=r"^`lr_scheduler.config` is not valid: The length of `final_lr` must match the number of optimizer parameter groups \(2\), but is 4 instead\.$"  # fmt: skip
+        ):
+            factory.create(config)
+
+    def test_create_raises_error_when_final_lr_scales_do_not_match_param_groups(
+        self,
+    ) -> None:
+        proj = Linear(10, 10, bias=True)
+
+        optimizer = SGD([{"params": proj.weight}, {"params": proj.bias}], lr=1.0)  # type: ignore[arg-type]
+
+        regime_section = RegimeSection(num_steps=100)
+
+        config = CosineAnnealingLRConfig(
+            start_lr=[1.0, 2.0], final_lr=None, final_lr_scale=[1.0, 2.0, 3.0, 4.0]
+        )
+
+        factory = _CosineAnnealingLRFactory(optimizer, regime_section)
+
+        with pytest.raises(
+            ValidationError, match=r"^`lr_scheduler.config` is not valid: The length of `final_lr_scale` must match the number of optimizer parameter groups \(2\), but is 4 instead\.$"  # fmt: skip
+        ):
+            factory.create(config)
+
+    def test_create_raises_error_when_both_final_lr_and_final_lr_scale_are_specified(
+        self,
+    ) -> None:
+        proj = Linear(10, 10, bias=True)
+
+        optimizer = SGD(proj.parameters(), lr=1.0)
+
+        regime_section = RegimeSection(num_steps=100)
+
+        config = CosineAnnealingLRConfig(start_lr=0.5, final_lr=0.3, final_lr_scale=0.4)
+
+        factory = _CosineAnnealingLRFactory(optimizer, regime_section)
+
+        with pytest.raises(
+            InternalError, match=r"^`config.final_lr` and `config.final_lr_scale` are both specified\.$"  # fmt: skip
+        ):
+            factory.create(config)
+
+    def test_create_raises_error_when_both_final_lr_and_final_lr_scale_are_none(
+        self,
+    ) -> None:
+        proj = Linear(10, 10, bias=True)
+
+        optimizer = SGD(proj.parameters(), lr=1.0)
+
+        regime_section = RegimeSection(num_steps=100)
+
+        config = CosineAnnealingLRConfig(
+            start_lr=0.5, final_lr=None, final_lr_scale=None
+        )
+
+        factory = _CosineAnnealingLRFactory(optimizer, regime_section)
+
+        with pytest.raises(
+            InternalError, match=r"^`config.final_lr` and `config.final_lr_scale` are both `None`\.$"  # fmt: skip
+        ):
+            factory.create(config)
+
+    def test_create_warns_when_final_lr_is_larger_than_lr(self, caplog: Any) -> None:
+        caplog.set_level(logging.INFO, logger="fairseq2")
+
+        proj = Linear(10, 10, bias=True)
+
+        optimizer = SGD([{"params": proj.weight}, {"params": proj.bias}], lr=2.0)  # type: ignore[arg-type]
+
+        regime_section = RegimeSection(num_steps=100)
+
+        config = CosineAnnealingLRConfig(
+            start_lr=0.5, final_lr=None, final_lr_scale=[0.2, 1.2]
+        )
+
+        factory = _CosineAnnealingLRFactory(optimizer, regime_section)
+
+        factory.create(config)
+
+        assert caplog.record_tuples == [
+            ("fairseq2", logging.WARNING, "The final learning rate (2.4) of optimizer parameter group 1 is greater than the learning rate (2.0). This means the learning rate will increase over the course of the training.")  # fmt: skip
+        ]
+
+
+class TestMyleLRFactory:
+    def test_create_works(self) -> None:
+        proj = Linear(10, 10, bias=True)
+
+        optimizer = SGD(proj.parameters(), lr=1.0)
+
+        config = MyleLRConfig(num_warmup_steps=100, start_lr=0.5)
+
+        factory = _MyleLRFactory(optimizer)
+
+        scheduler = factory.create(config)
+
+        start_lrs = [config.start_lr]
+
+        assert scheduler.num_warmup_steps == config.num_warmup_steps
+        assert scheduler.start_lrs == start_lrs
+
+    @pytest.mark.parametrize("start_lrs", [0.5, [0.5, 0.3]])
+    def test_create_works_with_param_groups(
+        self, start_lrs: float | list[float]
+    ) -> None:
+        proj = Linear(10, 10, bias=True)
+
+        optimizer = SGD([{"params": proj.weight}, {"params": proj.bias}], lr=1.0)  # type: ignore[arg-type]
+
+        config = MyleLRConfig(num_warmup_steps=100, start_lr=start_lrs)
+
+        factory = _MyleLRFactory(optimizer)
+
+        scheduler = factory.create(config)
+
+        num_param_groups = len(optimizer.param_groups)
+
+        if isinstance(start_lrs, float):
+            start_lrs = [start_lrs] * num_param_groups
+
+        assert scheduler.num_warmup_steps == config.num_warmup_steps
+        assert scheduler.start_lrs == start_lrs
+
+    def test_create_raises_error_when_start_lrs_do_not_match_param_groups(self) -> None:
+        proj = Linear(10, 10, bias=True)
+
+        optimizer = SGD([{"params": proj.weight}, {"params": proj.bias}], lr=1.0)  # type: ignore[arg-type]
+
+        config = MyleLRConfig(start_lr=[1.0, 2.0, 3.0])
+
+        factory = _MyleLRFactory(optimizer)
+
+        with pytest.raises(
+            ValidationError, match=r"^`lr_scheduler.config` is not valid: The length of `start_lr` must match the number of optimizer parameter groups \(2\), but is 3 instead\.$"  # fmt: skip
+        ):
+            factory.create(config)
+
+
+class TestNoamLRFactory:
+    def test_create_works(self) -> None:
+        proj = Linear(10, 10, bias=True)
+
+        optimizer = SGD(proj.parameters(), lr=1.0)
+
+        config = NoamLRConfig(num_warmup_steps=100)
+
+        factory = _NoamLRFactory(optimizer)
+
+        scheduler = factory.create(config)
+
+        assert scheduler.num_warmup_steps == config.num_warmup_steps
+
+
+class TestPolynomialDecayLRFactory:
+    @pytest.mark.parametrize("num_warmup_steps", [0, 20, 99])
+    def test_create_works(self, num_warmup_steps: int) -> None:
+        proj = Linear(10, 10, bias=True)
+
+        optimizer = SGD(proj.parameters(), lr=1.0)
+
+        regime_section = RegimeSection(num_steps=100)
+
+        config = PolynomialDecayLRConfig(
+            num_warmup_steps=num_warmup_steps, power=2.0, start_lr=0.5, final_lr=0.3
+        )
+
+        factory = _PolynomialDecayLRFactory(optimizer, regime_section)
+
+        scheduler = factory.create(config)
+
+        start_lrs = [config.start_lr]
+        final_lrs = [config.final_lr]
+
+        assert scheduler.num_steps == regime_section.num_steps
+        assert scheduler.num_warmup_steps == config.num_warmup_steps
+        assert scheduler.power == config.power
+        assert scheduler.start_lrs == start_lrs
+        assert scheduler.final_lrs == final_lrs
+
+    @pytest.mark.parametrize(
+        "start_lrs,final_lrs", [[0.5, 0.3], [[0.5, 0.3], [0.3, 0.4]]]
+    )
+    def test_create_works_with_param_groups(
+        self, start_lrs: float | list[float], final_lrs: float | list[float]
+    ) -> None:
+        proj = Linear(10, 10, bias=True)
+
+        optimizer = SGD([{"params": proj.weight}, {"params": proj.bias}], lr=1.0)  # type: ignore[arg-type]
+
+        regime_section = RegimeSection(num_steps=100)
+
+        config = PolynomialDecayLRConfig(start_lr=start_lrs, final_lr=final_lrs)
+
+        factory = _PolynomialDecayLRFactory(optimizer, regime_section)
+
+        scheduler = factory.create(config)
+
+        num_param_groups = len(optimizer.param_groups)
+
+        if isinstance(start_lrs, float):
+            start_lrs = [start_lrs] * num_param_groups
+
+        if isinstance(final_lrs, float):
+            final_lrs = [final_lrs] * num_param_groups
+
+        assert scheduler.num_steps == regime_section.num_steps
+        assert scheduler.num_warmup_steps == config.num_warmup_steps
+        assert scheduler.power == config.power
+        assert scheduler.start_lrs == start_lrs
+        assert scheduler.final_lrs == final_lrs
+
+    def test_create_raises_error_when_num_steps_is_none(self) -> None:
+        proj = Linear(10, 10, bias=True)
+
+        optimizer = SGD(proj.parameters(), lr=1.0)
+
+        regime_section = RegimeSection(num_steps=None)
+
+        config = PolynomialDecayLRConfig()
+
+        factory = _PolynomialDecayLRFactory(optimizer, regime_section)
+
+        with pytest.raises(
+            ValidationError, match=r"^`regime.num_steps` must be specified when `lr_scheduler` is 'polynomial_decay'\.$"  # fmt: skip
+        ):
+            factory.create(config)
+
+    @pytest.mark.parametrize("num_warmup_steps", [100, 200])
+    def test_create_raises_error_when_num_warmup_steps_is_gte_num_steps(
+        self, num_warmup_steps: int
+    ) -> None:
+        proj = Linear(10, 10, bias=True)
+
+        optimizer = SGD(proj.parameters(), lr=1.0)
+
+        regime_section = RegimeSection(num_steps=100)
+
+        config = PolynomialDecayLRConfig(
+            num_warmup_steps=num_warmup_steps, start_lr=0.5, final_lr=0.3
+        )
+
+        factory = _PolynomialDecayLRFactory(optimizer, regime_section)
+
+        with pytest.raises(
+            ValidationError, match=rf"^`lr_scheduler.config` is not valid: `num_warmup_steps` must be less than `regime.warmup_steps` \(100\), but is {num_warmup_steps} instead\.$"  # fmt: skip
+        ):
+            factory.create(config)
+
+    def test_create_raises_error_when_start_lrs_do_not_match_param_groups(self) -> None:
+        proj = Linear(10, 10, bias=True)
+
+        optimizer = SGD([{"params": proj.weight}, {"params": proj.bias}], lr=1.0)  # type: ignore[arg-type]
+
+        regime_section = RegimeSection(num_steps=100)
+
+        config = PolynomialDecayLRConfig(start_lr=[1.0, 2.0, 3.0], final_lr=[1.0, 2.0])
+
+        factory = _PolynomialDecayLRFactory(optimizer, regime_section)
+
+        with pytest.raises(
+            ValidationError, match=r"^`lr_scheduler.config` is not valid: The length of `start_lr` must match the number of optimizer parameter groups \(2\), but is 3 instead\.$"  # fmt: skip
+        ):
+            factory.create(config)
+
+    def test_create_raises_error_when_final_lrs_do_not_match_param_groups(self) -> None:
+        proj = Linear(10, 10, bias=True)
+
+        optimizer = SGD([{"params": proj.weight}, {"params": proj.bias}], lr=1.0)  # type: ignore[arg-type]
+
+        regime_section = RegimeSection(num_steps=100)
+
+        config = PolynomialDecayLRConfig(
+            start_lr=[1.0, 2.0], final_lr=[1.0, 2.0, 3.0, 4.0]
+        )
+
+        factory = _PolynomialDecayLRFactory(optimizer, regime_section)
+
+        with pytest.raises(
+            ValidationError, match=r"^`lr_scheduler.config` is not valid: The length of `final_lr` must match the number of optimizer parameter groups \(2\), but is 4 instead\.$"  # fmt: skip
+        ):
+            factory.create(config)
+
+
+class TestTriStageLRFactory:
+    def test_create_works(self) -> None:
+        proj = Linear(10, 10, bias=True)
+
+        optimizer = SGD(proj.parameters(), lr=1.0)
+
+        num_steps = 100
+
+        regime_section = RegimeSection(num_steps=num_steps)
+
+        config = TriStageLRConfig(
+            stage_ratio=(0.3, 0.2, 0.5), start_lr_scale=0.2, final_lr_scale=0.3
+        )
+
+        factory = _TriStageLRFactory(optimizer, regime_section)
+
+        scheduler = factory.create(config)
+
+        start_lr_scales = [config.start_lr_scale]
+        final_lr_scales = [config.final_lr_scale]
+
+        num_stage_steps = [int(r * num_steps) for r in config.stage_ratio]
+
+        assert scheduler.num_steps == regime_section.num_steps
+        assert scheduler.num_stage_steps == num_stage_steps
+        assert scheduler.start_lr_scales == start_lr_scales
+        assert scheduler.final_lr_scales == final_lr_scales
+
+    @pytest.mark.parametrize(
+        "start_scales,final_scales", [[0.5, 0.3], [[0.5, 0.3], [0.3, 0.4]]]
+    )
+    def test_create_works_with_param_groups(
+        self, start_scales: float | list[float], final_scales: float | list[float]
+    ) -> None:
+        proj = Linear(10, 10, bias=True)
+
+        optimizer = SGD([{"params": proj.weight}, {"params": proj.bias}], lr=1.0)  # type: ignore[arg-type]
+
+        num_steps = 100
+
+        regime_section = RegimeSection(num_steps=num_steps)
+
+        config = TriStageLRConfig(
+            start_lr_scale=start_scales, final_lr_scale=final_scales
+        )
+
+        factory = _TriStageLRFactory(optimizer, regime_section)
+
+        scheduler = factory.create(config)
+
+        num_param_groups = len(optimizer.param_groups)
+
+        if isinstance(start_scales, float):
+            start_scales = [start_scales] * num_param_groups
+
+        if isinstance(final_scales, float):
+            final_scales = [final_scales] * num_param_groups
+
+        num_stage_steps = [int(r * num_steps) for r in config.stage_ratio]
+
+        assert scheduler.num_steps == regime_section.num_steps
+        assert scheduler.num_stage_steps == num_stage_steps
+        assert scheduler.start_lr_scales == start_scales
+        assert scheduler.final_lr_scales == final_scales
+
+    def test_create_raises_error_when_num_steps_is_none(self) -> None:
+        proj = Linear(10, 10, bias=True)
+
+        optimizer = SGD(proj.parameters(), lr=1.0)
+
+        regime_section = RegimeSection(num_steps=None)
+
+        config = TriStageLRConfig()
+
+        factory = _TriStageLRFactory(optimizer, regime_section)
+
+        with pytest.raises(
+            ValidationError, match=r"^`regime.num_steps` must be specified when `lr_scheduler` is 'tri_stage'\.$"  # fmt: skip
+        ):
+            factory.create(config)
+
+    def test_create_raises_error_when_start_lrs_do_not_match_param_groups(self) -> None:
+        proj = Linear(10, 10, bias=True)
+
+        optimizer = SGD([{"params": proj.weight}, {"params": proj.bias}], lr=1.0)  # type: ignore[arg-type]
+
+        regime_section = RegimeSection(num_steps=100)
+
+        config = TriStageLRConfig(
+            start_lr_scale=[1.0, 2.0, 3.0], final_lr_scale=[1.0, 2.0]
+        )
+
+        factory = _TriStageLRFactory(optimizer, regime_section)
+
+        with pytest.raises(
+            ValidationError, match=r"^`lr_scheduler.config` is not valid: The length of `start_lr_scale` must match the number of optimizer parameter groups \(2\), but is 3 instead\.$"  # fmt: skip
+        ):
+            factory.create(config)
+
+    def test_create_raises_error_when_final_lrs_do_not_match_param_groups(self) -> None:
+        proj = Linear(10, 10, bias=True)
+
+        optimizer = SGD([{"params": proj.weight}, {"params": proj.bias}], lr=1.0)  # type: ignore[arg-type]
+
+        regime_section = RegimeSection(num_steps=100)
+
+        config = TriStageLRConfig(
+            start_lr_scale=[1.0, 2.0], final_lr_scale=[1.0, 2.0, 3.0, 4.0]
+        )
+
+        factory = _TriStageLRFactory(optimizer, regime_section)
+
+        with pytest.raises(
+            ValidationError, match=r"^`lr_scheduler.config` is not valid: The length of `final_lr_scale` must match the number of optimizer parameter groups \(2\), but is 4 instead\.$"  # fmt: skip
+        ):
+            factory.create(config)


### PR DESCRIPTION
This PR (1) adds support for multiple parameter groups in LR scheduler factories, (2) starts adding/improving docstrs for existing and new code constructs, and (3) adds unit tests for all LR factories with near 100% coverage. Resolves #1316 