### PR TITLE
Introduce FAIRSEQ2_NO_PROGRESS env variable

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -10,7 +10,6 @@ pyarrow-stubs~=10.0
 pytest~=8.4
 pytest-asyncio~=1.0
 shellcheck-py~=0.9
-types-tqdm~=4.67.0
 types-editdistance~=0.6
 types-psutil~=5.9
 types-setuptools~=75.8

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,6 @@ setup(
         "safetensors~=0.6",
         "tiktoken~=0.7",
         "torcheval~=0.0.6",
-        "tqdm~=4.62",
         "typing_extensions~=4.12",
         # This dependency is required for tiktoken.load.read_file, but it's
         # listed as optional in tiktoken's pyproject.toml

--- a/src/fairseq2/__init__.py
+++ b/src/fairseq2/__init__.py
@@ -21,8 +21,15 @@ _in_call: bool = False
 
 
 def init_fairseq2(
-    *, extras: Callable[[DependencyContainer], None] | None = None
+    *,
+    extras: Callable[[DependencyContainer], None] | None = None,
+    no_progress: bool | None = None,
 ) -> DependencyResolver:
+    """
+    If ``no_progress`` is ``True``, all progress bars will be disabled. If
+    ``None``, ``FAIRSEQ2_NO_PROGRESS`` environment variable will be checked
+    instead and progress bars will be disabled if it exists.
+    """
     from fairseq2.composition import _register_library
 
     global _in_call
@@ -38,7 +45,7 @@ def init_fairseq2(
     container = DependencyContainer()
 
     try:
-        _register_library(container)
+        _register_library(container, no_progress=no_progress)
 
         if extras is not None:
             extras(container)

--- a/src/fairseq2/assets/download_manager.py
+++ b/src/fairseq2/assets/download_manager.py
@@ -24,12 +24,12 @@ from zipfile import BadZipFile, ZipFile
 
 from huggingface_hub import snapshot_download
 from huggingface_hub.errors import HfHubHTTPError
-from tqdm import tqdm  # type: ignore[import]
 from typing_extensions import override
 
 from fairseq2.error import NotSupportedError
 from fairseq2.logging import log
 from fairseq2.runtime.dependency import get_dependency_resolver
+from fairseq2.utils.progress import ProgressReporter
 from fairseq2.utils.uri import Uri
 
 
@@ -48,16 +48,19 @@ class AssetDownloadManager(ABC):
         progress: bool = True,
     ) -> Path:
         """
-        Downloads the checkpoint at ``uri`` to the asset cache directory.
+        Downloads the model checkpoint at ``uri`` to the asset cache directory.
 
-        :param uri: The URI to download from.
-        :param model_name: The name of the associated model.
-        :param force: If ``True``, downloads the checkpoint even if it is
-            already in cache.
-        :param progress: If ``True``, displays a progress bar to stderr.
+        Returns the path to the downloaded model checkpoint.
 
-        :returns:
-            The path to the downloaded checkpoint.
+        If ``force`` is ``True``, the model checkpoint will be downloaded even
+        if it is already in cache.
+
+        ``progress`` is deprecated and will be removed in v0.13. Use
+        ``FAIRSEQ2_NO_PROGRESS=1`` environment variable or ``no_progress``
+        parameter of :func:`init_fairseq` to disable progress bars.
+
+        :raises AssetDownloadError: If the download operation fails due to a
+            network or server error.
         """
 
     @abstractmethod
@@ -72,13 +75,17 @@ class AssetDownloadManager(ABC):
         """
         Downloads the tokenizer at ``uri`` to the asset cache directory.
 
-        :param uri: The URI to download from.
-        :param tokenizer_name: The name of the tokenizer.
-        :param force: If ``True``, downloads the tokenizer even if it is already
-            in cache.
-        :param progress: If ``True``, displays a progress bar to stderr.
+        Returns the path to the downloaded tokenizer.
 
-        :returns: The path to the downloaded tokenizer.
+        If ``force`` is ``True``, the tokenizer will be downloaded even if it is
+        already in cache.
+
+        ``progress`` is deprecated and will be removed in v0.13. Use
+        ``FAIRSEQ2_NO_PROGRESS=1`` environment variable or ``no_progress``
+        parameter of :func:`init_fairseq` to disable progress bars.
+
+        :raises AssetDownloadError: If the download operation fails due to a
+            network or server error.
         """
 
     @abstractmethod
@@ -93,13 +100,17 @@ class AssetDownloadManager(ABC):
         """
         Downloads the dataset at ``uri`` to the asset cache directory.
 
-        :param uri: The URI to download from.
-        :param data_name: The name of the dataset.
-        :param force: If ``True``, downloads the dataset even if it is already
-            in cache.
-        :param progress: If ``True``, displays a progress bar to stderr.
+        Returns the path to the downloaded dataset.
 
-        :returns: The path to the downloaded dataset.
+        If ``force`` is ``True``, the dataset will be downloaded even if it is
+        already in cache.
+
+        ``progress`` is deprecated and will be removed in v0.13. Use
+        ``FAIRSEQ2_NO_PROGRESS=1`` environment variable or ``no_progress``
+        parameter of :func:`init_fairseq` to disable progress bars.
+
+        :raises AssetDownloadError: If the download operation fails due to a
+            network or server error.
         """
 
     @property
@@ -346,8 +357,9 @@ class HuggingFaceHub(AssetDownloadManager):
 class StandardAssetDownloadManager(AssetDownloadManager):
     _SCHEMES: Final = {"http", "https"}
 
-    def __init__(self, cache_dir: Path) -> None:
+    def __init__(self, cache_dir: Path, progress_reporter: ProgressReporter) -> None:
         self._cache_dir = cache_dir
+        self._progress_reporter = progress_reporter
 
     @override
     def download_model(
@@ -360,7 +372,9 @@ class StandardAssetDownloadManager(AssetDownloadManager):
     ) -> Path:
         kind = "model"
 
-        op = _AssetDownloadOp(self._cache_dir, uri, model_name, kind, force, progress)
+        op = _AssetDownloadOp(
+            self._cache_dir, uri, model_name, kind, force, self._progress_reporter
+        )
 
         return op.run()
 
@@ -376,7 +390,7 @@ class StandardAssetDownloadManager(AssetDownloadManager):
         kind = "tokenizer"
 
         op = _AssetDownloadOp(
-            self._cache_dir, uri, tokenizer_name, kind, force, progress
+            self._cache_dir, uri, tokenizer_name, kind, force, self._progress_reporter
         )
 
         return op.run()
@@ -392,7 +406,9 @@ class StandardAssetDownloadManager(AssetDownloadManager):
     ) -> Path:
         kind = "dataset"
 
