### PR TITLE
Revise shard dim handling in model checkpoint loaders

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -58,6 +58,7 @@ other content generation tasks.
     reference/datasets/index
     reference/device
     reference/fairseq2.gang
+    reference/fairseq2.model_checkpoint
     reference/fairseq2.recipe.optim
     reference/fairseq2.utils.validation
     reference/logging

--- a/doc/source/reference/fairseq2.model_checkpoint.rst
+++ b/doc/source/reference/fairseq2.model_checkpoint.rst
@@ -14,7 +14,7 @@ Classes
 .. autoclass:: SafetensorsCheckpointLoader
 .. autoclass:: DelegatingModelCheckpointLoader
 
-Utitilies
+Utilities
 =========
 
 .. autofunction:: reshard_tensor

--- a/doc/source/reference/fairseq2.model_checkpoint.rst
+++ b/doc/source/reference/fairseq2.model_checkpoint.rst
@@ -1,0 +1,26 @@
+=========================
+fairseq2.model_checkpoint
+=========================
+
+.. automodule:: fairseq2.model_checkpoint
+    :no-members:
+
+Classes
+=======
+
+.. autoclass:: ModelCheckpointLoader
+.. autoclass:: NativeModelCheckpointLoader
+.. autoclass:: BasicModelCheckpointLoader
+.. autoclass:: SafetensorsCheckpointLoader
+.. autoclass:: DelegatingModelCheckpointLoader
+
+Utitilies
+=========
+
+.. autofunction:: reshard_tensor
+
+
+Exceptions
+==========
+
+.. autoclass:: ModelCheckpointError

--- a/src/fairseq2/file_system.py
+++ b/src/fairseq2/file_system.py
@@ -11,6 +11,8 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterator, Sequence
 from contextlib import contextmanager
 from enum import Enum
+from errno import ENOENT
+from os import strerror
 from pathlib import Path
 from shutil import copytree, rmtree
 from tempfile import TemporaryDirectory
@@ -172,3 +174,9 @@ class LocalFileSystem(FileSystem):
     @override
     def is_local(self) -> bool:
         return True
+
+
+def raise_if_not_exists(file_system: FileSystem, path: Path) -> None:
+    """Raises a :class:`FileNotFoundError` if the specified path does not exist."""
+    if not file_system.exists(path):
+        raise FileNotFoundError(ENOENT, strerror(ENOENT), path)

--- a/src/fairseq2/file_system.py
+++ b/src/fairseq2/file_system.py
@@ -177,6 +177,6 @@ class LocalFileSystem(FileSystem):
 
 
 def raise_if_not_exists(file_system: FileSystem, path: Path) -> None:
-    """Raises a :class:`FileNotFoundError` if the specified path does not exist."""
+    """Raises a :class:`FileNotFoundError` if ``path`` does not exist."""
     if not file_system.exists(path):
         raise FileNotFoundError(ENOENT, strerror(ENOENT), path)

--- a/src/fairseq2/model_checkpoint/__init__.py
+++ b/src/fairseq2/model_checkpoint/__init__.py
@@ -12,7 +12,7 @@ distributed configurations with tensor resharding capability.
 The loaders support:
 
 - Memory-efficient lazy loading to avoid loading entire checkpoints into
-  memory at once (if the underlying format allows). In particular relevant for
+  memory at once if the underlying format allows it. In particular relevant for
   large checkpoints that may not fit entirely in memory.
 - On-the-fly tensor resharding across different distributed configurations.
 - Optional memory mapping for reduced memory footprint.

--- a/src/fairseq2/model_checkpoint/__init__.py
+++ b/src/fairseq2/model_checkpoint/__init__.py
@@ -7,14 +7,14 @@
 """
 This module provides a memory-efficient model checkpoint loading API that
 supports lazy loading of various checkpoint formats while also supporting
-distributed scenarios with tensor sharding and resharding capabilities.
+distributed configurations with tensor resharding capability.
 
 The loaders support:
 
 - Memory-efficient lazy loading to avoid loading entire checkpoints into
-  memory at once. In particular relevant for large checkpoints that may not
-  fit entirely in memory.
-- On-the-fly tensor resharding across different gang configurations.
+  memory at once (if the underlying format allows). In particular relevant for
+  large checkpoints that may not fit entirely in memory.
+- On-the-fly tensor resharding across different distributed configurations.
 - Optional memory mapping for reduced memory footprint.
 - State dict conversion for format compatibility.
 - Automatic format detection.

--- a/src/fairseq2/model_checkpoint/__init__.py
+++ b/src/fairseq2/model_checkpoint/__init__.py
@@ -4,6 +4,39 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+"""
+This module provides a memory-efficient model checkpoint loading API that
+supports lazy loading of various checkpoint formats while also supporting
+distributed scenarios with tensor sharding and resharding capabilities.
+
+The loaders support:
+
+- Memory-efficient lazy loading to avoid loading entire checkpoints into
+  memory at once. In particular relevant for large checkpoints that may not
+  fit entirely in memory.
+- On-the-fly tensor resharding across different gang configurations.
+- Optional memory mapping for reduced memory footprint.
+- State dict conversion for format compatibility.
+- Automatic format detection.
+
+.. code:: python
+    :caption: Example Usage
+
+    from fairseq2.model_checkpoint import DelegatingModelCheckpointLoader
+
+    gangs = ...  # Setup gangs
+
+    # Delegates model loading to the appropriate loader based on the checkpoint
+    # format.
+    loader = DelegatingModelCheckpointLoader()
+
+    checkpoint_path = ...  # Path to checkpoint file
+
+    # Load checkpoint parameters lazily
+    for key, tensor in loader.lazy_load(checkpoint_path, gangs):
+        # Process tensor without loading entire checkpoint
+"""
+
 from __future__ import annotations
 
 from fairseq2.model_checkpoint.basic import (

--- a/src/fairseq2/model_checkpoint/basic.py
+++ b/src/fairseq2/model_checkpoint/basic.py
@@ -28,6 +28,8 @@ from fairseq2.sharder import ShardSpec
 
 @final
 class BasicModelCheckpointLoader(ModelCheckpointLoader):
+    """Loads single-file PyTorch checkpoints (.pt, .pth, .bin)."""
+
     def __init__(self, file_system: FileSystem, tensor_loader: TensorLoader) -> None:
         self._file_system = file_system
         self._tensor_loader = tensor_loader
@@ -42,6 +44,7 @@ class BasicModelCheckpointLoader(ModelCheckpointLoader):
         restrict: bool = True,
         state_dict_converter: StateDictConverter | None = None,
         shard_specs: Mapping[str, ShardSpec] | None = None,
+        shard_dims: Mapping[str, int] | None = None,
     ) -> Iterator[tuple[str, Tensor]]:
         try:
             checkpoint = self._tensor_loader.load(
@@ -82,6 +85,7 @@ class BasicModelCheckpointLoader(ModelCheckpointLoader):
                 target_shard_sizes,
                 target_shard_ranks,
                 shard_specs,
+                shard_dims,
             )
 
             yield key, tensor

--- a/src/fairseq2/model_checkpoint/common.py
+++ b/src/fairseq2/model_checkpoint/common.py
@@ -29,11 +29,14 @@ def reshard_tensor(
     Reshards a parameter tensor from a distributed source configuration to a
     target configuration.
 
-    This function handles the complex task of resharding tensors when loading
-    checkpoints from one distributed configuration (e.g., 4-way tensor parallelism)
-    to a different target configuration (e.g., 8-way tensor parallelism). It
-    efficiently concatenates and slices tensors to produce the correct shards
-    for the target rank.
+    This function is meant for authors of new :class:`ModelCheckpointLoader`
+    implementations. It handles the complex task of resharding tensors when
+    loading checkpoints from one distributed configuration (e.g. 4-way tensor
+    parallelism) to a different target configuration (e.g. 8-way tensor
+    parallelism). It efficiently concatenates and slices tensors to produce the
+    correct shards for the target rank. The existing implementations such as
+    :class:`NativeModelCheckpointLoader` may be inspected to see how ``reshard_tensor``
+    is used in practice.
 
     The resharding process involves:
 

--- a/src/fairseq2/model_checkpoint/common.py
+++ b/src/fairseq2/model_checkpoint/common.py
@@ -26,8 +26,8 @@ def reshard_tensor(
     shard_dims: Mapping[str, int] | None = None,
 ) -> Tensor:
     """
