### PR TITLE
Fix metrics logged as percentage in wandb/tensorboard/jsonl

### DIFF
--- a/src/fairseq2/metrics/__init__.py
+++ b/src/fairseq2/metrics/__init__.py
@@ -17,3 +17,4 @@ from fairseq2.metrics.formatters import format_as_float as format_as_float
 from fairseq2.metrics.formatters import format_as_int as format_as_int
 from fairseq2.metrics.formatters import format_as_percentage as format_as_percentage
 from fairseq2.metrics.formatters import format_as_seconds as format_as_seconds
+from fairseq2.metrics.formatters import scale_as_percentage as scale_as_percentage

--- a/src/fairseq2/metrics/formatters.py
+++ b/src/fairseq2/metrics/formatters.py
@@ -62,6 +62,13 @@ def format_as_float(value: object, *, postfix: str | None = None) -> str:
     return s
 
 
+def scale_as_percentage(value: object) -> object:
+    """Scale metric ``value`` from [0, 1] to [0, 100] for numeric logging."""
+    if isinstance(value, (int, float, Tensor)):
+        return value * 100.0
+    return value
+
+
 def format_as_percentage(value: object) -> str:
     """Format metric ``value`` as percentage."""
     if isinstance(value, float):
@@ -76,9 +83,7 @@ def format_as_percentage(value: object) -> str:
     else:
         return f"{value}"
 
-    i = math.ceil(f * 100)
-
-    return f"{i}%"
+    return f"{f * 100:.2f}%"
 
 
 _UNITS: Final = ["B", "KiB", "MiB", "GiB", "TiB", "PiB"]

--- a/src/fairseq2/metrics/recorders/__init__.py
+++ b/src/fairseq2/metrics/recorders/__init__.py
@@ -17,6 +17,9 @@ from fairseq2.metrics.recorders.descriptor import (
     MetricDescriptorRegistry as MetricDescriptorRegistry,
 )
 from fairseq2.metrics.recorders.descriptor import MetricFormatter as MetricFormatter
