### PR TITLE
Handle OS and gang errors as operational in recipes

### DIFF
--- a/src/fairseq2/recipe/composition/eval_model.py
+++ b/src/fairseq2/recipe/composition/eval_model.py
@@ -10,6 +10,8 @@ from typing import final
 
 from typing_extensions import override
 
+from fairseq2.error import raise_operational_system_error
+from fairseq2.gang import GangError, raise_operational_gang_error
 from fairseq2.recipe.base import Recipe, RecipeContext
 from fairseq2.recipe.composition.config import register_config_section
 from fairseq2.recipe.config import ReferenceModelSection
@@ -61,9 +63,14 @@ class _CustomEvalModelPreparer(_EvalModelPreparer):
     ) -> RecipeModel:
         context = RecipeContext(self._resolver)
 
-        if section_name == "model":
-            return self._recipe.prepare_model(context, model)
-
-        return self._recipe.prepare_reference_model(
-            context, model, section_name, section
-        )
+        try:
+            if section_name == "model":
+                return self._recipe.prepare_model(context, model)
+            else:
+                return self._recipe.prepare_reference_model(
+                    context, model, section_name, section
+                )
+        except OSError as ex:
+            raise_operational_system_error(ex)
+        except GangError as ex:
+            raise_operational_gang_error(ex)

--- a/src/fairseq2/recipe/composition/model.py
+++ b/src/fairseq2/recipe/composition/model.py
@@ -10,6 +10,8 @@ from typing import final
 
 from typing_extensions import override
 
+from fairseq2.error import raise_operational_system_error
+from fairseq2.gang import GangError, raise_operational_gang_error
 from fairseq2.recipe.base import RecipeContext, TrainRecipe
 from fairseq2.recipe.internal.model import (
     _DelegatingTrainModelPreparer,
@@ -55,4 +57,9 @@ class _CustomTrainModelPreparer(_TrainModelPreparer):
     def prepare(self, model: RecipeModel) -> RecipeModel:
         context = RecipeContext(self._resolver)
 
-        return self._recipe.prepare_model(context, model)
+        try:
+            return self._recipe.prepare_model(context, model)
+        except OSError as ex:
+            raise_operational_system_error(ex)
+        except GangError as ex:
+            raise_operational_gang_error(ex)

--- a/src/fairseq2/recipe/composition/root.py
+++ b/src/fairseq2/recipe/composition/root.py
@@ -10,7 +10,8 @@ import torch
 
 from fairseq2.assets import AssetMetadataSource
 from fairseq2.checkpoint import CheckpointManager, StandardCheckpointManager
-from fairseq2.gang import Gangs
+from fairseq2.error import raise_operational_system_error
+from fairseq2.gang import GangError, Gangs, raise_operational_gang_error
 from fairseq2.recipe.base import (
     EvalRecipe,
     GenerationRecipe,
@@ -91,7 +92,12 @@ def _register_train_recipe(container: DependencyContainer, recipe: TrainRecipe) 
     def create_trainer(resolver: DependencyResolver) -> Trainer:
         context = RecipeContext(resolver)
 
-        return recipe.create_trainer(context)
+        try:
+            return recipe.create_trainer(context)
+        except OSError as ex:
+            raise_operational_system_error(ex)
+        except GangError as ex:
+            raise_operational_gang_error(ex)
 
     container.register(Task, create_trainer)
 
@@ -154,7 +160,12 @@ def _register_eval_recipe(container: DependencyContainer, recipe: EvalRecipe) ->
     def create_evaluator(resolver: DependencyResolver) -> Evaluator:
         context = RecipeContext(resolver)
 
-        return recipe.create_evaluator(context)
+        try:
+            return recipe.create_evaluator(context)
+        except OSError as ex:
+            raise_operational_system_error(ex)
+        except GangError as ex:
+            raise_operational_gang_error(ex)
 
     container.register(Task, create_evaluator)
 
@@ -199,7 +210,12 @@ def _register_generation_recipe(
     def create_generator(resolver: DependencyResolver) -> Generator:
         context = RecipeContext(resolver)
 
-        return recipe.create_generator(context)
+        try:
+            return recipe.create_generator(context)
+        except OSError as ex:
+            raise_operational_system_error(ex)
+        except GangError as ex:
+            raise_operational_gang_error(ex)
 
     container.register(Task, create_generator)
 

--- a/src/fairseq2/recipe/run.py
+++ b/src/fairseq2/recipe/run.py
@@ -25,6 +25,7 @@ from fairseq2.recipe.internal.logging import _DistributedLogConfigurer
 from fairseq2.recipe.internal.output_dir import _OutputDirectoryCreator
 from fairseq2.recipe.internal.task import _TaskRunner
 from fairseq2.recipe.internal.torch import _TorchConfigurer
+from fairseq2.recipe.task import Task
 from fairseq2.runtime.dependency import DependencyContainer, DependencyResolver
 from fairseq2.utils.rich import configure_rich_logging
 from fairseq2.utils.structured import ValueConverter
@@ -123,9 +124,11 @@ def _run_recipe(resolver: DependencyResolver) -> None:
     log_helper.log_environment_variables()
 
     # Run recipe task.
+    task = resolver.resolve(Task)
+
     task_runner = resolver.resolve(_TaskRunner)
 
-    task_runner.run()
+    task_runner.run(task)
 
 
 @contextmanager


### PR DESCRIPTION
Make life easier for recipe authors and handle `OSError` and `GangError` gracefully by converting them to `OperationalError` so they are reported in a nicely formatted way for users.