-    Reshards a parameter from a distributed source configuration to a target
-    configuration.
+    Reshards a parameter tensor from a distributed source configuration to a
+    target configuration.
 
     This function handles the complex task of resharding tensors when loading
     checkpoints from one distributed configuration (e.g., 4-way tensor parallelism)
@@ -47,20 +47,20 @@ def reshard_tensor(
     information from ``shard_dims``. See :func:`~fairseq2.nn.get_sharding_dims`
     for more information.
 
-    ``source_splits`` is a 2D list structure ``[tp_idx][dp_idx]`` containing
-    tensor shards from the source checkpoint. The outer list represents tensor
-    parallel shards, inner lists represent data parallel shards.
+    ``source_splits`` is a 2D list structure ``[tp_idx][dp_idx]`` containing the
+    source tensor shards. The outer list specifies tensor parallel shards and
+    inner lists specify data parallel shards.
 
-    ``source_shard_sizes`` specifies the distributed source configuration in the
-    form of ``(tp_size, dp_size)``. Similarly, ``target_shard_sizes`` specifies
-    the target configuration.
+    ``source_shard_sizes`` and ``target_shard_sizes`` specify the distributed
+    source and target configurations respectively in the form of ``(tp_size, dp_size)``.
 
     ``target_shard_ranks`` specifies the ranks of the current process in the
     target configuration in the form of ``(tp_rank, dp_rank)``.
 
-    ``shard_dims`` is the mapping from parameter names to dimensions along which
-    parameters should be sharded for tensor parallelism. Omitted for replicated
-    tensors. See :func:`~fairseq2.nn.get_sharding_dims` for more information.
+    If ``shard_dims`` is provided, it specifies the mapping from parameter names
+    to dimensions along which parameters should be sharded for tensor parallelism.
+    Omitted for replicated tensors. See :func:`~fairseq2.nn.get_sharding_dims`
+    for more information.
 
     ``shard_specs`` is deprecated and will be removed in a future release;
     please use ``shard_dims`` instead.

--- a/src/fairseq2/model_checkpoint/common.py
+++ b/src/fairseq2/model_checkpoint/common.py
@@ -13,6 +13,7 @@ import torch
 from torch import Tensor
 
 from fairseq2.sharder import ShardSpec
+from fairseq2.utils.warn import _warn_deprecated
 
 
 def reshard_tensor(
@@ -22,7 +23,86 @@ def reshard_tensor(
     target_shard_sizes: tuple[int, int],
     target_shard_ranks: tuple[int, int],
     shard_specs: Mapping[str, ShardSpec] | None,
+    shard_dims: Mapping[str, int] | None = None,
 ) -> Tensor:
+    """
+    Reshards a parameter from a distributed source configuration to a target
+    configuration.
+
+    This function handles the complex task of resharding tensors when loading
+    checkpoints from one distributed configuration (e.g., 4-way tensor parallelism)
+    to a different target configuration (e.g., 8-way tensor parallelism). It
+    efficiently concatenates and slices tensors to produce the correct shards
+    for the target rank.
+
+    The resharding process involves:
+
+    1. Determining if the tensor requires tensor parallelism based on specified
+       shard dimensions.
+    2. For tensor parallel tensors, concatenating source shards and re-slicing
+       for the target configuration in a memory-efficient way.
+    3. For replicated tensors, concatenating data parallel splits.
+
+    ``key`` specifies the name of the parameter to retrieve its sharding
+    information from ``shard_dims``. See :func:`~fairseq2.nn.get_sharding_dims`
+    for more information.
+
+    ``source_splits`` is a 2D list structure ``[tp_idx][dp_idx]`` containing
+    tensor shards from the source checkpoint. The outer list represents tensor
+    parallel shards, inner lists represent data parallel shards.
+
+    ``source_shard_sizes`` specifies the distributed source configuration in the
+    form of ``(tp_size, dp_size)``. Similarly, ``target_shard_sizes`` specifies
+    the target configuration as ``(tp_size, dp_size)``.
+
+    ``target_shard_ranks`` specifies the ranks of the current process in the
+    target configuration in the form of ``(tp_rank, dp_rank)``.
+
+    ``shard_dims`` is the mapping from parameter names to dimensions along which
+    parameters should be sharded for tensor parallelism. Omitted for replicated
+    tensors. See :func:`~fairseq2.nn.get_sharding_dims` for more information.
+
+    ``shard_specs`` is deprecated and will be removed in a future release;
+    please use ``shard_dims`` instead.
+
+    Returns the resharded tensor for the target rank and configuration.
+
+    .. code:: python
+        :caption: Resharding from 2-way TP to 4-way TP
+
+        # Resharding from 2-way TP to 4-way TP
+        source_splits = [[tensor_tp0_dp0], [tensor_tp1_dp0]]  # 2 TP shards, 1 DP shard each
+        source_shard_sizes = (2, 1)  # 2-way TP, 1-way DP
+        target_shard_sizes = (4, 1)  # 4-way TP, 1-way DP
+        target_shard_ranks = (2, 0)  # Want shard for TP rank 2
+
+        # For a tensor with TP dim=0, this will concatenate the 2 source shards
+        # and slice out the portion corresponding to TP rank 2 in 4-way setup
+        resharded = reshard_tensor(
+            "model.weight",
+            source_splits,
+            source_shard_sizes,
+            target_shard_sizes,
+            target_shard_ranks,
+            None,  # deprecated
+            {"model.weight": 0}
+        )
+
+    .. note::
+
+        This function deletes intermediate tensors during the resharding process
+        to minimize peak memory usage.
+    """
+    if shard_specs is not None:
+        if shard_dims is not None:
+            raise ValueError(
+                "`shard_specs` and `shard_dims` must not be specified at the same time."
+            )
+
+        _warn_deprecated(
+            "`shard_specs` parameter of `ModelCheckpointLoader` is deprecated and will be removed in fairseq2 v0.12."
+        )
+
     source_tp_size, source_dp_size = source_shard_sizes
     target_tp_size, target_dp_size = target_shard_sizes
 
@@ -38,7 +118,7 @@ def reshard_tensor(
 
         return torch.cat(source_dp_splits, dim=0)
 
-    tp_dim = _get_tp_dim(key, shard_specs)
+    tp_dim = _get_tp_dim(key, shard_specs, shard_dims)
 
     # We assume that non-tensor parallel parameters are always replicated.
     if tp_dim == -1:
@@ -91,7 +171,16 @@ def reshard_tensor(
     )
 
 
-def _get_tp_dim(key: str, shard_specs: Mapping[str, ShardSpec] | None) -> int:
+def _get_tp_dim(
+    key: str,
+    shard_specs: Mapping[str, ShardSpec] | None,
+    shard_dims: Mapping[str, int] | None,
+) -> int:
+    if shard_dims is not None:
+        dim = shard_dims.get(key)
+        if dim is not None:
+            return dim
+
     if shard_specs is None:
         return -1
 

--- a/src/fairseq2/model_checkpoint/delegating.py
+++ b/src/fairseq2/model_checkpoint/delegating.py
@@ -26,7 +26,7 @@ from fairseq2.sharder import ShardSpec
 @final
 class DelegatingModelCheckpointLoader(ModelCheckpointLoader):
     """
-    Composite loader that delegates to format-specific checkpoint loaders.
+    Delegates loading to format-specific checkpoint loaders.
 
     This loader maintains a collection of specialized loaders and automatically
     selects the appropriate one based on the checkpoint file format. It provides

--- a/src/fairseq2/model_checkpoint/delegating.py
+++ b/src/fairseq2/model_checkpoint/delegating.py
@@ -7,15 +7,13 @@
 from __future__ import annotations
 
 from collections.abc import Iterator, Mapping, Sequence
-from errno import ENOENT
-from os import strerror
 from pathlib import Path
 from typing import final
 
 from torch import Tensor
 from typing_extensions import override
 
-from fairseq2.file_system import FileSystem
+from fairseq2.file_system import FileSystem, raise_if_not_exists
 from fairseq2.gang import Gangs
 from fairseq2.model_checkpoint.loader import (
     ModelCheckpointError,
@@ -27,6 +25,19 @@ from fairseq2.sharder import ShardSpec
 
 @final
 class DelegatingModelCheckpointLoader(ModelCheckpointLoader):
+    """
+    Composite loader that delegates to format-specific checkpoint loaders.
+
+    This loader maintains a collection of specialized loaders and automatically
+    selects the appropriate one based on the checkpoint file format. It provides
+    a unified interface for loading various checkpoint formats without requiring
+    the caller to handle format-specific logic.
+
+    The loader iterates through its registered loaders in order and uses the
+    first one that reports it can handle the given path via
+    :meth:`ModelCheckpointLoader.supports_path()`.
+    """
+
     def __init__(
         self, loaders: Sequence[ModelCheckpointLoader], file_system: FileSystem
     ) -> None:
@@ -43,10 +54,9 @@ class DelegatingModelCheckpointLoader(ModelCheckpointLoader):
         restrict: bool = True,
         state_dict_converter: StateDictConverter | None = None,
         shard_specs: Mapping[str, ShardSpec] | None = None,
+        shard_dims: Mapping[str, int] | None = None,
     ) -> Iterator[tuple[str, Tensor]]:
-        path_exists = self._file_system.exists(path)
-        if not path_exists:
-            raise FileNotFoundError(ENOENT, strerror(ENOENT), path)
+        raise_if_not_exists(self._file_system, path)
 
         for loader in self._loaders:
             if loader.supports_path(path):
@@ -57,6 +67,7 @@ class DelegatingModelCheckpointLoader(ModelCheckpointLoader):
                     restrict=restrict,
                     state_dict_converter=state_dict_converter,
                     shard_specs=shard_specs,
+                    shard_dims=shard_dims,
                 )
 
         msg = f"{path} does not point to any known checkpoints."

--- a/src/fairseq2/model_checkpoint/loader.py
+++ b/src/fairseq2/model_checkpoint/loader.py
@@ -22,6 +22,14 @@ class StateDictConverter(Protocol):
 
 
 class ModelCheckpointLoader(ABC):
+    """
+    Abstract base class for model checkpoint loaders.
+
+    This class defines the interface for checkpoint loaders that can efficiently
+    load model state by yielding parameters lazily rather than loading
+    everything into memory at once.
+    """
+
     @abstractmethod
     def lazy_load(
         self,
@@ -32,10 +40,42 @@ class ModelCheckpointLoader(ABC):
         restrict: bool = True,
         state_dict_converter: StateDictConverter | None = None,
         shard_specs: Mapping[str, ShardSpec] | None = None,
-    ) -> Iterator[tuple[str, Tensor]]: ...
+        shard_dims: Mapping[str, int] | None = None,
+    ) -> Iterator[tuple[str, Tensor]]:
+        """
+        Lazily loads parameters from the specified checkpoint path.
+
+        Yields tensors one at a time to minimize memory usage. Supports tensor
+        resharding and optional state dictionary conversion.
+
+        If ``mmap`` is ``True``, uses memory mapping when possible to reduce
+        memory footprint.
+
+        If ``restrict`` is ``True``, restricts pickle (if used) to load only
+        tensors and other types that can be safely serialized and deserialized.
+
+        ``state_dict_converter`` can be used to transform a state dictionary.
+        This is typically used to convert from one format such as Hugging Face's
+        transformers library to fairseq2.
+
+        ``shard_dims`` specifies the sharding dimension for each parameter as
+        returned by :func:`~fairseq2.nn.get_sharding_dims`. Along with ``gangs``,
+        this enables on-the-fly parameter sharding/resharding during checkpoint
+        loading. If ``None``, no sharding/resharding will be performed and the
+        full tensor will be loaded.
+
+        ``shard_specs`` is deprecated and will be removed in a future release;
+        please use ``shard_dims`` instead.
+
+        Yields pairs of ``(parameter name, parameter)`` for each parameter in
+        the checkpoint.
+
+        :raises ModelCheckpointError: If the checkpoint is not valid.
+        """
 
     @abstractmethod
-    def supports_path(self, path: Path) -> bool: ...
+    def supports_path(self, path: Path) -> bool:
+        """Checks if this loader can handle the specified checkpoint path."""
 
 
 class ModelCheckpointError(Exception):

--- a/src/fairseq2/model_checkpoint/loader.py
+++ b/src/fairseq2/model_checkpoint/loader.py
@@ -46,11 +46,15 @@ class ModelCheckpointLoader(ABC):
         Lazily loads parameters from the specified checkpoint path.
 
         Yields tensors one at a time to minimize memory usage if the underlying
-        format allows. Supports tensor resharding and optional state dictionary
+        format allows it. Supports tensor resharding and optional state dictionary
         conversion.
 
-        If ``mmap`` is ``True``, the checkpoint will be memory-mapped when
-        possible to reduce memory footprint.
+        ``gangs`` is used to determine the distributed target configuration and
+        shard yielded parameters accordingly. If ``None``, no sharding will be
+        performed and full parameters will be yielded.
+
+        If ``mmap`` is ``True``, the checkpoint will be memory-mapped. This can
+        reduce memory usage but may cause slower load times on some systems.
 
         If ``restrict`` is ``True``, pickle (if used) will be restricted to load
         only tensors and types that can be safely serialized and deserialized.

--- a/src/fairseq2/model_checkpoint/loader.py
+++ b/src/fairseq2/model_checkpoint/loader.py
@@ -26,8 +26,8 @@ class ModelCheckpointLoader(ABC):
     Represents the abstract base class for model checkpoint loaders.
 
     This class defines the interface for checkpoint loaders that can efficiently
-    load model state by yielding parameters lazily rather than loading
-    everything into memory at once.
+    load model state by yielding parameters lazily rather than loading everything
+    into memory at once.
     """
 
     @abstractmethod
@@ -45,24 +45,25 @@ class ModelCheckpointLoader(ABC):
         """
         Lazily loads parameters from the specified checkpoint path.
 
-        Yields tensors one at a time to minimize memory usage. Supports tensor
-        resharding and optional state dictionary conversion.
+        Yields tensors one at a time to minimize memory usage if the underlying
+        format allows. Supports tensor resharding and optional state dictionary
+        conversion.
 
-        If ``mmap`` is ``True``, uses memory mapping when possible to reduce
-        memory footprint.
+        If ``mmap`` is ``True``, the checkpoint will be memory-mapped when
+        possible to reduce memory footprint.
 
-        If ``restrict`` is ``True``, restricts pickle (if used) to load only
-        tensors and other types that can be safely serialized and deserialized.
+        If ``restrict`` is ``True``, pickle (if used) will be restricted to load
+        only tensors and types that can be safely serialized and deserialized.
 
-        If ``state_dict_converter`` is specified, it will be used to transform
-        the state dictionaries in the checkpoint. Typically used to convert from
-        one format such as Hugging Face Transformers to fairseq2.
+        If ``state_dict_converter`` is provided, it will be used to transform
+        the (sharded) state dictionaries in the checkpoint. Typically used to
+        convert from one format such as Hugging Face Transformers to fairseq2.
 
-        ``shard_dims`` specifies the sharding dimension for each parameter as
-        returned by :func:`~fairseq2.nn.get_sharding_dims`. Along with ``gangs``,
-        this enables on-the-fly parameter sharding/resharding during checkpoint
-        loading. If ``None``, no sharding/resharding will be performed and the
-        full tensor will be loaded.
+        If ``shard_dims`` is provided, it specifies the sharding dimension of
+        each parameter as returned by :func:`~fairseq2.nn.get_sharding_dims`.
+        Along with ``gangs``, they enable on-the-fly parameter resharding during
+        checkpoint loading. If ``None``, no resharding will be performed and
+        full parameters will be loaded.
 
         ``shard_specs`` is deprecated and will be removed in a future release;
         please use ``shard_dims`` instead.
@@ -79,6 +80,8 @@ class ModelCheckpointLoader(ABC):
 
 
 class ModelCheckpointError(Exception):
+    """Raised when a model checkpoint is not valid."""
+
     def __init__(self, path: Path, message: str) -> None:
         super().__init__(message)
 

--- a/src/fairseq2/model_checkpoint/loader.py
+++ b/src/fairseq2/model_checkpoint/loader.py
@@ -23,7 +23,7 @@ class StateDictConverter(Protocol):
 
 class ModelCheckpointLoader(ABC):
     """
-    Abstract base class for model checkpoint loaders.
+    Represents the abstract base class for model checkpoint loaders.
 
     This class defines the interface for checkpoint loaders that can efficiently
     load model state by yielding parameters lazily rather than loading
@@ -54,9 +54,9 @@ class ModelCheckpointLoader(ABC):
         If ``restrict`` is ``True``, restricts pickle (if used) to load only
         tensors and other types that can be safely serialized and deserialized.
 
-        ``state_dict_converter`` can be used to transform a state dictionary.
-        This is typically used to convert from one format such as Hugging Face's
-        transformers library to fairseq2.
+        If ``state_dict_converter`` is specified, it will be used to transform
+        the state dictionaries in the checkpoint. Typically used to convert from
+        one format such as Hugging Face Transformers to fairseq2.
 
         ``shard_dims`` specifies the sharding dimension for each parameter as
         returned by :func:`~fairseq2.nn.get_sharding_dims`. Along with ``gangs``,

--- a/src/fairseq2/model_checkpoint/native.py
+++ b/src/fairseq2/model_checkpoint/native.py
@@ -33,7 +33,7 @@ class NativeModelCheckpointLoader(ModelCheckpointLoader):
     Loads native fairseq2 checkpoints.
 
     The native fairseq2 format is optimized for efficient storage and loading of
-    model checkpoints with built-in support for distributed metadata.
+    model checkpoints in distributed configurations.
     """
 
     def __init__(self, file_system: FileSystem, tensor_loader: TensorLoader) -> None:

--- a/src/fairseq2/model_checkpoint/safetensors.py
+++ b/src/fairseq2/model_checkpoint/safetensors.py
@@ -29,6 +29,13 @@ from fairseq2.sharder import ShardSpec
 
 @final
 class SafetensorsCheckpointLoader(ModelCheckpointLoader):
+    """
+    Loads checkpoints saved in Safetensors format.
+
+    This loader supports both single-file and directory-based Safetensors
+    checkpoints.
+    """
+
     def __init__(
         self, file_system: FileSystem, safetensors_loader: SafetensorsLoader
     ) -> None:
@@ -45,6 +52,7 @@ class SafetensorsCheckpointLoader(ModelCheckpointLoader):
         restrict: bool = True,
         state_dict_converter: StateDictConverter | None = None,
         shard_specs: Mapping[str, ShardSpec] | None = None,
+        shard_dims: Mapping[str, int] | None = None,
     ) -> Iterator[tuple[str, Tensor]]:
         is_dir = self._file_system.is_dir(path)
         if is_dir:
@@ -102,6 +110,7 @@ class SafetensorsCheckpointLoader(ModelCheckpointLoader):
                 target_shard_sizes,
                 target_shard_ranks,
                 shard_specs,
+                shard_dims,
             )
 
             yield key, tensor

--- a/src/fairseq2/model_checkpoint/safetensors.py
+++ b/src/fairseq2/model_checkpoint/safetensors.py
@@ -34,7 +34,7 @@ class SafetensorsCheckpointLoader(ModelCheckpointLoader):
 
     This loader supports both single-file and multi-file Safetensors checkpoints
     where multi-file checkpoints typically follow the "model-x-of-N.safetensors"
-    naming pattern as in Hugging Face Hub.
+    pattern as in Hugging Face Hub.
     """
 
     def __init__(

--- a/src/fairseq2/model_checkpoint/safetensors.py
+++ b/src/fairseq2/model_checkpoint/safetensors.py
@@ -30,10 +30,11 @@ from fairseq2.sharder import ShardSpec
 @final
 class SafetensorsCheckpointLoader(ModelCheckpointLoader):
     """
-    Loads checkpoints saved in Safetensors format.
+    Loads Safetensors checkpoints.
 
-    This loader supports both single-file and directory-based Safetensors
-    checkpoints.
+    This loader supports both single-file and multi-file Safetensors checkpoints
+    where multi-file checkpoints typically follow the "model-x-of-N.safetensors"
+    naming pattern as in Hugging Face Hub.
     """
 
     def __init__(

--- a/src/fairseq2/models/family.py
+++ b/src/fairseq2/models/family.py
@@ -464,6 +464,9 @@ class StandardModelFamily(ModelFamily):
             )
 
         if self._shard_specs is None:
+            # Initialize a dummy model solely for the purpose of extracting its
+            # parameter sharding information. In the future, require this to be
+            # a meta-initialization to avoid the cost of a full initialization.
             model = self._do_create_model(
                 config, gangs, torch.float16, self._supports_meta
             )

--- a/src/fairseq2/models/family.py
+++ b/src/fairseq2/models/family.py
@@ -9,12 +9,11 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Iterator, Mapping, Sequence
 from dataclasses import dataclass
-from errno import ENOENT
 from functools import partial
-from os import strerror
 from pathlib import Path
 from typing import Any, Protocol, TypeVar, final
 
+import torch
 from torch import Tensor
 from torch.nn import Module
 from typing_extensions import override
@@ -32,18 +31,20 @@ from fairseq2.error import (
     NotSupportedError,
     raise_operational_system_error,
 )
-from fairseq2.file_system import FileSystem
+from fairseq2.file_system import FileSystem, raise_if_not_exists
 from fairseq2.gang import Gangs
 from fairseq2.model_checkpoint import ModelCheckpointError, ModelCheckpointLoader
 from fairseq2.models.utils.checkpoint import (
     ModelCheckpointMismatchError,
     set_model_state,
 )
+from fairseq2.nn import get_shard_dims
 from fairseq2.nn.fsdp import FSDPWrapper, load_with_sdp_gang
 from fairseq2.nn.utils.module import reset_non_persistent_buffers, to_device, to_empty
 from fairseq2.runtime.lookup import Lookup
 from fairseq2.sharder import ModelSharder, ShardSpec, ShardSpecError
 from fairseq2.utils.progress import NOOP_PROGRESS_REPORTER, ProgressReporter
+from fairseq2.utils.warn import _warn_deprecated
 
 
 @dataclass
@@ -409,9 +410,7 @@ class StandardModelFamily(ModelFamily):
         restrict: bool | None,
         progress: bool,
     ) -> Module:
-        path_exists = self._file_system.exists(path)
-        if not path_exists:
-            raise FileNotFoundError(ENOENT, strerror(ENOENT), path)
+        raise_if_not_exists(self._file_system, path)
 
         model = self._do_create_model(config, gangs, dtype, self._supports_meta)
 
@@ -420,7 +419,14 @@ class StandardModelFamily(ModelFamily):
             # so there is no need to redundantly initialize them.
             to_empty(model, device=gangs.root.device)
 
-        checkpoint = self._do_iter_checkpoint(path, config, gangs, mmap, restrict)
+        if self._shard_specs is None:
+            shard_dims = get_shard_dims(model)
+        else:
+            shard_dims = None
+
+        checkpoint = self._do_iter_checkpoint(
+            path, config, shard_dims, gangs, mmap, restrict
+        )
 
         pr = self._progress_reporter if progress else NOOP_PROGRESS_REPORTER
 
@@ -452,12 +458,27 @@ class StandardModelFamily(ModelFamily):
                 f"`config` must be of type `{self._configs.kls}`, but is of type `{type(config)}` instead."
             )
 
-        return self._do_iter_checkpoint(path, config, gangs, mmap, restrict)
+        if not self._supports_meta:
+            _warn_deprecated(
+                "In fairseq2 v0.12, `ModelFamily.iter_checkpoint` will stop supporting models that cannot be meta-initialized."
+            )
+
+        if self._shard_specs is None:
+            model = self._do_create_model(
+                config, gangs, torch.float16, self._supports_meta
+            )
+
+            shard_dims = get_shard_dims(model)
+        else:
+            shard_dims = None
+
+        return self._do_iter_checkpoint(path, config, shard_dims, gangs, mmap, restrict)
 
     def _do_iter_checkpoint(
         self,
         path: Path,
         config: object,
+        shard_dims: Mapping[str, int] | None,
         gangs: Gangs,
         mmap: bool,
         restrict: bool | None,
@@ -488,6 +509,7 @@ class StandardModelFamily(ModelFamily):
                 restrict=restrict,
                 state_dict_converter=state_dict_converter,
                 shard_specs=shard_specs,
+                shard_dims=shard_dims,
             )
 
     def _do_create_model(

--- a/src/fairseq2/models/family.py
+++ b/src/fairseq2/models/family.py
@@ -472,6 +472,8 @@ class StandardModelFamily(ModelFamily):
             )
 
             shard_dims = get_shard_dims(model)
+
+            del model
         else:
             shard_dims = None
 

--- a/src/fairseq2/nn/__init__.py
+++ b/src/fairseq2/nn/__init__.py
@@ -51,3 +51,5 @@ from fairseq2.nn.residual import AdditiveResidualConnect as AdditiveResidualConn
 from fairseq2.nn.residual import DropPathResidualConnect as DropPathResidualConnect
 from fairseq2.nn.residual import ResidualConnect as ResidualConnect
 from fairseq2.nn.residual import ScaledResidualConnect as ScaledResidualConnect
+from fairseq2.nn.sharded import Sharded as Sharded
+from fairseq2.nn.sharded import get_shard_dims as get_shard_dims

--- a/src/fairseq2/nn/embedding.py
+++ b/src/fairseq2/nn/embedding.py
@@ -32,9 +32,8 @@ class Embedding(Module, ABC):
         self, num_embeddings: int, embed_dim: int, pad_idx: int | None
     ) -> None:
         """
-        If not ``None``, entries at ``pad_idx`` do not contribute to the
-        gradient; therefore, the embedding at ``pad_idx`` is not updated
-        during training.
+        If ``pad_idx`` is specified, the entry at that index won't contribute to
+        the gradient and therefore won't be updated during training.
         """
         super().__init__()
 
@@ -48,8 +47,8 @@ class Embedding(Module, ABC):
         Returns the embeddings corresponding to the specified indices. ``x`` can
         have any shape.
 
-        The return value will a shape of :math:`(*,E)`, where :math:`*` is the
-        input shape and :math:`E` is the dimensionality of the embeddings.
+        The return value will have a shape of :math:`(*,E)`, where :math:`*` is
+        the input shape and :math:`E` is the dimensionality of the embeddings.
         """
 
     if TYPE_CHECKING:
@@ -71,8 +70,8 @@ class StandardEmbedding(Embedding):
         dtype: DataType | None = None,
     ) -> None:
         """
-        If ``init_fn`` is specified, it will be called to initialize the
-        embedding table in :meth:`reset_parameters`.
+        If ``init_fn`` is specified, it will be used to initialize the embedding
+        table in :meth:`reset_parameters`.
         """
         super().__init__(num_embeddings, embed_dim, pad_idx)
 

--- a/src/fairseq2/nn/embedding.py
+++ b/src/fairseq2/nn/embedding.py
@@ -32,8 +32,8 @@ class Embedding(Module, ABC):
         self, num_embeddings: int, embed_dim: int, pad_idx: int | None
     ) -> None:
         """
-        If ``pad_idx`` is specified, the entry at that index won't contribute to
-        the gradient and therefore won't be updated during training.
+        If ``pad_idx`` is provided, the embedding at the specified index won't
+        contribute to the gradient and therefore won't be updated during training.
         """
         super().__init__()
 
@@ -44,11 +44,12 @@ class Embedding(Module, ABC):
     @abstractmethod
     def forward(self, x: Tensor) -> Tensor:
         """
-        Returns the embeddings corresponding to the specified indices. ``x`` can
-        have any shape.
+        Returns the embeddings corresponding to the specified indices.
 
-        The return value will have a shape of :math:`(*,E)`, where :math:`*` is
-        the input shape and :math:`E` is the dimensionality of the embeddings.
+        ``x`` can have any shape.
+
+        The return value will be of shape :math:`(*,E)`, where :math:`*` is the
+        input shape and :math:`E` is the dimensionality of the embeddings.
         """
 
     if TYPE_CHECKING:
@@ -70,7 +71,7 @@ class StandardEmbedding(Embedding):
         dtype: DataType | None = None,
     ) -> None:
         """
-        If ``init_fn`` is specified, it will be used to initialize the embedding
+        If ``init_fn`` is provided, it will be used to initialize the embedding
         table in :meth:`reset_parameters`.
         """
         super().__init__(num_embeddings, embed_dim, pad_idx)
@@ -123,7 +124,7 @@ class VocabShardedEmbedding(Embedding, Sharded):
     def from_embedding(embed: StandardEmbedding, gang: Gang) -> VocabShardedEmbedding:
         """
         Creates a :class:`VocabShardedEmbedding` by sharding ``embed`` over its
-        vocabulary dimension using the specified gang.
+        vocabulary dimension using ``gang``.
         """
         device = embed.weight.device
 
@@ -295,7 +296,7 @@ class ShardedEmbedding(Embedding, Sharded):
     def from_embedding(embed: StandardEmbedding, gang: Gang) -> ShardedEmbedding:
         """
         Creates a :class:`ShardedEmbedding` by sharding ``embed`` over its
-        embedding dimension using the specified gang.
+        embedding dimension using ``gang``.
         """
         device = embed.weight.device
 

--- a/src/fairseq2/nn/projection.py
+++ b/src/fairseq2/nn/projection.py
@@ -40,12 +40,14 @@ class Projection(Module, ABC):
     @abstractmethod
     def forward(self, x: Tensor) -> Tensor:
         """
-        Projects the input data. ``x`` is expected to be of shape :math:`(*,H_{inp})`,
-        where :math:`H_{inp}` is the input dimensionality of this module.
+        Projects the input data.
 
-        The projected output will have a shape of :math:`(*,H_{out})`, where all
-        but the last dimension are the same shape as the input and :math:`H_{out}`
-        is the output dimensionality of this module.
+        ``x`` must be of shape :math:`(*,H_{inp})`, where :math:`H_{inp}` is the
+        input dimensionality of this module.
+
+        The projected output will be of shape :math:`(*,H_{out})`, where all but
+        the last dimension are the same shape as ``x`` and :math:`H_{out}` is
+        the output dimensionality of this module.
         """
 
     if TYPE_CHECKING:
@@ -77,8 +79,8 @@ class Linear(Projection):
         initialized from :math:`\\mathcal{U}(-\\sqrt{k}, \\sqrt{k})`, where
         :math:`k = \\frac{1}{\\text{input_dim}}`.
 
-        If ``init_fn`` is specified, it will be used to initialize the weight
-        and bias in :meth:`reset_parameters`.
+        If ``init_fn`` is provided, it will be used to initialize the weight and
+        bias in :meth:`reset_parameters`.
         """
         super().__init__(input_dim, output_dim)
 
@@ -134,7 +136,7 @@ class ColumnShardedLinear(Projection, Sharded):
     ) -> ColumnShardedLinear:
         """
         Creates a :class:`ColumnShardedLinear` by sharding ``linear`` over its
-        output dimension using the specified gang.
+        output dimension using ``gang``.
 
         If ``gather_output`` is ``True``, the sharded outputs of all ranks will
         be gathered into a single tensor.
@@ -332,12 +334,12 @@ class RowShardedLinear(Projection, Sharded):
     ) -> RowShardedLinear:
         """
         Creates a :class:`RowShardedLinear` by sharding ``linear`` over its
