### PR TITLE
fix(data): align filter() kwarg between Python stub and pybind

### DIFF
--- a/native/python/src/fairseq2n/bindings/data/data_pipeline.cc
+++ b/native/python/src/fairseq2n/bindings/data/data_pipeline.cc
@@ -513,7 +513,7 @@ def_data_pipeline(py::module_ &data_module)
 
                 return self;
             },
-            py::arg("fn"))
+            py::arg("predicate"))
         .def(
             "map",
             [](

--- a/tests/unit/data/data_pipeline/test_filter.py
+++ b/tests/unit/data/data_pipeline/test_filter.py
@@ -39,3 +39,13 @@ class TestFilterOp:
                 pass
 
         assert str(exc_info.value) == "filter error"
+
+    def test_op_works_when_predicate_is_passed_as_kwarg(self) -> None:
+        # Same kwarg-mismatch bug as #1103 / #1510 (dynamic_bucket), for filter().
+        seq = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+        pipeline = (
+            read_sequence(seq).filter(predicate=lambda d: d % 2 == 1).and_return()
+        )
+
+        assert list(pipeline) == [1, 3, 5, 7, 9]


### PR DESCRIPTION
Follow up to #1510 for the same bug class.

The Python stub at `src/fairseq2/data/data_pipeline.py:275` declares `def filter(self, predicate: ...)`, but the pybind binding at `native/python/src/fairseq2n/bindings/data/data_pipeline.cc:516` exposed the arg as `py::arg("fn")`. So calling `pipeline.filter(predicate=...)` blows up:

```
TypeError: filter(): incompatible function arguments. The following argument types are supported:
    1. (..., fn: Callable[[Any], bool]) -> ...
Invoked with: ...; kwargs: predicate=<lambda>
```

Renamed the pybind kwarg from `fn` to `predicate` to match the documented Python signature. I grep'd every `.filter(` call across `src/`, `tests/`, `examples/`, and `recipes/`: there are 17 callers, all of them pass the predicate positionally, none use `fn=`. So no internal breakage.

Added a regression test in `tests/unit/data/data_pipeline/test_filter.py` that calls `filter` with `predicate=` as a kwarg. Built fairseq2n from source on Linux + Python 3.12 + Torch 2.12 and ran the A/B cycle: test fails against the unpatched binding with the exact `TypeError` above, passes against the patched one. The other two tests in `TestFilterOp` are unchanged and still pass.

As promised in the description of #1510.