### PR TITLE
Rename resolve_optional to maybe_resolve

### DIFF
--- a/doc/source/basics/design_philosophy.rst
+++ b/doc/source/basics/design_philosophy.rst
@@ -87,7 +87,7 @@ Core Components
 The dependency injection system is built around several key abstractions:
 
 .. autoclass:: DependencyResolver
-   :members: resolve, resolve_optional, iter_keys
+   :members: resolve, iter_keys
    :noindex:
 
 .. autoclass:: DependencyContainer

--- a/src/fairseq2/data/tokenizers/hub.py
+++ b/src/fairseq2/data/tokenizers/hub.py
@@ -128,7 +128,7 @@ class TokenizerHubAccessor(Generic[TokenizerT, TokenizerConfigT]):
 
         name = self._family_name
 
-        family = resolver.resolve_optional(TokenizerFamily, key=name)
+        family = resolver.maybe_resolve(TokenizerFamily, key=name)
         if family is None:
             raise TokenizerFamilyNotKnownError(name)
 

--- a/src/fairseq2/datasets/hub.py
+++ b/src/fairseq2/datasets/hub.py
@@ -96,7 +96,7 @@ class DatasetHubAccessor(Generic[DatasetT, DatasetConfigT]):
 
         name = self._family_name
 
-        family = resolver.resolve_optional(DatasetFamily, key=name)
+        family = resolver.maybe_resolve(DatasetFamily, key=name)
         if family is None:
             raise DatasetFamilyNotKnownError(name)
 

--- a/src/fairseq2/models/hg.py
+++ b/src/fairseq2/models/hg.py
@@ -133,7 +133,7 @@ def get_hugging_face_converter(family_name: str) -> HuggingFaceConverter:
     """
     resolver = get_dependency_resolver()
 
-    hg_converter = resolver.resolve_optional(HuggingFaceConverter, key=family_name)
+    hg_converter = resolver.maybe_resolve(HuggingFaceConverter, key=family_name)
     if hg_converter is None:
         raise NotSupportedError(
             f"{family_name} model family does not support Hugging Face conversion."

--- a/src/fairseq2/models/hub.py
+++ b/src/fairseq2/models/hub.py
@@ -584,7 +584,7 @@ class ModelHubAccessor(Generic[ModelT, ModelConfigT]):
 
         name = self._family_name
 
-        family = resolver.resolve_optional(ModelFamily, key=name)
+        family = resolver.maybe_resolve(ModelFamily, key=name)
         if family is None:
             raise ModelFamilyNotKnownError(name)
 


### PR DESCRIPTION
This PR renames `DependencyResolver.resolve_optional()` to `DependencyResolver.maybe_resolve()` to be consistent with the naming convention of the code base.