### PR TITLE
Introduce ${env:<NAME>} config directive

### DIFF
--- a/src/fairseq2/composition/assets.py
+++ b/src/fairseq2/composition/assets.py
@@ -47,46 +47,46 @@ from fairseq2.utils.progress import ProgressReporter
 def register_file_assets(
     container: DependencyContainer, path: Path, *, not_exist_ok: bool = False
 ) -> None:
-    def create_source(resolver: DependencyResolver) -> AssetMetadataSource:
+    def get_source(resolver: DependencyResolver) -> AssetMetadataSource:
         return wire_object(
             resolver, FileAssetMetadataSource, path=path, not_exist_ok=not_exist_ok
         )
 
-    container.collection.register(AssetMetadataSource, create_source)
+    container.collection.register(AssetMetadataSource, get_source)
 
 
 def register_package_assets(container: DependencyContainer, package: str) -> None:
-    def create_source(resolver: DependencyResolver) -> AssetMetadataSource:
+    def get_source(resolver: DependencyResolver) -> AssetMetadataSource:
         return wire_object(resolver, PackageAssetMetadataSource, package=package)
 
-    container.collection.register(AssetMetadataSource, create_source)
+    container.collection.register(AssetMetadataSource, get_source)
 
 
 def register_in_memory_assets(
     container: DependencyContainer, source: str, entries: Sequence[dict[str, object]]
 ) -> None:
-    def create_source(resolver: DependencyResolver) -> AssetMetadataSource:
+    def get_source(resolver: DependencyResolver) -> AssetMetadataSource:
         return wire_object(
             resolver, InMemoryAssetMetadataSource, name=source, entries=entries
         )
 
-    container.collection.register(AssetMetadataSource, create_source)
+    container.collection.register(AssetMetadataSource, get_source)
 
 
 def register_checkpoint_models(
     container: DependencyContainer, checkpoint_dir: Path
 ) -> None:
-    def create_source(resolver: DependencyResolver) -> AssetMetadataSource:
+    def get_source(resolver: DependencyResolver) -> AssetMetadataSource:
         return wire_object(resolver, ModelMetadataSource, checkpoint_dir=checkpoint_dir)
 
-    container.collection.register(AssetMetadataSource, create_source)
+    container.collection.register(AssetMetadataSource, get_source)
 
 
 def _register_asset(container: DependencyContainer) -> None:
     container.register_type(AssetDirectoryAccessor, StandardAssetDirectoryAccessor)
 
     # Store
-    def create_asset_store(resolver: DependencyResolver) -> AssetStore:
+    def get_asset_store(resolver: DependencyResolver) -> AssetStore:
         sources = resolver.collection.resolve(AssetMetadataSource)
 
         def load_providers() -> Iterator[AssetMetadataProvider]:
@@ -104,7 +104,7 @@ def _register_asset(container: DependencyContainer) -> None:
             default_env=env,
         )
 
-    container.register(AssetStore, create_asset_store, singleton=True)
+    container.register(AssetStore, get_asset_store, singleton=True)
 
     container.register_type(AssetEnvironmentDetector)
 
@@ -128,7 +128,7 @@ def _register_asset(container: DependencyContainer) -> None:
     container.collection.register_type(AssetDownloadManager, LocalAssetDownloadManager)
     container.collection.register_type(AssetDownloadManager, HuggingFaceHub)
 
-    def create_standard_asset_download_manager(
+    def get_standard_asset_download_manager(
         resolver: DependencyResolver,
     ) -> AssetDownloadManager:
         dirs = resolver.resolve(AssetDirectoryAccessor)
@@ -150,5 +150,5 @@ def _register_asset(container: DependencyContainer) -> None:
         )
 
     container.collection.register(
-        AssetDownloadManager, create_standard_asset_download_manager
+        AssetDownloadManager, get_standard_asset_download_manager
     )

