### PR TITLE
Add tqdm interop support to ProgressReporter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
         "safetensors~=0.6",
         "tiktoken~=0.7",
         "torcheval~=0.0.6",
-        "tqdm~=4.62",
+        "tqdm~=4.67",
         "typing_extensions~=4.12",
         # This dependency is required for tiktoken.load.read_file, but it's
         # listed as optional in tiktoken's pyproject.toml


### PR DESCRIPTION
This PR introduces a new `maybe_get_tqdm_class` method to `ProgressReporter` to work around the peculiar interface of huggingface_hub APIs where progress reporting can only be intervened by passing a tqdm class instead of an instance. The follow-up PR right after this one, will update the calls to `snapshot_download` in `AssetDownloadManager` to use this method.