### PR TITLE
Add family to ModelArchitectureNotKnownError

### DIFF
--- a/src/fairseq2/recipe/cli.py
+++ b/src/fairseq2/recipe/cli.py
@@ -96,7 +96,7 @@ from fairseq2.recipe.error import (
 )
 from fairseq2.recipe.internal.config_preparer import _RecipeConfigPreparer
 from fairseq2.recipe.internal.output_dir import _OutputDirectoryCreator
-from fairseq2.recipe.run import _run_recipe, _swap_default_resolver
+from fairseq2.recipe.run import _run_recipe, _setup_warnings, _swap_default_resolver
 from fairseq2.recipe.task import TaskStopException
 from fairseq2.runtime.dependency import (
     DependencyContainer,
@@ -120,6 +120,8 @@ from fairseq2.utils.yaml import YamlDumper, YamlError, YamlLoader
 def train_main(recipe: TrainRecipe) -> None:
     from fairseq2.recipe.composition import _register_train_recipe
 
+    _setup_warnings()
+
     args = _parse_args()
 
     configure_rich_logging()
@@ -141,6 +143,8 @@ def train_main(recipe: TrainRecipe) -> None:
 def eval_main(recipe: EvalRecipe) -> None:
     from fairseq2.recipe.composition import _register_eval_recipe
 
+    _setup_warnings()
+
     args = _parse_args()
 
     configure_rich_logging()
@@ -161,6 +165,8 @@ def eval_main(recipe: EvalRecipe) -> None:
 @torch.inference_mode()
 def generate_main(recipe: GenerationRecipe) -> None:
     from fairseq2.recipe.composition import _register_generation_recipe
+
+    _setup_warnings()
 
     args = _parse_args()
 
@@ -723,7 +729,10 @@ def _handle_minimim_loss_scale_reached_error(ex: MinimumLossScaleReachedError) -
 
 
 def _handle_model_arch_not_known_error(ex: ModelArchitectureNotKnownError) -> int:
-    log.error("{} is not a known model architecture.", ex.arch)
+    if ex.family is None:
+        log.error("{} is not a known model architecture.", ex.arch)
+    else:
+        log.error("{} is not a known {} model architecture.", ex.arch, ex.family)
 
     return 2
 

--- a/src/fairseq2/recipe/internal/eval_model.py
+++ b/src/fairseq2/recipe/internal/eval_model.py
@@ -189,7 +189,7 @@ class _StandardEvalModelBootstrapper(_EvalModelBootstrapper):
         else:
             config = family.maybe_get_arch_config(arch)
             if config is None:
-                raise ModelArchitectureNotKnownError(arch) from None
+                raise ModelArchitectureNotKnownError(arch, family_name) from None
 
         if section.config_overrides is not None:
             config = self._asset_config_overrider.apply_overrides(

--- a/src/fairseq2/recipe/internal/model.py
+++ b/src/fairseq2/recipe/internal/model.py
@@ -222,7 +222,7 @@ class _StandardTrainModelBootstrapper(_TrainModelBootstrapper):
         else:
             config = family.maybe_get_arch_config(arch)
             if config is None:
-                raise ModelArchitectureNotKnownError(arch) from None
+                raise ModelArchitectureNotKnownError(arch, family_name) from None
 
         if self._section.config_overrides is not None:
             config = self._asset_config_overrider.apply_overrides(
@@ -318,7 +318,7 @@ class _StandardTrainModelBootstrapper(_TrainModelBootstrapper):
         else:
             config = family.maybe_get_arch_config(arch)
             if config is None:
-                raise ModelArchitectureNotKnownError(arch) from None
+                raise ModelArchitectureNotKnownError(arch, family_name) from None
 
         if self._section.config_overrides is not None:
             config = self._asset_config_overrider.apply_overrides(

--- a/src/fairseq2/recipe/run.py
+++ b/src/fairseq2/recipe/run.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
@@ -35,6 +36,8 @@ from fairseq2.world_info import WorldInfo
 def train(recipe: TrainRecipe, config: object, output_dir: Path) -> None:
     from fairseq2.recipe.composition import _register_train_recipe
 
+    _setup_warnings()
+
     configure_rich_logging()
 
     container = DependencyContainer()
@@ -53,6 +56,8 @@ def train(recipe: TrainRecipe, config: object, output_dir: Path) -> None:
 def evaluate(recipe: EvalRecipe, config: object, output_dir: Path) -> None:
     from fairseq2.recipe.composition import _register_eval_recipe
 
+    _setup_warnings()
+
     configure_rich_logging()
 
     container = DependencyContainer()
@@ -70,6 +75,8 @@ def evaluate(recipe: EvalRecipe, config: object, output_dir: Path) -> None:
 @torch.inference_mode()
 def generate(recipe: GenerationRecipe, config: object, output_dir: Path) -> None:
     from fairseq2.recipe.composition import _register_generation_recipe
+
+    _setup_warnings()
 
     configure_rich_logging()
 
@@ -158,6 +165,10 @@ def _register_run(
         return dir_creator.create(output_dir)
 
     container.register(Path, create_output_dir)
+
+
+def _setup_warnings() -> None:
+    warnings.filterwarnings("once", category=DeprecationWarning, module="fairseq2.*")
 
 
 @final


### PR DESCRIPTION
This nit PR introduces a new `family` parameter to `ModelArchitectureNotKnownError` to improve error messaging. We also use the deprecation notice feature for the first time.