-        input dimension using the specified gang.
+        input dimension using ``gang``.
 
-        If ``scatter_input`` is ``True``, inputs on all ranks are considered
+        If ``scatter_input`` is ``True``, the inputs on all ranks are considered
         already sharded and won't be scattered.
 
-        If ``reduce_output`` is ``True``, outputs of all ranks will be
+        If ``reduce_output`` is ``True``, the outputs of all ranks will be
         all-reduced into a single tensor.
         """
         device = linear.weight.device
@@ -535,7 +537,7 @@ class TiedProjection(Projection):
 
 @final
 class IdentityProjection(Projection):
-    """Disables a projection layer without changing the architecture."""
+    """Disables a projection without changing architecture."""
 
     def __init__(self, dim: int) -> None:
         super().__init__(input_dim=dim, output_dim=dim)

--- a/src/fairseq2/nn/projection.py
+++ b/src/fairseq2/nn/projection.py
@@ -77,7 +77,7 @@ class Linear(Projection):
         initialized from :math:`\\mathcal{U}(-\\sqrt{k}, \\sqrt{k})`, where
         :math:`k = \\frac{1}{\\text{input_dim}}`.
 
-        If ``init_fn`` is specified, it will be called to initialize the weight
+        If ``init_fn`` is specified, it will be used to initialize the weight
         and bias in :meth:`reset_parameters`.
         """
         super().__init__(input_dim, output_dim)
