### PR TITLE
Fix typo in WerMetric: use hyp_seqs instead of ref_seqs for hyp_seqs_list

### DIFF
--- a/src/fairseq2/metrics/text/wer.py
+++ b/src/fairseq2/metrics/text/wer.py
@@ -79,7 +79,7 @@ class WerMetric(Metric[tuple[Tensor, Tensor]]):
         hyp_seq_lens = hyp_seqs_layout.seq_lens
         # editdistance requires lists
         ref_seqs_list = ref_seqs.cpu().tolist()
-        hyp_seqs_list = ref_seqs.cpu().tolist()
+        hyp_seqs_list = hyp_seqs.cpu().tolist()
 
         for ref, ref_seq, ref_seq_len, hyp, hyp_seq, hyp_seq_len in zip(
             refs, ref_seqs_list, ref_seq_lens, hyps, hyp_seqs_list, hyp_seq_lens


### PR DESCRIPTION
**What does this PR do? Please describe:**
Fix a typo in `WerMetric.update()` where `hyp_seqs_list` was incorrectly assigned from `ref_seqs.cpu().tolist()` instead of `hyp_seqs.cpu().tolist()`. This caused the unit-level edit distance to always compare reference sequences against themselves, making UER always 0 regardless of actual model output.

**Does your PR introduce any breaking changes? If yes, please list them:**
No breaking changes.

**Check list:**
- [x] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)