-        op = _AssetDownloadOp(self._cache_dir, uri, dataset_name, kind, force, progress)
+        op = _AssetDownloadOp(
+            self._cache_dir, uri, dataset_name, kind, force, self._progress_reporter
+        )
 
         return op.run()
 
@@ -403,15 +419,6 @@ class StandardAssetDownloadManager(AssetDownloadManager):
 
 
 class _AssetDownloadOp:
-    _cache_dir: Path
-    _uri: str
-    _uri_params: dict[str, str]
-    _asset_dir: Path | None
-    _asset_name: str
-    _asset_kind: str
-    _force: bool
-    _progress: bool
-
     def __init__(
         self,
         cache_dir: Path,
@@ -419,16 +426,16 @@ class _AssetDownloadOp:
         asset_name: str,
         kind: str,
         force: bool,
-        progress: bool,
+        progress_reporter: ProgressReporter,
     ) -> None:
         self._cache_dir = cache_dir
         self._uri = str(uri)
-        self._uri_params = {}
-        self._asset_dir = None
+        self._uri_params: dict[str, str] = {}
+        self._asset_dir: Path | None = None
         self._asset_name = asset_name
         self._asset_kind = kind
         self._force = force
-        self._progress = progress
+        self._progress_reporter = progress_reporter
 
     def run(self) -> Path:
         self._process_uri()
@@ -593,15 +600,11 @@ class _AssetDownloadOp:
 
             num_bytes_read = 0
 
-            progress_bar = cleanup_stack.enter_context(
-                tqdm(
-                    total=size,
-                    disable=not self._progress,
-                    unit="B",
-                    unit_scale=True,
-                    unit_divisor=1024,
-                )
-            )
+            cleanup_stack.enter_context(self._progress_reporter)
+
+            task = self._progress_reporter.create_task("download", total=size)
+
+            cleanup_stack.enter_context(task)
 
             while True:
                 try:
@@ -628,7 +631,7 @@ class _AssetDownloadOp:
 
                 fp.write(buffer)
 
