### PR TITLE
Register no-op as the CPU stat tracker to avoid recipes crashing on CPU

### DIFF
--- a/src/fairseq2/recipe/composition/device_stat.py
+++ b/src/fairseq2/recipe/composition/device_stat.py
@@ -9,9 +9,9 @@ from __future__ import annotations
 from fairseq2.recipe.internal.device_stat import _RecipeDeviceStatTrackerProvider
 from fairseq2.runtime.dependency import DependencyContainer, DependencyResolver
 from fairseq2.utils.device_stat import (
+    NOOP_DEVICE_STAT_TRACKER,
     CudaDeviceStatTracker,
     DeviceStatTracker,
-    _NoopDeviceStatTracker,
 )
 
 
@@ -31,4 +31,4 @@ def _register_device_stat(container: DependencyContainer) -> None:
 
     # CPU
     # No-op implementation is enough for now, since CPU-only is not a primary use case
-    container.register_type(DeviceStatTracker, _NoopDeviceStatTracker, key="cpu")
+    container.register_instance(DeviceStatTracker, NOOP_DEVICE_STAT_TRACKER, key="cpu")


### PR DESCRIPTION
**What does this PR do? Please describe:**
Register the no-op tracker as the recipe default CPU stat tracker to avoid recipes crashing on CPU.

A subsequent PR might add an actual CPU stat tracker, but for now since CPU-only is not a major use-case, no-op is good enough, while allowing users to debug and unit test their recipes on CPU.

**Does your PR introduce any breaking changes? If yes, please list them:**
No

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [ ] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