--- a/src/fairseq2/composition/datasets.py
+++ b/src/fairseq2/composition/datasets.py
@@ -49,7 +49,7 @@ def register_dataset_family(
     elif opener is None:
         raise ValueError("`opener` or `advanced_opener` must be specified.")
 
-    def create_family(resolver: DependencyResolver) -> DatasetFamily:
+    def get_family(resolver: DependencyResolver) -> DatasetFamily:
         nonlocal opener
 
         if advanced_opener is not None:
@@ -70,7 +70,7 @@ def register_dataset_family(
             opener=opener,
         )
 
-    container.register(DatasetFamily, create_family, key=name)
+    container.register(DatasetFamily, get_family, key=name)
 
 
 def _register_dataset_families(container: DependencyContainer) -> None:

--- a/src/fairseq2/composition/models.py
+++ b/src/fairseq2/composition/models.py
@@ -176,7 +176,7 @@ def register_model_family(
     elif factory is None:
         raise ValueError("`factory` or `advanced_factory` must be specified.")
 
-    def create_family(resolver: DependencyResolver) -> ModelFamily:
+    def get_family(resolver: DependencyResolver) -> ModelFamily:
         nonlocal factory
 
         if advanced_factory is not None:
@@ -207,7 +207,7 @@ def register_model_family(
             hg_exporter=hg_exporter,
         )
 
-    container.register(ModelFamily, create_family, key=name)
+    container.register(ModelFamily, get_family, key=name)
 
 
 def _register_model_families(container: DependencyContainer) -> None:

--- a/src/fairseq2/composition/tokenizers.py
+++ b/src/fairseq2/composition/tokenizers.py
@@ -84,7 +84,7 @@ def register_tokenizer_family(
     elif loader is None:
         raise ValueError("`loader` or `advanced_loader` must be specified.")
 
-    def create_family(resolver: DependencyResolver) -> TokenizerFamily:
+    def get_family(resolver: DependencyResolver) -> TokenizerFamily:
         nonlocal loader
 
         if advanced_loader is not None:
@@ -105,7 +105,7 @@ def register_tokenizer_family(
             loader=loader,
         )
 
-    container.register(TokenizerFamily, create_family, key=name)
+    container.register(TokenizerFamily, get_family, key=name)
 
 
 def _register_tokenizer_families(container: DependencyContainer) -> None:

--- a/src/fairseq2/utils/config.py
+++ b/src/fairseq2/utils/config.py
@@ -6,14 +6,18 @@
 
 from __future__ import annotations
 
+import re
 from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence
 from copy import deepcopy
 from itertools import chain
 from pathlib import Path
+from re import Match
 from typing import final
 
 from typing_extensions import override
+
+from fairseq2.utils.env import Environment
 
 
 class ConfigMerger(ABC):
@@ -182,3 +186,33 @@ class ReplacePathDirective(ConfigDirective):
     @override
     def execute(self, value: str, unstructured_config: object) -> object:
         return value.replace("${dir}", self._config_path)
+
+
+@final
+class ReplaceEnvDirective(ConfigDirective):
+    """
+    Replaces directives of the form ``${env:VAR}`` or ``${env:VAR:default}``
+    with the corresponding environment variable, or the default value if the
+    environment variable is not set.
+    """
+
+    def __init__(self, env: Environment) -> None:
+        pattern = re.compile(r"\$\{env:([A-Za-z_][A-Za-z0-9_]*)(?::([^}]*))?\}")
+
+        self._env = env
+        self._pattern = pattern
+
+    @override
+    def execute(self, value: str, unstructure_config: object) -> object:
+        return self._pattern.sub(self._replace, value)
+
+    def _replace(self, match: Match[str]) -> str:
+        var_name = match.group(1)
+
+        value = self._env.maybe_get(var_name)
+        if value is None:
+            value = match.group(2)
+            if value is None:
+                value = ""
+
+        return value

--- a/src/fairseq2/utils/env.py
+++ b/src/fairseq2/utils/env.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import os
 from abc import ABC, abstractmethod
-from typing import final
+from typing import final, overload
 
 from typing_extensions import override
 
@@ -17,14 +17,23 @@ class Environment(ABC):
     @abstractmethod
     def get(self, name: str) -> str: ...
 
-    @abstractmethod
+    @overload
     def maybe_get(self, name: str) -> str | None: ...
+
+    @overload
+    def maybe_get(self, name: str, default: str) -> str: ...
+
+    @abstractmethod
+    def maybe_get(self, name: str, default: str | None = None) -> str | None: ...
 
     @abstractmethod
     def set(self, name: str, value: str) -> None: ...
 
     @abstractmethod
     def has(self, name: str) -> bool: ...
+
+    @abstractmethod
+    def to_dict(self) -> dict[str, str]: ...
 
 
 @final
@@ -33,9 +42,15 @@ class StandardEnvironment(Environment):
     def get(self, name: str) -> str:
         return os.environ[name]
 
+    @overload
+    def maybe_get(self, name: str) -> str | None: ...
+
+    @overload
+    def maybe_get(self, name: str, default: str) -> str: ...
+
     @override
-    def maybe_get(self, name: str) -> str | None:
-        return os.environ.get(name)
+    def maybe_get(self, name: str, default: str | None = None) -> str | None:
+        return os.environ.get(name, default)
 
     @override
     def set(self, name: str, value: str) -> None:
@@ -44,6 +59,10 @@ class StandardEnvironment(Environment):
     @override
     def has(self, name: str) -> bool:
         return name in os.environ
+
+    @override
+    def to_dict(self) -> dict[str, str]:
+        return dict(os.environ)
 
 
 class EnvironmentVariableError(Exception):

--- a/tests/unit/helper.py
+++ b/tests/unit/helper.py
@@ -1,0 +1,45 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from typing import final, overload
+
+from typing_extensions import override
+
+from fairseq2.utils.env import Environment
+
+
+@final
+class FooEnvironment(Environment):
+    def __init__(self, data: dict[str, str] = {}) -> None:
+        self._data = data
+
+    @override
+    def get(self, name: str) -> str:
+        return self._data[name]
+
+    @overload
+    def maybe_get(self, name: str) -> str | None: ...
+
+    @overload
+    def maybe_get(self, name: str, default: str) -> str: ...
+
+    @override
+    def maybe_get(self, name: str, default: str | None = None) -> str | None:
+        return self._data.get(name, default)
+
+    @override
+    def set(self, name: str, value: str) -> None:
+        self._data[name] = value
+
+    @override
+    def has(self, name: str) -> bool:
+        return name in self._data
+
+    @override
+    def to_dict(self) -> dict[str, str]:
+        return dict(self._data)

--- a/tests/unit/utils/test_config.py
+++ b/tests/unit/utils/test_config.py
@@ -10,7 +10,8 @@ from collections.abc import Mapping
 
 import pytest
 
-from fairseq2.utils.config import StandardConfigMerger
+from fairseq2.utils.config import ReplaceEnvDirective, StandardConfigMerger
+from tests.unit.helper import FooEnvironment
 
 
 def test_config_merge_works() -> None:
@@ -136,3 +137,15 @@ def test_config_merge_raises_error_when_type_is_invalid() -> None:
         TypeError, match=rf"^Each key under foo1\.foo2\._set_ at `overrides` must be of type `{str}`, but the key at index 0 is of type `{int}` instead\.$"  # fmt: skip
     ):
         merger.merge(target, source)
+
+
+def test_replace_env_directive_works() -> None:
+    env = FooEnvironment({"FOO1": "f001", "FOO2": "f002"})
+
+    directive = ReplaceEnvDirective(env)
+
+    output = directive.execute(
+        "abc ${env:FOO1} xyz ${env:FOO2} ijk ${env:FOO3:f003} ${env:FOO4}", None
+    )
+
+    assert output == "abc f001 xyz f002 ijk f003 "


### PR DESCRIPTION
This PR introduces a new `${env:NAME:default}` configuration directive to dynamically use environment variables in recipe and asset configurations. For instance:

```yaml
common:
  prev_checkpoint_dir: ${env:PREV_CHECKPOINT_DIR}
```