### PR TITLE
Improve implementation of tensor sharded modules

### DIFF
--- a/recipes/lm/sft/config.py
+++ b/recipes/lm/sft/config.py
@@ -52,7 +52,7 @@ class LMSFTConfig:
     )
 
     tokenizer: TokenizerSection = field(
-        default_factory=lambda: TokenizerSection(name="llama3_2_1b")
+        default_factory=lambda: TokenizerSection(name="llama3_2_1b_instruct")
     )
 
     gang: GangSection = field(default_factory=lambda: GangSection())

--- a/src/fairseq2/models/llama4/factory.py
+++ b/src/fairseq2/models/llama4/factory.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 from typing_extensions import override
 
-from fairseq2.gang import Gangs, maybe_get_current_gangs
 from fairseq2.models.llama import LLaMAFactory
 from fairseq2.models.llama4.config import Llama4Config
 from fairseq2.models.llama4.moe import MoE
@@ -33,16 +32,14 @@ from fairseq2.nn import (
 
 
 def create_llama4_model(config: Llama4Config) -> TransformerLM:
-    gangs = maybe_get_current_gangs()
-
-    return Llama4Factory(config, gangs).create_model()
+    return Llama4Factory(config).create_model()
 
 
 class Llama4Factory(LLaMAFactory):
     _config: Llama4Config
 
-    def __init__(self, config: Llama4Config, gangs: Gangs | None = None) -> None:
-        super().__init__(config, gangs=None)
+    def __init__(self, config: Llama4Config) -> None:
+        super().__init__(config)
         # TODO(mgleize): for now we zero out _gangs here,
         # until the L4 sharder is updated to the new sharding API.
         self._config = config

--- a/src/fairseq2/models/transformer/ffn.py
+++ b/src/fairseq2/models/transformer/ffn.py
@@ -17,7 +17,7 @@ from typing_extensions import override
 from fairseq2.data_type import DataType
 from fairseq2.device import Device
 from fairseq2.gang import Gangs
-from fairseq2.nn import ColumnShardedLinear, Linear, Projection, RowShardedLinear
+from fairseq2.nn import ColumnShardedLinear, Linear, RowShardedLinear
 
 
 class FeedForwardNetwork(Module, ABC):
@@ -79,20 +79,16 @@ class StandardFeedForwardNetwork(FeedForwardNetwork):
         """
         super().__init__()
 
-        inner_proj = Linear(
-            model_dim, inner_dim, bias, init_fn=proj_init_fn, device=device, dtype=dtype
+        self.inner_proj = ColumnShardedLinear(
+            model_dim,
+            inner_dim,
+            bias,
+            gather_output=False,
+            init_fn=proj_init_fn,
+            gangs=gangs,
+            device=device,
+            dtype=dtype,
         )
-
-        self.inner_proj: Projection
-
-        if gangs is None or gangs.tp.size == 1:
-            self.inner_proj = inner_proj
-        else:
-            self.inner_proj = ColumnShardedLinear.from_linear(
-                inner_proj, gangs.tp, gather_output=False
-            )
-
-            del inner_proj
 
         if inner_activation is not None:
             self.inner_activation = inner_activation
@@ -108,20 +104,16 @@ class StandardFeedForwardNetwork(FeedForwardNetwork):
 
         self.register_module("inner_dropout", inner_dropout)
 
-        output_proj = Linear(
-            inner_dim, model_dim, bias, init_fn=proj_init_fn, device=device, dtype=dtype
+        self.output_proj = RowShardedLinear(
+            inner_dim,
+            model_dim,
+            bias,
+            scatter_input=False,
+            init_fn=proj_init_fn,
+            gangs=gangs,
+            device=device,
+            dtype=dtype,
         )
-
-        self.output_proj: Projection
-
-        if gangs is None or gangs.tp.size == 1:
-            self.output_proj = output_proj
-        else:
-            self.output_proj = RowShardedLinear.from_linear(
-                output_proj, gangs.tp, scatter_input=False
-            )
-
-            del output_proj
 
     @override
     def forward(self, seqs: Tensor) -> Tensor:
@@ -179,25 +171,16 @@ class DauphinFeedForwardNetwork(FeedForwardNetwork):
         """
         super().__init__()
 
-        inner_proj = Linear(
+        self.inner_proj = ColumnShardedLinear(
             model_dim,
             inner_dim * 2,
             bias,
+            gather_output=False,
             init_fn=proj_init_fn,
+            gangs=gangs,
             device=device,
             dtype=dtype,
         )
-
-        self.inner_proj: Projection
-
-        if gangs is None or gangs.tp.size == 1:
-            self.inner_proj = inner_proj
-        else:
-            self.inner_proj = ColumnShardedLinear.from_linear(
-                inner_proj, gangs.tp, gather_output=False
-            )
-
-            del inner_proj
 
         if inner_activation is not None:
             self.inner_activation = inner_activation
@@ -213,18 +196,16 @@ class DauphinFeedForwardNetwork(FeedForwardNetwork):
 
         self.register_module("inner_dropout", inner_dropout)
 
-        output_proj = Linear(inner_dim, model_dim, bias, device=device, dtype=dtype)
-
-        self.output_proj: Projection
-
-        if gangs is None or gangs.tp.size == 1:
-            self.output_proj = output_proj
-        else:
-            self.output_proj = RowShardedLinear.from_linear(
-                output_proj, gangs.tp, scatter_input=False
-            )
-
-            del output_proj
+        self.output_proj = RowShardedLinear(
+            inner_dim,
+            model_dim,
+            bias,
+            scatter_input=False,
+            init_fn=proj_init_fn,
+            gangs=gangs,
+            device=device,
+            dtype=dtype,
+        )
 
     @override
     def forward(self, seqs: Tensor) -> Tensor:
@@ -301,50 +282,32 @@ class GLUFeedForwardNetwork(FeedForwardNetwork):
                 (inner_dim + inner_dim_to_multiple - 1) // inner_dim_to_multiple
             )
 
-        gate_proj = Linear(
+        self.gate_proj = ColumnShardedLinear(
             model_dim,
             inner_dim,
             bias,
+            gather_output=False,
             init_fn=proj_init_fn,
+            gangs=gangs,
             device=device,
             dtype=dtype,
         )
-
-        self.gate_proj: Projection
-
-        if gangs is None or gangs.tp.size == 1:
-            self.gate_proj = gate_proj
-        else:
-            self.gate_proj = ColumnShardedLinear.from_linear(
-                gate_proj, gangs.tp, gather_output=False
-            )
-
-            del gate_proj
 
         if gate_activation is not None:
             self.gate_activation = gate_activation
         else:
             self.gate_activation = SiLU()
 
-        inner_proj = Linear(
+        self.inner_proj = ColumnShardedLinear(
             model_dim,
             inner_dim,
             bias,
+            gather_output=False,
             init_fn=proj_init_fn,
+            gangs=gangs,
             device=device,
             dtype=dtype,
         )
-
-        self.inner_proj: Projection
-
-        if gangs is None or gangs.tp.size == 1:
-            self.inner_proj = inner_proj
-        else:
-            self.inner_proj = ColumnShardedLinear.from_linear(
-                inner_proj, gangs.tp, gather_output=False
-            )
-
-            del inner_proj
 
         if inner_dropout_p > 0.0:
             inner_dropout = Dropout(inner_dropout_p)
@@ -355,25 +318,16 @@ class GLUFeedForwardNetwork(FeedForwardNetwork):
 
         self.register_module("inner_dropout", inner_dropout)
 
-        output_proj = Linear(
+        self.output_proj = RowShardedLinear(
             inner_dim,
             model_dim,
             bias,
+            scatter_input=False,
             init_fn=proj_init_fn,
+            gangs=gangs,
             device=device,
             dtype=dtype,
         )
-
-        self.output_proj: Projection
-
-        if gangs is None or gangs.tp.size == 1:
-            self.output_proj = output_proj
-        else:
-            self.output_proj = RowShardedLinear.from_linear(
-                output_proj, gangs.tp, scatter_input=False
-            )
-
-            del output_proj
 
     @override
     def forward(self, seqs: Tensor) -> Tensor:

--- a/src/fairseq2/models/transformer/multihead_attention.py
+++ b/src/fairseq2/models/transformer/multihead_attention.py
@@ -258,27 +258,33 @@ class StandardMultiheadAttention(MultiheadAttention):
         self.num_query_groups = num_heads // num_key_value_heads
 
         if q_proj is None and k_proj is None and v_proj is None:
-            q_proj = Linear(
+            self.q_proj: Projection = ColumnShardedLinear(
                 model_dim,
                 head_dim * num_heads,
                 bias,
+                gather_output=False,
                 init_fn=qkv_proj_init_fn or init_qkv_projection,
+                gangs=gangs,
                 device=device,
                 dtype=dtype,
             )
-            k_proj = Linear(
+            self.k_proj: Projection = ColumnShardedLinear(
                 kv_dim,
                 head_dim * num_key_value_heads,
                 bias,
+                gather_output=False,
                 init_fn=qkv_proj_init_fn or init_qkv_projection,
+                gangs=gangs,
                 device=device,
                 dtype=dtype,
             )
-            v_proj = Linear(
+            self.v_proj: Projection = ColumnShardedLinear(
                 kv_dim,
                 head_dim * num_key_value_heads,
                 bias,
+                gather_output=False,
                 init_fn=qkv_proj_init_fn or init_qkv_projection,
+                gangs=gangs,
                 device=device,
                 dtype=dtype,
             )
@@ -316,41 +322,9 @@ class StandardMultiheadAttention(MultiheadAttention):
                     f"`v_proj.output_dim` must be a multiple of `num_key_value_heads` ({num_key_value_heads}), but is {v_proj.output_dim} instead."
                 )
 
-        self.q_proj: Projection
-        self.k_proj: Projection
-        self.v_proj: Projection
-
-        if gangs is None or gangs.tp.size == 1:
             self.q_proj = q_proj
             self.k_proj = k_proj
             self.v_proj = v_proj
-        else:
-            if isinstance(q_proj, Linear):
-                self.q_proj = ColumnShardedLinear.from_linear(
-                    q_proj, gangs.tp, gather_output=False
-                )
-            else:
-                self.q_proj = q_proj
-
-            del q_proj
-
-            if isinstance(k_proj, Linear):
-                self.k_proj = ColumnShardedLinear.from_linear(
-                    k_proj, gangs.tp, gather_output=False
-                )
-            else:
-                self.k_proj = k_proj
-
-            del k_proj
-
-            if isinstance(v_proj, Linear):
-                self.v_proj = ColumnShardedLinear.from_linear(
-                    v_proj, gangs.tp, gather_output=False
-                )
-            else:
-                self.v_proj = v_proj
-
-            del v_proj
 
         self.q_norm: LayerNorm | None
         self.k_norm: LayerNorm | None
@@ -380,11 +354,13 @@ class StandardMultiheadAttention(MultiheadAttention):
             if output_proj_bias is None:
                 output_proj_bias = bias
 
-            output_proj = Linear(
+            self.output_proj: Projection = RowShardedLinear(
                 v_dim,
                 model_dim,
                 output_proj_bias,
+                scatter_input=False,
                 init_fn=output_proj_init_fn or init_mha_output_projection,
+                gangs=gangs,
                 device=device,
                 dtype=dtype,
             )
@@ -408,19 +384,7 @@ class StandardMultiheadAttention(MultiheadAttention):
                     f"`output_proj.output_dim` must be equal to `model_dim` ({model_dim}), but is {output_proj.output_dim} instead."
                 )
 
-        self.output_proj: Projection
-
-        if gangs is None or gangs.tp.size == 1:
             self.output_proj = output_proj
-        else:
-            if isinstance(output_proj, Linear):
-                self.output_proj = RowShardedLinear.from_linear(
-                    output_proj, gangs.tp, scatter_input=False
-                )
-            else:
-                self.ouput_proj = output_proj
-
-            del output_proj
 
         self.state_factory = state_factory
 

--- a/src/fairseq2/nn/embedding.py
+++ b/src/fairseq2/nn/embedding.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Callable
-from typing import TYPE_CHECKING, final
+from typing import TYPE_CHECKING, cast, final
 
 import torch
 import torch.nn as nn
@@ -18,11 +18,12 @@ from torch.nn.functional import embedding
 from typing_extensions import override
 
 from fairseq2.data_type import DataType
-from fairseq2.device import META_DEVICE, Device
-from fairseq2.gang import Gang
+from fairseq2.device import META_DEVICE, Device, get_current_device
+from fairseq2.gang import Gang, Gangs, get_current_gangs
 from fairseq2.nn.sharded import Sharded
 from fairseq2.nn.utils.module import get_name_or_self, to_empty
 from fairseq2.ops.tensor_parallel import gather, reduce, reduce_on_backward
+from fairseq2.utils.warn import _warn_deprecated
 
 
 class Embedding(Module, ABC):
@@ -85,14 +86,7 @@ class StandardEmbedding(Embedding):
         self.reset_parameters()
 
     def reset_parameters(self) -> None:
-        if self.init_fn is not None:
-            self.init_fn(self)
-        else:
-            nn.init.normal_(self.weight)
-
-        if self.pad_idx is not None:
-            with torch.no_grad():
-                self.weight[self.pad_idx].fill_(0.0)
+        _init_embedding(self)
 
     @override
     def forward(self, x: Tensor) -> Tensor:
@@ -121,11 +115,34 @@ class VocabShardedEmbedding(Embedding, Sharded):
     """
 
     @staticmethod
-    def from_embedding(embed: StandardEmbedding, gang: Gang) -> VocabShardedEmbedding:
+    def from_embedding(
+        embed: StandardEmbedding,
+        gang: Gang | None = None,
+        *,
+        gangs: Gangs | None = None,
+    ) -> VocabShardedEmbedding:
         """
         Creates a :class:`VocabShardedEmbedding` by sharding ``embed`` over its
-        vocabulary dimension using ``gang``.
+        vocabulary dimension using ``gangs.tp``.
+
+        If ``gangs`` is ``None``, acts like a regular :class:`StandardEmbedding`
+        module.
         """
+        if gang is not None:
+            _warn_deprecated(
+                "`gang` parameter of `VocabShardedEmbedding.from_embedding` is deprecated and will be removed in v0.14. Please use the `gangs` parameter instead."
+            )
+
+            if gangs is not None:
+                raise ValueError(
+                    "`gang` and `gangs` cannot be provided at the same time."
+                )
+        else:
+            if gangs is None:
+                gangs = get_current_gangs(embed.weight.device)
+
+            gang = gangs.tp
+
         device = embed.weight.device
 
         if device != gang.device and device.type != "meta":
@@ -134,49 +151,59 @@ class VocabShardedEmbedding(Embedding, Sharded):
             )
 
         sharded_embed = VocabShardedEmbedding(
-            gang,
             embed.num_embeddings,
             embed.embed_dim,
             embed.pad_idx,
             init_fn=embed.init_fn,
+            gangs=gangs,
             device=META_DEVICE,
             dtype=embed.weight.dtype,
+            _tp_gang=gang,
         )
 
         if device.type != "meta":
             to_empty(sharded_embed, device)
 
-        sharded_embed._copy_weight(embed)
+        sharded_embed._copy_from_embedding(embed)
 
         return sharded_embed
 
     def __init__(
         self,
-        gang: Gang,
         num_embeddings: int,
         embed_dim: int,
         pad_idx: int | None = None,
         *,
         init_fn: Callable[[StandardEmbedding], None] | None = None,
+        gangs: Gangs | None = None,
         device: Device | None = None,
         dtype: DataType | None = None,
+        _tp_gang: Gang | None = None,
     ) -> None:
         super().__init__(num_embeddings, embed_dim, pad_idx)
 
-        if num_embeddings % gang.size != 0:
+        if gangs is None:
+            gangs = get_current_gangs(device)
+
+        tp_gang = gangs.tp if _tp_gang is None else _tp_gang
+
+        if num_embeddings % tp_gang.size != 0:
             raise ValueError(
-                f"`num_embeddings` must be a multiple of `gang.size` ({gang.size}), but is {num_embeddings} instead."
+                f"`num_embeddings` must be a multiple of `gangs.tp.size` ({tp_gang.size}), but is {num_embeddings} instead."
             )
 
-        self.gang = gang
+        self.tp_gang = tp_gang
 
-        self.sharded_num_embeddings = num_embeddings // gang.size
+        self.sharded = tp_gang.size > 1
+
+        self.sharded_num_embeddings = num_embeddings // tp_gang.size
 
         if device is None:
-            device = gang.device
-        elif device != gang.device and device.type != "meta":
+            device = get_current_device()
+
+        if device.type != "meta" and device != tp_gang.device:
             raise ValueError(
-                f"`device` must match `gang.device` or must be of type `meta`, but is `{device}` instead."
+                f"`device` must match `gangs.device` or must be of type `meta`, but is `{device}` instead."
             )
 
         weight = torch.empty(
@@ -190,24 +217,30 @@ class VocabShardedEmbedding(Embedding, Sharded):
         self.reset_parameters()
 
     def reset_parameters(self) -> None:
-        embed = self._embedding_like(device=self.gang.device)
+        if self.sharded:
+            embed = self._embedding_like(device=self.tp_gang.device)
 
-        self._copy_weight(embed)
+            self._copy_from_embedding(embed)
+        else:
+            _init_embedding(self)
 
-    def _copy_weight(self, embed: StandardEmbedding) -> None:
+    def _copy_from_embedding(self, embed: StandardEmbedding) -> None:
         with torch.no_grad():
             weight_shards = embed.weight.split(self.sharded_num_embeddings, dim=0)
 
-            weight = weight_shards[self.gang.rank]
+            weight = weight_shards[self.tp_gang.rank]
 
             self.weight.copy_(weight, non_blocking=True)
 
     @override
     def forward(self, x: Tensor) -> Tensor:
+        if not self.sharded:
+            return embedding(x, self.weight, self.pad_idx)
+
         num_embeds = self.sharded_num_embeddings
 
         vocab_begin_idx, vocab_end_idx = (
-            self.gang.rank * num_embeds, (self.gang.rank + 1) * num_embeds  # fmt: skip
+            self.tp_gang.rank * num_embeds, (self.tp_gang.rank + 1) * num_embeds  # fmt: skip
         )
 
         if self.pad_idx is None:
@@ -233,7 +266,7 @@ class VocabShardedEmbedding(Embedding, Sharded):
         x = torch.where(mask, 0.0, x)
 
         # (N, S, E)
-        x = reduce(x, self.gang)
+        x = reduce(x, self.tp_gang)
 
         return x
 
@@ -241,10 +274,13 @@ class VocabShardedEmbedding(Embedding, Sharded):
         """Unshards this instance to a :class:`StandardEmbedding`."""
         embed = self._embedding_like(device=META_DEVICE)
 
-        to_empty(embed, device or self.gang.device)
+        to_empty(embed, device or self.tp_gang.device)
 
         with torch.no_grad():
-            weight = gather(self.weight, self.gang, dim=0)
+            if self.sharded:
+                weight = gather(self.weight, self.tp_gang, dim=0)
+            else:
+                weight = self.weight
 
             embed.weight.copy_(weight, non_blocking=True)
 
@@ -268,8 +304,8 @@ class VocabShardedEmbedding(Embedding, Sharded):
     def extra_repr(self) -> str:
         """:meta private:"""
         s = (
-            f"tp_rank={self.gang.rank}, "
-            f"tp_size={self.gang.size}, "
+            f"tp_rank={self.tp_gang.rank}, "
+            f"tp_size={self.tp_gang.size}, "
             f"num_embeddings={self.num_embeddings}, "
             f"sharded_num_embeddings={self.sharded_num_embeddings}, "
             f"embed_dim={self.embed_dim}"
@@ -293,11 +329,34 @@ class ShardedEmbedding(Embedding, Sharded):
     """
 
     @staticmethod
-    def from_embedding(embed: StandardEmbedding, gang: Gang) -> ShardedEmbedding:
+    def from_embedding(
+        embed: StandardEmbedding,
+        gang: Gang | None = None,
+        *,
+        gangs: Gangs | None = None,
+    ) -> ShardedEmbedding:
         """
         Creates a :class:`ShardedEmbedding` by sharding ``embed`` over its
-        embedding dimension using ``gang``.
+        embedding dimension using ``gangs.tp``.
+
+        If ``gangs`` is ``None``, acts like a regular :class:`StandardEmbedding`
+        module.
         """
+        if gang is not None:
+            _warn_deprecated(
+                "`gang` parameter of `VocabShardedEmbedding.from_embedding` is deprecated and will be removed in v0.14. Please use the `gangs` parameter instead."
+            )
+
+            if gangs is not None:
+                raise ValueError(
+                    "`gang` and `gangs` cannot be provided at the same time."
+                )
+        else:
+            if gangs is None:
+                gangs = get_current_gangs(embed.weight.device)
+
+            gang = gangs.tp
+
         device = embed.weight.device
 
         if device != gang.device and device.type != "meta":
@@ -306,49 +365,59 @@ class ShardedEmbedding(Embedding, Sharded):
             )
 
         sharded_embed = ShardedEmbedding(
-            gang,
             embed.num_embeddings,
             embed.embed_dim,
             embed.pad_idx,
             init_fn=embed.init_fn,
+            gangs=gangs,
             device=META_DEVICE,
             dtype=embed.weight.dtype,
+            _tp_gang=gang,
         )
 
         if device.type != "meta":
             to_empty(sharded_embed, device)
 
-        sharded_embed._copy_weight(embed)
+        sharded_embed._copy_from_embedding(embed)
 
         return sharded_embed
 
     def __init__(
         self,
-        gang: Gang,
         num_embeddings: int,
         embed_dim: int,
         pad_idx: int | None = None,
         *,
         init_fn: Callable[[StandardEmbedding], None] | None = None,
+        gangs: Gangs | None = None,
         device: Device | None = None,
         dtype: DataType | None = None,
+        _tp_gang: Gang | None = None,
     ) -> None:
         super().__init__(num_embeddings, embed_dim, pad_idx)
 
-        if embed_dim % gang.size != 0:
+        if gangs is None:
+            gangs = get_current_gangs(device)
+
+        tp_gang = gangs.tp if _tp_gang is None else _tp_gang
+
+        if embed_dim % tp_gang.size != 0:
             raise ValueError(
-                f"`embed_dim` must be a multiple of `gang.size` ({gang.size}), but is {embed_dim} instead."
+                f"`embed_dim` must be a multiple of `gangs.tp.size` ({tp_gang.size}), but is {embed_dim} instead."
             )
 
-        self.gang = gang
+        self.tp_gang = tp_gang
 
-        self.sharded_embed_dim = embed_dim // gang.size
+        self.sharded = tp_gang.size > 1
+
+        self.sharded_embed_dim = embed_dim // tp_gang.size
 
         if device is None:
-            device = gang.device
-        elif device != gang.device and device.type != "meta":
+            device = get_current_device()
+
+        if device.type != "meta" and device != tp_gang.device:
             raise ValueError(
-                f"`device` must match `gang.device` or must be of type `meta`, but is `{device}` instead."
+                f"`device` must match `gangs.device` or must be of type `meta`, but is `{device}` instead."
             )
 
         weight = torch.empty(
@@ -362,25 +431,31 @@ class ShardedEmbedding(Embedding, Sharded):
         self.reset_parameters()
 
     def reset_parameters(self) -> None:
-        embed = self._embedding_like(self.gang.device)
+        if self.sharded:
+            embed = self._embedding_like(self.tp_gang.device)
 
-        self._copy_weight(embed)
+            self._copy_from_embedding(embed)
+        else:
+            _init_embedding(self)
 
-    def _copy_weight(self, embed: StandardEmbedding) -> None:
+    def _copy_from_embedding(self, embed: StandardEmbedding) -> None:
         with torch.no_grad():
             weight_shards = embed.weight.split(self.sharded_embed_dim, dim=1)
 
-            weight = weight_shards[self.gang.rank]
+            weight = weight_shards[self.tp_gang.rank]
 
             self.weight.copy_(weight, non_blocking=True)
 
     @override
     def forward(self, x: Tensor) -> Tensor:
-        x = reduce_on_backward(x, self.gang)
+        if not self.sharded:
+            return embedding(x, self.weight, self.pad_idx)
+
+        x = reduce_on_backward(x, self.tp_gang)
 
         x = embedding(x, self.weight, self.pad_idx)
 
-        x = gather(x, self.gang)
+        x = gather(x, self.tp_gang)
 
         return x
 
@@ -388,10 +463,13 @@ class ShardedEmbedding(Embedding, Sharded):
         """Unshards this instance to a :class:`StandardEmbedding`."""
         embed = self._embedding_like(device=META_DEVICE)
 
-        to_empty(embed, device or self.gang.device)
+        to_empty(embed, device or self.tp_gang.device)
 
         with torch.no_grad():
-            weight = gather(self.weight, self.gang, dim=1)
+            if self.sharded:
+                weight = gather(self.weight, self.tp_gang, dim=1)
+            else:
+                weight = self.weight
 
             embed.weight.copy_(weight, non_blocking=True)
 
@@ -415,8 +493,8 @@ class ShardedEmbedding(Embedding, Sharded):
     def extra_repr(self) -> str:
         """:meta private:"""
         s = (
-            f"tp_rank={self.gang.rank}, "
-            f"tp_size={self.gang.size}, "
+            f"tp_rank={self.tp_gang.rank}, "
+            f"tp_size={self.tp_gang.size}, "
             f"num_embeddings={self.num_embeddings}, "
             f"embed_dim={self.embed_dim}, "
             f"sharded_embed_dim={self.sharded_embed_dim}"
@@ -428,6 +506,19 @@ class ShardedEmbedding(Embedding, Sharded):
             s = f"{s}, init_fn={init_fn}"
 
         return s
+
+
+def _init_embedding(embed: Embedding) -> None:
+    m = cast(StandardEmbedding, embed)
+
+    if m.init_fn is not None:
+        m.init_fn(m)
+    else:
+        nn.init.normal_(m.weight)
+
+    if m.pad_idx is not None:
+        with torch.no_grad():
+            m.weight[m.pad_idx].fill_(0.0)
 
 
 def init_scaled_embedding(embed: StandardEmbedding) -> None:

--- a/tests/unit/nn/test_sharded.py
+++ b/tests/unit/nn/test_sharded.py
@@ -8,20 +8,31 @@ from __future__ import annotations
 
 from torch.nn import Sequential
 
-from fairseq2.gang import FakeGang
+from fairseq2.gang import FakeGang, Gangs
 from fairseq2.nn import ColumnShardedLinear, Linear, RowShardedLinear, get_shard_dims
 from tests.common import device
 
 
 def test_get_shard_dims_work() -> None:
-    gang = FakeGang(device, rank=1, size=16)
+    fake_gang = FakeGang(device)
+
+    root_gang = FakeGang(device, rank=1, size=16)
+
+    gangs = Gangs(
+        root=root_gang,
+        dp=fake_gang,
+        rdp=fake_gang,
+        sdp=fake_gang,
+        tp=root_gang,
+        pp=fake_gang,
+    )
 
     module = Sequential(
         Linear(32, 32, bias=True),
-        ColumnShardedLinear(gang, 32, 32, bias=True),
+        ColumnShardedLinear(32, 32, bias=True, gangs=gangs),
         Linear(32, 32, bias=False),
         Sequential(
-            RowShardedLinear(gang, 32, 32, bias=True),
+            RowShardedLinear(32, 32, bias=True, gangs=gangs),
         ),
     )
 


### PR DESCRIPTION
This PR further streamlines the construction and initialization of tensor parallel models. All tensor-parallel modules such as `ShardedEmbedding` and `RowShardedProjection` now behave as their non-sharded counterparts when the provided tensor parallel gang has a world size of 1. With this change, the first-party models LLaMA and Qwen are now always constructed with sharded modules regardless if tensor parallelism is enabled. This simplifies model construction further and also makes it possible to extract sharded dimension specifications without tensor parallelism.