@@ -136,8 +136,8 @@ class ColumnShardedLinear(Projection, Sharded):
         Creates a :class:`ColumnShardedLinear` by sharding ``linear`` over its
         output dimension using the specified gang.
 
-        If ``gather_output`` is ``True``, gathers the sharded outputs of all
-        ranks into a single tensor.
+        If ``gather_output`` is ``True``, the sharded outputs of all ranks will
+        be gathered into a single tensor.
         """
         device = linear.weight.device
 
@@ -338,7 +338,7 @@ class RowShardedLinear(Projection, Sharded):
         already sharded and won't be scattered.
 
         If ``reduce_output`` is ``True``, outputs of all ranks will be
-        all-reduced to a single tensor.
+        all-reduced into a single tensor.
         """
         device = linear.weight.device
 

--- a/src/fairseq2/nn/projection.py
+++ b/src/fairseq2/nn/projection.py
@@ -14,23 +14,24 @@ from typing import TYPE_CHECKING, final
 import torch
 import torch.nn as nn
 from torch import Tensor
-from torch.nn import Module
+from torch.nn import Module, Parameter
 from torch.nn.functional import linear
-from torch.nn.parameter import Parameter
 from typing_extensions import override
 
 from fairseq2.data_type import DataType
 from fairseq2.device import META_DEVICE, Device
 from fairseq2.error import InternalError
 from fairseq2.gang import Gang
