### PR TITLE
Respect wandb environment variables

### DIFF
--- a/src/fairseq2/recipe/composition/metric_recorders.py
+++ b/src/fairseq2/recipe/composition/metric_recorders.py
@@ -95,7 +95,7 @@ def _register_metric_recorders(container: DependencyContainer) -> None:
 
         return run_factory.create()
 
-    container.register(WandbRun, get_wandb_run)
+    container.register(WandbRun, get_wandb_run, singleton=True)
 
     container.register_type(_WandbRunFactory)
 


### PR DESCRIPTION
This PR updates Weights & Biases recipe initialization so that wandb environment variables take precedence over recipe configuration.