### PR TITLE
Introduce --no-rich flag

### DIFF
--- a/recipes/chatbot/cli.py
+++ b/recipes/chatbot/cli.py
@@ -40,7 +40,7 @@ from fairseq2.gang import (
     raise_operational_gang_error,
 )
 from fairseq2.generation.sampling import SamplingSequenceGenerator, TopPSampler
-from fairseq2.logging import log
+from fairseq2.logging import configure_logging, log
 from fairseq2.model_checkpoint import ModelCheckpointError
 from fairseq2.models import ModelNotKnownError, load_model
 from fairseq2.models.clm import CausalLM
@@ -50,7 +50,7 @@ from fairseq2.recipe.error import (
     raise_model_type_not_valid_error,
 )
 from fairseq2.utils.argparse import parse_dtype
-from fairseq2.utils.rich import configure_rich_logging, get_console
+from fairseq2.utils.rich import get_console
 from fairseq2.utils.rng import RngBag
 from fairseq2.world_info import get_world_info
 
@@ -64,7 +64,7 @@ from .program import Program, ProgramView
 def _main() -> None:
     args = _parse_args()
 
-    configure_rich_logging()
+    configure_logging()
 
     try:
         _run(args)

--- a/src/fairseq2/assets/cli.py
+++ b/src/fairseq2/assets/cli.py
@@ -19,14 +19,14 @@ from fairseq2.assets.metadata_provider import AssetMetadataError
 from fairseq2.assets.store import AssetNotFoundError, AssetStore, get_asset_store
 from fairseq2.composition import ExtensionError
 from fairseq2.error import InternalError, OperationalError
-from fairseq2.logging import log
-from fairseq2.utils.rich import configure_rich_logging, get_console
+from fairseq2.logging import configure_logging, log
+from fairseq2.utils.rich import get_console
 
 
 def _main() -> None:
     args = _parse_args()
 
-    configure_rich_logging()
+    configure_logging()
 
     try:
         args.command(args)

--- a/src/fairseq2/models/utils/hg_export.py
+++ b/src/fairseq2/models/utils/hg_export.py
@@ -28,14 +28,13 @@ from fairseq2.device import CPU
 from fairseq2.error import OperationalError, raise_operational_system_error
 from fairseq2.file_system import FileSystem
 from fairseq2.gang import create_fake_gangs
-from fairseq2.logging import log
+from fairseq2.logging import configure_logging, log
 from fairseq2.model_checkpoint import ModelCheckpointError
 from fairseq2.models import ModelFamily, ModelNotKnownError, get_model_family
 from fairseq2.models.family import HuggingFaceExport
 from fairseq2.runtime.dependency import DependencyContainer
 from fairseq2.runtime.lookup import Lookup
 from fairseq2.utils.progress import ProgressReporter
-from fairseq2.utils.rich import configure_rich_logging
 
 
 def save_hugging_face_model(save_dir: Path, export: HuggingFaceExport) -> None:
@@ -84,7 +83,7 @@ def save_hugging_face_model(save_dir: Path, export: HuggingFaceExport) -> None:
 def _main() -> None:
     args = _parse_args()
 
-    configure_rich_logging()
+    configure_logging()
 
     try:
         _run(args)


### PR DESCRIPTION
This PR introduces a new `--no-rich` command line flag along with a counterpart `no_rich` parameter in `run()` to disable all rich log output.