+from fairseq2.nn.sharded import Sharded
 from fairseq2.nn.utils.module import get_name_or_self, to_empty
 from fairseq2.ops.tensor_parallel import gather, reduce, reduce_on_backward, scatter
 
 
 class Projection(Module, ABC):
-    """Applies a linear transformation to incoming data."""
+    """Applies a linear transformation to input data."""
 
     def __init__(self, input_dim: int, output_dim: int) -> None:
+        """:meta private:"""
         super().__init__()
 
         self.input_dim = input_dim
@@ -39,12 +40,12 @@ class Projection(Module, ABC):
     @abstractmethod
     def forward(self, x: Tensor) -> Tensor:
         """
-        :param x: The input to project. *Shape:* :math:`(*,H_{inp})`, where
-            :math:`H_{inp}` is the input dimensionality.
+        Projects the input data. ``x`` is expected to be of shape :math:`(*,H_{inp})`,
+        where :math:`H_{inp}` is the input dimensionality of this module.
 
-        :returns: The projected output. *Shape:* :math:`(*,H_{out})`, where all
-            but the last dimension are the same shape as the input and
-            :math:`H_{out}` is the output dimensionality.
+        The projected output will have a shape of :math:`(*,H_{out})`, where all
+        but the last dimension are the same shape as the input and :math:`H_{out}`
+        is the output dimensionality of this module.
         """
 
     if TYPE_CHECKING:
@@ -54,13 +55,10 @@ class Projection(Module, ABC):
 @final
 class Linear(Projection):
     """
-    Applies a linear transformation to incoming data using weights and bias.
-
-    Unless overridden by a subclass, the weights and bias are initialized from
-    :math:`\\mathcal{U}(-\\sqrt{k}, \\sqrt{k})`, where
-    :math:`k = \\frac{1}{\\text{input_dim}}`.
+    Represents the standard implementation of :class:`Projection`.
 
     .. note::
+
         This class is identical to :class:`torch.nn.Linear`.
     """
 
@@ -75,10 +73,12 @@ class Linear(Projection):
         dtype: DataType | None = None,
     ) -> None:
         """
-        :param input_dim: The dimensionality of inputs.
-        :param output_dim: The dimensionality of projected outputs.
-        :param bias: If ``True``, learns an additive bias.
-        :param init_fn: The callable to initialize the weight and bias.
+        Unless overridden by ``init_fn``, the weight and bias of this module are
+        initialized from :math:`\\mathcal{U}(-\\sqrt{k}, \\sqrt{k})`, where
+        :math:`k = \\frac{1}{\\text{input_dim}}`.
+
+        If ``init_fn`` is specified, it will be called to initialize the weight
+        and bias in :meth:`reset_parameters`.
         """
         super().__init__(input_dim, output_dim)
 
@@ -125,26 +125,25 @@ class Linear(Projection):
 
 
 @final
-class ColumnShardedLinear(Projection):
-    """Represents a :class:`Linear` that is sharded across its output dimension."""
+class ColumnShardedLinear(Projection, Sharded):
+    """Represents a :class:`Projection` sharded across its output dimension."""
 
     @staticmethod
     def from_linear(
         linear: Linear, gang: Gang, *, gather_output: bool = True
     ) -> ColumnShardedLinear:
         """
-        Constructs a :class:`ColumnShardedLinear` by sharding ``linear``.
+        Creates a :class:`ColumnShardedLinear` by sharding ``linear`` over its
+        output dimension using the specified gang.
 
-        :param linear: The projection to shard.
-        :param gang: The gang over which to shard ``linear``.
-        :param gather_output: If ``True``, gather the sharded output into a
-            single tensor.
+        If ``gather_output`` is ``True``, gathers the sharded outputs of all
+        ranks into a single tensor.
         """
         device = linear.weight.device
 
         if device != gang.device and device.type != "meta":
             raise ValueError(
-                "The device of `linear` must be same as `gang.device` or must be of type `meta`."
+                f"Device of `linear` must match `gang.device` or must be of type `meta`, but is `{device}` instead."
             )
 
         sharded_linear = ColumnShardedLinear(
@@ -177,15 +176,6 @@ class ColumnShardedLinear(Projection):
         device: Device | None = None,
         dtype: DataType | None = None,
     ) -> None:
