### PR TITLE
Adding model configs for V8 tokenizer vocab

### DIFF
--- a/src/fairseq2/models/wav2vec2/asr/_config.py
+++ b/src/fairseq2/models/wav2vec2/asr/_config.py
@@ -445,6 +445,30 @@ def register_wav2vec2_asr_configs(context: RuntimeContext) -> None:
         )
         return config
 
+    @wav2vec2_asr_arch("7b_v8_tokenizer")
+    def v8_tokenizer_7b() -> Wav2Vec2AsrConfig:
+        config = bib1143_7b()
+        config.vocab_info = VocabularyInfo(
+            size=10288,
+            unk_idx=3,
+            bos_idx=0,
+            eos_idx=2,
+            pad_idx=1,
+        )
+        return config
+
+    @wav2vec2_asr_arch("7b_a_z_tokenizer")
+    def a_z_tokenizer_7b() -> Wav2Vec2AsrConfig:
+        config = bib1143_7b()
+        config.vocab_info = VocabularyInfo(
+            size=31,
+            unk_idx=3,
+            bos_idx=0,
+            eos_idx=2,
+            pad_idx=1,
+        )
+        return config
+
     @wav2vec2_asr_arch("7b_bpe_tokenizer")
     def bpe_tokenizer_7b() -> Wav2Vec2AsrConfig:
         config = bib1143_7b()
@@ -489,6 +513,18 @@ def register_wav2vec2_asr_configs(context: RuntimeContext) -> None:
         )
         return config
 
+    @wav2vec2_asr_arch("3b_v7_tokenizer")
+    def v7_tokenizer_3b() -> Wav2Vec2AsrConfig:
+        config = bib1143_3b()
+        config.vocab_info = VocabularyInfo(
+            size=9818,
+            unk_idx=3,
+            bos_idx=0,
+            eos_idx=2,
+            pad_idx=1,
+        )
+        return config
+
     @wav2vec2_asr_arch("1b_v4_tokenizer_updated")
     def v4_tokenizer_updated_1b() -> Wav2Vec2AsrConfig:
         config = bib1143_1b()
@@ -501,11 +537,35 @@ def register_wav2vec2_asr_configs(context: RuntimeContext) -> None:
         )
         return config
 
+    @wav2vec2_asr_arch("1b_v7_tokenizer")
+    def v7_tokenizer_updated_1b() -> Wav2Vec2AsrConfig:
+        config = bib1143_1b()
+        config.vocab_info = VocabularyInfo(
+            size=9818,
+            unk_idx=3,
+            bos_idx=0,
+            eos_idx=2,
+            pad_idx=1,
+        )
+        return config
+
     @wav2vec2_asr_arch("300m_v4_tokenizer_updated")
     def v4_tokenizer_updated_300m() -> Wav2Vec2AsrConfig:
         config = bib1143_300m()
         config.vocab_info = VocabularyInfo(
             size=9812,
+            unk_idx=3,
+            bos_idx=0,
+            eos_idx=2,
+            pad_idx=1,
+        )
+        return config
+
+    @wav2vec2_asr_arch("300m_v7_tokenizer")
+    def v7_tokenizer_300m() -> Wav2Vec2AsrConfig:
+        config = bib1143_300m()
+        config.vocab_info = VocabularyInfo(
+            size=9818,
             unk_idx=3,
             bos_idx=0,
             eos_idx=2,


### PR DESCRIPTION
mms companion: https://github.com/fairinternal/mms/pull/162

also adds configs for v5_digits vocab, at some of the smaller model sizes

**What does this PR do? Please describe:**
A summary of the change or the issue that is fixed.

Fixes #{issue number}

**Does your PR introduce any breaking changes? If yes, please list them:**
List of all backwards-incompatible changes.

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [ ] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