-                progress_bar.update(buffer_len)
+                task.step(buffer_len)
 
             if size is not None and num_bytes_read < size:
                 msg = f"The server sent {num_bytes_read:,} bytes which is less than the expected size of {size:,} bytes."

--- a/src/fairseq2/composition/assets.py
+++ b/src/fairseq2/composition/assets.py
@@ -41,6 +41,7 @@ from fairseq2.runtime.dependency import (
     DependencyResolver,
     wire_object,
 )
+from fairseq2.utils.progress import ProgressReporter
 
 
 def register_file_assets(
@@ -134,7 +135,14 @@ def _register_asset(container: DependencyContainer) -> None:
 
         cache_dir = dirs.get_cache_dir()
 
-        return wire_object(resolver, StandardAssetDownloadManager, cache_dir=cache_dir)
+        progress_reporter = resolver.resolve(ProgressReporter, key="download_reporter")
+
+        return wire_object(
+            resolver,
+            StandardAssetDownloadManager,
+            cache_dir=cache_dir,
+            progress_reporter=progress_reporter,
+        )
 
     container.collection.register(
         AssetDownloadManager, create_standard_asset_download_manager

--- a/src/fairseq2/composition/lib.py
+++ b/src/fairseq2/composition/lib.py
@@ -57,7 +57,11 @@ from fairseq2.model_checkpoint import (
 from fairseq2.models.hub import GlobalModelLoader
 from fairseq2.models.llama import LLaMACheckpointLoader
 from fairseq2.models.llama4.sharder import MoESharder
-from fairseq2.runtime.dependency import DependencyContainer, DependencyResolver
+from fairseq2.runtime.dependency import (
+    DependencyContainer,
+    DependencyResolver,
+    wire_object,
+)
 from fairseq2.sharder import (
     EmbeddingSharder,
     LinearSharder,
@@ -72,8 +76,12 @@ from fairseq2.utils.config import (
     StandardConfigProcessor,
 )
 from fairseq2.utils.env import Environment, StandardEnvironment
-from fairseq2.utils.progress import ProgressReporter
-from fairseq2.utils.rich import RichProgressReporter, get_error_console
+from fairseq2.utils.progress import NOOP_PROGRESS_REPORTER, ProgressReporter
+from fairseq2.utils.rich import (
+    RichProgressReporter,
+    create_rich_download_progress_columns,
+    get_error_console,
+)
 from fairseq2.utils.rng import RngBag
 from fairseq2.utils.structured import StandardValueConverter, ValueConverter
 from fairseq2.utils.threading import StandardThreadPool, ThreadPool
@@ -87,7 +95,9 @@ from fairseq2.utils.yaml import (
 from fairseq2.world_info import WorldInfo
 
 
-def _register_library(container: DependencyContainer) -> None:
+def _register_library(
+    container: DependencyContainer, *, no_progress: bool | None = None
+) -> None:
     # Environment Variables
     env = StandardEnvironment()
 
@@ -97,6 +107,33 @@ def _register_library(container: DependencyContainer) -> None:
     error_console = get_error_console()
 
     container.register_instance(Console, error_console)
+
+    # Progress Reporters
+    if no_progress is None:
+        no_progress = env.has("FAIRSEQ2_NO_PROGRESS")
+
+    if no_progress:
+        container.register_instance(ProgressReporter, NOOP_PROGRESS_REPORTER)
+
+        container.register_instance(
+            ProgressReporter, NOOP_PROGRESS_REPORTER, key="download_reporter"
+        )
+    else:
+        container.register_type(ProgressReporter, RichProgressReporter, singleton=True)
+
+        def create_download_progress_reporter(
+            resolver: DependencyResolver,
+        ) -> ProgressReporter:
+            columns = create_rich_download_progress_columns()
+
+            return wire_object(resolver, RichProgressReporter, columns=columns)
+
+        container.register(
+            ProgressReporter,
+            create_download_progress_reporter,
+            key="download_reporter",
+            singleton=True,
+        )
 
     # WorldInfo
     def create_world_info(resolver: DependencyResolver) -> WorldInfo:
@@ -145,7 +182,6 @@ def _register_library(container: DependencyContainer) -> None:
     container.register_type(ModelMetadataLoader, StandardModelMetadataLoader)
     container.register_type(ModelSharder, StandardModelSharder, singleton=True)
     container.register_type(ObjectValidator, StandardObjectValidator, singleton=True)
-    container.register_type(ProgressReporter, RichProgressReporter, singleton=True)
     container.register_type(SafetensorsLoader, HuggingFaceSafetensorsLoader)
     container.register_type(SentencePieceModelLoader, StandardSentencePieceModelLoader, singleton=True)
     container.register_type(TensorDumper, TorchTensorDumper, singleton=True)

--- a/src/fairseq2/data/tokenizers/family.py
+++ b/src/fairseq2/data/tokenizers/family.py
@@ -135,9 +135,7 @@ class StandardTokenizerFamily(TokenizerFamily):
 
             raise AssetCardError(name, msg)
 
-        path = self._asset_download_manager.download_tokenizer(
-            uri, name, progress=progress
-        )
+        path = self._asset_download_manager.download_tokenizer(uri, name)
 
         # Load the configuration.
         if config is None:

--- a/src/fairseq2/data/tokenizers/hub.py
+++ b/src/fairseq2/data/tokenizers/hub.py
@@ -17,6 +17,7 @@ from fairseq2.data.tokenizers.tokenizer import Tokenizer
 from fairseq2.error import InternalError
 from fairseq2.runtime.dependency import get_dependency_resolver
 from fairseq2.runtime.lookup import Lookup
+from fairseq2.utils.warn import _warn_progress_deprecated
 
 TokenizerT = TypeVar("TokenizerT", bound=Tokenizer)
 
@@ -61,8 +62,10 @@ class TokenizerHub(Generic[TokenizerT, TokenizerConfigT]):
         card: AssetCard | str,
         *,
         config: TokenizerConfigT | None = None,
-        progress: bool = True,
+        progress: bool | None = None,
     ) -> TokenizerT:
+        _warn_progress_deprecated(progress)
+
         if isinstance(card, str):
             name = card
 
@@ -82,7 +85,7 @@ class TokenizerHub(Generic[TokenizerT, TokenizerConfigT]):
 
             raise AssetCardError(name, msg)
 
-        tokenizer = self._family.load_tokenizer(card, config, progress)
+        tokenizer = self._family.load_tokenizer(card, config, progress=True)
 
         return cast(TokenizerT, tokenizer)
 
@@ -143,7 +146,7 @@ class TokenizerFamilyNotKnownError(Exception):
 
 
 def load_tokenizer(
-    card: AssetCard | str, *, config: object | None = None, progress: bool = True
+    card: AssetCard | str, *, config: object | None = None, progress: bool | None = None
 ) -> Tokenizer:
     resolver = get_dependency_resolver()
 
@@ -161,8 +164,10 @@ class GlobalTokenizerLoader:
         self._families = families
 
     def load(
-        self, card: AssetCard | str, config: object | None, progress: bool
+        self, card: AssetCard | str, config: object | None, progress: bool | None
     ) -> Tokenizer:
+        _warn_progress_deprecated(progress)
+
         if isinstance(card, str):
             name = card
 
@@ -183,4 +188,4 @@ class GlobalTokenizerLoader:
 
             raise AssetCardError(name, msg)
 
-        return family.load_tokenizer(card, config, progress)
+        return family.load_tokenizer(card, config, progress=True)

--- a/src/fairseq2/model_checkpoint/common.py
+++ b/src/fairseq2/model_checkpoint/common.py
@@ -65,8 +65,8 @@ def reshard_tensor(
     Omitted for replicated tensors. See :func:`~fairseq2.nn.get_sharding_dims`
     for more information.
 
-    ``shard_specs`` is deprecated and will be removed in a future release;
-    please use ``shard_dims`` instead.
+    ``shard_specs`` is deprecated and will be removed in v0.12; please use
+    ``shard_dims`` instead.
 
     Returns the resharded tensor for the target rank and configuration.
 

--- a/src/fairseq2/model_checkpoint/loader.py
+++ b/src/fairseq2/model_checkpoint/loader.py
@@ -50,8 +50,7 @@ class ModelCheckpointLoader(ABC):
         conversion.
 
         ``gangs`` is used to determine the distributed target configuration and
-        shard yielded parameters accordingly. If ``None``, no sharding will be
-        performed and full parameters will be yielded.
+        shard yielded parameters accordingly.
 
         If ``mmap`` is ``True``, the checkpoint will be memory-mapped. This can
         reduce memory usage but may cause slower load times on some systems.
@@ -69,8 +68,8 @@ class ModelCheckpointLoader(ABC):
         checkpoint loading. If ``None``, no resharding will be performed and
         full parameters will be loaded.
 
-        ``shard_specs`` is deprecated and will be removed in a future release;
-        please use ``shard_dims`` instead.
+        ``shard_specs`` is deprecated and will be removed in v0.12; please use
+        ``shard_dims`` instead.
 
         Yields pairs of ``(parameter name, parameter)`` for each parameter in
         the checkpoint.

--- a/src/fairseq2/models/hub.py
+++ b/src/fairseq2/models/hub.py
@@ -22,7 +22,7 @@ from fairseq2.gang import Gangs, create_fake_gangs
 from fairseq2.models.family import ModelFamily
 from fairseq2.runtime.dependency import get_dependency_resolver
 from fairseq2.runtime.lookup import Lookup
-from fairseq2.utils.warn import _warn_deprecated
+from fairseq2.utils.warn import _warn_deprecated, _warn_progress_deprecated
 
 ModelT = TypeVar("ModelT", bound=Module)
 
@@ -244,7 +244,7 @@ class ModelHub(Generic[ModelT, ModelConfigT]):
         dtype: DataType | None = None,
         config: ModelConfigT | None = None,
         mmap: bool = False,
-        progress: bool = True,
+        progress: bool | None = None,
     ) -> ModelT: ...
 
     @overload
@@ -256,7 +256,7 @@ class ModelHub(Generic[ModelT, ModelConfigT]):
         dtype: DataType | None = None,
         config: ModelConfigT | None = None,
         mmap: bool = False,
-        progress: bool = True,
+        progress: bool | None = None,
     ) -> ModelT: ...
 
     def load_model(
@@ -268,7 +268,7 @@ class ModelHub(Generic[ModelT, ModelConfigT]):
         dtype: DataType | None = None,
         config: ModelConfigT | None = None,
         mmap: bool = False,
-        progress: bool = True,
+        progress: bool | None = None,
     ) -> ModelT:
         """
         Loads a pretrained model from an asset card.
@@ -306,8 +306,9 @@ class ModelHub(Generic[ModelT, ModelConfigT]):
         If ``mmap`` is ``True``, the model checkpoint will be memory-mapped. This
         can reduce memory usage but may cause slower load times on some systems.
 
-        If ``progress`` is ``True``, displays a progress bar during model
-        download and loading.
+        ``progress`` is deprecated and will be removed in v0.13. Use
+        ``FAIRSEQ2_NO_PROGRESS=1`` environment variable or ``no_progress``
+        parameter of :func:`init_fairseq` to disable progress bars.
 
         .. code:: python
 
@@ -330,6 +331,8 @@ class ModelHub(Generic[ModelT, ModelConfigT]):
 
         :raises ValueError: If both ``gangs`` and ``device`` are provided.
         """
+        _warn_progress_deprecated(progress)
+
         gangs = _get_effective_gangs(gangs, device)
 
         if isinstance(card, str):
@@ -352,7 +355,7 @@ class ModelHub(Generic[ModelT, ModelConfigT]):
         if dtype is None:
             dtype = torch.get_default_dtype()
 
-        model = self._family.load_model(card, gangs, dtype, config, mmap, progress)
+        model = self._family.load_model(card, gangs, dtype, config, mmap, progress=True)
 
         return cast(ModelT, model)
 
@@ -366,7 +369,7 @@ class ModelHub(Generic[ModelT, ModelConfigT]):
         dtype: DataType | None = None,
         mmap: bool = False,
         restrict: bool | None = None,
-        progress: bool = True,
+        progress: bool | None = None,
     ) -> ModelT: ...
 
     @overload
@@ -379,7 +382,7 @@ class ModelHub(Generic[ModelT, ModelConfigT]):
         dtype: DataType | None = None,
         mmap: bool = False,
         restrict: bool | None = None,
-        progress: bool = True,
+        progress: bool | None = None,
     ) -> ModelT: ...
 
     def load_custom_model(
@@ -392,7 +395,7 @@ class ModelHub(Generic[ModelT, ModelConfigT]):
         dtype: DataType | None = None,
         mmap: bool = False,
         restrict: bool | None = None,
-        progress: bool = True,
+        progress: bool | None = None,
     ) -> ModelT:
         """
         Loads a model from a custom checkpoint file.
@@ -427,8 +430,9 @@ class ModelHub(Generic[ModelT, ModelConfigT]):
         only tensors and types that can be safely serialized and deserialized.
         If ``None``, the default restriction setting of the family will be used.
 
-        If ``progress`` is ``True``, displays a progress bar during model
-        download and loading.
+        ``progress`` is deprecated and will be removed in v0.13. Use
+        ``FAIRSEQ2_NO_PROGRESS=1`` environment variable or ``no_progress``
+        parameter of :func:`init_fairseq` to disable progress bars.
 
         .. code:: python
 
@@ -448,13 +452,15 @@ class ModelHub(Generic[ModelT, ModelConfigT]):
         :raises ModelCheckpointError: If the checkpoint format is not valid or
             incompatible with the model.
         """
+        _warn_progress_deprecated(progress)
+
         gangs = _get_effective_gangs(gangs, device)
 
         if dtype is None:
             dtype = torch.get_default_dtype()
 
         model = self._family.load_custom_model(
-            path, config, gangs, dtype, mmap, restrict, progress
+            path, config, gangs, dtype, mmap, restrict, progress=True
         )
 
         return cast(ModelT, model)
@@ -611,7 +617,7 @@ def load_model(
     dtype: DataType | None = None,
     config: object | None = None,
     mmap: bool = False,
-    progress: bool = True,
+    progress: bool | None = None,
 ) -> Module: ...
 
 
@@ -623,7 +629,7 @@ def load_model(
     dtype: DataType | None = None,
     config: object | None = None,
     mmap: bool = False,
-    progress: bool = True,
+    progress: bool | None = None,
 ) -> Module: ...
 
 
@@ -635,7 +641,7 @@ def load_model(
     dtype: DataType | None = None,
     config: object | None = None,
     mmap: bool = False,
-    progress: bool = True,
+    progress: bool | None = None,
 ) -> Module:
     """
     Loads a pretrained model from an asset card.
@@ -686,8 +692,9 @@ def load_model(
     If ``mmap`` is ``True``, the model checkpoint will be memory-mapped. This
     can reduce memory usage but may cause slower load times on some systems.
 
-    If ``progress`` is ``True``, displays a progress bar during model
-    download and loading.
+    ``progress`` is deprecated and will be removed in v0.13. Use
+    ``FAIRSEQ2_NO_PROGRESS=1`` environment variable or ``no_progress`` parameter
+    of :func:`init_fairseq` to disable progress bars.
 
     .. code:: python
 
@@ -740,9 +747,11 @@ class GlobalModelLoader:
         dtype: DataType | None,
         config: object | None,
         mmap: bool,
-        progress: bool,
+        progress: bool | None,
     ) -> Module:
         """See :func:`load_model`."""
+        _warn_progress_deprecated(progress)
+
         gangs = _get_effective_gangs(gangs, device)
 
         if isinstance(card, str):
@@ -766,7 +775,7 @@ class GlobalModelLoader:
         if dtype is None:
             dtype = torch.get_default_dtype()
 
-        return family.load_model(card, gangs, dtype, config, mmap, progress)
+        return family.load_model(card, gangs, dtype, config, mmap, progress=True)
 
 
 def _get_effective_gangs(gangs: Gangs | None, device: Device | None) -> Gangs:

--- a/src/fairseq2/utils/warn.py
+++ b/src/fairseq2/utils/warn.py
@@ -23,3 +23,11 @@ def enable_deprecation_warnings() -> None:
 
 def _warn_deprecated(msg: str) -> None:
     warnings.warn(msg, DeprecationWarning, stacklevel=2)
+
+
+# TODO: Remove in v0.13
+def _warn_progress_deprecated(value: bool | None) -> None:
+    if value is not None:
+        _warn_deprecated(
+            "`progress` parameter in all fairseq2 APIs is deprecated, has no effect, and will be removed in v0.13."
+        )


### PR DESCRIPTION
This PR introduces a new `FAIRSEQ2_NO_PROGRESS` environment variable and a new `no_progress` parameter in `init_fairseq2` function. As their names suggest, they are meant to switch off all progress bars used for various purposes such as asset downloading and model checkpoint loading. With that, the current `progress` parameters spread out through the code base are all deprecated and will be removed in v0.13. Note though due to the limitations of huggingface_hub, we cannot intervene its progress bars and users should explicitly disable it via `HF_HUB_DISABLE_PROGRESS_BARS` environment variable as described [here](https://huggingface.co/docs/huggingface_hub/v1.0.0.rc6/en/package_reference/file_download#huggingface_hub.snapshot_download).