### PR TITLE
Replace _WandbClient with wandb.Run

### DIFF
--- a/src/fairseq2/metrics/recorders/wandb.py
+++ b/src/fairseq2/metrics/recorders/wandb.py
@@ -7,10 +7,11 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from typing import Any, final
+from typing import final
 
 from torch import Tensor
 from typing_extensions import override
+from wandb import Run as WandbRun
 
 from fairseq2.error import OperationalError, raise_operational_system_error
 from fairseq2.metrics.recorders.descriptor import MetricDescriptorRegistry
@@ -21,7 +22,9 @@ from fairseq2.metrics.recorders.recorder import MetricRecorder
 class WandbRecorder(MetricRecorder):
     """Records metric values to Weights & Biases."""
 
-    def __init__(self, run: Any, metric_descriptors: MetricDescriptorRegistry) -> None:
+    def __init__(
+        self, run: WandbRun, metric_descriptors: MetricDescriptorRegistry
+    ) -> None:
         """
         In order to use W&B, run `wandb login` from the command line and enter
         the API key when prompted.

--- a/src/fairseq2/recipe/composition/metric_recorders.py
+++ b/src/fairseq2/recipe/composition/metric_recorders.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from wandb import Run as WandbRun
+
 from fairseq2.metrics import (
     format_as_byte_size,
     format_as_float,
@@ -32,10 +34,9 @@ from fairseq2.recipe.internal.metric_recorders import (
     _MaybeWandbRecorderFactory,
     _MetricRecorderFactory,
     _StandardWandbRunIdManager,
-    _WandbClient,
-    _WandbClientFactory,
     _WandbIdGenerator,
     _WandbInitializer,
+    _WandbRunFactory,
     _WandbRunIdManager,
 )
 from fairseq2.runtime.dependency import DependencyContainer, DependencyResolver
@@ -89,14 +90,14 @@ def _register_metric_recorders(container: DependencyContainer) -> None:
     container.register_type(WandbRecorder)
 
     # Weights & Biases Client
-    def get_wandb_client(resolver: DependencyResolver) -> _WandbClient:
-        client_factory = resolver.resolve(_WandbClientFactory)
+    def get_wandb_run(resolver: DependencyResolver) -> WandbRun:
+        run_factory = resolver.resolve(_WandbRunFactory)
 
-        return client_factory.create()
+        return run_factory.create()
 
-    container.register(_WandbClient, get_wandb_client)
+    container.register(WandbRun, get_wandb_run)
 
-    container.register_type(_WandbClientFactory)
+    container.register_type(_WandbRunFactory)
 
     container.register_instance(_WandbInitializer, _init_wandb)
 


### PR DESCRIPTION
This PR replaces the internal `_WandbClient` with `wandb.Run` considering that the latest Weights & Biases Python library has improved type annotations.