### PR TITLE
Support for custom download subpaths

### DIFF
--- a/src/fairseq2/assets/cards/models/mistral.yaml
+++ b/src/fairseq2/assets/cards/models/mistral.yaml
@@ -7,8 +7,10 @@
 name: mistral_7b
 model_family: mistral
 model_arch: 7b
-checkpoint: "https://files.mistral-7b-v0-1.mistral.ai/mistral-7B-v0.1.tar;path=mistral-7B-v0.1%2Fconsolidated.00.pth"
-tokenizer: "https://files.mistral-7b-v0-1.mistral.ai/mistral-7B-v0.1.tar;path=mistral-7B-v0.1%2Ftokenizer.model"
+checkpoint: "https://files.mistral-7b-v0-1.mistral.ai/mistral-7B-v0.1.tar"
+checkpoint_path: "mistral-7B-v0.1/consolidated.00.pth"
+tokenizer: "https://files.mistral-7b-v0-1.mistral.ai/mistral-7B-v0.1.tar"
+tokenizer_path: "mistral-7B-v0.1/tokenizer.model"
 tokenizer_family: mistral
 
 ---
@@ -16,6 +18,8 @@ tokenizer_family: mistral
 name: mistral_7b_instruct
 model_family: mistral
 model_arch: 7b
-checkpoint: "https://files.mistral-7b-v0-1.mistral.ai/mistral-7B-instruct-v0.1b.tar;path=Mistral-7B-instruct-v0.1%2Fconsolidated.00.pth"
-tokenizer: "https://files.mistral-7b-v0-1.mistral.ai/mistral-7B-instruct-v0.1b.tar;path=Mistral-7B-instruct-v0.1%2Ftokenizer.model"
+checkpoint: "https://files.mistral-7b-v0-1.mistral.ai/mistral-7B-instruct-v0.1b.tar"
+checkpoint_path: "Mistral-7B-instruct-v0.1/consolidated.00.pth"
+tokenizer: "https://files.mistral-7b-v0-1.mistral.ai/mistral-7B-instruct-v0.1b.tar"
+tokenizer_path: "Mistral-7B-instruct-v0.1/tokenizer.model"
 tokenizer_family: mistral

--- a/src/fairseq2/assets/cards/models/s2t_conformer.yaml
+++ b/src/fairseq2/assets/cards/models/s2t_conformer.yaml
@@ -9,7 +9,8 @@ model_family: s2t_conformer
 model_arch: medium
 checkpoint: "https://dl.fbaipublicfiles.com/fairseq/conformer/covost2/en_de/abs_asr_pt_avg_last_10_checkpoint.pt"
 restrict: false
-tokenizer: "https://dl.fbaipublicfiles.com/fairseq/s2t/covost2_en_de_st_vocab_char.zip;path=spm_char.model"
+tokenizer: "https://dl.fbaipublicfiles.com/fairseq/s2t/covost2_en_de_st_vocab_char.zip"
+tokenizer_path: "spm_char.model"
 tokenizer_family: s2t_transformer
 tokenizer_config_overrides:
   task: translation
@@ -25,7 +26,8 @@ model_config_overrides:
   use_relative_pos: true
 checkpoint: "https://dl.fbaipublicfiles.com/fairseq/conformer/covost2/en_de/rel_pos_asr_pt_avg_last_10_checkpoint.pt"
 restrict: false
-tokenizer: "https://dl.fbaipublicfiles.com/fairseq/s2t/covost2_en_de_st_vocab_char.zip;path=spm_char.model"
+tokenizer: "https://dl.fbaipublicfiles.com/fairseq/s2t/covost2_en_de_st_vocab_char.zip"
+tokenizer_path: "spm_char.model"
 tokenizer_family: s2t_transformer
 tokenizer_config_overrides:
   task: translation