-        """
-        :param gang: The gang over which to shard the weight tensor.
-        :param input_dim: The dimensionality of inputs.
-        :param output_dim: The dimensionality of projected outputs.
-        :param bias: If ``True``, learns an additive bias.
-        :param gather_output: If ``True``, gather the sharded output into a
-            single tensor.
-        :param init_fn: The callable to initialize the weight and bias.
-        """
         super().__init__(input_dim, output_dim)
 
         if output_dim % gang.size != 0:
@@ -203,7 +193,7 @@ class ColumnShardedLinear(Projection):
             device = gang.device
         elif device != gang.device and device.type != "meta":
             raise ValueError(
-                "`device` must be same as `gang.device` or must be of type `meta`."
+                "`device` must match `gang.device` or must be of type `meta`."
             )
 
         weight = torch.empty(
@@ -234,7 +224,7 @@ class ColumnShardedLinear(Projection):
 
     def _copy_weight(self, linear: Linear) -> None:
         with torch.no_grad():
-            weight_shards = linear.weight.split(self.sharded_output_dim)
+            weight_shards = linear.weight.split(self.sharded_output_dim, dim=0)
 
             weight = weight_shards[self.gang.rank]
 
@@ -245,7 +235,7 @@ class ColumnShardedLinear(Projection):
                 raise InternalError("`linear.bias` is `None`.")
 
             with torch.no_grad():
-                bias_shards = linear.bias.split(self.sharded_output_dim)
+                bias_shards = linear.bias.split(self.sharded_output_dim, dim=0)
 
                 bias = bias_shards[self.gang.rank]
 
@@ -263,7 +253,7 @@ class ColumnShardedLinear(Projection):
         return x
 
     def to_linear(self, device: Device | None = None) -> Linear:
-        """Converts this instance to a :class:`Linear`."""
+        """Unshards this instance to a :class:`Linear`."""
         linear = self._linear_like(device=META_DEVICE)
 
         to_empty(linear, device or self.gang.device)
@@ -295,6 +285,13 @@ class ColumnShardedLinear(Projection):
         )
 
     @override
+    def get_shard_dims(self) -> list[tuple[Parameter, int]]:
+        if self.bias is None:
+            return [(self.weight, 0)]
+        else:
+            return [(self.weight, 0), (self.bias, 0)]
+
+    @override
     def extra_repr(self) -> str:
         """:meta private:"""
         bias = self.bias is not None
