### PR TITLE
Move _log_ranks to log.py

### DIFF
--- a/src/fairseq2/recipe/composition/root.py
+++ b/src/fairseq2/recipe/composition/root.py
@@ -47,10 +47,9 @@ from fairseq2.recipe.internal.cluster import _ClusterPreparer
 from fairseq2.recipe.internal.gang import (
     _FSDPGangsFactory,
     _GangsFactory,
-    _log_ranks,
     _warmup_gangs,
 )
-from fairseq2.recipe.internal.log import _LogHelper, _StandardLogHelper
+from fairseq2.recipe.internal.log import _log_ranks, _LogHelper, _StandardLogHelper
 from fairseq2.recipe.internal.logging import _DistributedLogConfigurer
 from fairseq2.recipe.internal.model import _ModelHolder
 from fairseq2.recipe.internal.output_dir import _OutputDirectoryCreator

--- a/src/fairseq2/recipe/internal/gang.py
+++ b/src/fairseq2/recipe/internal/gang.py
@@ -139,16 +139,3 @@ def _warmup_gangs(gangs: Gangs) -> None:
         raise_operational_gang_error(ex)
 
     log.info("Gangs warmed up.")
-
-
-def _log_ranks(gangs: Gangs) -> None:
-    s = (
-        f"World: {gangs.root.rank}/{gangs.root.size} | "
-        f"Data: {gangs.dp.rank}/{gangs.dp.size} | "
-        f"Data (Replicated): {gangs.rdp.rank}/{gangs.rdp.size} | "
-        f"Data (Sharded): {gangs.sdp.rank}/{gangs.sdp.size} | "
-        f"Tensor: {gangs.tp.rank}/{gangs.tp.size} | "
-        f"Pipeline: {gangs.pp.rank}/{gangs.pp.size}"
-    )
-
-    log.info("Process Ranks - {}", s)

--- a/src/fairseq2/recipe/internal/log.py
+++ b/src/fairseq2/recipe/internal/log.py
@@ -219,6 +219,19 @@ class _StandardLogHelper(_LogHelper):
         log.info("{}: {}", title, pretty_repr(unstructured_config, max_width=88))
 
 
+def _log_ranks(gangs: Gangs) -> None:
+    s = (
+        f"World: {gangs.root.rank}/{gangs.root.size} | "
+        f"Data: {gangs.dp.rank}/{gangs.dp.size} | "
+        f"Data (Replicated): {gangs.rdp.rank}/{gangs.rdp.size} | "
+        f"Data (Sharded): {gangs.sdp.rank}/{gangs.sdp.size} | "
+        f"Tensor: {gangs.tp.rank}/{gangs.tp.size} | "
+        f"Pipeline: {gangs.pp.rank}/{gangs.pp.size}"
+    )
+
+    log.info("Process Ranks - {}", s)
+
+
 def _log_model(model: Module, gangs: Gangs) -> None:
     if not log.is_enabled_for_info():
         return


### PR DESCRIPTION
A nit PR that moves `_log_ranks` from `fairseq2.recipe.internal.gangs` to `fairseq2.recipe.internal.log`.