### PR TITLE
fix wrong importance sampling ratio logging.

### DIFF
--- a/src/fairseq2/recipes/lm/_online_finetune/_common.py
+++ b/src/fairseq2/recipes/lm/_online_finetune/_common.py
@@ -746,3 +746,10 @@ def get_parameter_converter(model_config):
         raise RuntimeError(f"{model_config} not supported in online recipe")
 
     return _convert_parameter
+
+
+def masked_mean(x, mask, eps=1e-8):
+    # mask: boolean tensor with same shape as x
+    masked_x = x * mask
+    denom = mask.sum().clamp_min(eps)
+    return masked_x.sum() / denom

--- a/src/fairseq2/recipes/lm/_online_finetune/_grpo.py
+++ b/src/fairseq2/recipes/lm/_online_finetune/_grpo.py
@@ -49,6 +49,7 @@ from fairseq2.recipes.lm._online_finetune._common import (
     update_grpo_loss,
     update_logit_entropy,
     update_std_reward,
+    masked_mean,
 )
 from fairseq2.recipes.lm._online_finetune._handler import OnlineFinetuneUnitHandler
 from fairseq2.recipes.lm._online_finetune._remote_model import (
@@ -720,7 +721,7 @@ class GrpoFinetuneUnit(TrainUnit[SequenceBatch]):
 
         # self._gangs.root.barrier()
 
-        return per_seq_loss.sum(), total_tokens, tis_imp_ratio
+        return per_seq_loss.sum(), total_tokens, masked_mean(tis_imp_ratio, target_mask)
 
     @override
     def set_step_nr(self, step_nr: int) -> None:


### PR DESCRIPTION
**What does this PR do? Please describe:**
fix wrong importance sampling ratio metric - current calculation include positions supposed to be masked out including padding and prompt tokens. metric is abnormal even for quite on-policy setup.

Fixes #{issue number}

**Does your PR introduce any breaking changes? If yes, please list them:**
List of all backwards-incompatible changes.

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [X] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [ ] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [X] Did you write any **new necessary tests**?
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