@@ -305,8 +302,8 @@ class ColumnShardedLinear(Projection):
             s = f"output_dim={self.sharded_output_dim}"
 
         s = (
-            f"rank={self.gang.rank}, "
-            f"world_size={self.gang.size}, "
+            f"tp_rank={self.gang.rank}, "
+            f"tp_size={self.gang.size}, "
             f"input_dim={self.input_dim}, "
             f"{s}, "
             f"gather_output={self.gather_output}, "
@@ -322,26 +319,32 @@ class ColumnShardedLinear(Projection):
 
 
 @final
-class RowShardedLinear(Projection):
-    """Represents a :class:`Linear` that is sharded across its input dimension."""
+class RowShardedLinear(Projection, Sharded):
+    """Represents a :class:`Projection` sharded across its input dimension."""
 
     @staticmethod
     def from_linear(
-        linear: Linear, gang: Gang, *, scatter_input: bool = False
+        linear: Linear,
+        gang: Gang,
+        *,
+        scatter_input: bool = False,
+        reduce_output: bool = True,
     ) -> RowShardedLinear:
         """
-        Constructs a :class:`RowShardedLinear` by sharding ``linear``.
+        Creates a :class:`RowShardedLinear` by sharding ``linear`` over its
+        input dimension using the specified gang.
 
-        :param linear: The projection to shard.
-        :param gang: The gang over which to shard ``linear``.
-        :param scatter_input: If ``True``, inputs are considered already sharded
-            and won't be scattered.
+        If ``scatter_input`` is ``True``, inputs on all ranks are considered
+        already sharded and won't be scattered.
+
+        If ``reduce_output`` is ``True``, outputs of all ranks will be
+        all-reduced to a single tensor.
         """
         device = linear.weight.device
 
         if device != gang.device and device.type != "meta":
             raise ValueError(
-                "The device of `linear` must be same as `gang.device` or must be of type `meta`."
+                f"Device of `linear` must match `gang.device` or must be of type `meta`, but is `{device}` instead."
             )
 
         sharded_linear = RowShardedLinear(
@@ -350,6 +353,7 @@ class RowShardedLinear(Projection):
             linear.output_dim,
             bias=linear.bias is not None,
             scatter_input=scatter_input,
+            reduce_output=reduce_output,
             init_fn=linear.init_fn,
             device=META_DEVICE,
             dtype=linear.weight.dtype,
@@ -370,19 +374,11 @@ class RowShardedLinear(Projection):
         bias: bool,
         *,
         scatter_input: bool = True,
+        reduce_output: bool = True,
         init_fn: Callable[[Linear], None] | None = None,
         device: Device | None = None,
         dtype: DataType | None = None,
     ) -> None:
-        """
-        :param gang: The gang over which to shard the weight tensor.
-        :param input_dim: The dimensionality of inputs.
-        :param output_dim: The dimensionality of projected outputs.
-        :param bias: If ``True``, learns an additive bias.
-        :param scatter_input: If ``True``, scatters the input tensor; otherwise,
-            considers it already sharded.
-        :param init_fn: The callable to initialize the weight and bias.
-        """
         super().__init__(input_dim, output_dim)
 
         if input_dim % gang.size != 0:
@@ -395,12 +391,13 @@ class RowShardedLinear(Projection):
         self.sharded_input_dim = input_dim // gang.size
 
         self.scatter_input = scatter_input
+        self.reduce_output = reduce_output
 
         if device is None:
             device = gang.device
         elif device != gang.device and device.type != "meta":
             raise ValueError(
-                "`device` must be same as `gang.device` or must be of type `meta`."
+                "`device` must match `gang.device` or must be of type `meta`."
             )
 
         weight = torch.empty(
@@ -449,7 +446,8 @@ class RowShardedLinear(Projection):
 
         x = linear(x, self.weight)
 
-        x = reduce(x, self.gang)
+        if self.reduce_output:
+            x = reduce(x, self.gang)
 
         if self.bias is not None:
             x = x + self.bias
@@ -457,7 +455,7 @@ class RowShardedLinear(Projection):
         return x
 
     def to_linear(self, device: Device | None = None) -> Linear:
-        """Converts this instance to a :class:`Linear`."""
+        """Unshards this instance to a :class:`Linear`."""
         linear = self._linear_like(device=META_DEVICE)
 
         to_empty(linear, device or self.gang.device)
@@ -487,6 +485,10 @@ class RowShardedLinear(Projection):
         )
 
     @override
+    def get_shard_dims(self) -> list[tuple[Parameter, int]]:
+        return [(self.weight, 1)]
+
+    @override
     def extra_repr(self) -> str:
         """:meta private:"""
         bias = self.bias is not None
@@ -497,8 +499,8 @@ class RowShardedLinear(Projection):
             s = f"input_dim={self.sharded_input_dim}"
 
         s = (
-            f"rank={self.gang.rank}, "
-            f"world_size={self.gang.size}, "
+            f"tp_rank={self.gang.rank}, "
+            f"tp_size={self.gang.size}, "
             f"{s}, "
             f"scatter_input={self.scatter_input}, "
             f"output_dim={self.output_dim}, "
@@ -516,15 +518,11 @@ class RowShardedLinear(Projection):
 @final
 class TiedProjection(Projection):
     """
-    Applies a linear transformation to incoming data using the weights and bias
+    Applies a linear transformation to input data using the weight and bias
     of another :class:`~torch.nn.Module` instance.
     """
 
     def __init__(self, weight: Parameter, bias: Parameter | None) -> None:
-        """
-        :param weight: The shared weights.
-        :param bias: The shared bias.
-        """
         super().__init__(input_dim=weight.size(1), output_dim=weight.size(0))
 
         self.weight = weight
@@ -537,9 +535,7 @@ class TiedProjection(Projection):
 
 @final
 class IdentityProjection(Projection):
-    """
-    Used to disable a projection layer without changing the module architecture.
-    """
+    """Disables a projection layer without changing the architecture."""
 
     def __init__(self, dim: int) -> None:
         super().__init__(input_dim=dim, output_dim=dim)

--- a/src/fairseq2/nn/sharded.py
+++ b/src/fairseq2/nn/sharded.py
@@ -15,7 +15,7 @@ class Sharded(ABC):
     """
     Indicates that a PyTorch module has tensor-sharded parameters.
 
-    Modules implementing this interface can specify which of their parameters
+    Modules implementing this interface must specify which of their parameters
     are sharded and along which dimensions the sharding occurs.
 
     See :class:`fairseq2.nn.ColumnShardedLinear` for an example.
@@ -34,8 +34,8 @@ class Sharded(ABC):
 
 def get_shard_dims(module: Module) -> dict[str, int]:
     """
-    Recursively traverses the specified module and collects sharding information
-    from all :class:`Sharded` modules.
+    Recursively traverses ``module`` and collects sharding information from all
+    :class:`Sharded` modules.
 
     Returns a dictionary mapping fully qualified parameter names to their
     sharded dimensions.

--- a/src/fairseq2/nn/sharded.py
+++ b/src/fairseq2/nn/sharded.py
@@ -1,0 +1,75 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from torch.nn import Module, Parameter
+
+
+class Sharded(ABC):
+    """
+    Indicates that a PyTorch module has tensor-sharded parameters.
+
+    Modules implementing this interface can specify which of their parameters
+    are sharded and along which dimensions the sharding occurs.
+
+    See :class:`fairseq2.nn.ColumnShardedLinear` for an example.
+    """
+
+    @abstractmethod
+    def get_shard_dims(self) -> list[tuple[Parameter, int]]:
+        """
+        Returns the sharding information for this module's parameters.
+
+        This function returns a list of tuples where each tuple contains the
+        sharded parameter within this module and the tensor dimension along
+        which the parameter is sharded.
+        """
+
+
+def get_shard_dims(module: Module) -> dict[str, int]:
+    """
+    Recursively traverses the specified module and collects sharding information
+    from all :class:`Sharded` modules.
+
+    Returns a dictionary mapping fully qualified parameter names to their
+    sharded dimensions.
+
+    .. code:: python
+        :caption: Example usage with sharded embedding layers
+
+        # Given a model with sharded embeddings
+        model = TransformerModel(...)
+
+        # Get all sharding information
+        shard_dims = get_shard_dims(model)
+
+        # Returns: {
+        #   "encoder.embed_tokens.weight": 0,
+        #   "decoder.embed_tokens.weight": 0,
+        #   "encoder.layers.0.self_attn.q_proj.weight": 1,
+        #   "encoder.layers.0.self_attn.q_proj.bias": 1,
+        #   ...
+        # }
+    """
+    shard_dims = {}
+
+    for m in module.modules():
+        if isinstance(m, Sharded):
+            for param, shard_dim in m.get_shard_dims():
+                if param not in shard_dims:
+                    shard_dims[param] = shard_dim
+
+    output = {}
+
+    for param_name, param in module.named_parameters():
+        dim = shard_dims.get(param)
+        if dim is not None:
+            output[param_name] = dim
+
+    return output

--- a/src/fairseq2/utils/validation.py
+++ b/src/fairseq2/utils/validation.py
@@ -16,7 +16,7 @@ to make its intent more clear.
 
 A typical implementation of a ``validate()`` method looks like the following:
 
-.. code-block:: python
+.. code:: python
 
     from dataclasses import dataclass
 
@@ -49,7 +49,7 @@ that it is validated before setting :attr:`RecipeContext.config`. To manually
 validate an object outside of recipes, :class:`StandardObjectValidator` can
 be used:
 
-.. code-block:: python
+.. code:: python
 
     from dataclasses import dataclass
 

--- a/src/fairseq2/utils/validation.py
+++ b/src/fairseq2/utils/validation.py
@@ -16,7 +16,7 @@ to make its intent more clear.
 
 A typical implementation of a ``validate()`` method looks like the following:
 
-.. code:: python
+.. code-block:: python
 
     from dataclasses import dataclass
 
@@ -49,7 +49,7 @@ that it is validated before setting :attr:`RecipeContext.config`. To manually
 validate an object outside of recipes, :class:`StandardObjectValidator` can
 be used:
 
-.. code:: python
+.. code-block:: python
 
     from dataclasses import dataclass
 

--- a/tests/unit/nn/test_sharded.py
+++ b/tests/unit/nn/test_sharded.py
@@ -1,0 +1,30 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from torch.nn import Sequential
+
+from fairseq2.gang import FakeGang
+from fairseq2.nn import ColumnShardedLinear, Linear, RowShardedLinear, get_shard_dims
+from tests.common import device
+
+
+def test_get_shard_dims_work() -> None:
+    gang = FakeGang(device, rank=1, size=16)
+
+    module = Sequential(
+        Linear(32, 32, bias=True),
+        ColumnShardedLinear(gang, 32, 32, bias=True),
+        Linear(32, 32, bias=False),
+        Sequential(
+            RowShardedLinear(gang, 32, 32, bias=True),
+        ),
+    )
+
+    dims = get_shard_dims(module)
+
+    assert dims == {"1.weight": 0, "1.bias": 0, "3.0.weight": 1}


### PR DESCRIPTION
This PR includes several closely related changes:

(1) Introduces a new and simpler `shard_dims: dict[str, int]` parameter in `ModelCheckpointLoader` that works at parameter granularity to overcome the limitation of `shard_specs`' module-level handling. We maintain full backwards compatibility. The existing `shard_specs` parameter will be removed in fairseq2 v0.12 (in about 6 months). Till then, both parameters will function as documented, but we will print a warning/deprecation message if `shard_specs` is specified instead of `shard_dims`.
(2) Introduces a new `fairseq2.nn.Sharded` interface and a standalone helper `get_shard_dims()` function. As its name suggests, `Sharded` interface marks a class as sharded and is implemented by `ColumnShardedLinear`, `RowShardedLinear`, `VocabShardedEmbedding` and `ShardedEmbedding`. It exposes only a single method called `get_shard_dims()` that returns a list of `(parameter, shard_dim)` tuples indicating which parameters/buffers of the module are sharded along which dimension. The standalone `get_shard_dims()` accepts a PyTorch module, traverses its submodules, and for each `Sharded` module it finds, adds its sharded parameters' fully-qualified name along with the dimension information to a dictionary that it returns at the end of the call. The returned dictionary can be passed to `ModelCheckpointLoader` to specify the sharding information. The advantage of this approach is two-fold: (1) it operates at the parameter level (2) it is dynamically extracted at runtime and does not require the model author to manually create a "shard spec".
(3) Updates `StandardModelFamily` to support the new `shard_dims` feature in a backwards compatible way. If a model family has an explicit `shard_spec`, things work as in the past. If no `shard_spec` is defined, the implementation attempts to dynamically extract the sharding information via `get_shard_dims()`. With v0.12, we will remove the `shard_spec` implementation.
(4) Revises and/or significantly extends the documentation of projection modules, embedding modules, as well as model checkpoint APIs.
(5) Squeezes a small extra feature in `RowShardedLinear` and introduces a `reduce_output` option which is required for MoE models. This feature was taken from Martin's LLaMA-4 Scout PR.

This PR will be accompanied by a quick follow-up PR that also revises/simplifies sharded model loading that will entirely deprecate the existing `ModelSharder` API. 