+from fairseq2.metrics.recorders.descriptor import (
+    MetricValueTransform as MetricValueTransform,
+)
 from fairseq2.metrics.recorders.jsonl import JsonlMetricRecorder as JsonlMetricRecorder
 from fairseq2.metrics.recorders.log import LogMetricRecorder as LogMetricRecorder
 from fairseq2.metrics.recorders.recorder import (

--- a/src/fairseq2/metrics/recorders/descriptor.py
+++ b/src/fairseq2/metrics/recorders/descriptor.py
@@ -15,6 +15,10 @@ class MetricFormatter(Protocol):
     def __call__(self, value: object) -> str: ...
 
 
+class MetricValueTransform(Protocol):
+    def __call__(self, value: object) -> object: ...
+
+
 @dataclass
 class MetricDescriptor:
     name: str
@@ -23,6 +27,7 @@ class MetricDescriptor:
     formatter: MetricFormatter
     log: bool = True
     higher_better: bool = False
+    value_transform: MetricValueTransform | None = None
 
 
 NOOP_METRIC_DESCRIPTOR: Final = MetricDescriptor(

--- a/src/fairseq2/metrics/recorders/jsonl.py
+++ b/src/fairseq2/metrics/recorders/jsonl.py
@@ -91,6 +91,8 @@ class JsonlMetricRecorder(MetricRecorder):
             output["Step"] = step_nr
 
         for value, descriptor in values_and_descriptors:
+            if descriptor.value_transform is not None:
+                value = descriptor.value_transform(value)
             output[descriptor.display_name] = sanitize(value)
 
         try:

--- a/src/fairseq2/metrics/recorders/tensorboard.py
+++ b/src/fairseq2/metrics/recorders/tensorboard.py
@@ -49,6 +49,8 @@ class TensorBoardRecorder(MetricRecorder):
                     display_name = name
                 else:
                     display_name = descriptor.display_name
+                    if descriptor.value_transform is not None:
+                        value = descriptor.value_transform(value)
 
                 self._add_value(writer, step_nr, display_name, value)
 

--- a/src/fairseq2/metrics/recorders/wandb.py
+++ b/src/fairseq2/metrics/recorders/wandb.py
@@ -44,6 +44,8 @@ class WandbRecorder(MetricRecorder):
                 display_name = f"{category}/{name}"
             else:
                 display_name = f"{category}/{descriptor.display_name}"
+                if descriptor.value_transform is not None:
+                    value = descriptor.value_transform(value)
 
             self._add_value(display_name, value, output)
 

--- a/src/fairseq2/recipe/composition/metric_recorders.py
+++ b/src/fairseq2/recipe/composition/metric_recorders.py
@@ -17,6 +17,7 @@ from fairseq2.metrics import (
     format_as_int,
     format_as_percentage,
     format_as_seconds,
+    scale_as_percentage,
 )
 from fairseq2.metrics.recorders import (
     CompositeMetricRecorder,
@@ -180,7 +181,8 @@ def _register_metric_descriptors(container: DependencyContainer) -> None:
     register("num_source_elements",       "Number of Source Elements",       830, format_as_int)
     register("num_target_elements",       "Number of Target Elements",       830, format_as_int)
     register("padding",                   "Padding",                         835, format_as_int)
-    register("padding_ratio",             "Padding Ratio (%)",               835, format_as_percentage)
+    register("padding_ratio",             "Padding Ratio (%)",               835, format_as_percentage,
+             value_transform=scale_as_percentage)
     register("total_num_examples",        "Total Number of Examples",        840, format_as_int)
     register("total_num_elements",        "Total Number of Elements",        850, format_as_int)
     register("total_num_source_elements", "Total Number of Source Elements", 850, format_as_int)
@@ -195,7 +197,9 @@ def _register_metric_descriptors(container: DependencyContainer) -> None:
 
     # Memory
     register("peak_active_mem_bytes",   "Peak Active Device Memory",       920, format_as_byte_size)
-    register("peak_active_mem_ratio",   "Peak Active Device Memory (%)",   920, format_as_percentage)
+    register("peak_active_mem_ratio",   "Peak Active Device Memory (%)",   920, format_as_percentage,
+             value_transform=scale_as_percentage)
     register("peak_reserved_mem_bytes", "Peak Reserved Device Memory",     925, format_as_byte_size)
-    register("peak_reserved_mem_ratio", "Peak Reserved Device Memory (%)", 925, format_as_percentage)
+    register("peak_reserved_mem_ratio", "Peak Reserved Device Memory (%)", 925, format_as_percentage,
+             value_transform=scale_as_percentage)
     # fmt: on

--- a/tests/unit/metrics/__init__.py
+++ b/tests/unit/metrics/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/tests/unit/metrics/recorders/__init__.py
+++ b/tests/unit/metrics/recorders/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/tests/unit/metrics/recorders/test_jsonl.py
+++ b/tests/unit/metrics/recorders/test_jsonl.py
@@ -1,0 +1,92 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from fairseq2.file_system import FileMode
+from fairseq2.metrics.formatters import (
+    format_as_float,
+    format_as_percentage,
+    scale_as_percentage,
+)
+from fairseq2.metrics.recorders.descriptor import (
+    MetricDescriptor,
+    MetricDescriptorRegistry,
+)
+from fairseq2.metrics.recorders.jsonl import JsonlMetricRecorder
+
+
+def _make_mock_file_system(tmp_path: Path) -> MagicMock:
+    mock_fs = MagicMock()
+    mock_fs.make_directory.side_effect = lambda p: p.mkdir(parents=True, exist_ok=True)
+    mock_fs.open_text.side_effect = lambda p, mode=FileMode.APPEND: open(
+        p, "a" if mode == FileMode.APPEND else "r"
+    )
+    return mock_fs
+
+
+class TestJsonlRecorderValueTransform:
+    def setup_method(self) -> None:
+        descriptors = [
+            MetricDescriptor(
+                "padding_ratio",
+                "Padding Ratio (%)",
+                835,
+                format_as_percentage,
+                value_transform=scale_as_percentage,
+            ),
+            MetricDescriptor(
+                "loss",
+                "Loss",
+                90,
+                format_as_float,
+            ),
+        ]
+        self.registry = MetricDescriptorRegistry(descriptors)
+
+    def test_applies_value_transform_for_percentage_metrics(
+        self, tmp_path: Path
+    ) -> None:
+        fs = _make_mock_file_system(tmp_path)
+        recorder = JsonlMetricRecorder(tmp_path, fs, self.registry)
+
+        recorder.record_metric_values("train", {"padding_ratio": 0.42}, step_nr=1)
+        recorder.close()
+
+        jsonl_file = tmp_path / "metrics" / "train.jsonl"
+        line = json.loads(jsonl_file.read_text().strip())
+        assert line["Padding Ratio (%)"] == 42.0
+
+    def test_does_not_transform_metrics_without_value_transform(
+        self, tmp_path: Path
+    ) -> None:
+        fs = _make_mock_file_system(tmp_path)
+        recorder = JsonlMetricRecorder(tmp_path, fs, self.registry)
+
+        recorder.record_metric_values("train", {"loss": 2.5}, step_nr=1)
+        recorder.close()
+
+        jsonl_file = tmp_path / "metrics" / "train.jsonl"
+        line = json.loads(jsonl_file.read_text().strip())
+        assert line["Loss"] == 2.5
+
+    def test_mixed_metrics_transforms_only_percentage(self, tmp_path: Path) -> None:
+        fs = _make_mock_file_system(tmp_path)
+        recorder = JsonlMetricRecorder(tmp_path, fs, self.registry)
+
+        recorder.record_metric_values(
+            "train", {"loss": 3.0, "padding_ratio": 0.1}, step_nr=5
+        )
+        recorder.close()
+
+        jsonl_file = tmp_path / "metrics" / "train.jsonl"
+        line = json.loads(jsonl_file.read_text().strip())
+        assert line["Loss"] == 3.0
+        assert line["Padding Ratio (%)"] == 10.0

--- a/tests/unit/metrics/recorders/test_log.py
+++ b/tests/unit/metrics/recorders/test_log.py
@@ -1,0 +1,63 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from fairseq2.metrics.formatters import (
+    format_as_float,
+    format_as_percentage,
+    scale_as_percentage,
+)
+from fairseq2.metrics.recorders.descriptor import (
+    MetricDescriptor,
+    MetricDescriptorRegistry,
+)
+from fairseq2.metrics.recorders.log import LogMetricRecorder
+
+
+class TestLogRecorderValueTransform:
+    """Verify LogMetricRecorder uses the formatter (not value_transform) for display."""
+
+    def setup_method(self) -> None:
+        descriptors = [
+            MetricDescriptor(
+                "padding_ratio",
+                "Padding Ratio (%)",
+                835,
+                format_as_percentage,
+                value_transform=scale_as_percentage,
+            ),
+            MetricDescriptor(
+                "loss",
+                "Loss",
+                90,
+                format_as_float,
+            ),
+        ]
+        registry = MetricDescriptorRegistry(descriptors)
+        self.recorder = LogMetricRecorder(registry)
+
+    def test_formatter_still_produces_percentage_string(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with caplog.at_level(logging.INFO, logger="fairseq2"):
+            self.recorder.record_metric_values(
+                "train", {"padding_ratio": 0.42}, step_nr=1
+            )
+
+        assert any("42.00%" in record.message for record in caplog.records)
+
+    def test_formatter_still_produces_float_string(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with caplog.at_level(logging.INFO, logger="fairseq2"):
+            self.recorder.record_metric_values("train", {"loss": 2.5}, step_nr=1)
+
+        assert any("2.5" in record.message for record in caplog.records)

--- a/tests/unit/metrics/recorders/test_tensorboard.py
+++ b/tests/unit/metrics/recorders/test_tensorboard.py
@@ -1,0 +1,69 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from fairseq2.metrics.formatters import (
+    format_as_float,
+    format_as_percentage,
+    scale_as_percentage,
+)
+from fairseq2.metrics.recorders.descriptor import (
+    MetricDescriptor,
+    MetricDescriptorRegistry,
+)
+from fairseq2.metrics.recorders.tensorboard import TensorBoardRecorder
+
+
+class TestTensorBoardRecorderValueTransform:
+    def setup_method(self) -> None:
+        descriptors = [
+            MetricDescriptor(
+                "padding_ratio",
+                "Padding Ratio (%)",
+                835,
+                format_as_percentage,
+                value_transform=scale_as_percentage,
+            ),
+            MetricDescriptor(
+                "loss",
+                "Loss",
+                90,
+                format_as_float,
+            ),
+        ]
+        self.registry = MetricDescriptorRegistry(descriptors)
+
+    @patch(
+        "fairseq2.metrics.recorders.tensorboard.SummaryWriter",
+    )
+    def test_applies_value_transform_for_percentage_metrics(
+        self, mock_writer_cls: MagicMock, tmp_path: Path
+    ) -> None:
+        mock_writer = MagicMock()
+        mock_writer_cls.return_value = mock_writer
+
+        recorder = TensorBoardRecorder(tmp_path, self.registry)
+        recorder.record_metric_values("train", {"padding_ratio": 0.42}, step_nr=1)
+
+        mock_writer.add_scalar.assert_called_once_with("Padding Ratio (%)", 42.0, 1)
+
+    @patch(
+        "fairseq2.metrics.recorders.tensorboard.SummaryWriter",
+    )
+    def test_does_not_transform_metrics_without_value_transform(
+        self, mock_writer_cls: MagicMock, tmp_path: Path
+    ) -> None:
+        mock_writer = MagicMock()
+        mock_writer_cls.return_value = mock_writer
+
+        recorder = TensorBoardRecorder(tmp_path, self.registry)
+        recorder.record_metric_values("train", {"loss": 2.5}, step_nr=1)
+
+        mock_writer.add_scalar.assert_called_once_with("Loss", 2.5, 1)

--- a/tests/unit/metrics/recorders/test_wandb.py
+++ b/tests/unit/metrics/recorders/test_wandb.py
@@ -1,0 +1,74 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from wandb import Run as WandbRun
+
+from fairseq2.metrics.formatters import (
+    format_as_float,
+    format_as_percentage,
+    scale_as_percentage,
+)
+from fairseq2.metrics.recorders.descriptor import (
+    MetricDescriptor,
+    MetricDescriptorRegistry,
+)
+from fairseq2.metrics.recorders.wandb import WandbRecorder
+
+
+class TestWandbRecorderValueTransform:
+    def setup_method(self) -> None:
+        self.mock_run = MagicMock(spec=WandbRun)
+
+        descriptors = [
+            MetricDescriptor(
+                "padding_ratio",
+                "Padding Ratio (%)",
+                835,
+                format_as_percentage,
+                value_transform=scale_as_percentage,
+            ),
+            MetricDescriptor(
+                "loss",
+                "Loss",
+                90,
+                format_as_float,
+            ),
+        ]
+        registry = MetricDescriptorRegistry(descriptors)
+        self.recorder = WandbRecorder(self.mock_run, registry)
+
+    def test_applies_value_transform_for_percentage_metrics(self) -> None:
+        self.recorder.record_metric_values("train", {"padding_ratio": 0.42}, step_nr=1)
+
+        self.mock_run.log.assert_called_once_with(
+            {"train/Padding Ratio (%)": 42.0}, step=1
+        )
+
+    def test_does_not_transform_metrics_without_value_transform(self) -> None:
+        self.recorder.record_metric_values("train", {"loss": 2.5}, step_nr=1)
+
+        self.mock_run.log.assert_called_once_with({"train/Loss": 2.5}, step=1)
+
+    def test_applies_transform_only_to_metrics_with_transform(self) -> None:
+        self.recorder.record_metric_values(
+            "train", {"padding_ratio": 0.1, "loss": 3.0}, step_nr=5
+        )
+
+        self.mock_run.log.assert_called_once()
+        logged = self.mock_run.log.call_args[0][0]
+        assert logged["train/Padding Ratio (%)"] == 10.0
+        assert logged["train/Loss"] == 3.0
+
+    def test_unknown_metric_passes_raw_value(self) -> None:
+        self.recorder.record_metric_values("train", {"unknown_metric": 0.75}, step_nr=1)
+
+        self.mock_run.log.assert_called_once_with(
+            {"train/unknown_metric": 0.75}, step=1
+        )

--- a/tests/unit/metrics/test_formatters.py
+++ b/tests/unit/metrics/test_formatters.py
@@ -1,0 +1,64 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from fairseq2.metrics.formatters import (
+    format_as_percentage,
+    scale_as_percentage,
+)
+
+
+class TestScaleAsPercentage:
+    def test_scales_float(self) -> None:
+        assert scale_as_percentage(0.42) == 42.0
+
+    def test_scales_zero(self) -> None:
+        assert scale_as_percentage(0.0) == 0.0
+
+    def test_scales_one(self) -> None:
+        assert scale_as_percentage(1.0) == 100.0
+
+    def test_scales_int(self) -> None:
+        assert scale_as_percentage(1) == 100.0
+
+    def test_returns_non_numeric_unchanged(self) -> None:
+        assert scale_as_percentage("hello") == "hello"
+
+    def test_returns_none_unchanged(self) -> None:
+        assert scale_as_percentage(None) is None
+
+    def test_scales_tensor(self) -> None:
+        t = torch.tensor(0.42)
+        result = scale_as_percentage(t)
+        assert torch.is_tensor(result)
+        assert float(result) == pytest.approx(42.0)
+
+
+class TestFormatAsPercentage:
+    def test_formats_float(self) -> None:
+        assert format_as_percentage(0.4212) == "42.12%"
+
+    def test_formats_zero(self) -> None:
+        assert format_as_percentage(0.0) == "0.00%"
+
+    def test_formats_one(self) -> None:
+        assert format_as_percentage(1.0) == "100.00%"
+
+    def test_formats_tensor(self) -> None:
+        assert format_as_percentage(torch.tensor(0.5)) == "50.00%"
+
+    def test_formats_string_number(self) -> None:
+        assert format_as_percentage("0.75") == "75.00%"
+
+    def test_formats_non_numeric_string(self) -> None:
+        assert format_as_percentage("abc") == "abc"
+
+    def test_keeps_two_decimal_places(self) -> None:
+        assert format_as_percentage(0.4213) == "42.13%"


### PR DESCRIPTION
**What does this PR do? Please describe:**

Metrics using format_as_percentage (padding_ratio, peak_active_mem_ratio, peak_reserved_mem_ratio) were logged as raw 0-1 floats to numeric backends (wandb, TensorBoard, JSONL) while the console logger correctly displayed them as percentages. This happened because the formatter returns a string ("42%") which only the console logger uses — numeric backends skip it entirely and pass raw values through.

**Fix** 

The fix adds an optional `value_transform` field to MetricDescriptor that applies a numeric transformation before logging. A new `scale_as_percentage` function handles int, float, and Tensor types by multiplying by 100. The three numeric recorders (wandb, TensorBoard, JSONL) now apply this transform when present, while the console logger continues using the string formatter.

Also changes format_as_percentage to display 2 decimal places ("42.26%" instead of "42%").

Changes:
- Add MetricValueTransform protocol and value_transform field to MetricDescriptor
- Add scale_as_percentage function to formatters
- Apply value_transform in WandbRecorder, TensorBoardRecorder, JsonlMetricRecorder
- Register value_transform=scale_as_percentage for the 3 percentage metrics
- Update format_as_percentage to use 2 decimal places
- Add 25 unit tests covering formatters and all 4 recorders



**Does your PR introduce any breaking changes? If yes, please list them:**
None

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**?
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
