### PR TITLE
Introduce current_dtype context manager

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -58,6 +58,7 @@ other content generation tasks.
     reference/fairseq2.data
     reference/fairseq2.data.tokenizers
     reference/fairseq2.data.tokenizers.hub
+    reference/fairseq2.data_type
     reference/fairseq2.datasets
     reference/fairseq2.datasets.hub
     reference/fairseq2.device

--- a/doc/source/reference/fairseq2.data_type.rst
+++ b/doc/source/reference/fairseq2.data_type.rst
@@ -1,0 +1,12 @@
+==================
+fairseq2.data_type
+==================
+
+.. automodule:: fairseq2.data_type
+    :no-members:
+
+Functions
+=========
+
+.. autofunction:: current_dtype
+.. autofunction:: get_current_dtype

--- a/src/fairseq2/composition/lib.py
+++ b/src/fairseq2/composition/lib.py
@@ -87,7 +87,7 @@ from fairseq2.utils.rich import (
 )
 from fairseq2.utils.rng import RngBag
 from fairseq2.utils.structured import StandardValueConverter, ValueConverter
-from fairseq2.utils.threading import StandardThreadPool, ThreadPool
+from fairseq2.utils.threading import ThreadPool, _StandardThreadPool
 from fairseq2.utils.validation import ObjectValidator, StandardObjectValidator
 from fairseq2.utils.yaml import (
     RuamelYamlDumper,
@@ -163,7 +163,7 @@ def _register_library(
     def create_thread_pool(resolver: DependencyResolver) -> ThreadPool:
         world_info = resolver.resolve(WorldInfo)
 
-        return StandardThreadPool.create_default(world_info.local_size)
+        return _StandardThreadPool.create_default(world_info.local_size)
 
     container.register(ThreadPool, create_thread_pool, singleton=True)
 

--- a/src/fairseq2/data_type.py
+++ b/src/fairseq2/data_type.py
@@ -4,24 +4,159 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+"""
+This module provides functions for managing PyTorch data types.
+"""
+
 from __future__ import annotations
 
 from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import TypeAlias
+from functools import cache
+from typing import Any, ContextManager, TypeAlias, cast, final
 
 import torch
+from torch import get_default_dtype
+from torch.overrides import TorchFunctionMode
+
+from fairseq2.utils.threading import _tls
+from fairseq2.utils.warn import _warn_deprecated
 
 DataType: TypeAlias = torch.dtype
 
 
-@contextmanager
-def default_dtype(dtype: DataType) -> Iterator[None]:
-    original_dtype = torch.get_default_dtype()
+# Holds the stack of current thread-local data types.
+_tls.dtype_contexts = []
 
-    torch.set_default_dtype(dtype)
+
+@contextmanager
+def current_dtype(dtype: DataType) -> Iterator[None]:
+    """
+    Changes the floating-point data type of the calling thread to the specified
+    type.
+
+    This function acts as a context manager, ensuring that within its scope, any
+    operation that constructs tensors uses the specified data type - unless an
+    explicit ``dtype`` argument is provided.
+
+    .. code:: python
+
+        import torch
+
+        from fairseq2.data_type import current_dtype
+
+        with current_dtype(torch.bfloat16):
+            t = torch.ones((4,4))
+
+            assert t.dtype == torch.bfloat16
+
+            with current_dtype(torch.float16):
+                t = torch.ones((4, 4))
+
+                assert t.dtype == torch.float16
+
+        t = torch.ones((4, 4))
+
+        assert t.dtype == torch.float32
+    """
+    contexts = _tls.dtype_contexts
+
+    if contexts:
+        contexts[-1].enabled = False
 
     try:
-        yield
+        constructors = _tensor_constructors()
+
+        context = _DataTypeContext(dtype, constructors)
+
+        contexts.append(context)
+
+        try:
+            with context:
+                yield
+        finally:
+            contexts.pop()
     finally:
-        torch.set_default_dtype(original_dtype)
+        if contexts:
+            contexts[-1].enabled = True
+
+
+def default_dtype(dtype: DataType) -> ContextManager[None]:
+    _warn_deprecated(
+        "`default_dtype()` is deprecated and will be removed in v0.14. Use `current_dtype()` instead."
+    )
+
+    return current_dtype(dtype)
+
+
+def get_current_dtype() -> DataType:
+    """Returns the current floating point data type of the calling thread."""
+    contexts = _tls.dtype_contexts
+    if contexts:
+        return cast(DataType, contexts[-1].dtype)
+
+    return get_default_dtype()
+
+
+@final
+class _DataTypeContext(TorchFunctionMode):
+    def __init__(self, dtype: DataType, constructors: set[Any]) -> None:
+        self.dtype = dtype
+        self.constructors = constructors
+        self.enabled = True
+
+    def __torch_function__(  # type: ignore[override]
+        self, func: Any, types: Any, args: Any, kwargs: Any = None
+    ) -> Any:
+        if kwargs is None:
+            kwargs = {}
+
+        if self.enabled and func in self.constructors:
+            dtype = kwargs.get("dtype", None)
+            if dtype is None:
+                kwargs["dtype"] = self.dtype
+
+        return func(*args, **kwargs)
+
+
+@cache
+def _tensor_constructors() -> set[Any]:
+    # Taken from torch/utils/_device.py.
+    return {
+        torch.empty,
+        torch.empty_permuted,
+        torch.empty_strided,
+        torch.empty_quantized,
+        torch.ones,
+        torch.arange,
+        torch.bartlett_window,
+        torch.blackman_window,
+        torch.eye,
+        torch.fft.fftfreq,
+        torch.fft.rfftfreq,
+        torch.full,
+        torch.hamming_window,
+        torch.hann_window,
+        torch.kaiser_window,
+        torch.linspace,
+        torch.logspace,
+        torch.nested.nested_tensor,
+        torch.rand,
+        torch.randn,
+        torch.randint,
+        torch.randperm,
+        torch.range,
+        torch.sparse_coo_tensor,
+        torch.sparse_compressed_tensor,
+        torch.sparse_csr_tensor,
+        torch.sparse_csc_tensor,
+        torch.sparse_bsr_tensor,
+        torch.sparse_bsc_tensor,
+        torch.tril_indices,
+        torch.triu_indices,
+        torch.zeros,
+        torch.asarray,
+        torch.tensor,
+        torch.as_tensor,
+        torch.scalar_tensor,
+    }

--- a/src/fairseq2/models/family.py
+++ b/src/fairseq2/models/family.py
@@ -26,7 +26,7 @@ from fairseq2.assets import (
     AssetDownloadManager,
     AssetStore,
 )
-from fairseq2.data_type import DataType, default_dtype
+from fairseq2.data_type import DataType, current_dtype
 from fairseq2.device import META_DEVICE
 from fairseq2.error import (
     InternalError,
@@ -694,7 +694,7 @@ class StandardModelFamily(ModelFamily):
 
         try:
             with device, gangs:
-                with default_dtype(dtype):
+                with current_dtype(dtype):
                     model = self._factory(config)
         except NotImplementedError as ex:
             if "'Meta' backend" not in str(ex):

--- a/src/fairseq2/utils/threading.py
+++ b/src/fairseq2/utils/threading.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import os
+import threading
 from abc import ABC, abstractmethod
 from concurrent.futures import Future, ThreadPoolExecutor
 from typing import ParamSpec, Protocol, TypeVar, final
@@ -14,6 +15,9 @@ from typing import ParamSpec, Protocol, TypeVar, final
 from typing_extensions import override
 
 from fairseq2.error import OperationalError
+
+_tls = threading.local()
+
 
 P = ParamSpec("P")
 
@@ -35,14 +39,14 @@ class ThreadPool(ABC):
 
 
 @final
-class StandardThreadPool(ThreadPool):
+class _StandardThreadPool(ThreadPool):
     @staticmethod
-    def create_default(local_world_size: int) -> StandardThreadPool:
+    def create_default(local_world_size: int) -> _StandardThreadPool:
         num_threads = get_num_threads(local_world_size)
 
         # Due to GIL, threads in CPython are typically used to overlap I/O with
         # CPU work; therefore, we can slightly oversubscribe here (i.e. +4).
-        return StandardThreadPool(max_num_workers=num_threads + 4)
+        return _StandardThreadPool(max_num_workers=num_threads + 4)
 
     def __init__(self, max_num_workers: int) -> None:
         self._executor = ThreadPoolExecutor(max_workers=max_num_workers)

--- a/tests/unit/test_data_type.py
+++ b/tests/unit/test_data_type.py
@@ -1,0 +1,31 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import torch
+
+from fairseq2.data_type import DataType, current_dtype, get_current_dtype
+from tests.common import device
+
+
+def test_current_dtype_works() -> None:
+    def check_dtype(dtype: DataType) -> None:
+        t = torch.ones((4, 4), device=device)
+
+        assert t.dtype == dtype
+
+        assert get_current_dtype() == dtype
+
+    with current_dtype(torch.bfloat16):
+        check_dtype(torch.bfloat16)
+
+        with current_dtype(torch.float16):
+            check_dtype(torch.float16)
+
+        check_dtype(torch.bfloat16)
+
+    check_dtype(torch.float32)


### PR DESCRIPTION
This PR introduces `current_dtype()` context manager that provides same functionality as `with device` in PyTorch. It sets the "current" data type of the calling thread and using a `__torch_function__` ensures that it gets injected to all known tensor constructor operations unless they have an explicitly provided `dtype` argument.