### PR TITLE
Save the HG export command line

### DIFF
--- a/src/fairseq2/checkpoint/manager.py
+++ b/src/fairseq2/checkpoint/manager.py
@@ -664,7 +664,7 @@ class StandardCheckpointManager(CheckpointManager):
                 try:
                     if keep_model:
                         for path in self._file_system.glob(step_dir, pattern="*"):
-                            if path.name == "model" or path.name == "hg":
+                            if path.stem in ("model", "hg", "hook"):
                                 continue
 
                             if self._file_system.is_dir(path):


### PR DESCRIPTION
This PR dumps the HG export command to a `hg.run` file under the checkpoint directory along with `hg.stderr` and `hg.stdout` for troubleshooting purposes. It also makes sure that those three files do not get removed as part of stale checkpoint deletion.