--- a/src/fairseq2/assets/cards/models/s2t_transformer.yaml
+++ b/src/fairseq2/assets/cards/models/s2t_transformer.yaml
@@ -11,7 +11,8 @@ model_config_overrides:
   target_vocab_size: 5000
 checkpoint: "https://dl.fbaipublicfiles.com/fairseq/s2t/mustc_de_asr_transformer_s.pt"
 restrict: false
-tokenizer: "https://dl.fbaipublicfiles.com/fairseq/s2t/mustc_de_asr_vocab_unigram5000.zip;path=spm_unigram_5000.model"
+tokenizer: "https://dl.fbaipublicfiles.com/fairseq/s2t/mustc_de_asr_vocab_unigram5000.zip"
+tokenizer_path: "spm_unigram_5000.model"
 tokenizer_family: s2t_transformer
 tokenizer_config_overrides:
   task: transcription
@@ -27,7 +28,8 @@ model_config_overrides:
   target_vocab_size: 5000
 checkpoint: "https://dl.fbaipublicfiles.com/fairseq/s2t/mustc_es_asr_transformer_s.pt"
 restrict: false
-tokenizer: "https://dl.fbaipublicfiles.com/fairseq/s2t/mustc_es_asr_vocab_unigram5000.zip;path=spm_unigram_5000.model"
+tokenizer: "https://dl.fbaipublicfiles.com/fairseq/s2t/mustc_es_asr_vocab_unigram5000.zip"
+tokenizer_path: "spm_unigram_5000.model"
 tokenizer_family: s2t_transformer
 tokenizer_config_overrides:
   task: transcription
@@ -41,7 +43,8 @@ model_family: s2t_transformer
 model_arch: medium
 checkpoint: "https://dl.fbaipublicfiles.com/fairseq/s2t/mustc_joint_asr_transformer_m.pt"
 restrict: false
-tokenizer: "https://dl.fbaipublicfiles.com/fairseq/s2t/mustc_joint_asr_vocab_unigram10000.zip;path=spm_unigram_10000.model"
+tokenizer: "https://dl.fbaipublicfiles.com/fairseq/s2t/mustc_joint_asr_vocab_unigram10000.zip"
+tokenizer_path: "spm_unigram_10000.model"
 tokenizer_family: s2t_transformer
 tokenizer_config_overrides:
   task: transcription
@@ -57,7 +60,8 @@ model_config_overrides:
   target_vocab_size: 8000
 checkpoint: "https://dl.fbaipublicfiles.com/fairseq/s2t/mustc_de_st_transformer_s.pt"
 restrict: false
-tokenizer: "https://dl.fbaipublicfiles.com/fairseq/s2t/mustc_de_st_vocab_unigram8000.zip;path=spm_unigram_8000.model"
+tokenizer: "https://dl.fbaipublicfiles.com/fairseq/s2t/mustc_de_st_vocab_unigram8000.zip"
+tokenizer_path: "spm_unigram_8000.model"
 tokenizer_family: s2t_transformer
 tokenizer_config_overrides:
   task: translation
@@ -71,7 +75,8 @@ model_family: s2t_transformer
 model_arch: medium
 checkpoint: "https://dl.fbaipublicfiles.com/fairseq/s2t/mustc_multilingual_st_transformer_m.pt"
 restrict: false
-tokenizer: "https://dl.fbaipublicfiles.com/fairseq/s2t/mustc_multilingual_st_vocab_unigram10000.zip;path=spm_unigram_10000.model"
+tokenizer: "https://dl.fbaipublicfiles.com/fairseq/s2t/mustc_multilingual_st_vocab_unigram10000.zip"
+tokenizer_path: "spm_unigram_10000.model"
 tokenizer_family: s2t_transformer
 tokenizer_config_overrides:
   task: translation


### PR DESCRIPTION
This PR introduces two new optional asset card fields `checkpoint_path` and `tokenizer_path` that can be used along with `checkpoint` and `tokenizer` respectively to specify a subpath within the downloaded asset.