### PR TITLE
don't throttle RCS in online recipe

### DIFF
--- a/src/fairseq2/recipes/lm/_online_finetune/_recipe.py
+++ b/src/fairseq2/recipes/lm/_online_finetune/_recipe.py
@@ -253,10 +253,11 @@ def load_online_finetuner(
     vocab_size = tokenizer.vocab_info.size
 
     # initialize ray and vllm actors
-    ray.init(
-        address=f"ray://{config.vllm.ray_cluster_ip_address}:10001",
-        namespace="vllm_workers",
-    )
+    if gangs.dp.rank == 0 and gangs.tp.rank == 0:
+        ray.init(
+            address=f"ray://{config.vllm.ray_cluster_ip_address}:10001",
+            namespace="vllm_workers",
+        )
 
     vllm_actors = {}
     # go over actor configs and initialize all of them


### PR DESCRIPTION
**What does this PR do? Please describe:**

with too many workers on trainer side ray didnt handle init very well
but we only comm with ray from one rank, so we restrict it now