### PR TITLE
remove unused vllm library (Worker)

### DIFF
--- a/src/fairseq2/recipes/lm/_online_finetune/_remote_model.py
+++ b/src/fairseq2/recipes/lm/_online_finetune/_remote_model.py
@@ -21,7 +21,6 @@ from vllm import LLM, SamplingParams
 from vllm.engine.arg_utils import PoolerConfig
 from vllm.inputs import TokensPrompt, TextPrompt
 from vllm.utils import get_ip, get_open_port
-from vllm.worker.worker import Worker
 
 from fairseq2.context import RuntimeContext
 from fairseq2.gang import Gangs


### PR DESCRIPTION
**What does this PR do? Please describe:**
A summary of the change or the issue that is fixed.

Removes unused vllm function import (Worker) which was removed in v0.11.0

**Does your PR introduce any breaking changes? If yes, please list them:**
List of all backwards-incompatible changes.

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [ ] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
