### PR TITLE
fix synchronization bug - no avg_think_rollout_length metrics for ran…

### DIFF
--- a/src/fairseq2/recipes/lm/_online_finetune/_grpo.py
+++ b/src/fairseq2/recipes/lm/_online_finetune/_grpo.py
@@ -616,13 +616,17 @@ class GrpoFinetuneUnit(TrainUnit[SequenceBatch]):
 
         # Calculate average think rollout length (tokens before </think>)
         think_rollout_lengths = get_think_rollout_lengths(rollouts)
-        if think_rollout_lengths:
-            avg_think_rollout_length = (
+        avg_think_rollout_length = (
+            (
                 torch.tensor(think_rollout_lengths, device=self._gangs.dp.device)
                 .float()
                 .mean()
             )
-            update_avg_think_rollout_length(metric_bag, avg_think_rollout_length)
+            if think_rollout_lengths
+            else torch.tensor(0, device=self._gangs.dp.device)
+        )
+
+        update_avg_think_rollout_length(metric_bag, avg_think_rollout_length)
 
         update_grpo_batch_metrics(
             metric_bag,


### PR DESCRIPTION
…ks w/o think in rollout.

**What does this PR do? Please describe:**
A summary of the change or the issue that is fixed.
fix the training pipeline bug: update_avg_think_rollout_length is not always called and later causes synchronization issue in ALLGATHER called by sync_and_compute_collection (in metrics/_bag.py)

Fixes #{issue number}

**Does your PR introduce any breaking changes? If yes, please list them:**
List of all backwards-incompatible changes.

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [X] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [X] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
