### PR TITLE
Fix gangs coordinator rank check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Gemma 4 model family (E4B, 31B, 26B-A4B) with base and instruction-tuned variants. Includes decoder with Per-Layer Embeddings (PLE), partial RoPE, KV sharing across sliding/global attention layers, Mixture-of-Experts (26B-A4B), QK/V-norm, logit soft-capping, audio tower (Conformer encoder for multimodal E4B), bidirectional HuggingFace state dict conversion, FSDP/activation checkpointing/tensor parallel support, and SFT recipe configs.
 - Bump transformers~=v5.5 and loosen huggingface_hub upper bound. (#1508)
 - Fixed typo in WerMetric: use `hyp_seqs` instead of `ref_seqs` for `hyp_seqs_list`. (#1506)
+- Fixed operator precedence in the `Gangs` coordinator rank check so that a `root.rank == 0` process that is not rank 0 in any single parallel gang (data, tensor, or pipeline) is correctly rejected.
 
 ## [0.8.0] - March 25th, 2026
 - fsspec integration for remote filesystem support. Checkpoints can be saved to and loaded from S3 via `--checkpoint-dir s3://bucket/path/`. Requires `s3fs`. (#1126)

--- a/src/fairseq2/gang.py
+++ b/src/fairseq2/gang.py
@@ -689,7 +689,7 @@ class Gangs(Closable):
 
     def __post_init__(self) -> None:
         if self.root.rank == 0:
-            if self.dp.rank != 0 or self.tp.rank != 0 and self.pp.rank != 0:
+            if self.dp.rank != 0 or self.tp.rank != 0 or self.pp.rank != 0:
                 raise ValueError(
                     "Coordinator process of the root gang (i.e. `root.rank == 0`) must be rank 0 in all parallel gangs."
                 )

--- a/tests/unit/test_gang.py
+++ b/tests/unit/test_gang.py
@@ -6,8 +6,11 @@
 
 from __future__ import annotations
 
+import pytest
+
 from fairseq2.gang import (
     FakeGang,
+    Gangs,
     create_fake_gangs,
     get_current_gangs,
     get_default_gangs,
@@ -47,3 +50,50 @@ def test_get_current_gangs_works() -> None:
 
     assert get_current_gangs(device) is fake_gangs1
     assert get_default_gangs(device) is fake_gangs1
+
+
+def _gangs_with_ranks(*, dp: int = 0, tp: int = 0, pp: int = 0) -> Gangs:
+    # The root gang's coordinator is rank 0; build each parallel gang as a
+    # `FakeGang` at the requested rank, with `size` just large enough to make
+    # that rank valid.
+    root = FakeGang(device=device, rank=0, size=1)
+
+    def gang(rank: int) -> FakeGang:
+        return FakeGang(device=device, rank=rank, size=rank + 1)
+
+    dp_gang = gang(dp)
+
+    return Gangs(
+        root=root,
+        dp=dp_gang,
+        rdp=dp_gang,
+        sdp=dp_gang,
+        tp=gang(tp),
+        pp=gang(pp),
+    )
+
+
+def test_gangs_accept_coordinator_that_is_rank_0_in_every_parallel_gang() -> None:
+    # `root.rank == 0` and dp/tp/pp all rank 0 is a valid coordinator; must not
+    # raise.
+    _gangs_with_ranks(dp=0, tp=0, pp=0)
+
+
+@pytest.mark.parametrize(
+    "dp,tp,pp",
+    [
+        (1, 0, 0),  # data parallel rank non-zero
+        (0, 1, 0),  # tensor parallel rank non-zero
+        (0, 0, 1),  # pipeline parallel rank non-zero
+        (0, 1, 1),  # tensor and pipeline parallel ranks non-zero
+    ],
+)
+def test_gangs_reject_coordinator_with_a_non_zero_parallel_rank(
+    dp: int, tp: int, pp: int
+) -> None:
+    # A `root.rank == 0` process that is not rank 0 in *every* parallel gang is
+    # an invalid coordinator and must be rejected. The `(0, 1, 0)` and
+    # `(0, 0, 1)` cases in particular are the ones an `and`/`or` precedence bug
+    # in the check would let slip through.
+    with pytest.raises(ValueError, match="must be rank 0 in all parallel gangs"):
+        _gangs_with_ranks(dp=dp, tp=tp, pp=pp)


### PR DESCRIPTION
**What does this PR do? Please describe:**

`Gangs.__post_init__` enforces that when `root.rank == 0`, the coordinator process must be rank 0 in every parallel gang. The check read:

```python
if self.dp.rank != 0 or self.tp.rank != 0 and self.pp.rank != 0:
```

Since Python binds `and` tighter than `or`, this evaluates as `dp.rank != 0 or (tp.rank != 0 and pp.rank != 0)`. As a result, a `root.rank == 0` process that is non-zero in exactly one of the tensor- or pipeline-parallel gangs (for example `tp.rank == 1, pp.rank == 0`, or `tp.rank == 0, pp.rank == 1`) passes validation, contradicting the error message ("must be rank 0 in all parallel gangs"). This PR joins all three checks with `or`, adds parametrized regression tests, and adds a CHANGELOG entry.

No associated issue.

**Does your PR introduce any breaking changes? If yes, please list them:**

No. It only makes the validation reject coordinator configurations it was always meant to reject; valid configurations (rank 0 in every parallel gang) behave exactly as before.

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? No prior issue; this is a one-line logic-bug fix accompanied by a test.
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? No documentation change is needed for this fix.
- [x] Did you write any **new necessary tests**? Added parametrized tests in `tests/unit/test_gang.py` covering the previously-accepted `(tp=1, pp=0)` and `(tp=0, pp=1)` coordinator configurations.
- [ ] Did you verify new and **existing tests pass** locally with your changes? Verified the fix with a standalone reproduction of the check and ran `isort` / `black` / `flake8` clean. The full `pytest` suite could not run locally because the native `fairseq2n` module has no macOS build; the new tests exercise the real `Gangs` class and run in CI.
- [x] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**?