### PR TITLE
cleanup legacy cli

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,5 +80,4 @@ setup(
             "xxhash~=3.5",
         ],
     },
-    entry_points={"console_scripts": ["fairseq2=fairseq2.cli:main"]},
 )


### PR DESCRIPTION
**What does this PR do? Please describe:**

`fairseq2.cli` has been deprecated. The 2 "cli"-s that are supported now are:
1. the assets cli like `python -m fairseq2.assets show llama3_2_1b_instruct`
2. `python run.py --config-file /path/to/yaml --config foo=bar` where `run.py` contains something like:

```py
from fairseq2.recipe.cli import train_main
your_recipe = YourTrainRecipe()
train_main(your_recipe)
```

**Does your PR introduce any breaking changes? If yes, please list them:**

N/A

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
