### PR TITLE
[Draft] hg model integration (v0)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+[report]
+include_namespace_packages = true
+
+[run]
+omit = tests/*

--- a/.github/workflows/_build_doc.yaml
+++ b/.github/workflows/_build_doc.yaml
@@ -64,7 +64,7 @@ jobs:
           pip install --editable native/python
       - name: Install fairseq2
         run: |
-          pip install --editable .
+          pip install --editable ".[hg]"
       - name: Generate documentation
         working-directory: doc
         run: |

--- a/.github/workflows/_build_wheel-linux.yaml
+++ b/.github/workflows/_build_wheel-linux.yaml
@@ -193,7 +193,7 @@ jobs:
           whl=$(ls ~/artifacts/build/wheelhouse/*.whl)
 
           pip install --no-cache-dir\
-            "fairseq2@file://$whl" "fairseq2[arrow]@file://$whl"
+            "fairseq2@file://$whl" "fairseq2[arrow,hg]@file://$whl"
       - name: Set the sanitizer variables
         if: inputs.sanitizers != 'nosan'
         env:

--- a/.github/workflows/_build_wheel-macos.yaml
+++ b/.github/workflows/_build_wheel-macos.yaml
@@ -127,7 +127,7 @@ jobs:
           whl=$(ls ~/artifacts/build/wheelhouse/*.whl)
           
           pip install --no-cache-dir\
-            "fairseq2@file://$whl" "fairseq2[arrow]@file://$whl"
+            "fairseq2@file://$whl" "fairseq2[arrow,hg]@file://$whl"
       - name: Run native tests
         run: |
           chmod 755 ~/artifacts/native/build/tests/run-tests

--- a/.github/workflows/_lint_py.yaml
+++ b/.github/workflows/_lint_py.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Install fairseq2
         id: install_fairseq2
         run: |
-          pip install --editable .
+          pip install --editable ".[hg]"
       - name: Run isort
         if: success() || (failure() && steps.install_fairseq2.outcome == 'success')
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,9 @@ __pycache__/
 
 # Other
 .DS_Store
+
+# coverage
+.coverage
+
+# mypy
+.mypy_cache/

--- a/doc/source/reference/api/fairseq2.models.hg.rst
+++ b/doc/source/reference/api/fairseq2.models.hg.rst
@@ -1,0 +1,193 @@
+fairseq2.models.hg
+==================
+
+The :mod:`fairseq2.models.hg` module provides seamless integration with HuggingFace Transformers models within the fairseq2 framework. This module allows you to load and use any HuggingFace model with fairseq2's training and inference pipelines.
+
+API Reference
+-------------
+
+High-Level API
+~~~~~~~~~~~~~~
+
+.. autofunction:: fairseq2.models.hg.load_hg_model_simple
+
+.. autofunction:: fairseq2.models.hg.load_hg_tokenizer_simple
+
+Convenience Functions
+~~~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: fairseq2.models.hg.load_causal_lm
+
+.. autofunction:: fairseq2.models.hg.load_seq2seq_lm
+
+.. autofunction:: fairseq2.models.hg.load_multimodal_model
+
+Configuration
+~~~~~~~~~~~~~
+
+.. autoclass:: fairseq2.models.hg.HuggingFaceModelConfig
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. autoclass:: fairseq2.models.hg.HgTokenizerConfig
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+Factory Functions
+~~~~~~~~~~~~~~~~~
+
+.. autofunction:: fairseq2.models.hg.create_hg_model
+
+.. autofunction:: fairseq2.models.hg.register_hg_model_class
+
+Tokenizer Classes
+~~~~~~~~~~~~~~~~~
+
+.. autoclass:: fairseq2.models.hg.HgTokenizer
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. autofunction:: fairseq2.models.hg.load_hg_tokenizer
+
+Hub Integration
+~~~~~~~~~~~~~~~
+
+.. autofunction:: fairseq2.models.hg.get_hg_model_hub
+
+.. autofunction:: fairseq2.models.hg.get_hg_tokenizer_hub
+
+Exceptions
+~~~~~~~~~~
+
+.. autoexception:: fairseq2.models.hg.HuggingFaceModelError
+    :members:
+    :undoc-members:
+
+
+Examples
+--------
+
+Basic Model Loading
+~~~~~~~~~~~~~~~~~~~
+
+Use DialoGPT for conversational AI:
+
+.. code-block:: python
+
+    from fairseq2.models.hg import load_causal_lm, load_hg_tokenizer_simple
+    import torch
+
+    # Load DialoGPT model
+    model = load_causal_lm("microsoft/DialoGPT-small")
+    tokenizer = load_hg_tokenizer_simple("microsoft/DialoGPT-small")
+
+    # Conversation
+    user_input = "How are you doing today?"
+    inputs = tokenizer.encode(user_input + tokenizer.eos_token).unsqueeze(0)
+
+    with torch.no_grad():
+        outputs = model.generate(
+            inputs,
+            max_length=inputs.shape[1] + 20,
+            num_return_sequences=1,
+            pad_token_id=tokenizer.vocab_info.eos_idx,
+            do_sample=True,
+            temperature=0.7,
+        )
+
+response = tokenizer.decode(outputs[0], skip_special_tokens=True)
+print(f"Bot: {response[len(user_input):]}")
+
+Sequence-to-Sequence Tasks
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use T5 for translation and summarization:
+
+.. code-block:: python
+
+    from fairseq2.models.hg import load_seq2seq_lm, load_hg_tokenizer_simple
+    import torch
+
+    # Load T5 model
+    model = load_seq2seq_lm("t5-small")
+    tokenizer = load_hg_tokenizer_simple("t5-small")
+
+    # Translation task
+    text = "translate English to French: Hello, how are you?"
+    inputs = tokenizer.encode(text).unsqueeze(0)
+
+    with torch.no_grad():
+        outputs = model.generate(inputs, max_length=50)
+
+    translation = tokenizer.decode(outputs[0], skip_special_tokens=True)
+    print(f"Translation: {translation}")
+
+
+Custom Model Registration
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Register custom models not supported by Auto classes:
+
+.. code-block:: python
+
+    from fairseq2.models.hg import register_hg_model_class, load_hg_model_simple
+
+    # Register a custom model class
+    register_hg_model_class(
+        config_class_name="Qwen2_5OmniConfig",
+        model_class="Qwen2_5OmniForConditionalGeneration",
+        processor_class="Qwen2_5OmniProcessor",
+    )
+
+    # Now load the custom model
+    model = load_hg_model_simple(
+        "Qwen/Qwen2.5-Omni-3B",
+        model_type="custom",
+        use_processor=True,
+        trust_remote_code=True,
+    )
+
+Hub Loading
+~~~~~~~~~~~
+
+Load models/tokenizers using the fairseq2 hub system:
+
+.. code-block:: python
+
+    from fairseq2.models.hg import get_hg_model_hub, get_hg_tokenizer_hub
+
+    name = "hg_qwen25_omni_3b"
+
+    # Load a pre-configured model
+    model_hub = get_hg_model_hub()
+    model = model_hub.load_model(name)
+
+    # Load the corresponding tokenizer
+    tokenizer_hub = get_hg_tokenizer_hub()
+    tokenizer = tokenizer_hub.load_tokenizer(name)
+
+
+.. note::
+    This module requires the ``transformers`` library. Install it with:
+    ``pip install transformers``
+
+.. warning::
+    Some models require ``trust_remote_code=True`` for custom architectures.
+    Only use this with trusted model sources.
+
+
+Module Structure
+----------------
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   fairseq2.models.hg.api
+   fairseq2.models.hg.config
+   fairseq2.models.hg.factory
+   fairseq2.models.hg.hub
+   fairseq2.models.hg.tokenizer

--- a/doc/source/reference/api/models/index.rst
+++ b/doc/source/reference/api/models/index.rst
@@ -14,6 +14,7 @@ The models module includes:
 - Mistral models
 - Wav2Vec2 models
 - NLLB translation models
+- HuggingFace Transformers integration
 - Model loading and configuration utilities
 - Model hub interface for advanced operations
 
@@ -23,6 +24,7 @@ The models module includes:
    hub
    qwen
    llama
+   ../fairseq2.models.hg
 
 Quick Start
 -----------

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,11 @@ setup(
             "polars>=1.19.0",
             "xxhash~=3.5",
         ],
+        "hg": [
+            "accelerate>=1.10.0",
+            "transformers>=4.56.1",
+            "qwen-omni-utils~=0.0.8",
+        ],
     },
     entry_points={"console_scripts": ["fairseq2=fairseq2.cli:main"]},
 )

--- a/src/fairseq2/assets/cards/models/hg.yaml
+++ b/src/fairseq2/assets/cards/models/hg.yaml
@@ -1,0 +1,59 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+
+name: hg_qwen25_omni_3b
+model_family: hg
+model_arch: custom
+model_config:
+  hf_name: Qwen/Qwen2.5-Omni-3B
+  use_processor: true
+  custom_model_class: Qwen2_5OmniForConditionalGeneration
+  custom_processor_class: Qwen2_5OmniProcessor
+  trust_remote_code: true
+checkpoint: hg://Qwen/Qwen2.5-Omni-3B
+tokenizer: hg://Qwen/Qwen2.5-Omni-3B
+tokenizer_family: hg
+
+---
+
+name: hg_qwen25_omni_7b
+model_family: hg
+model_arch: custom
+model_config:
+  hf_name: Qwen/Qwen2.5-Omni-7B
+  use_processor: true
+  custom_model_class: Qwen2_5OmniForConditionalGeneration
+  custom_processor_class: Qwen2_5OmniProcessor
+  trust_remote_code: true
+checkpoint: hg://Qwen/Qwen2.5-Omni-7B
+tokenizer: hg://Qwen/Qwen2.5-Omni-7B
+tokenizer_family: hg
+
+---
+
+name: hg_qwen3_0.6b
+model_family: hg
+model_arch: causal_lm
+model_config:
+  hf_name: Qwen/Qwen3-0.6B
+  trust_remote_code: true
+checkpoint: hg://Qwen/Qwen3-0.6B
+tokenizer: hg://Qwen/Qwen3-0.6B
+tokenizer_family: hg
+
+---
+
+name: hg_qwen3_1.7b
+model_family: hg
+model_arch: causal_lm
+model_config:
+  hf_name: Qwen/Qwen3-1.7B
+  trust_remote_code: true
+checkpoint: hg://Qwen/Qwen3-1.7B
+tokenizer: hg://Qwen/Qwen3-1.7B
+tokenizer_family: hg

--- a/src/fairseq2/composition/models.py
+++ b/src/fairseq2/composition/models.py
@@ -22,6 +22,12 @@ from fairseq2.models import (
     ShardSpecsProvider,
     StandardModelFamily,
 )
+from fairseq2.models.hg import (
+    HG_FAMILY,
+    HuggingFaceModelConfig,
+    create_hg_model,
+    register_hg_configs,
+)
 from fairseq2.models.jepa import (
     JEPA_FAMILY,
     JepaConfig,
@@ -358,3 +364,23 @@ def _register_model_families(container: DependencyContainer) -> None:
     )
 
     register_wav2vec2_asr_configs(container)
+
+    # HuggingFace
+    hg_kls: type[Module] | type[PreTrainedModel]
+    try:
+        from transformers import PreTrainedModel
+
+        hg_kls = PreTrainedModel
+    except ImportError:
+        hg_kls = Module
+
+    register_model_family(
+        container,
+        HG_FAMILY,
+        kls=hg_kls,
+        config_kls=HuggingFaceModelConfig,
+        factory=create_hg_model,
+        supports_meta=False,  # HF models don't support meta device initialization
+    )
+
+    register_hg_configs(container)

--- a/src/fairseq2/composition/tokenizers.py
+++ b/src/fairseq2/composition/tokenizers.py
@@ -18,6 +18,12 @@ from fairseq2.data.tokenizers import (
 )
 from fairseq2.data.tokenizers.char import CHAR_TOKENIZER_FAMILY, load_char_tokenizer
 from fairseq2.error import InternalError
+from fairseq2.models.hg import (
+    HG_FAMILY,
+    HgTokenizer,
+    HgTokenizerConfig,
+    load_hg_tokenizer,
+)
 from fairseq2.models.llama import (
     LLAMA_FAMILY,
     LLaMATokenizerConfig,
@@ -156,4 +162,13 @@ def _register_tokenizer_families(container: DependencyContainer) -> None:
         kls=S2TTransformerTokenizer,
         config_kls=S2TTransformerTokenizerConfig,
         loader=load_s2t_transformer_tokenizer,
+    )
+
+    # HuggingFace
+    register_tokenizer_family(
+        container,
+        HG_FAMILY,
+        kls=HgTokenizer,
+        config_kls=HgTokenizerConfig,
+        loader=load_hg_tokenizer,
     )

--- a/src/fairseq2/data/tokenizers/hg.py
+++ b/src/fairseq2/data/tokenizers/hg.py
@@ -93,20 +93,25 @@ else:
 
         vocab_size = len(tok)
 
-        def maybe_index(token: str | None) -> int | None:
+        def maybe_index(token: str | None, token_type: str | None) -> int | None:
+            """Get token index from explicit token or tokenizer's default."""
             if token:
                 return tok.convert_tokens_to_ids(token)
+
+            if token_type:
+                token_id_attr = f"{token_type}_token_id"
+                return getattr(tok, token_id_attr, None)
 
             return None
 
         vocab_info = VocabularyInfo(
             vocab_size,
-            unk_idx=maybe_index(unk_token),
-            bos_idx=maybe_index(bos_token),
-            eos_idx=maybe_index(eos_token),
-            pad_idx=maybe_index(pad_token),
-            boh_idx=maybe_index(boh_token),
-            eoh_idx=maybe_index(eoh_token),
+            unk_idx=maybe_index(unk_token, token_type="unk"),
+            bos_idx=maybe_index(bos_token, token_type="bos"),
+            eos_idx=maybe_index(eos_token, token_type="eos"),
+            pad_idx=maybe_index(pad_token, token_type="pad"),
+            boh_idx=maybe_index(boh_token, token_type="boh"),
+            eoh_idx=maybe_index(eoh_token, token_type="eoh"),
         )
 
         return HuggingFaceTokenModel(tok, vocab_info)

--- a/src/fairseq2/models/hg/__init__.py
+++ b/src/fairseq2/models/hg/__init__.py
@@ -1,0 +1,80 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+HuggingFace model integration for fairseq2.
+
+This module provides seamless integration between HuggingFace Transformers
+and fairseq2, allowing you to use any HuggingFace model within fairseq2's
+training and inference pipelines.
+
+Key Features:
+    - Load any HuggingFace model with minimal configuration
+    - Automatic device placement and dtype handling
+    - Support for custom model architectures
+    - Integration with fairseq2's model hub system
+    - Compatible tokenizer interface
+    - Comprehensive error handling
+
+Quick Start:
+    Load a GPT-2 model and tokenizer::
+
+        from fairseq2.models.hg import (
+            load_hg_model_simple,
+            load_hg_tokenizer_simple,
+        )
+
+        model = load_hg_model_simple("gpt2")
+        tokenizer = load_hg_tokenizer_simple("gpt2")
+
+    Use convenience functions for specific model types::
+
+        from fairseq2.models.hg import load_causal_lm, load_seq2seq_lm
+
+        gpt_model = load_causal_lm("gpt2")
+        t5_model = load_seq2seq_lm("t5-small")
+
+    Register custom model classes::
+
+        from fairseq2.models.hg import register_hg_model_class
+
+        register_hg_model_class(
+            "Qwen2_5OmniConfig",
+            "Qwen2_5OmniForConditionalGeneration",
+            processor_class="Qwen2_5OmniProcessor",
+        )
+
+Modules:
+    api: High-level API functions for model and tokenizer loading
+    config: Configuration classes for HuggingFace models
+    factory: Factory classes for model creation and loading
+    hub: Integration with fairseq2's model hub system
+    tokenizer: HuggingFace tokenizer integration
+
+For detailed documentation, see: :doc:`/reference/api/fairseq2.models.hg`
+"""
+
+from __future__ import annotations
+
+from fairseq2.models.hg.api import load_causal_lm as load_causal_lm
+from fairseq2.models.hg.api import load_hg_model_simple as load_hg_model_simple
+from fairseq2.models.hg.api import load_hg_tokenizer_simple as load_hg_tokenizer_simple
+from fairseq2.models.hg.api import load_multimodal_model as load_multimodal_model
+from fairseq2.models.hg.api import load_seq2seq_lm as load_seq2seq_lm
+from fairseq2.models.hg.config import HG_FAMILY as HG_FAMILY
+from fairseq2.models.hg.config import HuggingFaceModelConfig as HuggingFaceModelConfig
+from fairseq2.models.hg.config import register_hg_configs as register_hg_configs
+from fairseq2.models.hg.factory import HgFactory as HgFactory
+from fairseq2.models.hg.factory import HuggingFaceModelError as HuggingFaceModelError
+from fairseq2.models.hg.factory import create_hg_model as create_hg_model
+from fairseq2.models.hg.factory import (
+    register_hg_model_class as register_hg_model_class,
+)
+from fairseq2.models.hg.hub import get_hg_model_hub as get_hg_model_hub
+from fairseq2.models.hg.hub import get_hg_tokenizer_hub as get_hg_tokenizer_hub
+from fairseq2.models.hg.tokenizer import HgTokenizer as HgTokenizer
+from fairseq2.models.hg.tokenizer import HgTokenizerConfig as HgTokenizerConfig
+from fairseq2.models.hg.tokenizer import load_hg_tokenizer as load_hg_tokenizer

--- a/src/fairseq2/models/hg/api.py
+++ b/src/fairseq2/models/hg/api.py
@@ -1,0 +1,203 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+High-level API for HuggingFace model integration.
+
+This module provides the main entry points for loading HuggingFace models and
+tokenizers within the fairseq2 framework. It offers simplified functions that
+handle common use cases while providing flexibility for advanced
+configurations.
+
+Key Functions:
+    - load_hg_model_simple: Load any HuggingFace model with minimal config
+    - load_hg_tokenizer_simple: Load a HuggingFace tokenizer with custom tokens
+    - load_causal_lm: Convenient wrapper for causal language models (GPT-style)
+    - load_seq2seq_lm: Convenient wrapper for seq2seq models (T5-style)
+    - load_multimodal_model: Convenient wrapper for multimodal models
+
+Example:
+    Basic usage for loading a GPT-2 model::
+
+        from fairseq2.models.hg import (
+            load_hg_model_simple,
+            load_hg_tokenizer_simple,
+        )
+
+        model = load_hg_model_simple("gpt2")
+        tokenizer = load_hg_tokenizer_simple("gpt2")
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from fairseq2.models.hg.config import HuggingFaceModelConfig
+from fairseq2.models.hg.factory import create_hg_model
+from fairseq2.models.hg.tokenizer import (
+    HgTokenizer,
+    HgTokenizerConfig,
+    load_hg_tokenizer,
+)
+
+
+def load_hg_model_simple(
+    name: str,
+    *,
+    model_type: str = "auto",
+    use_processor: bool = False,
+    device: str = "cpu",
+    trust_remote_code: bool = False,
+    dtype: str = "auto",
+    **kwargs: Any,
+) -> Any:
+    """Load a HuggingFace model with simplified configuration.
+
+    This is the main entry point for users who want to load HuggingFace models
+    into fairseq2 with minimal configuration.
+
+    :param name: HuggingFace model identifier (e.g., 'gpt2', 'microsoft/DialoGPT')
+    :param model_type: Type of AutoModel to use ('auto', 'causal_lm', 'seq2seq_lm', 'custom')
+    :param use_processor: Whether to use AutoProcessor instead of AutoTokenizer
+    :param device: Device placement ('cpu', 'cuda:0', or 'auto' for HF accelerate)
+    :param trust_remote_code: Whether to trust remote code for custom architectures
+    :param dtype: PyTorch dtype to use ('auto', 'float16', 'bfloat16', etc.)
+    :param kwargs: Additional kwargs passed to from_pretrained
+    :returns: The loaded HuggingFace model
+
+    Examples:
+        Load a standard causal language model::
+
+            model = load_hg_model_simple("gpt2")
+
+        Load a seq2seq model::
+
+            model = load_hg_model_simple("t5-small", model_type="seq2seq_lm")
+
+        Load a multimodal model with processor::
+
+            model = load_hg_model_simple(
+                "Qwen/Qwen2.5-Omni-7B",
+                use_processor=True,
+                trust_remote_code=True
+            )
+    """
+    config = HuggingFaceModelConfig(
+        hf_name=name,
+        model_type=model_type,
+        use_processor=use_processor,
+        device=device,
+        trust_remote_code=trust_remote_code,
+        dtype=dtype,
+        load_kwargs=kwargs if kwargs else None,
+    )
+
+    return create_hg_model(config)
+
+
+def load_hg_tokenizer_simple(
+    name: str,
+    *,
+    unk_token: str | None = None,
+    bos_token: str | None = None,
+    eos_token: str | None = None,
+    pad_token: str | None = None,
+    boh_token: str | None = None,
+    eoh_token: str | None = None,
+) -> HgTokenizer:
+    """Load a HuggingFace tokenizer with custom special tokens.
+
+    :param name: HuggingFace tokenizer identifier (same as model name)
+    :param unk_token: Custom unknown token
+    :param bos_token: Custom beginning of sequence token
+    :param eos_token: Custom end of sequence token
+    :param pad_token: Custom padding token
+    :param boh_token: Custom beginning of human token
+    :param eoh_token: Custom end of human token
+    :returns: The loaded tokenizer with custom tokens
+
+    Examples:
+        Load a tokenizer with default settings::
+
+            tokenizer = load_hg_tokenizer_simple("gpt2")
+
+        Load with custom tokens::
+
+            tokenizer = load_hg_tokenizer_simple(
+                "gpt2",
+                pad_token="<pad>",
+                eos_token="<end>"
+            )
+    """
+    config = HgTokenizerConfig(
+        unk_token=unk_token,
+        bos_token=bos_token,
+        eos_token=eos_token,
+        pad_token=pad_token,
+        boh_token=boh_token,
+        eoh_token=eoh_token,
+    )
+    return load_hg_tokenizer(Path(name), config)
+
+
+# Convenience aliases for common use cases
+def load_causal_lm(name: str, **kwargs: Any) -> Any:
+    """Load a causal language model (GPT-style).
+
+    Convenience function for loading causal language models like GPT-2,
+    DialoGPT, or LLaMA.
+
+    :param name: HuggingFace model identifier
+    :param kwargs: Additional arguments passed to load_hg_model_simple
+    :returns: A causal language model
+
+    Example:
+        Load GPT-2 for text generation::
+
+            model = load_causal_lm("gpt2")
+    """
+    return load_hg_model_simple(name, model_type="causal_lm", **kwargs)
+
+
+def load_seq2seq_lm(name: str, **kwargs: Any) -> Any:
+    """Load a sequence-to-sequence model (T5-style).
+
+    Convenience function for loading seq2seq models like T5, BART, or
+    Pegasus for tasks like translation, summarization, and question
+    answering.
+
+    :param name: HuggingFace model identifier
+    :param kwargs: Additional arguments passed to load_hg_model_simple
+    :returns: A sequence-to-sequence model
+
+    Example:
+        Load T5 for translation::
+
+            model = load_seq2seq_lm("t5-small")
+    """
+    return load_hg_model_simple(name, model_type="seq2seq_lm", **kwargs)
+
+
+def load_multimodal_model(name: str, **kwargs: Any) -> Any:
+    """Load a multimodal model with processor.
+
+    Convenience function for loading multimodal models that require
+    processors instead of tokenizers (e.g., vision-language models).
+
+    :param name: HuggingFace model identifier
+    :param kwargs: Additional arguments passed to load_hg_model_simple
+    :returns: A multimodal model
+
+    Example:
+        Load a multimodal model::
+
+            model = load_multimodal_model(
+                "Qwen/Qwen2.5-Omni-3B",
+                trust_remote_code=True
+            )
+    """
+    return load_hg_model_simple(name, use_processor=True, **kwargs)

--- a/src/fairseq2/models/hg/config.py
+++ b/src/fairseq2/models/hg/config.py
@@ -1,0 +1,135 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Configuration classes for HuggingFace model integration.
+
+This module defines the configuration dataclasses used to specify how
+HuggingFace models should be loaded and configured within fairseq2.
+
+Classes:
+    HuggingFaceModelConfig: Main configuration class for HuggingFace models
+
+Functions:
+    register_hg_configs: Register predefined HuggingFace model configurations
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Final
+
+from fairseq2.runtime.config_registry import ConfigRegistrar
+from fairseq2.runtime.dependency import DependencyContainer
+
+HG_FAMILY: Final = "hg"
+"""The family identifier for HuggingFace models in fairseq2."""
+
+
+@dataclass(kw_only=True)
+class HuggingFaceModelConfig:
+    """Configuration for loading HuggingFace models.
+
+    This dataclass contains all the parameters needed to configure how a
+    HuggingFace model should be loaded, including device placement, dtype,
+    custom classes, and special loading options.
+
+    :param hf_name: The HuggingFace model identifier (e.g., 'gpt2')
+    :param model_type: Type of AutoModel ('auto', 'causal_lm', 'seq2seq_lm',
+        'custom')
+    :param use_processor: Whether to use AutoProcessor for multimodal models
+    :param device: Device placement ('cpu', 'cuda:0', or 'auto')
+    :param custom_model_class: Custom model class name for special cases
+    :param custom_processor_class: Custom processor class name for special
+        cases
+    :param trust_remote_code: Whether to trust remote code for custom
+        architectures
+    :param dtype: PyTorch dtype to use ('auto', 'float16', 'bfloat16', etc.)
+    :param load_kwargs: Additional kwargs to pass to from_pretrained
+
+    Example:
+        Create a configuration for GPT-2::
+
+            config = HuggingFaceModelConfig(
+                hf_name="gpt2",
+                model_type="causal_lm",
+                device="cuda:0"
+            )
+    """
+
+    hf_name: str
+    """The HuggingFace model identifier (e.g., 'gpt2')."""
+
+    model_type: str = "auto"
+    """Type of AutoModel ('auto', 'causal_lm', 'seq2seq_lm', 'custom')."""
+
+    use_processor: bool = False
+    """Whether to use AutoProcessor for multimodal models."""
+
+    device: str = "cpu"
+    """Device placement: 'cpu', 'cuda:0', or 'auto' for HF accelerate."""
+
+    custom_model_class: str | None = None
+    """Custom model class name for special cases."""
+
+    custom_processor_class: str | None = None
+    """Custom processor class name for special cases."""
+
+    trust_remote_code: bool = False
+    """Whether to trust remote code for custom architectures."""
+
+    dtype: str = "auto"
+    """PyTorch dtype to use ('auto', 'float16', 'bfloat16', etc.)."""
+
+    load_kwargs: dict[str, Any] | None = None
+    """Additional kwargs to pass to from_pretrained."""
+
+
+def register_hg_configs(container: DependencyContainer) -> None:
+    """Register predefined HuggingFace model configurations.
+
+    This function registers several predefined configurations for common
+    HuggingFace models, making them available through the fairseq2 model
+    hub system.
+
+    :param container: The dependency container to register configurations with
+
+    Registered Configurations:
+        - `Stack Overflow home <https://stackoverflow.com/>`_
+        - `auto <https://huggingface.co/docs/transformers/model_doc/auto#transformers.AutoModel>`_
+        - `causal_lm <https://huggingface.co/docs/transformers/modeldoc/auto#transformers.AutoModelForCausalLM>`_
+        - `seq2seq_lm <https://huggingface.co/docs/transformers/model_doc/auto#transformers.AutoModelForSeq2SeqLM>`_
+        - custom: Custom model configuration for untracked models in auto classes
+    """
+    arch = ConfigRegistrar(container, HuggingFaceModelConfig)
+
+    @arch("causal_lm")
+    def causal_lm() -> HuggingFaceModelConfig:
+        return HuggingFaceModelConfig(
+            hf_name="gpt2",
+            model_type="causal_lm",
+        )
+
+    @arch("seq2seq_lm")
+    def seq2seq_lm() -> HuggingFaceModelConfig:
+        return HuggingFaceModelConfig(
+            hf_name="google-t5/t5-small",
+            model_type="seq2seq_lm",
+        )
+
+    @arch("auto")
+    def auto() -> HuggingFaceModelConfig:
+        return HuggingFaceModelConfig(
+            hf_name="bert-base-uncased",
+            model_type="auto",
+        )
+
+    @arch("custom")
+    def custom() -> HuggingFaceModelConfig:
+        return HuggingFaceModelConfig(
+            hf_name="Qwen/Qwen2.5-Omni-3B",
+            model_type="custom",
+        )

--- a/src/fairseq2/models/hg/factory.py
+++ b/src/fairseq2/models/hg/factory.py
@@ -1,0 +1,436 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Factory functions for creating HuggingFace models.
+
+This module provides the core factory functionality for creating HuggingFace
+models within fairseq2. It handles model loading, device placement, custom
+model classes, and error handling.
+
+Key Components:
+    - HgFactory: Main factory class for model creation
+    - HuggingFaceModelError: Custom exception for model loading errors
+    - Model registries for special cases and custom models
+    - Utility functions for device and dtype handling
+
+The factory supports:
+    - Auto model detection and loading
+    - Custom model classes for unsupported architectures
+    - Device placement with accelerate integration
+    - Processor and tokenizer handling
+    - Comprehensive error handling and logging
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from typing import Any, Dict, Type
+
+from fairseq2.assets import HuggingFaceHub
+from fairseq2.error import NotSupportedError, OperationalError
+from fairseq2.logging import log
+from fairseq2.models.hg.config import HuggingFaceModelConfig
+from fairseq2.utils.uri import Uri
+
+try:
+    from transformers import (
+        AutoConfig,
+        AutoModel,
+        AutoModelForCausalLM,
+        AutoModelForSeq2SeqLM,
+        AutoProcessor,
+        PreTrainedModel,
+        PreTrainedTokenizer,
+    )
+except ImportError:
+    _has_transformers = False
+else:
+    _has_transformers = True
+
+
+# Registry for special cases where AutoModel doesn't work
+_HF_SPECIAL_MODELS: Dict[str, Dict[str, str]] = {
+    "Qwen2_5OmniConfig": {
+        "model_class": "Qwen2_5OmniForConditionalGeneration",
+        "processor_class": "Qwen2_5OmniProcessor",
+    },
+    # Add more special cases as needed
+}
+"""Built-in registry for models that require special handling."""
+
+# User-defined registry for custom model mappings
+_USER_REGISTRY: Dict[str, Dict[str, Any]] = {}
+"""User-defined registry for custom model class mappings."""
+
+
+class HuggingFaceModelError(Exception):
+    """
+    Exception raised when HuggingFace model loading fails.
+
+    This exception provides detailed information about model loading failures,
+    including the model name and specific error details.
+
+    Attributes:
+        model_name: The name of the model that failed to load
+        message: Detailed error message
+    """
+
+    def __init__(self, model_name: str, message: str) -> None:
+        super().__init__(message)
+        self.model_name = model_name
+
+
+def register_hg_model_class(
+    config_class_name: str,
+    model_class: Type[PreTrainedModel] | str,
+    tokenizer_class: Type[PreTrainedTokenizer] | str | None = None,
+    processor_class: str | None = None,
+) -> None:
+    """
+    Register a custom model class for models not supported by Auto classes.
+
+    This function allows registration of custom model classes that cannot be
+    loaded automatically by HuggingFace's Auto classes. This is useful for
+    new or experimental model architectures.
+
+    :param config_class_name: The name of the config class (e.g., 'Qwen2_5OmniConfig')
+    :param model_class: The model class or its string name
+    :param tokenizer_class: The tokenizer class or its string name (optional)
+    :param processor_class: The processor class or its string name (optional)
+    :raises: OperationalError: If transformers library is not available
+
+    Example:
+        Register a custom model::
+
+            register_hg_model_class(
+                "Qwen2_5OmniConfig",
+                "Qwen2_5OmniForConditionalGeneration",
+                processor_class="Qwen2_5OmniProcessor",
+            )
+    """
+    if not _has_transformers:
+        raise OperationalError(
+            "HuggingFace Transformers is not available. Install it with "
+            "`pip install transformers`."
+        )
+
+    entry = {}
+
+    if isinstance(model_class, str):
+        entry["model_class"] = model_class
+    else:
+        entry["model_class"] = model_class.__name__
+
+    if tokenizer_class is not None:
+        if isinstance(tokenizer_class, str):
+            entry["tokenizer_class"] = tokenizer_class
+        else:
+            entry["tokenizer_class"] = tokenizer_class.__name__
+
+    if processor_class is not None:
+        if isinstance(processor_class, str):
+            entry["processor_class"] = processor_class
+        else:
+            entry["processor_class"] = processor_class.__name__
+
+    _USER_REGISTRY[config_class_name] = entry
+
+    log.info(f"Registered custom HF model mapping: {config_class_name} -> {entry}")
+
+
+def create_hg_model(
+    config: HuggingFaceModelConfig,
+) -> Any:
+    """
+    Create a HuggingFace model from configuration.
+
+    This factory loads models directly from HuggingFace Hub with transformers.
+
+    :param config: HuggingFace model configuration
+    :returns: HuggingFace PreTrainedModel
+    :raises: OperationalError: If transformers library is not available
+    :raises: HuggingFaceModelError: If model loading fails
+    :raises: NotSupportedError: If transformers library is not available
+    """
+    return HgFactory(config).create_model()
+
+
+class HgFactory:
+    """
+    Factory for creating HuggingFace models.
+
+    This class handles the logic of loading HuggingFace models,
+    including device placement, dtype conversion, custom classes, and
+    error handling.
+
+    Args:
+        config: The HuggingFace model configuration
+    """
+
+    def __init__(self, config: HuggingFaceModelConfig) -> None:
+        """Initialize the factory with configuration."""
+        self._config = config
+
+    def create_model(self) -> Any:
+        """Create the model according to the configuration.
+
+        Returns:
+            PreTrainedModel: The loaded model
+
+        Raises:
+            NotSupportedError: If transformers is not available
+            HuggingFaceModelError: If model loading fails
+        """
+        config = self._config
+
+        log.info(f"Creating HuggingFace model: {config.hf_name}")
+
+        if not _has_transformers:
+            raise NotSupportedError(
+                "HuggingFace Transformers is not available. Install it with "
+                "`pip install transformers`."
+            )
+
+        name = config.hf_name
+
+        try:
+            # Get the model configuration first
+            hf_config = AutoConfig.from_pretrained(name)
+            config_class_name = hf_config.__class__.__name__
+
+            log.info(
+                f"Loading HuggingFace model '{name}' with config "
+                f"{config_class_name}"
+            )
+
+            # Check if this is a special case model
+            model_info = _get_model_info(config_class_name, config)
+
+            if model_info:
+                return _load_special_model(name, config, model_info)
+            else:
+                return _load_auto_model(name, config, hf_config)
+
+        except Exception as ex:
+            if "not found" in str(ex).lower() or "404" in str(ex):
+                raise HuggingFaceModelError(
+                    name,
+                    f"Model '{name}' not found. Please ensure the model name "
+                    f"is correct and refer to HuggingFace documentation: "
+                    f"https://huggingface.co/docs/transformers/model_doc/auto",
+                ) from ex
+            else:
+                raise HuggingFaceModelError(
+                    name, f"Failed to load model '{name}': {str(ex)}"
+                ) from ex
+
+
+def _get_model_info(
+    config_class_name: str, config: HuggingFaceModelConfig
+) -> Dict[str, str] | None:
+    """Get model info from registries or config."""
+
+    # Check user registry first
+    if config_class_name in _USER_REGISTRY:
+        return _USER_REGISTRY[config_class_name]
+
+    # Check built-in special models
+    if config_class_name in _HF_SPECIAL_MODELS:
+        return _HF_SPECIAL_MODELS[config_class_name]
+
+    # Check if config specifies custom classes
+    if config.model_type == "custom" and config.custom_model_class:
+        info = {"model_class": config.custom_model_class}
+        if config.custom_processor_class:
+            info["processor_class"] = config.custom_processor_class
+        return info
+
+    return None
+
+
+def _load_special_model(
+    name: str, config: HuggingFaceModelConfig, model_info: Dict[str, str]
+) -> Any:
+    """Load a model using special/custom classes."""
+
+    log.info(f"Loading special model '{name}' using custom classes")
+
+    # Prepare kwargs for from_pretrained
+    load_kwargs = _prepare_load_kwargs(config)
+
+    # Import and load the model class
+    model_class_name = model_info["model_class"]
+    try:
+        model_class = _import_class_from_transformers(model_class_name)
+        model = model_class.from_pretrained(**load_kwargs)
+    except Exception as ex:
+        raise HuggingFaceModelError(
+            name,
+            f"Failed to load model using custom class '{model_class_name}': {str(ex)}",
+        ) from ex
+
+    # Load tokenizer/processor
+    if "processor_class" in model_info:
+        processor_class_name = model_info["processor_class"]
+        try:
+            processor_class = _import_class_from_transformers(processor_class_name)
+            processor = processor_class.from_pretrained(name)
+            model.processor = processor
+        except Exception as ex:
+            log.warning(
+                f"Failed to load processor '{processor_class_name}', skipping: {str(ex)}"
+            )
+
+    return model
+
+
+def _load_auto_model(name: str, config: HuggingFaceModelConfig, hf_config: Any) -> Any:
+    """Load a model using Auto classes."""
+
+    log.info(f"Loading model '{name}' using Auto classes")
+
+    # Prepare kwargs for from_pretrained
+    load_kwargs = _prepare_load_kwargs(config)
+
+    # Determine which AutoModel class to use
+    auto_model_class = _get_auto_model_class(config, hf_config)
+
+    try:
+        model = auto_model_class.from_pretrained(**load_kwargs)
+    except Exception as ex:
+        # Check if this might be an unsupported model
+        if "does not appear to have a file named config.json" not in str(ex):
+            raise HuggingFaceModelError(
+                name,
+                f"Model '{name}' is not supported by HuggingFace AutoModel.\nError: {str(ex)}.\nPlease refer to https://huggingface.co/docs/transformers/model_doc/auto\nfor supported architectures or register a custom class.",  # fmt: skip
+            ) from ex
+        else:
+            raise
+
+    # Load tokenizer/processor
+    if config.use_processor:
+        try:
+            processor = AutoProcessor.from_pretrained(name)
+            # Set processor to model
+            model.processor = processor
+        except Exception:
+            log.warning(f"AutoProcessor failed for '{name}', skipping")
+
+    return model
+
+
+def _get_auto_model_class(config: HuggingFaceModelConfig, hf_config: Any) -> Any:
+    """Determine which AutoModel class to use."""
+
+    if config.model_type == "causal_lm":
+        return AutoModelForCausalLM
+    elif config.model_type == "seq2seq_lm":
+        return AutoModelForSeq2SeqLM
+    elif config.model_type == "auto":
+        return AutoModel
+    else:
+        # Auto-detect based on config
+        if hasattr(hf_config, "is_encoder_decoder") and hf_config.is_encoder_decoder:
+            return AutoModelForSeq2SeqLM
+        else:
+            # Default to causal LM for decoder-only models
+            return AutoModelForCausalLM
+
+
+def _prepare_load_kwargs(config: HuggingFaceModelConfig) -> Dict[str, Any]:
+    """Prepare kwargs for from_pretrained call."""
+
+    kwargs: Dict[str, Any] = {}
+
+    # Get the local model path (download if necessary)
+    model_path = _get_model_path(config)
+    kwargs["pretrained_model_name_or_path"] = model_path
+    kwargs["use_safetensors"] = True
+
+    # Set dtype
+    _set_dtype_kwargs(config, kwargs)
+
+    # Set trust_remote_code
+    if config.trust_remote_code:
+        kwargs["trust_remote_code"] = True
+
+    # Handle device_map for auto device placement
+    _set_device_kwargs(config, kwargs)
+
+    # Add any additional kwargs from config
+    if config.load_kwargs:
+        kwargs.update(config.load_kwargs)
+
+    return kwargs
+
+
+def _get_model_path(config: HuggingFaceModelConfig) -> Path:
+    """
+    Download and return the local path to the HuggingFace model.
+    Uses caching to avoid re-downloading the same model.
+
+    .. note::
+        This function requires internet access on the first call to download the model.
+        Subsequent calls will use the cached version in ``$HF_HOME``.
+
+    :param config: HuggingFace model configuration
+    :returns: Local path to the downloaded model
+    """
+    uri = Uri.maybe_parse(f"hg://{config.hf_name}")
+
+    if uri is None or uri.scheme != "hg":
+        raise ValueError(f"Invalid HuggingFace model URI: {config.hf_name}")
+
+    hf_hub = HuggingFaceHub()
+    path = hf_hub.download_model(uri, config.hf_name)
+
+    return path
+
+
+def _set_dtype_kwargs(config: HuggingFaceModelConfig, kwargs: Dict[str, Any]) -> None:
+    """Set dtype-related kwargs."""
+    if config.dtype != "auto":
+        import torch
+
+        dtype_map = {
+            "float16": torch.float16,
+            "bfloat16": torch.bfloat16,
+            "float32": torch.float32,
+        }
+        if config.dtype in dtype_map:
+            kwargs["dtype"] = dtype_map[config.dtype]
+    else:
+        kwargs["dtype"] = "auto"
+
+
+def _set_device_kwargs(config: HuggingFaceModelConfig, kwargs: Dict[str, Any]) -> None:
+    """Set device-related kwargs."""
+    if config.device == "auto":
+        try:
+            import accelerate  # type: ignore[import-untyped]  # noqa: F401
+
+            kwargs["device_map"] = "auto"
+        except ImportError:
+            log.warning(
+                "accelerate library not found. Cannot use device_map='auto'. Install with `pip install accelerate`."
+            )
+
+
+def _import_class_from_transformers(class_name: str) -> Any:
+    """Import a class from the transformers library."""
+
+    try:
+        # Try importing from transformers directly
+        transformers_module = importlib.import_module("transformers")
+        return getattr(transformers_module, class_name)
+    except AttributeError:
+        # If not found in main module, it might be in a submodule
+        # This is a simplified approach
+        raise ImportError(
+            f"Class '{class_name}' not found in transformers library. Make sure you have the correct version installed."  # fmt: skip
+        )

--- a/src/fairseq2/models/hg/hub.py
+++ b/src/fairseq2/models/hg/hub.py
@@ -1,0 +1,41 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Hub integration for HuggingFace models and tokenizers.
+
+This module provides hub accessors that integrate HuggingFace models and
+tokenizers with fairseq2's model hub system. This allows you to load
+preconfigured HuggingFace models using the fairseq2 hub interface.
+
+Hub Accessors:
+    get_hg_model_hub: Access to HuggingFace model configurations
+    get_hg_tokenizer_hub: Access to HuggingFace tokenizer configurations
+
+Example:
+    Load a model through the hub system::
+
+        from fairseq2.models.hg.hub import get_hg_model_hub
+
+        model_hub = get_hg_model_hub()
+        model = model_hub.load_model("hg_qwen25_omni_3b")
+"""
+
+from __future__ import annotations
+
+from transformers import PreTrainedModel
+
+from fairseq2.data.tokenizers import TokenizerHubAccessor
+from fairseq2.models import ModelHubAccessor
+from fairseq2.models.hg.config import HG_FAMILY, HuggingFaceModelConfig
+from fairseq2.models.hg.tokenizer import HgTokenizer, HgTokenizerConfig
+
+get_hg_model_hub = ModelHubAccessor(
+    HG_FAMILY, kls=PreTrainedModel, config_kls=HuggingFaceModelConfig
+)
+
+get_hg_tokenizer_hub = TokenizerHubAccessor(
+    HG_FAMILY, kls=HgTokenizer, config_kls=HgTokenizerConfig
+)

--- a/src/fairseq2/models/hg/tokenizer.py
+++ b/src/fairseq2/models/hg/tokenizer.py
@@ -1,0 +1,219 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""HuggingFace tokenizer integration for fairseq2.
+
+This module provides a bridge between HuggingFace tokenizers and fairseq2's
+tokenizer interface. It allows you to use any HuggingFace tokenizer within
+the fairseq2 ecosystem while maintaining compatibility with fairseq2's
+training and inference pipelines.
+
+Classes:
+    HgTokenizerConfig: Configuration for HuggingFace tokenizers
+    HgTokenizer: Wrapper class that adapts HuggingFace tokenizers
+
+Functions:
+    load_hg_tokenizer: Load a HuggingFace tokenizer from path and config
+
+Example:
+    Load a GPT-2 tokenizer::
+
+        from fairseq2.models.hg.tokenizer import (
+            load_hg_tokenizer,
+            HgTokenizerConfig,
+        )
+
+        config = HgTokenizerConfig()
+        tokenizer = load_hg_tokenizer("gpt2", config)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from torch import Tensor
+from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast
+from typing_extensions import override
+
+from fairseq2.data.tokenizers import (
+    TokenDecoder,
+    TokenEncoder,
+    Tokenizer,
+    VocabularyInfo,
+)
+from fairseq2.data.tokenizers.hg import (
+    HuggingFaceTokenDecoder,
+    HuggingFaceTokenEncoder,
+    HuggingFaceTokenModel,
+    load_hg_token_model,
+)
+from fairseq2.device import Device
+
+
+@dataclass(kw_only=True)
+class HgTokenizerConfig:
+    """Configuration for HuggingFace tokenizers."""
+
+    unk_token: str | None = None
+    """The unknown token."""
+
+    bos_token: str | None = None
+    """The beginning-of-sequence token."""
+
+    eos_token: str | None = None
+    """The end-of-sequence token."""
+
+    pad_token: str | None = None
+    """The padding token."""
+
+    boh_token: str | None = None
+    """The beginning-of-head token."""
+
+    eoh_token: str | None = None
+    """The end-of-head token."""
+
+
+class HgTokenizer(Tokenizer):
+    """HuggingFace tokenizer adapter for fairseq2.
+
+    This class wraps a HuggingFace tokenizer to make it compatible with
+    fairseq2's Tokenizer interface. It provides access to both fairseq2
+    tokenizer methods and the underlying HuggingFace tokenizer.
+
+    Example:
+        Create a tokenizer from a model::
+
+            model = load_hg_token_model("gpt2")
+            tokenizer = HgTokenizer(model)
+
+            # Use fairseq2 interface
+            tokens = tokenizer.encode("Hello world")
+            text = tokenizer.decode(tokens)
+
+            # Access underlying HuggingFace tokenizer
+            hf_tokenizer = tokenizer.raw
+    """
+
+    def __init__(self, model: HuggingFaceTokenModel) -> None:
+        self._model = model
+        self._encoder: TokenEncoder | None = None
+        self._decoder: TokenDecoder | None = None
+
+    @override
+    def create_encoder(
+        self,
+        *,
+        task: str | None = None,
+        lang: str | None = None,
+        mode: str | None = None,
+        device: Device | None = None,
+        pin_memory: bool = False,
+    ) -> TokenEncoder:
+        return self.create_raw_encoder(device=device, pin_memory=pin_memory)
+
+    @override
+    def create_raw_encoder(
+        self, *, device: Device | None = None, pin_memory: bool = False
+    ) -> TokenEncoder:
+        if self._encoder is not None:
+            return self._encoder
+        self._encoder = HuggingFaceTokenEncoder(
+            self._model, device=device, pin_memory=pin_memory
+        )
+        return self._encoder
+
+    @override
+    def create_decoder(self, *, skip_special_tokens: bool = False) -> TokenDecoder:
+        if self._decoder is not None:
+            return self._decoder
+        self._decoder = HuggingFaceTokenDecoder(
+            self._model, skip_special_tokens=skip_special_tokens
+        )
+        return self._decoder
+
+    def encode(
+        self, text: str, *, device: Device | None = None, pin_memory: bool = False
+    ) -> Tensor:
+        encoder = self.create_raw_encoder(device=device, pin_memory=pin_memory)
+        return encoder(text)
+
+    def decode(
+        self, token_indices: Tensor, *, skip_special_tokens: bool = False
+    ) -> str:
+        decoder = self.create_decoder(skip_special_tokens=skip_special_tokens)
+        return decoder(token_indices)
+
+    @property
+    @override
+    def vocab_info(self) -> VocabularyInfo:
+        return self._model.vocab_info
+
+    @property
+    def unk_token(self) -> str | None:
+        if hasattr(self._model._tok, "unk_token"):
+            return str(self._model._tok.unk_token)
+        return None
+
+    @property
+    def bos_token(self) -> str | None:
+        if hasattr(self._model._tok, "bos_token"):
+            return str(self._model._tok.bos_token)
+        return None
+
+    @property
+    def eos_token(self) -> str | None:
+        if hasattr(self._model._tok, "eos_token"):
+            return str(self._model._tok.eos_token)
+        return None
+
+    @property
+    def pad_token(self) -> str | None:
+        if hasattr(self._model._tok, "pad_token"):
+            return str(self._model._tok.pad_token)
+        return None
+
+    @property
+    def boh_token(self) -> str | None:
+        if hasattr(self._model._tok, "boh_token"):
+            return str(self._model._tok.boh_token)
+        return None
+
+    @property
+    def eoh_token(self) -> str | None:
+        if hasattr(self._model._tok, "eoh_token"):
+            return str(self._model._tok.eoh_token)
+        return None
+
+    @property
+    def raw(self) -> PreTrainedTokenizer | PreTrainedTokenizerFast:
+        return self._model._tok
+
+    @property
+    def model(self) -> HuggingFaceTokenModel:
+        return self._model
+
+
+def load_hg_tokenizer(path: Path, config: HgTokenizerConfig) -> HgTokenizer:
+    """
+    Load a HuggingFace tokenizer.
+
+    :param config: Tokenizer configuration
+    :returns: HgTokenizer instance
+    """
+
+    # Load the HuggingFace token model
+    model = load_hg_token_model(
+        path,
+        unk_token=config.unk_token,
+        bos_token=config.bos_token,
+        eos_token=config.eos_token,
+        pad_token=config.pad_token,
+        boh_token=config.boh_token,
+        eoh_token=config.eoh_token,
+    )
+
+    return HgTokenizer(model)

--- a/tests/unit/models/hg/test_hg_factory.py
+++ b/tests/unit/models/hg/test_hg_factory.py
@@ -1,0 +1,513 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+from fairseq2.models.hg.config import HuggingFaceModelConfig
+from fairseq2.models.hg.factory import (
+    HgFactory,
+    HuggingFaceModelError,
+    _get_auto_model_class,
+    _get_model_info,
+    _get_model_path,
+    _import_class_from_transformers,
+    _prepare_load_kwargs,
+    _set_device_kwargs,
+    _set_dtype_kwargs,
+    create_hg_model,
+    register_hg_model_class,
+)
+
+
+class TestRegisterHgModelClass:
+    """Test the register_hg_model_class function."""
+
+    @patch("fairseq2.models.hg.factory._has_transformers", True)
+    def test_register_model_class_with_strings(self) -> None:
+        """Test registering model class with string names."""
+        register_hg_model_class(
+            config_class_name="TestConfig",
+            model_class="TestModel",
+            tokenizer_class="TestTokenizer",
+            processor_class="TestProcessor",
+        )
+
+        # Import the registry to check
+        from fairseq2.models.hg.factory import _USER_REGISTRY
+
+        assert "TestConfig" in _USER_REGISTRY
+        entry = _USER_REGISTRY["TestConfig"]
+        assert entry["model_class"] == "TestModel"
+        assert entry["tokenizer_class"] == "TestTokenizer"
+        assert entry["processor_class"] == "TestProcessor"
+
+    @patch("fairseq2.models.hg.factory._has_transformers", True)
+    def test_register_model_class_with_types(self) -> None:
+        """Test registering model class with actual types."""
+        # Use string names instead of actual classes to avoid type issues
+        register_hg_model_class(
+            config_class_name="TestConfig2",
+            model_class="MockModel",
+            tokenizer_class="MockTokenizer",
+        )
+
+        from fairseq2.models.hg.factory import _USER_REGISTRY
+
+        assert "TestConfig2" in _USER_REGISTRY
+        entry = _USER_REGISTRY["TestConfig2"]
+        assert entry["model_class"] == "MockModel"
+        assert entry["tokenizer_class"] == "MockTokenizer"
+
+    @patch("fairseq2.models.hg.factory._has_transformers", True)
+    def test_register_model_class_minimal(self) -> None:
+        """Test registering model class with minimal params."""
+        register_hg_model_class(
+            config_class_name="TestConfig3",
+            model_class="MinimalModel",
+        )
+
+        from fairseq2.models.hg.factory import _USER_REGISTRY
+
+        assert "TestConfig3" in _USER_REGISTRY
+        entry = _USER_REGISTRY["TestConfig3"]
+        assert entry["model_class"] == "MinimalModel"
+        assert "tokenizer_class" not in entry
+        assert "processor_class" not in entry
+
+    @patch("fairseq2.models.hg.factory._has_transformers", False)
+    def test_register_model_class_no_transformers(self) -> None:
+        """Test error when transformers is not available."""
+        with pytest.raises(Exception) as exc_info:
+            register_hg_model_class("TestConfig", "TestModel")
+
+        assert "transformers" in str(exc_info.value).lower()
+
+
+class TestCreateHgModel:
+    """Test the create_hg_model function."""
+
+    @patch("fairseq2.models.hg.factory.HgFactory")
+    def test_create_hg_model(self, mock_factory_class: MagicMock) -> None:
+        """Test create_hg_model delegates to HgFactory."""
+        mock_factory = MagicMock()
+        mock_model = MagicMock()
+        mock_factory.create_model.return_value = mock_model
+        mock_factory_class.return_value = mock_factory
+
+        config = HuggingFaceModelConfig(hf_name="gpt2")
+        result = create_hg_model(config)
+
+        mock_factory_class.assert_called_once_with(config)
+        mock_factory.create_model.assert_called_once()
+        assert result is mock_model
+
+
+class TestHgFactory:
+    """Test the HgFactory class."""
+
+    def setup_method(self) -> None:
+        """Set up test fixtures."""
+        self.config = HuggingFaceModelConfig(hf_name="gpt2")
+        self.factory = HgFactory(self.config)
+
+    @patch("fairseq2.models.hg.factory._has_transformers", False)
+    def test_create_model_no_transformers(self) -> None:
+        """Test error when transformers is not available."""
+        with pytest.raises(Exception) as exc_info:
+            self.factory.create_model()
+
+        assert "transformers" in str(exc_info.value).lower()
+
+    @patch("fairseq2.models.hg.factory._has_transformers", True)
+    @patch("fairseq2.models.hg.factory.AutoConfig")
+    @patch("fairseq2.models.hg.factory._get_model_info")
+    @patch("fairseq2.models.hg.factory._load_auto_model")
+    def test_create_model_auto_model(
+        self,
+        mock_load_auto: MagicMock,
+        mock_get_info: MagicMock,
+        mock_auto_config: MagicMock,
+    ) -> None:
+        """Test creating model using auto model."""
+        mock_hf_config = MagicMock()
+        mock_hf_config.__class__.__name__ = "GPT2Config"
+        mock_auto_config.from_pretrained.return_value = mock_hf_config
+        mock_get_info.return_value = None
+        mock_model = MagicMock()
+        mock_load_auto.return_value = mock_model
+
+        result = self.factory.create_model()
+
+        mock_auto_config.from_pretrained.assert_called_once_with("gpt2")
+        mock_get_info.assert_called_once_with("GPT2Config", self.config)
+        mock_load_auto.assert_called_once_with("gpt2", self.config, mock_hf_config)
+        assert result is mock_model
+
+    @patch("fairseq2.models.hg.factory._has_transformers", True)
+    @patch("fairseq2.models.hg.factory.AutoConfig")
+    @patch("fairseq2.models.hg.factory._get_model_info")
+    @patch("fairseq2.models.hg.factory._load_special_model")
+    def test_create_model_special_model(
+        self,
+        mock_load_special: MagicMock,
+        mock_get_info: MagicMock,
+        mock_auto_config: MagicMock,
+    ) -> None:
+        """Test creating model using special model."""
+        mock_hf_config = MagicMock()
+        mock_hf_config.__class__.__name__ = "Qwen2_5OmniConfig"
+        mock_auto_config.from_pretrained.return_value = mock_hf_config
+        model_class = "Qwen2_5OmniForConditionalGeneration"
+        mock_model_info = {"model_class": model_class}
+        mock_get_info.return_value = mock_model_info
+        mock_model = MagicMock()
+        mock_load_special.return_value = mock_model
+
+        result = self.factory.create_model()
+
+        mock_load_special.assert_called_once_with("gpt2", self.config, mock_model_info)
+        assert result is mock_model
+
+    @patch("fairseq2.models.hg.factory._has_transformers", True)
+    @patch("fairseq2.models.hg.factory.AutoConfig")
+    def test_create_model_not_found_error(self, mock_auto_config: MagicMock) -> None:
+        """Test error handling for model not found."""
+        error = Exception("404 Not Found")
+        mock_auto_config.from_pretrained.side_effect = error
+
+        with pytest.raises(HuggingFaceModelError) as exc_info:
+            self.factory.create_model()
+
+        assert exc_info.value.model_name == "gpt2"
+        assert "not found" in str(exc_info.value).lower()
+
+    @patch("fairseq2.models.hg.factory._has_transformers", True)
+    @patch("fairseq2.models.hg.factory.AutoConfig")
+    def test_create_model_generic_error(self, mock_auto_config: MagicMock) -> None:
+        """Test error handling for generic errors."""
+        error = Exception("Generic error")
+        mock_auto_config.from_pretrained.side_effect = error
+
+        with pytest.raises(HuggingFaceModelError) as exc_info:
+            self.factory.create_model()
+
+        assert exc_info.value.model_name == "gpt2"
+        assert "Failed to load model" in str(exc_info.value)
+
+
+class TestUtilityFunctions:
+    """Test utility functions."""
+
+    def test_get_model_info_user_registry(self) -> None:
+        """Test _get_model_info with user registry."""
+        from fairseq2.models.hg.factory import _USER_REGISTRY
+
+        # Add test entry
+        _USER_REGISTRY["TestConfig"] = {"model_class": "TestModel"}
+
+        config = HuggingFaceModelConfig(hf_name="test")
+        result = _get_model_info("TestConfig", config)
+
+        assert result == {"model_class": "TestModel"}
+
+        # Clean up
+        del _USER_REGISTRY["TestConfig"]
+
+    def test_get_model_info_builtin_registry(self) -> None:
+        """Test _get_model_info with built-in registry."""
+        config = HuggingFaceModelConfig(hf_name="test")
+        result = _get_model_info("Qwen2_5OmniConfig", config)
+
+        assert result is not None
+        assert result["model_class"] == "Qwen2_5OmniForConditionalGeneration"
+
+    def test_get_model_info_custom_config(self) -> None:
+        """Test _get_model_info with custom config."""
+        config = HuggingFaceModelConfig(
+            hf_name="test",
+            model_type="custom",
+            custom_model_class="CustomModel",
+            custom_processor_class="CustomProcessor",
+        )
+        result = _get_model_info("UnknownConfig", config)
+
+        assert result == {
+            "model_class": "CustomModel",
+            "processor_class": "CustomProcessor",
+        }
+
+    def test_get_model_info_no_match(self) -> None:
+        """Test _get_model_info with no match."""
+        config = HuggingFaceModelConfig(hf_name="test")
+        result = _get_model_info("UnknownConfig", config)
+
+        assert result is None
+
+    @patch("fairseq2.models.hg.factory._has_transformers", True)
+    @patch("fairseq2.models.hg.factory.AutoModelForCausalLM")
+    def test_get_auto_model_class_causal_lm(self, mock_auto_causal: MagicMock) -> None:
+        """Test _get_auto_model_class for causal LM."""
+        config = HuggingFaceModelConfig(hf_name="test", model_type="causal_lm")
+        hf_config = MagicMock()
+        result = _get_auto_model_class(config, hf_config)
+
+        assert result is mock_auto_causal
+
+    @patch("fairseq2.models.hg.factory._has_transformers", True)
+    @patch("fairseq2.models.hg.factory.AutoModelForSeq2SeqLM")
+    def test_get_auto_model_class_seq2seq_lm(
+        self, mock_auto_seq2seq: MagicMock
+    ) -> None:
+        """Test _get_auto_model_class for seq2seq LM."""
+        config = HuggingFaceModelConfig(hf_name="test", model_type="seq2seq_lm")
+        hf_config = MagicMock()
+        result = _get_auto_model_class(config, hf_config)
+
+        assert result is mock_auto_seq2seq
+
+    @patch("fairseq2.models.hg.factory._has_transformers", True)
+    @patch("fairseq2.models.hg.factory.AutoModel")
+    def test_get_auto_model_class_auto(self, mock_auto: MagicMock) -> None:
+        """Test _get_auto_model_class for auto."""
+        config = HuggingFaceModelConfig(hf_name="test", model_type="auto")
+        hf_config = MagicMock()
+        result = _get_auto_model_class(config, hf_config)
+
+        assert result is mock_auto
+
+    @patch("fairseq2.models.hg.factory._has_transformers", True)
+    @patch("fairseq2.models.hg.factory.AutoModelForSeq2SeqLM")
+    def test_get_auto_model_class_encoder_decoder(
+        self, mock_auto_seq2seq: MagicMock
+    ) -> None:
+        """Test _get_auto_model_class for encoder-decoder models."""
+        config = HuggingFaceModelConfig(hf_name="test", model_type="unknown")
+        hf_config = MagicMock()
+        hf_config.is_encoder_decoder = True
+        result = _get_auto_model_class(config, hf_config)
+
+        assert result is mock_auto_seq2seq
+
+    @patch("fairseq2.models.hg.factory._has_transformers", True)
+    @patch("fairseq2.models.hg.factory.AutoModelForCausalLM")
+    def test_get_auto_model_class_decoder_only(
+        self, mock_auto_causal: MagicMock
+    ) -> None:
+        """Test _get_auto_model_class for decoder-only models."""
+        config = HuggingFaceModelConfig(hf_name="test", model_type="unknown")
+        hf_config = MagicMock()
+        hf_config.is_encoder_decoder = False
+        result = _get_auto_model_class(config, hf_config)
+
+        assert result is mock_auto_causal
+
+
+class TestPrepareLoadKwargs:
+    """Test the _prepare_load_kwargs function."""
+
+    @patch("fairseq2.models.hg.factory._get_model_path")
+    @patch("fairseq2.models.hg.factory._set_dtype_kwargs")
+    @patch("fairseq2.models.hg.factory._set_device_kwargs")
+    def test_prepare_load_kwargs_basic(
+        self,
+        mock_set_device: MagicMock,
+        mock_set_dtype: MagicMock,
+        mock_get_path: MagicMock,
+    ) -> None:
+        """Test basic kwargs preparation."""
+        mock_path = Path("/test/path")
+        mock_get_path.return_value = mock_path
+
+        config = HuggingFaceModelConfig(hf_name="gpt2")
+        result = _prepare_load_kwargs(config)
+
+        expected_base = {
+            "pretrained_model_name_or_path": mock_path,
+            "use_safetensors": True,
+        }
+
+        # Check base kwargs
+        for key, value in expected_base.items():
+            assert result[key] == value
+
+        # Check that helper functions were called
+        mock_get_path.assert_called_once_with(config)
+        mock_set_dtype.assert_called_once_with(config, result)
+        mock_set_device.assert_called_once_with(config, result)
+
+    @patch("fairseq2.models.hg.factory._get_model_path")
+    @patch("fairseq2.models.hg.factory._set_dtype_kwargs")
+    @patch("fairseq2.models.hg.factory._set_device_kwargs")
+    def test_prepare_load_kwargs_with_trust_remote_code(
+        self,
+        mock_set_device: MagicMock,
+        mock_set_dtype: MagicMock,
+        mock_get_path: MagicMock,
+    ) -> None:
+        """Test kwargs with trust_remote_code."""
+        mock_get_path.return_value = Path("/test/path")
+
+        config = HuggingFaceModelConfig(hf_name="gpt2", trust_remote_code=True)
+        result = _prepare_load_kwargs(config)
+
+        assert result["trust_remote_code"] is True
+
+    @patch("fairseq2.models.hg.factory._get_model_path")
+    @patch("fairseq2.models.hg.factory._set_dtype_kwargs")
+    @patch("fairseq2.models.hg.factory._set_device_kwargs")
+    def test_prepare_load_kwargs_with_additional_kwargs(
+        self,
+        mock_set_device: MagicMock,
+        mock_set_dtype: MagicMock,
+        mock_get_path: MagicMock,
+    ) -> None:
+        """Test kwargs with additional load_kwargs."""
+        mock_get_path.return_value = Path("/test/path")
+
+        load_kwargs: Dict[str, Any] = {"temperature": 0.7, "max_length": 100}
+        config = HuggingFaceModelConfig(hf_name="gpt2", load_kwargs=load_kwargs)
+        result = _prepare_load_kwargs(config)
+
+        assert result["temperature"] == 0.7
+        assert result["max_length"] == 100
+
+
+class TestSetDtypeKwargs:
+    """Test the _set_dtype_kwargs function."""
+
+    def test_set_dtype_kwargs_auto(self) -> None:
+        """Test dtype auto."""
+        config = HuggingFaceModelConfig(hf_name="test", dtype="auto")
+        kwargs: Dict[str, Any] = {}
+        _set_dtype_kwargs(config, kwargs)
+
+        assert kwargs["dtype"] == "auto"
+
+    def test_set_dtype_kwargs_float16(self) -> None:
+        """Test dtype float16."""
+        config = HuggingFaceModelConfig(hf_name="test", dtype="float16")
+        kwargs: Dict[str, Any] = {}
+        _set_dtype_kwargs(config, kwargs)
+
+        assert kwargs["dtype"] == torch.float16
+
+    def test_set_dtype_kwargs_bfloat16(self) -> None:
+        """Test dtype bfloat16."""
+        config = HuggingFaceModelConfig(hf_name="test", dtype="bfloat16")
+        kwargs: Dict[str, Any] = {}
+        _set_dtype_kwargs(config, kwargs)
+
+        assert kwargs["dtype"] == torch.bfloat16
+
+
+class TestSetDeviceKwargs:
+    """Test the _set_device_kwargs function."""
+
+    def test_set_device_kwargs_not_auto(self) -> None:
+        """Test device kwargs when not auto."""
+        config = HuggingFaceModelConfig(hf_name="test", device="cpu")
+        kwargs: Dict[str, Any] = {}
+        _set_device_kwargs(config, kwargs)
+
+        assert "device_map" not in kwargs
+
+    def test_set_device_kwargs_auto_with_accelerate(self) -> None:
+        """Test device kwargs auto with accelerate available."""
+        # Mock successful accelerate import
+        with patch("builtins.__import__") as mock_import:
+
+            def side_effect(name: str, *args: Any, **kwargs: Any) -> Any:
+                if name == "accelerate":
+                    return MagicMock()  # Mock accelerate module
+                return __import__(name, *args, **kwargs)
+
+            mock_import.side_effect = side_effect
+
+            config = HuggingFaceModelConfig(hf_name="test", device="auto")
+            kwargs: Dict[str, Any] = {}
+            _set_device_kwargs(config, kwargs)
+
+            assert kwargs["device_map"] == "auto"
+
+    def test_set_device_kwargs_auto_no_accelerate(self) -> None:
+        """Test device kwargs auto without accelerate."""
+        # Mock failed accelerate import
+        with patch("builtins.__import__") as mock_import:
+
+            def side_effect(name: str, *args: Any, **kwargs: Any) -> Any:
+                if name == "accelerate":
+                    raise ImportError("No module named 'accelerate'")
+                return __import__(name, *args, **kwargs)
+
+            mock_import.side_effect = side_effect
+
+            config = HuggingFaceModelConfig(hf_name="test", device="auto")
+            kwargs: Dict[str, Any] = {}
+            _set_device_kwargs(config, kwargs)
+
+            assert "device_map" not in kwargs
+
+
+class TestGetModelPath:
+    """Test the _get_model_path function."""
+
+    @patch("fairseq2.models.hg.factory.HuggingFaceHub")
+    @patch("fairseq2.models.hg.factory.Uri.maybe_parse")
+    def test_get_model_path(
+        self, mock_uri_parse: MagicMock, mock_hub_class: MagicMock
+    ) -> None:
+        """Test getting model path."""
+        mock_hub = MagicMock()
+        mock_path = Path("/test/model/path")
+        mock_hub.download_model.return_value = mock_path
+        mock_hub_class.return_value = mock_hub
+        mock_uri = MagicMock()
+        mock_uri.scheme = "hg"
+        mock_uri_parse.return_value = mock_uri
+
+        config = HuggingFaceModelConfig(hf_name="gpt2")
+        result = _get_model_path(config)
+
+        mock_uri_parse.assert_called_once_with("hg://gpt2")
+        mock_hub.download_model.assert_called_once_with(mock_uri, "gpt2")
+        assert result == mock_path
+
+
+class TestImportClassFromTransformers:
+    """Test the _import_class_from_transformers function."""
+
+    @patch("fairseq2.models.hg.factory.importlib.import_module")
+    def test_import_class_success(self, mock_import: MagicMock) -> None:
+        """Test successful class import."""
+        mock_module = MagicMock()
+        mock_class = MagicMock()
+        mock_module.TestClass = mock_class
+        mock_import.return_value = mock_module
+
+        result = _import_class_from_transformers("TestClass")
+
+        mock_import.assert_called_once_with("transformers")
+        assert result is mock_class
+
+    @patch("fairseq2.models.hg.factory.importlib.import_module")
+    def test_import_class_not_found(self, mock_import: MagicMock) -> None:
+        """Test class not found error."""
+        mock_module = MagicMock()
+        mock_import.return_value = mock_module
+        del mock_module.TestClass  # Ensure attribute doesn't exist
+
+        with pytest.raises(ImportError) as exc_info:
+            _import_class_from_transformers("TestClass")
+
+        assert "TestClass" in str(exc_info.value)
+        assert "not found" in str(exc_info.value)

--- a/tests/unit/models/hg/test_hg_tokenizer.py
+++ b/tests/unit/models/hg/test_hg_tokenizer.py
@@ -1,0 +1,332 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+from torch import Tensor
+
+from fairseq2.data.tokenizers import VocabularyInfo
+from fairseq2.device import CPU
+from fairseq2.models.hg.tokenizer import (
+    HgTokenizer,
+    HgTokenizerConfig,
+    load_hg_tokenizer,
+)
+
+
+class TestHgTokenizerConfig:
+    """Test the HgTokenizerConfig dataclass."""
+
+    def test_config_creation_with_defaults(self) -> None:
+        """Test creating config with default values."""
+        config = HgTokenizerConfig()
+
+        assert config.unk_token is None
+        assert config.bos_token is None
+        assert config.eos_token is None
+        assert config.pad_token is None
+        assert config.boh_token is None
+        assert config.eoh_token is None
+
+    def test_config_creation_with_custom_values(self) -> None:
+        """Test creating config with custom values."""
+        config = HgTokenizerConfig(
+            unk_token="<unk>",
+            bos_token="<bos>",
+            eos_token="<eos>",
+            pad_token="<pad>",
+            boh_token="<boh>",
+            eoh_token="<eoh>",
+        )
+
+        assert config.unk_token == "<unk>"
+        assert config.bos_token == "<bos>"
+        assert config.eos_token == "<eos>"
+        assert config.pad_token == "<pad>"
+        assert config.boh_token == "<boh>"
+        assert config.eoh_token == "<eoh>"
+
+    def test_config_equality(self) -> None:
+        """Test config equality comparison."""
+        config1 = HgTokenizerConfig(
+            unk_token="<unk>",
+            bos_token="<bos>",
+        )
+        config2 = HgTokenizerConfig(
+            unk_token="<unk>",
+            bos_token="<bos>",
+        )
+        config3 = HgTokenizerConfig(
+            unk_token="<unk>",
+            bos_token="<s>",  # Different bos_token
+        )
+
+        assert config1 == config2
+        assert config1 != config3
+
+
+class TestHgTokenizer:
+    """Test the HgTokenizer class."""
+
+    def setup_method(self) -> None:
+        """Set up test fixtures."""
+        self.mock_model = MagicMock()
+        self.mock_vocab_info = MagicMock(spec=VocabularyInfo)
+        self.mock_model.vocab_info = self.mock_vocab_info
+        self.tokenizer = HgTokenizer(self.mock_model)
+
+    def test_init(self) -> None:
+        """Test tokenizer initialization."""
+        assert self.tokenizer._model is self.mock_model
+        assert self.tokenizer._encoder is None
+        assert self.tokenizer._decoder is None
+
+    @patch("fairseq2.models.hg.tokenizer.HuggingFaceTokenEncoder")
+    def test_create_encoder(self, mock_encoder_class: MagicMock) -> None:
+        """Test encoder creation."""
+        mock_encoder = MagicMock()
+        mock_encoder_class.return_value = mock_encoder
+
+        encoder = self.tokenizer.create_encoder()
+
+        mock_encoder_class.assert_called_once_with(
+            self.mock_model, device=None, pin_memory=False
+        )
+        assert encoder is mock_encoder
+        assert self.tokenizer._encoder is mock_encoder
+
+    @patch("fairseq2.models.hg.tokenizer.HuggingFaceTokenEncoder")
+    def test_create_encoder_with_device(self, mock_encoder_class: MagicMock) -> None:
+        """Test encoder creation with device."""
+        mock_encoder = MagicMock()
+        mock_encoder_class.return_value = mock_encoder
+
+        encoder = self.tokenizer.create_encoder(device=CPU, pin_memory=True)
+
+        mock_encoder_class.assert_called_once_with(
+            self.mock_model, device=CPU, pin_memory=True
+        )
+        assert encoder is mock_encoder
+
+    @patch("fairseq2.models.hg.tokenizer.HuggingFaceTokenEncoder")
+    def test_create_raw_encoder(self, mock_encoder_class: MagicMock) -> None:
+        """Test raw encoder creation."""
+        mock_encoder = MagicMock()
+        mock_encoder_class.return_value = mock_encoder
+
+        encoder = self.tokenizer.create_raw_encoder()
+
+        mock_encoder_class.assert_called_once_with(
+            self.mock_model, device=None, pin_memory=False
+        )
+        assert encoder is mock_encoder
+        assert self.tokenizer._encoder is mock_encoder
+
+    def test_create_raw_encoder_cached(self) -> None:
+        """Test that raw encoder is cached."""
+        mock_encoder = MagicMock()
+        self.tokenizer._encoder = mock_encoder
+
+        encoder = self.tokenizer.create_raw_encoder()
+
+        assert encoder is mock_encoder
+
+    @patch("fairseq2.models.hg.tokenizer.HuggingFaceTokenDecoder")
+    def test_create_decoder(self, mock_decoder_class: MagicMock) -> None:
+        """Test decoder creation."""
+        mock_decoder = MagicMock()
+        mock_decoder_class.return_value = mock_decoder
+
+        decoder = self.tokenizer.create_decoder()
+
+        mock_decoder_class.assert_called_once_with(
+            self.mock_model, skip_special_tokens=False
+        )
+        assert decoder is mock_decoder
+        assert self.tokenizer._decoder is mock_decoder
+
+    @patch("fairseq2.models.hg.tokenizer.HuggingFaceTokenDecoder")
+    def test_create_decoder_skip_special_tokens(
+        self, mock_decoder_class: MagicMock
+    ) -> None:
+        """Test decoder creation with skip_special_tokens."""
+        mock_decoder = MagicMock()
+        mock_decoder_class.return_value = mock_decoder
+
+        decoder = self.tokenizer.create_decoder(skip_special_tokens=True)
+
+        mock_decoder_class.assert_called_once_with(
+            self.mock_model, skip_special_tokens=True
+        )
+        assert decoder is mock_decoder
+
+    def test_create_decoder_cached(self) -> None:
+        """Test that decoder is cached."""
+        mock_decoder = MagicMock()
+        self.tokenizer._decoder = mock_decoder
+
+        decoder = self.tokenizer.create_decoder()
+
+        assert decoder is mock_decoder
+
+    def test_encode(self) -> None:
+        """Test text encoding."""
+        mock_encoder = MagicMock()
+        mock_tensor = MagicMock(spec=Tensor)
+        mock_encoder.return_value = mock_tensor
+        self.tokenizer._encoder = mock_encoder
+
+        result = self.tokenizer.encode("Hello world")
+
+        mock_encoder.assert_called_once_with("Hello world")
+        assert result is mock_tensor
+
+    def test_decode(self) -> None:
+        """Test token decoding."""
+        mock_decoder = MagicMock()
+        mock_decoder.return_value = "Hello world"
+        self.tokenizer._decoder = mock_decoder
+
+        input_tensor = torch.as_tensor([1, 2, 3])
+        result = self.tokenizer.decode(input_tensor)
+
+        # Verify decoder was called once
+        mock_decoder.assert_called_once()
+        # Verify the tensor argument by checking it's equivalent
+        call_args = mock_decoder.call_args[0][0]
+        assert torch.equal(call_args, input_tensor)
+        assert result == "Hello world"
+
+    def test_vocab_info(self) -> None:
+        """Test vocab info property."""
+        assert self.tokenizer.vocab_info is self.mock_vocab_info
+
+    def test_token_properties_with_attributes(self) -> None:
+        """Test token properties when attributes exist."""
+        mock_tok = MagicMock()
+        mock_tok.unk_token = "<unk>"
+        mock_tok.bos_token = "<bos>"
+        mock_tok.eos_token = "<eos>"
+        mock_tok.pad_token = "<pad>"
+        mock_tok.boh_token = "<boh>"
+        mock_tok.eoh_token = "<eoh>"
+        self.mock_model._tok = mock_tok
+
+        assert self.tokenizer.unk_token == "<unk>"
+        assert self.tokenizer.bos_token == "<bos>"
+        assert self.tokenizer.eos_token == "<eos>"
+        assert self.tokenizer.pad_token == "<pad>"
+        assert self.tokenizer.boh_token == "<boh>"
+        assert self.tokenizer.eoh_token == "<eoh>"
+
+    def test_token_properties_without_attributes(self) -> None:
+        """Test token properties when attributes don't exist."""
+        mock_tok = MagicMock()
+        # Remove attributes to test hasattr check
+        for attr in [
+            "unk_token",
+            "bos_token",
+            "eos_token",
+            "pad_token",
+            "boh_token",
+            "eoh_token",
+        ]:
+            if hasattr(mock_tok, attr):
+                delattr(mock_tok, attr)
+        self.mock_model._tok = mock_tok
+
+        assert self.tokenizer.unk_token is None
+        assert self.tokenizer.bos_token is None
+        assert self.tokenizer.eos_token is None
+        assert self.tokenizer.pad_token is None
+        assert self.tokenizer.boh_token is None
+        assert self.tokenizer.eoh_token is None
+
+    def test_raw_property(self) -> None:
+        """Test raw tokenizer property."""
+        mock_tok = MagicMock()
+        self.mock_model._tok = mock_tok
+
+        assert self.tokenizer.raw is mock_tok
+
+    def test_model_property(self) -> None:
+        """Test model property."""
+        assert self.tokenizer.model is self.mock_model
+
+
+class TestLoadHgTokenizer:
+    """Test the load_hg_tokenizer function."""
+
+    @patch("fairseq2.models.hg.tokenizer.load_hg_token_model")
+    def test_load_hg_tokenizer_basic(self, mock_load_model: MagicMock) -> None:
+        """Test basic tokenizer loading."""
+        mock_model = MagicMock()
+        mock_load_model.return_value = mock_model
+
+        path = Path("/test/path")
+        config = HgTokenizerConfig()
+        result = load_hg_tokenizer(path, config)
+
+        mock_load_model.assert_called_once_with(
+            path,
+            unk_token=None,
+            bos_token=None,
+            eos_token=None,
+            pad_token=None,
+            boh_token=None,
+            eoh_token=None,
+        )
+        assert isinstance(result, HgTokenizer)
+        assert result._model is mock_model
+
+    @patch("fairseq2.models.hg.tokenizer.load_hg_token_model")
+    def test_load_hg_tokenizer_with_tokens(self, mock_load_model: MagicMock) -> None:
+        """Test tokenizer loading with custom tokens."""
+        mock_model = MagicMock()
+        mock_load_model.return_value = mock_model
+
+        path = Path("/test/path")
+        config = HgTokenizerConfig(
+            unk_token="<unk>",
+            bos_token="<bos>",
+            eos_token="<eos>",
+            pad_token="<pad>",
+            boh_token="<boh>",
+            eoh_token="<eoh>",
+        )
+        result = load_hg_tokenizer(path, config)
+
+        mock_load_model.assert_called_once_with(
+            path,
+            unk_token="<unk>",
+            bos_token="<bos>",
+            eos_token="<eos>",
+            pad_token="<pad>",
+            boh_token="<boh>",
+            eoh_token="<eoh>",
+        )
+        assert isinstance(result, HgTokenizer)
+        assert result._model is mock_model
+
+    @patch("fairseq2.models.hg.tokenizer.load_hg_token_model")
+    def test_load_hg_tokenizer_propagates_errors(
+        self, mock_load_model: MagicMock
+    ) -> None:
+        """Test that load_hg_tokenizer propagates errors."""
+        mock_load_model.side_effect = ValueError("Token model loading failed")
+
+        path = Path("/test/path")
+        config = HgTokenizerConfig()
+
+        with pytest.raises(ValueError) as exc_info:
+            load_hg_tokenizer(path, config)
+
+        assert str(exc_info.value) == "Token model loading failed"


### PR DESCRIPTION
**What does this PR do? Please describe:**

- A simple model family implementation to wrap models/processor/tokenizer loaded from transformers auto classes
- Currently support 4 types of Auto classes (auto, causal lm, seq2seq lm, custom)
- Added basic asset examples for qwen3 and qwen2.5 omni (+doc and tests)
- Exposed some additional convenience api-s (free to remove them)
- Wrapping (yet another) layer for hg tokenizers (maybe not ideal but trying to make the interfaces similar to the original huggingface ones to help with the migration)
- [nit] added `.coveragerc` and some gitignore for dev and test

Fixes #1301 

TBD:
- A wrapper class to handle `AutoXXX.from_pretrained(...) -> Any` types
- Device placement and customized sharder
- Integration w/ post-training recipes

**Does your PR introduce any breaking changes? If yes, please list them:**

- Added tests for hg models so it requires installation of [hg] (e.g. `pip install -e '.[hg]') for the full test suite to pass
- For hg tokenizers, added logic to retrieve default special token idx if not overridden by user input

**Check list:**
- [x] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**?
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
