### PR TITLE
Workaround backwards-compatibility breakages of PyTorch 2.9

### DIFF
--- a/src/fairseq2/optim/lr_schedulers/cosine_annealing.py
+++ b/src/fairseq2/optim/lr_schedulers/cosine_annealing.py
@@ -10,6 +10,7 @@ import math
 from collections.abc import Sequence
 from typing import final
 
+from torch import Tensor
 from torch.optim import Optimizer
 from typing_extensions import override
 
@@ -92,7 +93,7 @@ class CosineAnnealingLR(AbstractLRScheduler):
         super().__init__(optimizer, last_epoch)
 
     @override
-    def _compute_lrs(self) -> list[float]:
+    def _compute_lrs(self) -> list[float | Tensor]:
         base_lrs = self.base_lrs
 
         # Linearly increase the learning rate to its base value during warmup.
@@ -137,7 +138,7 @@ class CosineAnnealingLR(AbstractLRScheduler):
 
         min_lrs, max_lrs = self.final_lrs, base_lrs
 
-        def cycle_lr(min_lr: float, max_lr: float) -> float:
+        def cycle_lr(min_lr: float | Tensor, max_lr: float | Tensor) -> float | Tensor:
             min_lr *= lr_mul
             max_lr *= lr_mul
 

--- a/src/fairseq2/optim/lr_schedulers/myle.py
+++ b/src/fairseq2/optim/lr_schedulers/myle.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import final
 
+from torch import Tensor
 from torch.optim import Optimizer
 from typing_extensions import override
 
@@ -65,7 +66,7 @@ class MyleLR(AbstractLRScheduler):
         super().__init__(optimizer, last_epoch)
 
     @override
-    def _compute_lrs(self) -> list[float]:
+    def _compute_lrs(self) -> list[float | Tensor]:
         base_lrs = self.base_lrs
 
         # Linearly increase the learning rate to its base value during warmup.

--- a/src/fairseq2/optim/lr_schedulers/noam.py
+++ b/src/fairseq2/optim/lr_schedulers/noam.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from typing import final
 
+from torch import Tensor
 from torch.optim import Optimizer
 from typing_extensions import override
 
@@ -54,7 +55,7 @@ class NoamLR(AbstractLRScheduler):
         super().__init__(optimizer, last_epoch)
 
     @override
-    def _compute_lrs(self) -> list[float]:
+    def _compute_lrs(self) -> list[float | Tensor]:
         # Linearly increase the learning rate during warmup.
         if self.last_epoch < self.num_warmup_steps:
             c = self.last_epoch * self.num_warmup_steps**-1.5

--- a/src/fairseq2/optim/lr_schedulers/polynomial_decay.py
+++ b/src/fairseq2/optim/lr_schedulers/polynomial_decay.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import final
 
+from torch import Tensor
 from torch.optim import Optimizer
 from typing_extensions import override
 
@@ -83,7 +84,7 @@ class PolynomialDecayLR(AbstractLRScheduler):
         super().__init__(optimizer, last_epoch)
 
     @override
-    def _compute_lrs(self) -> list[float]:
+    def _compute_lrs(self) -> list[float | Tensor]:
         base_lrs = self.base_lrs
 
         # The decay is already complete, return the final learning rate.

--- a/src/fairseq2/optim/lr_schedulers/tri_stage.py
+++ b/src/fairseq2/optim/lr_schedulers/tri_stage.py
@@ -10,6 +10,7 @@ import math
 from collections.abc import Sequence
 from typing import final
 
+from torch import Tensor
 from torch.optim import Optimizer
 from typing_extensions import override
 
@@ -72,8 +73,8 @@ class TriStageLR(AbstractLRScheduler):
         num_stage_steps = [int(r * num_steps) for r in stage_ratio]
 
         self.num_steps = num_steps
-        self.start_lrs: Sequence[float] | None = None
-        self.final_lrs: Sequence[float] | None = None
+        self.start_lrs: Sequence[float | Tensor] | None = None
+        self.final_lrs: Sequence[float | Tensor] | None = None
         self.start_lr_scales = start_lr_scales
         self.final_lr_scales = final_lr_scales
         self.num_stage_steps = num_stage_steps
@@ -81,7 +82,7 @@ class TriStageLR(AbstractLRScheduler):
         super().__init__(optimizer, last_epoch)
 
     @override
-    def _compute_lrs(self) -> list[float]:
+    def _compute_lrs(self) -> list[float | Tensor]:
         base_lrs = self.base_lrs
 
         # Due to `LRScheduler`'s constructor quirks, we delay the initialization

--- a/src/fairseq2/trainer.py
+++ b/src/fairseq2/trainer.py
@@ -265,7 +265,7 @@ class Trainer(Task):
                 "`publish_metrics_every_n_data_epochs` must be greater than or equal to 1."
             )
 
-        last_lrs = [0.0] * len(optimizer.param_groups)
+        last_lrs: list[float | Tensor] = [0.0] * len(optimizer.param_groups)
 
         self._model = model
         self._model_dp_facade = model_dp_facade
@@ -615,7 +615,7 @@ class Trainer(Task):
 
             return _TrainerState.GRAD_OVERFLOW
 
-        self._last_lrs = self._lr_scheduler.get_last_lr()
+        self._last_lrs = self._lr_scheduler.get_last_lr()  # type: ignore[assignment]
 
         self._lr_scheduler.step()
 


### PR DESCRIPTION
PyTorch 2.9 introduces a backwards incompatible change in `LRScheduler` API where the return value of `get_lr()` and `base_lrs` attribute are changed from `list[float]` to `list[float | Tensor]`. There is also a distribution bug in PyTorch 2.9 and this breakage occurs only in CPU-only build. To work around the issue with minimal code changes, this PR updates the signature of fairseq2 LR schedulers to use `list[float | Tensor]` and suppresses the mypy warning in `AbstractLRScheduler`.