### PR TITLE
Revise get_family functions

### DIFF
--- a/src/fairseq2/data/tokenizers/__init__.py
+++ b/src/fairseq2/data/tokenizers/__init__.py
@@ -19,9 +19,11 @@ from fairseq2.data.tokenizers.family import TokenizerModelError as TokenizerMode
 from fairseq2.data.tokenizers.family import (
     _maybe_get_tokenizer_family as _maybe_get_tokenizer_family,
 )
-from fairseq2.data.tokenizers.family import get_tokenizer_family as get_tokenizer_family
 from fairseq2.data.tokenizers.family import (
-    maybe_get_tokenizer_family as maybe_get_tokenizer_family,
+    get_tokenizer_family_name as get_tokenizer_family_name,
+)
+from fairseq2.data.tokenizers.family import (
+    maybe_get_tokenizer_family_name as maybe_get_tokenizer_family_name,
 )
 from fairseq2.data.tokenizers.hub import GlobalTokenizerLoader as GlobalTokenizerLoader
 from fairseq2.data.tokenizers.hub import TokenizerHub as TokenizerHub

--- a/src/fairseq2/datasets/__init__.py
+++ b/src/fairseq2/datasets/__init__.py
@@ -22,9 +22,9 @@ from fairseq2.datasets.family import StandardDatasetFamily as StandardDatasetFam
 from fairseq2.datasets.family import (
     _maybe_get_dataset_family as _maybe_get_dataset_family,
 )
-from fairseq2.datasets.family import get_dataset_family as get_dataset_family
+from fairseq2.datasets.family import get_dataset_family_name as get_dataset_family_name
 from fairseq2.datasets.family import (
-    maybe_get_dataset_family as maybe_get_dataset_family,
+    maybe_get_dataset_family_name as maybe_get_dataset_family_name,
 )
 from fairseq2.datasets.hub import DatasetHub as DatasetHub
 from fairseq2.datasets.hub import DatasetHubAccessor as DatasetHubAccessor

--- a/src/fairseq2/models/__init__.py
+++ b/src/fairseq2/models/__init__.py
@@ -19,8 +19,10 @@ from fairseq2.models.family import ModelStateDictConverter as ModelStateDictConv
 from fairseq2.models.family import ShardSpecsProvider as ShardSpecsProvider
 from fairseq2.models.family import StandardModelFamily as StandardModelFamily
 from fairseq2.models.family import _maybe_get_model_family as _maybe_get_model_family
-from fairseq2.models.family import get_model_family as get_model_family
-from fairseq2.models.family import maybe_get_model_family as maybe_get_model_family
+from fairseq2.models.family import get_model_family_name as get_model_family_name
+from fairseq2.models.family import (
+    maybe_get_model_family_name as maybe_get_model_family_name,
+)
 from fairseq2.models.hub import GlobalModelLoader as GlobalModelLoader
 from fairseq2.models.hub import (
     ModelArchitectureNotKnownError as ModelArchitectureNotKnownError,


### PR DESCRIPTION
A follow-up PR that changes `get_family` functions to `get_family_name` to not expose `ModelFamily` in user APIs.