### PR TITLE
Fix weakref Proxy error in DataParallelFacade

### DIFF
--- a/src/fairseq2/nn/data_parallel.py
+++ b/src/fairseq2/nn/data_parallel.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import weakref
 from abc import ABC, abstractmethod
 from contextlib import nullcontext
-from typing import Final, cast, final
+from typing import Final, final
 
 from torch import Tensor
 from torch.nn import Module


### PR DESCRIPTION
This PR fixes the `weakref.proxy` bug in `DataParallelFacade` that was causing failure during checkpoint loading due to the proxy type returned by `weakref` not being `Hashable` and raising an error when used with the internal `memo` variable of `fairseq2.nn.utils.module.load_state_dict`.