### PR TITLE
Ensure device index set for eager NCCL initialization

### DIFF
--- a/src/fairseq2/gang.py
+++ b/src/fairseq2/gang.py
@@ -327,6 +327,10 @@ class ProcessGroupGang(Gang):
         pg_options = None
 
         if device.type == "cuda":
+            # Eager process group initialization requires device index to be set.
+            if device.index is None:
+                device = Device("cuda", index=0)
+
             # Forces eager NCCL initialization.
             kwargs["device_id"] = device
 


### PR DESCRIPTION
For eager process group initialization, NCCL expects the index of the CUDA device to be set. We want to prevent a hard-to-decipher initialization error when the user provides only "cuda" as device (which should be treated as a valid input argument).

Tested in both single device and multi-device setting with `torchrun` and `srun`.